### PR TITLE
Added a timeout option in db cache lock

### DIFF
--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -4,6 +4,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/anuvu/zot/errors"
 	zlog "github.com/anuvu/zot/pkg/log"
@@ -11,7 +12,8 @@ import (
 )
 
 const (
-	BlobsCache = "blobs"
+	BlobsCache              = "blobs"
+	dbCacheLockCheckTimeout = 10 * time.Second
 )
 
 type Cache struct {
@@ -27,7 +29,11 @@ type Blob struct {
 
 func NewCache(rootDir string, name string, log zlog.Logger) *Cache {
 	dbPath := path.Join(rootDir, name+".db")
-	db, err := bbolt.Open(dbPath, 0600, nil)
+	dbOpts := &bbolt.Options{
+		Timeout:      dbCacheLockCheckTimeout,
+		FreelistType: bbolt.FreelistArrayType,
+	}
+	db, err := bbolt.Open(dbPath, 0600, dbOpts)
 
 	if err != nil {
 		log.Error().Err(err).Str("dbPath", dbPath).Msg("unable to create cache db")


### PR DESCRIPTION
Fix for https://github.com/anuvu/zot/issues/242

By default we are not sending any dbCache options when opening  a connection to db cache. Default option has timeout=0 meaning it will wait forever in a RW lock. If previously another process will acquire the lock, the second started process will block. In fact the http.listen code was not reached and "already bind address" was not triggered as I would expect.