### PR TITLE
Added S3 blobs dedupe functionality

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -101,13 +101,15 @@ func (c *Controller) Run() error {
 	c.StoreController = storage.StoreController{}
 
 	if c.Config.Storage.RootDirectory != "" {
-		if c.Config.Storage.Dedupe {
-			err := storage.ValidateHardLink(c.Config.Storage.RootDirectory)
-			if err != nil {
-				c.Log.Warn().Msg("input storage root directory filesystem does not supports hardlinking," +
-					"disabling dedupe functionality")
+		if len(c.Config.Storage.StorageDriver) == 0 {
+			if c.Config.Storage.Dedupe {
+				err := storage.ValidateHardLink(c.Config.Storage.RootDirectory)
+				if err != nil {
+					c.Log.Warn().Msg("input storage root directory filesystem does not supports hardlinking," +
+						"disabling dedupe functionality")
 
-				c.Config.Storage.Dedupe = false
+					c.Config.Storage.Dedupe = false
+				}
 			}
 		}
 

--- a/pkg/storage/storage_fs.go
+++ b/pkg/storage/storage_fs.go
@@ -994,7 +994,7 @@ retry:
 	}
 
 	if dstRecord == "" {
-		// cache record doesn't exist, so first disk and cache entry for this diges
+		// cache record doesn't exist, so first disk and cache entry for this digest
 		if err := is.cache.PutBlob(dstDigest.String(), dst); err != nil {
 			is.log.Error().Err(err).Str("blobPath", dst).Msg("dedupe: unable to insert blob record")
 


### PR DESCRIPTION
- now blobs are just files which contains a path to the real blob under rootDir/BLOBS/
- linked_blobs.json contains links between real blobs and the blobs which points to them.
eg: 
`{"links":{"sha256:801bfaa63ef2094d770c809815b9e2b9c1194728e5e754ef7bc764030e140cea":["/zot/alpine/blobs/sha256/801bfaa63ef2094d770c809815b9e2b9c1194728e5e754ef7bc764030e140cea"]}`

I'm using linked_blobs.json to check if I can safely delete real blobs.

Can not safely switch dedupe config value if zot already run with a given rootDir because of the entire different logic of dedupe vs non dedupe. I should add a check.


Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>