### PR TITLE
sync: Added support for syncing notary/cosign signatures, closes #261

### DIFF
--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -188,6 +188,22 @@ func TestVerify(t *testing.T) {
 		So(func() { _ = cli.NewServerRootCmd().Execute() }, ShouldPanic)
 	})
 
+	Convey("Test verify w/ sync and w/ filesystem storage", t, func(c C) {
+		tmpfile, err := ioutil.TempFile("", "zot-test*.json")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpfile.Name()) // clean up
+		content := []byte(`{"storage":{"rootDirectory":"/tmp/zot"},
+							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+							"extensions":{"sync": {"registries": [{"url":"localhost:9999"}]}}}`)
+		_, err = tmpfile.Write(content)
+		So(err, ShouldBeNil)
+		err = tmpfile.Close()
+		So(err, ShouldBeNil)
+		os.Args = []string{"cli_test", "verify", tmpfile.Name()}
+		So(func() { _ = cli.NewServerRootCmd().Execute() }, ShouldNotPanic)
+	})
+
 	Convey("Test verify with bad sync prefixes", t, func(c C) {
 		tmpfile, err := ioutil.TempFile("", "zot-test*.json")
 		So(err, ShouldBeNil)
@@ -270,6 +286,12 @@ func TestScrub(t *testing.T) {
 
 	Convey("Test scrub help", t, func(c C) {
 		os.Args = []string{"cli_test", "scrub", "-h"}
+		err := cli.NewServerRootCmd().Execute()
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Test scrub no args", t, func(c C) {
+		os.Args = []string{"cli_test", "scrub"}
 		err := cli.NewServerRootCmd().Execute()
 		So(err, ShouldBeNil)
 	})

--- a/pkg/extensions/sync/utils.go
+++ b/pkg/extensions/sync/utils.go
@@ -1,8 +1,11 @@
 package sync
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path"
 	"strings"
@@ -10,12 +13,19 @@ import (
 	glob "github.com/bmatcuk/doublestar/v4"
 	"github.com/containers/image/v5/docker/reference"
 	"github.com/containers/image/v5/types"
+	"github.com/notaryproject/notation-go-lib"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
+	"gopkg.in/resty.v1"
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"
 )
+
+type ReferenceList struct {
+	References []notation.Descriptor `json:"references"`
+}
 
 // getTagFromRef returns a tagged reference from an image reference.
 func getTagFromRef(ref types.ImageReference, log log.Logger) reference.Tagged {
@@ -91,6 +101,311 @@ func getFileCredentials(filepath string) (CredentialsFile, error) {
 	return creds, nil
 }
 
+func getHTTPClient(regCfg *RegistryConfig, credentials Credentials, log log.Logger) (*resty.Client, error) {
+	client := resty.New()
+
+	if regCfg.CertDir != "" {
+		log.Debug().Msgf("sync: using certs directory: %s", regCfg.CertDir)
+		clientCert := path.Join(regCfg.CertDir, "client.cert")
+		clientKey := path.Join(regCfg.CertDir, "client.key")
+		caCertPath := path.Join(regCfg.CertDir, "ca.crt")
+
+		caCert, err := ioutil.ReadFile(caCertPath)
+		if err != nil {
+			log.Error().Err(err).Msg("couldn't read CA certificate")
+
+			return nil, err
+		}
+
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+
+		client.SetTLSClientConfig(&tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12})
+
+		cert, err := tls.LoadX509KeyPair(clientCert, clientKey)
+		if err != nil {
+			log.Error().Err(err).Msg("couldn't read certificates key pairs")
+
+			return nil, err
+		}
+
+		client.SetCertificates(cert)
+	}
+
+	// nolint: gosec
+	if regCfg.TLSVerify != nil && !*regCfg.TLSVerify {
+		client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true})
+	}
+
+	if credentials.Username != "" && credentials.Password != "" {
+		log.Debug().Msgf("sync: using basic auth")
+		client.SetBasicAuth(credentials.Username, credentials.Password)
+	}
+
+	return client, nil
+}
+
+func syncCosignSignature(client *resty.Client, storeController storage.StoreController,
+	regURL url.URL, repo, digest string, log log.Logger) error {
+	log.Info().Msg("syncing cosign signatures")
+
+	getCosignManifestURL := regURL
+
+	cosignEncodedDigest := strings.Replace(digest, ":", "-", 1) + ".sig"
+	getCosignManifestURL.Path = path.Join(getCosignManifestURL.Path, "v2", repo, "manifests", cosignEncodedDigest)
+	getCosignManifestURL.RawQuery = getCosignManifestURL.Query().Encode()
+
+	mResp, err := client.R().Get(getCosignManifestURL.String())
+	if err != nil {
+		log.Error().Err(err).Str("url", getCosignManifestURL.String()).
+			Msgf("couldn't get cosign manifest: %s", cosignEncodedDigest)
+
+		return err
+	}
+
+	if mResp.IsError() {
+		log.Info().Msgf("couldn't find any cosign signature from %s, status code: %d skipping",
+			getCosignManifestURL.String(), mResp.StatusCode())
+
+		return nil
+	}
+
+	var m ispec.Manifest
+
+	err = json.Unmarshal(mResp.Body(), &m)
+	if err != nil {
+		log.Error().Err(err).Str("url", getCosignManifestURL.String()).
+			Msgf("couldn't unmarshal cosign manifest %s", cosignEncodedDigest)
+
+		return err
+	}
+
+	imageStore := storeController.GetImageStore(repo)
+
+	for _, blob := range m.Layers {
+		// get blob
+		getBlobURL := regURL
+		getBlobURL.Path = path.Join(getBlobURL.Path, "v2", repo, "blobs", blob.Digest.String())
+		getBlobURL.RawQuery = getBlobURL.Query().Encode()
+
+		resp, err := client.R().SetDoNotParseResponse(true).Get(getBlobURL.String())
+		if err != nil {
+			log.Error().Err(err).Msgf("couldn't get cosign blob: %s", blob.Digest.String())
+
+			return err
+		}
+
+		if resp.IsError() {
+			log.Info().Msgf("couldn't find cosign blob from %s, status code: %d", getBlobURL.String(), resp.StatusCode())
+
+			return errors.ErrBadBlobDigest
+		}
+
+		defer resp.RawBody().Close()
+
+		// push blob
+		_, _, err = imageStore.FullBlobUpload(repo, resp.RawBody(), blob.Digest.String())
+		if err != nil {
+			log.Error().Err(err).Msg("couldn't upload cosign blob")
+
+			return err
+		}
+	}
+
+	// get config blob
+	getBlobURL := regURL
+	getBlobURL.Path = path.Join(getBlobURL.Path, "v2", repo, "blobs", m.Config.Digest.String())
+	getBlobURL.RawQuery = getBlobURL.Query().Encode()
+
+	resp, err := client.R().SetDoNotParseResponse(true).Get(getBlobURL.String())
+	if err != nil {
+		log.Error().Err(err).Msgf("couldn't get cosign config blob: %s", getBlobURL.String())
+
+		return err
+	}
+
+	if resp.IsError() {
+		log.Info().Msgf("couldn't find cosign config blob from %s, status code: %d", getBlobURL.String(), resp.StatusCode())
+
+		return errors.ErrBadBlobDigest
+	}
+
+	defer resp.RawBody().Close()
+
+	// push config blob
+	_, _, err = imageStore.FullBlobUpload(repo, resp.RawBody(), m.Config.Digest.String())
+	if err != nil {
+		log.Error().Err(err).Msg("couldn't upload cosign blob")
+
+		return err
+	}
+
+	// push manifest
+	_, err = imageStore.PutImageManifest(repo, cosignEncodedDigest, ispec.MediaTypeImageManifest, mResp.Body())
+	if err != nil {
+		log.Error().Err(err).Msg("couldn't upload cosing manifest")
+
+		return err
+	}
+
+	return nil
+}
+
+func syncNotarySignature(client *resty.Client, storeController storage.StoreController,
+	regURL url.URL, repo, digest string, log log.Logger) error {
+	log.Info().Msg("syncing notary signatures")
+
+	getReferrersURL := regURL
+	getRefManifestURL := regURL
+
+	// based on manifest digest get referrers
+	getReferrersURL.Path = path.Join(getReferrersURL.Path, "oras/artifacts/v1/", repo, "manifests", digest, "referrers")
+	getReferrersURL.RawQuery = getReferrersURL.Query().Encode()
+
+	resp, err := client.R().
+		SetHeader("Content-Type", "application/json").
+		SetQueryParam("artifactType", "application/vnd.cncf.notary.v2.signature").
+		Get(getReferrersURL.String())
+	if err != nil {
+		log.Error().Err(err).Msgf("couldn't get referrers from %s", getReferrersURL.String())
+
+		return err
+	}
+
+	if resp.IsError() {
+		log.Info().Msgf("couldn't find any notary signature from %s, status code: %d, skipping",
+			getReferrersURL.String(), resp.StatusCode())
+
+		return nil
+	}
+
+	var referrers ReferenceList
+
+	err = json.Unmarshal(resp.Body(), &referrers)
+	if err != nil {
+		log.Error().Err(err).Msgf("couldn't unmarshal notary signature from %s", getReferrersURL.String())
+
+		return err
+	}
+
+	imageStore := storeController.GetImageStore(repo)
+
+	for _, ref := range referrers.References {
+		// get referrer manifest
+		getRefManifestURL.Path = path.Join(getRefManifestURL.Path, "v2", repo, "manifests", ref.Digest.String())
+		getRefManifestURL.RawQuery = getRefManifestURL.Query().Encode()
+
+		resp, err := client.R().
+			Get(getRefManifestURL.String())
+		if err != nil {
+			log.Error().Err(err).Msgf("couldn't get notary manifest: %s", getRefManifestURL.String())
+
+			return err
+		}
+
+		// read manifest
+		var m artifactspec.Manifest
+
+		err = json.Unmarshal(resp.Body(), &m)
+		if err != nil {
+			log.Error().Err(err).Msgf("couldn't unmarshal notary manifest: %s", getRefManifestURL.String())
+
+			return err
+		}
+
+		for _, blob := range m.Blobs {
+			getBlobURL := regURL
+			getBlobURL.Path = path.Join(getBlobURL.Path, "v2", repo, "blobs", blob.Digest.String())
+			getBlobURL.RawQuery = getBlobURL.Query().Encode()
+
+			resp, err := client.R().SetDoNotParseResponse(true).Get(getBlobURL.String())
+			if err != nil {
+				log.Error().Err(err).Msgf("couldn't get notary blob: %s", getBlobURL.String())
+
+				return err
+			}
+
+			defer resp.RawBody().Close()
+
+			if resp.IsError() {
+				log.Info().Msgf("couldn't find notary blob from %s, status code: %d",
+					getBlobURL.String(), resp.StatusCode())
+
+				return errors.ErrBadBlobDigest
+			}
+
+			_, _, err = imageStore.FullBlobUpload(repo, resp.RawBody(), blob.Digest.String())
+			if err != nil {
+				log.Error().Err(err).Msg("couldn't upload notary sig blob")
+
+				return err
+			}
+		}
+
+		_, err = imageStore.PutImageManifest(repo, ref.Digest.String(), artifactspec.MediaTypeArtifactManifest, resp.Body())
+		if err != nil {
+			log.Error().Err(err).Msg("couldn't upload notary sig manifest")
+
+			return err
+		}
+	}
+
+	return nil
+}
+
+func syncSignatures(client *resty.Client, storeController storage.StoreController,
+	registryURL, repo, tag string, log log.Logger) error {
+	log.Info().Msg("syncing signatures")
+	// get manifest and find out its digest
+	regURL, err := url.Parse(registryURL)
+	if err != nil {
+		log.Error().Err(err).Msgf("couldn't parse registry URL: %s", registryURL)
+
+		return err
+	}
+
+	getManifestURL := *regURL
+
+	getManifestURL.Path = path.Join(getManifestURL.Path, "v2", repo, "manifests", tag)
+
+	resp, err := client.R().SetHeader("Content-Type", "application/json").Head(getManifestURL.String())
+	if err != nil {
+		log.Error().Err(err).Str("url", getManifestURL.String()).
+			Msgf("couldn't query %s", registryURL)
+
+		return err
+	}
+
+	digests, ok := resp.Header()["Docker-Content-Digest"]
+	if !ok {
+		log.Error().Err(errors.ErrBadBlobDigest).Str("url", getManifestURL.String()).
+			Msgf("couldn't get digest for manifest: %s:%s", repo, tag)
+
+		return errors.ErrBadBlobDigest
+	}
+
+	if len(digests) != 1 {
+		log.Error().Err(errors.ErrBadBlobDigest).Str("url", getManifestURL.String()).
+			Msgf("multiple digests found for: %s:%s", repo, tag)
+
+		return errors.ErrBadBlobDigest
+	}
+
+	err = syncNotarySignature(client, storeController, *regURL, repo, digests[0], log)
+	if err != nil {
+		return err
+	}
+
+	err = syncCosignSignature(client, storeController, *regURL, repo, digests[0], log)
+	if err != nil {
+		return err
+	}
+
+	log.Info().Msg("successfully synced signatures")
+
+	return nil
+}
+
 func pushSyncedLocalImage(repo, tag, uuid string,
 	storeController storage.StoreController, log log.Logger) error {
 	log.Info().Msgf("pushing synced local image %s:%s to local registry", repo, tag)
@@ -164,4 +479,14 @@ func pushSyncedLocalImage(repo, tag, uuid string,
 	}
 
 	return nil
+}
+
+// sync feature will try to pull cosign signature because for sync cosign signature is just an image
+// this function will check if tag is a cosign tag.
+func isCosignTag(tag string) bool {
+	if strings.HasPrefix(tag, "sha256-") && strings.HasSuffix(tag, ".sig") {
+		return true
+	}
+
+	return false
 }

--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -37,6 +37,9 @@ func TestCache(t *testing.T) {
 		err = cache.PutBlob("key", path.Join(dir, "value"))
 		So(err, ShouldBeNil)
 
+		err = cache.PutBlob("key", "value")
+		So(err, ShouldNotBeNil)
+
 		exists = cache.HasBlob("key", "value")
 		So(exists, ShouldBeTrue)
 


### PR DESCRIPTION
Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#261 

**What does this PR do / Why do we need it**:
Added support for syncing notary and cosign signatures

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**: 
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:
no

**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no
```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
