### PR TITLE
coverage: add failure injection framework

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,7 +44,7 @@ jobs:
           go get github.com/wadey/gocovmerge
 
       - name: Run build and test
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: |
           cd $GITHUB_WORKSPACE && make && make ARCH=arm64 binary-arch-minimal && make ARCH=arm64 binary-arch
         env:

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -47,4 +47,5 @@ var (
 	ErrSyncMissingCatalog      = errors.New("sync: couldn't fetch upstream registry's catalog")
 	ErrMethodNotSupported      = errors.New("storage: method not supported")
 	ErrInvalidMetric           = errors.New("metrics: invalid metric func")
+	ErrInjected                = errors.New("test: injected failure")
 )

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -32,6 +32,7 @@ import (
 	ext "zotregistry.io/zot/pkg/extensions"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"
+	"zotregistry.io/zot/pkg/test"
 
 	// as required by swaggo.
 	_ "zotregistry.io/zot/swagger"
@@ -165,7 +166,7 @@ func (rh *RouteHandler) ListTags(response http.ResponseWriter, request *http.Req
 
 	name, ok := vars["name"]
 
-	if !ok || name == "" {
+	if !test.Ok(ok) || name == "" {
 		response.WriteHeader(http.StatusNotFound)
 
 		return
@@ -287,7 +288,7 @@ func (rh *RouteHandler) CheckManifest(response http.ResponseWriter, request *htt
 	vars := mux.Vars(request)
 	name, ok := vars["name"]
 
-	if !ok || name == "" {
+	if !test.Ok(ok) || name == "" {
 		response.WriteHeader(http.StatusNotFound)
 
 		return
@@ -296,7 +297,7 @@ func (rh *RouteHandler) CheckManifest(response http.ResponseWriter, request *htt
 	imgStore := rh.getImageStore(name)
 
 	reference, ok := vars["reference"]
-	if !ok || reference == "" {
+	if !test.Ok(ok) || reference == "" {
 		WriteJSON(response,
 			http.StatusNotFound,
 			NewErrorList(NewError(MANIFEST_INVALID, map[string]string{"reference": reference})))

--- a/pkg/compliance/v1_0_0/check.go
+++ b/pkg/compliance/v1_0_0/check.go
@@ -670,7 +670,23 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			So(err, ShouldBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 
+			resp, err = resty.R().Get(baseURL + "/v2/page0/tags/list?n= ")
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusBadRequest)
+
+			resp, err = resty.R().Get(baseURL + "/v2/page0/tags/list?n=a")
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusBadRequest)
+
 			resp, err = resty.R().Get(baseURL + "/v2/page0/tags/list?n=0")
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			resp, err = resty.R().Get(baseURL + "/v2/page0/tags/list?n=0&last=100")
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+			resp, err = resty.R().Get(baseURL + "/v2/page0/tags/list?n=0&last=test:0.0")
 			So(err, ShouldBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 

--- a/pkg/test/dev.go
+++ b/pkg/test/dev.go
@@ -1,0 +1,81 @@
+//go:build dev
+// +build dev
+
+// This file should be linked only in **development** mode.
+
+package test
+
+import (
+	"sync"
+
+	zerr "zotregistry.io/zot/errors"
+)
+
+func Ok(ok bool) bool {
+	if !ok {
+		return ok
+	}
+
+	if injectedFailure() {
+		return false
+	}
+
+	return true
+}
+
+func Error(err error) error {
+	if err != nil {
+		return err
+	}
+
+	if injectedFailure() {
+		return zerr.ErrInjected
+	}
+
+	return nil
+}
+
+/**
+ *
+ * Failure injection infrastructure to cover hard-to-reach code paths.
+ *
+ **/
+
+type inject struct {
+	skip    int
+	enabled bool
+}
+
+//nolint:gochecknoglobals // only used by test code
+var (
+	injlock sync.Mutex
+	injst   = inject{}
+)
+
+func InjectFailure(skip int) bool {
+	injlock.Lock()
+	injst = inject{enabled: true, skip: skip}
+	injlock.Unlock()
+
+	return true
+}
+
+func injectedFailure() bool {
+	injlock.Lock()
+	defer injlock.Unlock()
+
+	if !injst.enabled {
+		return false
+	}
+
+	if injst.skip == 0 {
+		// disable the injection point
+		injst.enabled = false
+
+		return true
+	}
+
+	injst.skip--
+
+	return false
+}

--- a/pkg/test/inject_test.go
+++ b/pkg/test/inject_test.go
@@ -1,0 +1,120 @@
+//go:build dev
+// +build dev
+
+// This file should be linked only in **development** mode.
+
+package test_test
+
+import (
+	"errors"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"zotregistry.io/zot/pkg/test"
+)
+
+var (
+	errKey1    = errors.New("key1 not found")
+	errKey2    = errors.New("key2 not found")
+	errNotZero = errors.New("not zero")
+	errCall1   = errors.New("call1 error")
+	errCall2   = errors.New("call2 error")
+)
+
+func foo() error {
+	fmap := map[string]string{"key1": "val1", "key2": "val2"}
+
+	_, ok := fmap["key1"] // should never fail
+	if !test.Ok(ok) {
+		return errKey1
+	}
+
+	_, ok = fmap["key2"] // should never fail
+	if !test.Ok(ok) {
+		return errKey2
+	}
+
+	return nil
+}
+
+func errgen(i int) error {
+	if i != 0 {
+		return errNotZero
+	}
+
+	return nil
+}
+
+func bar() error {
+	err := errgen(0) // should never fail
+	if test.Error(err) != nil {
+		return errCall1
+	}
+
+	err = errgen(0) // should never fail
+	if test.Error(err) != nil {
+		return errCall2
+	}
+
+	return nil
+}
+
+func alwaysErr() error {
+	return errNotZero
+}
+
+func alwaysNotOk() bool {
+	return false
+}
+
+func TestInject(t *testing.T) {
+	Convey("Injected failure", t, func(c C) {
+		// should be success without injection
+		err := foo()
+		So(err, ShouldBeNil)
+
+		Convey("Check Ok", func() {
+			Convey("Without skipping", func() {
+				test.InjectFailure(0)   // inject a failure
+				err := foo()            // should be a failure
+				So(err, ShouldNotBeNil) // should be a failure
+				So(errors.Is(err, errKey1), ShouldBeTrue)
+			})
+
+			Convey("With skipping", func() {
+				test.InjectFailure(1) // inject a failure but skip first one
+				err := foo()          // should be a failure
+				So(errors.Is(err, errKey1), ShouldBeFalse)
+				So(errors.Is(err, errKey2), ShouldBeTrue)
+			})
+		})
+
+		// should be success without injection
+		err = bar()
+		So(err, ShouldBeNil)
+
+		Convey("Check Err", func() {
+			Convey("Without skipping", func() {
+				test.InjectFailure(0)   // inject a failure
+				err := bar()            // should be a failure
+				So(err, ShouldNotBeNil) // should be a failure
+				So(errors.Is(err, errCall1), ShouldBeTrue)
+			})
+
+			Convey("With skipping", func() {
+				test.InjectFailure(1) // inject a failure but skip first one
+				err := bar()          // should be a failure
+				So(errors.Is(err, errCall1), ShouldBeFalse)
+				So(errors.Is(err, errCall2), ShouldBeTrue)
+			})
+		})
+	})
+
+	Convey("Without injected failure", t, func(c C) {
+		err := alwaysErr()
+		So(test.Error(err), ShouldNotBeNil)
+
+		ok := alwaysNotOk()
+		So(test.Ok(ok), ShouldBeFalse)
+	})
+}

--- a/pkg/test/prod.go
+++ b/pkg/test/prod.go
@@ -1,0 +1,20 @@
+//go:build !dev
+// +build !dev
+
+package test
+
+func Error(err error) error {
+	return err
+}
+
+func Ok(ok bool) bool {
+	return ok
+}
+
+/**
+ *
+ * Failure injection infrastructure to cover hard-to-reach code paths (nop in production).
+ *
+ **/
+
+func InjectFailure(skip int) bool { return false }


### PR DESCRIPTION
Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

Feature

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

Provides a failure injection framework to inject and cover hard to reach code paths by artificially injecting failures.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
