### PR TITLE
Added storage latency histogram metric closes #279

### DIFF
--- a/examples/metrics/Makefile
+++ b/examples/metrics/Makefile
@@ -1,4 +1,4 @@
-CONTAINER_RUNTIME := $(shell command -v podman 2> /dev/null || echo docker)
+CONTAINER_RUNTIME := docker
 
 .PHONY: binary-container
 binary-container:

--- a/pkg/exporter/api/exporter.go
+++ b/pkg/exporter/api/exporter.go
@@ -76,7 +76,7 @@ func (zc Collector) Collect(ch chan<- prometheus.Metric) {
 			zc.MetricsDesc[name], prometheus.CounterValue, h.Sum, h.LabelValues...)
 
 		if h.Buckets != nil {
-			for _, fvalue := range monitoring.GetDefaultBuckets() {
+			for _, fvalue := range monitoring.GetBuckets(h.Name) {
 				var svalue string
 				if fvalue == math.MaxFloat64 {
 					svalue = "+Inf"

--- a/pkg/extensions/monitoring/common.go
+++ b/pkg/extensions/monitoring/common.go
@@ -2,7 +2,6 @@ package monitoring
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"path/filepath"
 )
@@ -13,10 +12,6 @@ type MetricServer interface {
 	ForceSendMetric(interface{})
 	ReceiveMetrics() interface{}
 	IsEnabled() bool
-}
-
-func GetDefaultBuckets() []float64 {
-	return []float64{.05, .5, 1, 5, 30, 60, 600, math.MaxFloat64}
 }
 
 func getDirSize(path string) (int64, error) {

--- a/pkg/storage/scrub.go
+++ b/pkg/storage/scrub.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/olekukonko/tablewriter"
 	godigest "github.com/opencontainers/go-digest"
@@ -84,11 +85,12 @@ func checkImage(imageName string, imgStore ImageStore) ([]ScrubImageResult, erro
 	if err != nil {
 		return results, err
 	}
-
 	defer oci.Close()
 
-	imgStore.RLock()
-	defer imgStore.RUnlock()
+	var lockLatency time.Time
+
+	imgStore.RLock(&lockLatency)
+	defer imgStore.RUnlock(&lockLatency)
 
 	buf, err := ioutil.ReadFile(path.Join(dir, "index.json"))
 	if err != nil {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"io"
+	"time"
 
 	"github.com/notaryproject/notation-go-lib"
 	"github.com/opencontainers/go-digest"
@@ -14,10 +15,10 @@ const (
 type ImageStore interface {
 	DirExists(d string) bool
 	RootDir() string
-	RLock()
-	RUnlock()
-	Lock()
-	Unlock()
+	RLock(*time.Time)
+	RUnlock(*time.Time)
+	Lock(*time.Time)
+	Unlock(*time.Time)
 	InitRepo(name string) error
 	ValidateRepo(name string) (bool, error)
 	GetRepositories() ([]string, error)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	// Add s3 support.
 	"github.com/docker/distribution/registry/storage/driver"
@@ -599,16 +600,18 @@ func TestStorageAPIs(t *testing.T) {
 					for i := 0; i < 1000; i++ {
 						wg.Add(2)
 						go func() {
+							var lockLatency time.Time
 							defer wg.Done()
-							imgStore.Lock()
+							imgStore.Lock(&lockLatency)
 							func() {}()
-							imgStore.Unlock()
+							imgStore.Unlock(&lockLatency)
 						}()
 						go func() {
+							var lockLatency time.Time
 							defer wg.Done()
-							imgStore.RLock()
+							imgStore.RLock(&lockLatency)
 							func() {}()
-							imgStore.RUnlock()
+							imgStore.RUnlock(&lockLatency)
 						}()
 					}
 					wg.Wait()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**
feature

**Which issue does this PR fix**:
#279 

**What does this PR do / Why do we need it**:
We also want to track how long storage locks are being held so that we get better visibility into contention and latency.

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:


**Does this PR introduce any user-facing change?**:


```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
