### PR TITLE
sync: for a prefix, allow multiple registries as a list instead of on…

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -48,4 +48,5 @@ var (
 	ErrMethodNotSupported      = errors.New("storage: method not supported")
 	ErrInvalidMetric           = errors.New("metrics: invalid metric func")
 	ErrInjected                = errors.New("test: injected failure")
+	ErrSyncInvalidUpstreamURL  = errors.New("sync: upstream url not found in sync config")
 )

--- a/examples/README.md
+++ b/examples/README.md
@@ -383,7 +383,7 @@ Configure each registry sync:
 
 ```
 			"registries": [{
-				"url": "https://registry1:5000",
+				"urls": ["https://registry1:5000"],
 				"onDemand": false,                  # pull any image which the local registry doesn't have
 				"pollInterval": "6h",               # polling interval, if not set then periodically polling will not run
 				"tlsVerify": true,                  # whether or not to verify tls
@@ -405,7 +405,7 @@ Configure each registry sync:
 				]
 			},
 			{
-				"url": "https://registry2:5000",
+				"urls": ["https://registry2:5000", "https://registry3:5000"], // specify multiple URLs in case first encounters an error
 				"pollInterval": "12h",
 				"tlsVerify": false,
 				"onDemand": false,
@@ -419,7 +419,7 @@ Configure each registry sync:
 				]
 			},
 			{
-				"url": "https://docker.io/library",
+				"urls": ["https://docker.io/library"],
 				"onDemand": true,                   # doesn't have content, don't periodically pull, pull just on demand.
 				"tlsVerify": true
 			}

--- a/examples/config-sync.json
+++ b/examples/config-sync.json
@@ -14,7 +14,7 @@
 		"sync": {
 			"credentialsFile": "./examples/sync-auth-filepath.json",
 			"registries": [{
-				"url": "https://registry1:5000",
+				"urls": ["https://registry1:5000"],
 				"onDemand": false,
 				"pollInterval": "6h",
 				"tlsVerify": true,
@@ -33,7 +33,7 @@
 				]
 			},
 			{
-				"url": "https://registry2:5000",
+				"urls": ["https://registry2:5000", "https://registry3:5000"],
 				"pollInterval": "12h",
 				"tlsVerify": false,
 				"onDemand": false,
@@ -47,7 +47,7 @@
 				]
 			},
 			{
-				"url": "https://docker.io/library",
+				"urls": ["https://docker.io/library"],
 				"onDemand": true,
 				"tlsVerify": true
 			}

--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -10,6 +10,7 @@ import (
 	glob "github.com/bmatcuk/doublestar/v4"
 	"github.com/gorilla/mux"
 	"zotregistry.io/zot/pkg/api/config"
+	"zotregistry.io/zot/pkg/common"
 	"zotregistry.io/zot/pkg/log"
 )
 
@@ -52,12 +53,12 @@ func (ac *AccessController) getReadGlobPatterns(username string) map[string]bool
 
 	for pattern, policyGroup := range ac.Config.Repositories {
 		// check default policy
-		if contains(policyGroup.DefaultPolicy, READ) {
+		if common.Contains(policyGroup.DefaultPolicy, READ) {
 			globPatterns[pattern] = true
 		}
 		// check user based policy
 		for _, p := range policyGroup.Policies {
-			if contains(p.Users, username) && contains(p.Actions, READ) {
+			if common.Contains(p.Users, username) && common.Contains(p.Actions, READ) {
 				globPatterns[pattern] = true
 			}
 		}
@@ -94,7 +95,7 @@ func (ac *AccessController) can(username, action, repository string) bool {
 
 	// check admins based policy
 	if !can {
-		if ac.isAdmin(username) && contains(ac.Config.AdminPolicy.Actions, action) {
+		if ac.isAdmin(username) && common.Contains(ac.Config.AdminPolicy.Actions, action) {
 			can = true
 		}
 	}
@@ -104,7 +105,7 @@ func (ac *AccessController) can(username, action, repository string) bool {
 
 // isAdmin .
 func (ac *AccessController) isAdmin(username string) bool {
-	return contains(ac.Config.AdminPolicy.Users, username)
+	return common.Contains(ac.Config.AdminPolicy.Users, username)
 }
 
 // getContext builds ac context(allowed to read repos and if user is admin) and returns it.
@@ -128,7 +129,7 @@ func isPermitted(username, action string, policyGroup config.PolicyGroup) bool {
 	var result bool
 	// check repo/system based policies
 	for _, p := range policyGroup.Policies {
-		if contains(p.Users, username) && contains(p.Actions, action) {
+		if common.Contains(p.Users, username) && common.Contains(p.Actions, action) {
 			result = true
 
 			break
@@ -137,22 +138,12 @@ func isPermitted(username, action string, policyGroup config.PolicyGroup) bool {
 
 	// check defaultPolicy
 	if !result {
-		if contains(policyGroup.DefaultPolicy, action) {
+		if common.Contains(policyGroup.DefaultPolicy, action) {
 			result = true
 		}
 	}
 
 	return result
-}
-
-func contains(slice []string, item string) bool {
-	for _, v := range slice {
-		if item == v {
-			return true
-		}
-	}
-
-	return false
 }
 
 // returns either a user has or not rights on 'repository'.
@@ -212,7 +203,7 @@ func AuthzHandler(ctlr *Controller) mux.MiddlewareFunc {
 					is := ctlr.StoreController.GetImageStore(resource)
 					tags, err := is.GetImageTags(resource)
 					// if repo exists and request's tag doesn't exist yet then action is UPDATE
-					if err == nil && contains(tags, reference) && reference != "latest" {
+					if err == nil && common.Contains(tags, reference) && reference != "latest" {
 						action = UPDATE
 					}
 				}

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -179,7 +179,7 @@ func TestVerify(t *testing.T) {
 		content := []byte(`{"storage":{"rootDirectory":"/tmp/zot", "storageDriver": {"name": "s3"}},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
-							"extensions":{"sync": {"registries": [{"url":"localhost:9999"}]}}}`)
+							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"]}]}}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)
 		err = tmpfile.Close()
@@ -195,7 +195,7 @@ func TestVerify(t *testing.T) {
 		content := []byte(`{"storage":{"rootDirectory":"/tmp/zot"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
-							"extensions":{"sync": {"registries": [{"url":"localhost:9999"}]}}}`)
+							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"]}]}}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)
 		err = tmpfile.Close()
@@ -211,7 +211,7 @@ func TestVerify(t *testing.T) {
 		content := []byte(`{"storage":{"rootDirectory":"/tmp/zot"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
-							"extensions":{"sync": {"registries": [{"url":"localhost:9999",
+							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
 							"content": [{"prefix":"[repo%^&"}]}]}}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)
@@ -244,7 +244,7 @@ func TestVerify(t *testing.T) {
 		content := []byte(`{"storage":{"rootDirectory":"/tmp/zot"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
-							"extensions":{"sync": {"registries": [{"url":"localhost:9999",
+							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
 							"content": [{"prefix":"repo**"}]}]}}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,0 +1,11 @@
+package common
+
+func Contains(slice []string, item string) bool {
+	for _, v := range slice {
+		if item == v {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -241,7 +241,7 @@ func startDownstreamServer(secure bool, syncConfig *sync.Config) (*api.Controlle
 	return dctlr, destBaseURL, destDir, client
 }
 
-func TestSyncOnDemand(t *testing.T) {
+func TestOnDemand(t *testing.T) {
 	Convey("Verify sync on demand feature", t, func() {
 		sctlr, srcBaseURL, srcDir, _, srcClient := startUpstreamServer(false, false)
 		defer os.RemoveAll(srcDir)
@@ -265,7 +265,7 @@ func TestSyncOnDemand(t *testing.T) {
 					},
 				},
 			},
-			URL:       srcBaseURL,
+			URLs:      []string{srcBaseURL},
 			TLSVerify: &tlsVerify,
 			CertDir:   "",
 			OnDemand:  true,
@@ -369,7 +369,7 @@ func TestSyncOnDemand(t *testing.T) {
 	})
 }
 
-func TestSync(t *testing.T) {
+func TestPeriodically(t *testing.T) {
 	Convey("Verify sync feature", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
@@ -394,7 +394,7 @@ func TestSync(t *testing.T) {
 					},
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
 			CertDir:      "",
@@ -466,7 +466,7 @@ func TestSync(t *testing.T) {
 						},
 					},
 				},
-				URL:          srcBaseURL,
+				URLs:         []string{srcBaseURL},
 				PollInterval: updateDuration,
 				TLSVerify:    &tlsVerify,
 				CertDir:      "",
@@ -533,7 +533,7 @@ func TestSync(t *testing.T) {
 	})
 }
 
-func TestSyncPermsDenied(t *testing.T) {
+func TestPermsDenied(t *testing.T) {
 	Convey("Verify sync feature without perm on sync cache", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
@@ -558,7 +558,7 @@ func TestSyncPermsDenied(t *testing.T) {
 					},
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
 			CertDir:      "",
@@ -590,7 +590,7 @@ func TestSyncPermsDenied(t *testing.T) {
 	})
 }
 
-func TestSyncBadTLS(t *testing.T) {
+func TestBadTLS(t *testing.T) {
 	Convey("Verify sync TLS feature", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
@@ -615,7 +615,7 @@ func TestSyncBadTLS(t *testing.T) {
 					},
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			OnDemand:     true,
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
@@ -647,7 +647,7 @@ func TestSyncBadTLS(t *testing.T) {
 	})
 }
 
-func TestSyncTLS(t *testing.T) {
+func TestTLS(t *testing.T) {
 	Convey("Verify sync TLS feature", t, func() {
 		updateDuration, _ := time.ParseDuration("1h")
 
@@ -710,7 +710,7 @@ func TestSyncTLS(t *testing.T) {
 					},
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
 			CertDir:      destClientCertDir,
@@ -748,7 +748,7 @@ func TestSyncTLS(t *testing.T) {
 	})
 }
 
-func TestSyncBasicAuth(t *testing.T) {
+func TestBasicAuth(t *testing.T) {
 	Convey("Verify sync basic auth", t, func() {
 		updateDuration, _ := time.ParseDuration("1h")
 
@@ -761,7 +761,7 @@ func TestSyncBasicAuth(t *testing.T) {
 		}()
 
 		Convey("Verify sync basic auth with file credentials", func() {
-			registryName := strings.Replace(strings.Replace(srcBaseURL, "http://", "", 1), "https://", "", 1)
+			registryName := sync.StripRegistryTransport(srcBaseURL)
 			credentialsFile := makeCredentialsFile(fmt.Sprintf(`{"%s":{"username": "test", "password": "test"}}`, registryName))
 
 			var tlsVerify bool
@@ -772,7 +772,7 @@ func TestSyncBasicAuth(t *testing.T) {
 						Prefix: testImage,
 					},
 				},
-				URL:          srcBaseURL,
+				URLs:         []string{srcBaseURL},
 				PollInterval: updateDuration,
 				TLSVerify:    &tlsVerify,
 				CertDir:      "",
@@ -850,7 +850,7 @@ func TestSyncBasicAuth(t *testing.T) {
 			regex := ".*"
 			var semver bool
 
-			registryName := strings.Replace(strings.Replace(srcBaseURL, "http://", "", 1), "https://", "", 1)
+			registryName := sync.StripRegistryTransport(srcBaseURL)
 
 			credentialsFile := makeCredentialsFile(fmt.Sprintf(`{"%s":{"username": "test", "password": "invalid"}}`,
 				registryName))
@@ -867,7 +867,7 @@ func TestSyncBasicAuth(t *testing.T) {
 						},
 					},
 				},
-				URL:          srcBaseURL,
+				URLs:         []string{srcBaseURL},
 				PollInterval: updateDuration,
 				TLSVerify:    &tlsVerify,
 				CertDir:      "",
@@ -911,7 +911,7 @@ func TestSyncBasicAuth(t *testing.T) {
 		})
 
 		Convey("Verify sync basic auth with bad file credentials", func() {
-			registryName := strings.Replace(strings.Replace(srcBaseURL, "http://", "", 1), "https://", "", 1)
+			registryName := sync.StripRegistryTransport(srcBaseURL)
 
 			credentialsFile := makeCredentialsFile(fmt.Sprintf(`{"%s":{"username": "test", "password": "test"}}`,
 				registryName))
@@ -938,7 +938,7 @@ func TestSyncBasicAuth(t *testing.T) {
 						},
 					},
 				},
-				URL:          srcBaseURL,
+				URLs:         []string{srcBaseURL},
 				PollInterval: updateDuration,
 				TLSVerify:    &tlsVerify,
 				CertDir:      "",
@@ -964,21 +964,21 @@ func TestSyncBasicAuth(t *testing.T) {
 		})
 
 		Convey("Verify on demand sync with basic auth", func() {
-			registryName := strings.Replace(strings.Replace(srcBaseURL, "http://", "", 1), "https://", "", 1)
+			registryName := sync.StripRegistryTransport(srcBaseURL)
 			credentialsFile := makeCredentialsFile(fmt.Sprintf(`{"%s":{"username": "test", "password": "test"}}`, registryName))
 
 			syncRegistryConfig := sync.RegistryConfig{
-				URL:      srcBaseURL,
+				URLs:     []string{srcBaseURL},
 				OnDemand: true,
 			}
 
 			unreacheableSyncRegistryConfig1 := sync.RegistryConfig{
-				URL:      "localhost:999999",
+				URLs:     []string{"localhost:9999"},
 				OnDemand: true,
 			}
 
 			unreacheableSyncRegistryConfig2 := sync.RegistryConfig{
-				URL:      "localhost:999999",
+				URLs:     []string{"localhost:9999"},
 				OnDemand: false,
 			}
 
@@ -1034,6 +1034,10 @@ func TestSyncBasicAuth(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(resp.StatusCode(), ShouldEqual, 200)
 
+			resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + "inexistent")
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, 404)
+
 			resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/tags/list")
 			if err != nil {
 				panic(err)
@@ -1049,7 +1053,7 @@ func TestSyncBasicAuth(t *testing.T) {
 	})
 }
 
-func TestSyncBadURL(t *testing.T) {
+func TestBadURL(t *testing.T) {
 	Convey("Verify sync with bad url", t, func() {
 		updateDuration, _ := time.ParseDuration("1h")
 
@@ -1067,7 +1071,7 @@ func TestSyncBadURL(t *testing.T) {
 					},
 				},
 			},
-			URL:          "bad-registry-url",
+			URLs:         []string{"bad-registry-url"},
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
 			CertDir:      "",
@@ -1089,7 +1093,7 @@ func TestSyncBadURL(t *testing.T) {
 	})
 }
 
-func TestSyncNoImagesByRegex(t *testing.T) {
+func TestNoImagesByRegex(t *testing.T) {
 	Convey("Verify sync with no images on source based on regex", t, func() {
 		updateDuration, _ := time.ParseDuration("1h")
 
@@ -1112,7 +1116,7 @@ func TestSyncNoImagesByRegex(t *testing.T) {
 					},
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			TLSVerify:    &tlsVerify,
 			PollInterval: updateDuration,
 			CertDir:      "",
@@ -1146,7 +1150,7 @@ func TestSyncNoImagesByRegex(t *testing.T) {
 	})
 }
 
-func TestSyncInvalidRegex(t *testing.T) {
+func TestInvalidRegex(t *testing.T) {
 	Convey("Verify sync with invalid regex", t, func() {
 		updateDuration, _ := time.ParseDuration("1h")
 
@@ -1169,7 +1173,7 @@ func TestSyncInvalidRegex(t *testing.T) {
 					},
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			TLSVerify:    &tlsVerify,
 			PollInterval: updateDuration,
 			CertDir:      "",
@@ -1187,7 +1191,7 @@ func TestSyncInvalidRegex(t *testing.T) {
 	})
 }
 
-func TestSyncNotSemver(t *testing.T) {
+func TestNotSemver(t *testing.T) {
 	Convey("Verify sync feature semver compliant", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
@@ -1225,7 +1229,7 @@ func TestSyncNotSemver(t *testing.T) {
 					},
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
 			CertDir:      "",
@@ -1263,7 +1267,7 @@ func TestSyncNotSemver(t *testing.T) {
 	})
 }
 
-func TestSyncInvalidCerts(t *testing.T) {
+func TestInvalidCerts(t *testing.T) {
 	Convey("Verify sync with bad certs", t, func() {
 		updateDuration, _ := time.ParseDuration("1h")
 
@@ -1319,7 +1323,7 @@ func TestSyncInvalidCerts(t *testing.T) {
 					Prefix: "",
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
 			CertDir:      clientCertDir,
@@ -1355,7 +1359,7 @@ func makeCredentialsFile(fileContent string) string {
 	return tmpfile.Name()
 }
 
-func TestSyncInvalidUrl(t *testing.T) {
+func TestInvalidUrl(t *testing.T) {
 	Convey("Verify sync invalid url", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 		regex := ".*"
@@ -1373,7 +1377,7 @@ func TestSyncInvalidUrl(t *testing.T) {
 					},
 				},
 			},
-			URL:          "http://invalid.invalid/invalid/",
+			URLs:         []string{"http://invalid.invalid/invalid/"},
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
 			CertDir:      "",
@@ -1395,7 +1399,7 @@ func TestSyncInvalidUrl(t *testing.T) {
 	})
 }
 
-func TestSyncInvalidTags(t *testing.T) {
+func TestInvalidTags(t *testing.T) {
 	Convey("Verify sync invalid tags", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
@@ -1421,7 +1425,7 @@ func TestSyncInvalidTags(t *testing.T) {
 					},
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
 			CertDir:      "",
@@ -1445,7 +1449,7 @@ func TestSyncInvalidTags(t *testing.T) {
 	})
 }
 
-func TestSyncSubPaths(t *testing.T) {
+func TestSubPaths(t *testing.T) {
 	Convey("Verify sync with storage subPaths", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
@@ -1507,7 +1511,7 @@ func TestSyncSubPaths(t *testing.T) {
 					},
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
 			CertDir:      "",
@@ -1615,7 +1619,7 @@ func TestSyncOnDemandRepoErr(t *testing.T) {
 					Prefix: testImage,
 				},
 			},
-			URL:       "docker://invalid",
+			URLs:      []string{"docker://invalid"},
 			TLSVerify: &tlsVerify,
 			CertDir:   "",
 			OnDemand:  true,
@@ -1636,7 +1640,7 @@ func TestSyncOnDemandRepoErr(t *testing.T) {
 	})
 }
 
-func TestSyncOnDemandContentFiltering(t *testing.T) {
+func TestOnDemandContentFiltering(t *testing.T) {
 	Convey("Verify sync on demand feature", t, func() {
 		sctlr, srcBaseURL, srcDir, _, _ := startUpstreamServer(false, false)
 		defer os.RemoveAll(srcDir)
@@ -1661,7 +1665,7 @@ func TestSyncOnDemandContentFiltering(t *testing.T) {
 						},
 					},
 				},
-				URL:       srcBaseURL,
+				URLs:      []string{srcBaseURL},
 				TLSVerify: &tlsVerify,
 				CertDir:   "",
 				OnDemand:  true,
@@ -1697,7 +1701,7 @@ func TestSyncOnDemandContentFiltering(t *testing.T) {
 						},
 					},
 				},
-				URL:       srcBaseURL,
+				URLs:      []string{srcBaseURL},
 				TLSVerify: &tlsVerify,
 				CertDir:   "",
 				OnDemand:  true,
@@ -1719,7 +1723,7 @@ func TestSyncOnDemandContentFiltering(t *testing.T) {
 	})
 }
 
-func TestSyncConfigRules(t *testing.T) {
+func TestConfigRules(t *testing.T) {
 	Convey("Verify sync config rules", t, func() {
 		sctlr, srcBaseURL, srcDir, _, _ := startUpstreamServer(false, false)
 		defer os.RemoveAll(srcDir)
@@ -1743,7 +1747,7 @@ func TestSyncConfigRules(t *testing.T) {
 						},
 					},
 				},
-				URL:       srcBaseURL,
+				URLs:      []string{srcBaseURL},
 				TLSVerify: &tlsVerify,
 				CertDir:   "",
 				OnDemand:  false,
@@ -1770,7 +1774,7 @@ func TestSyncConfigRules(t *testing.T) {
 
 			syncRegistryConfig := sync.RegistryConfig{
 				PollInterval: updateDuration,
-				URL:          srcBaseURL,
+				URLs:         []string{srcBaseURL},
 				TLSVerify:    &tlsVerify,
 				CertDir:      "",
 				OnDemand:     false,
@@ -1794,7 +1798,7 @@ func TestSyncConfigRules(t *testing.T) {
 			var tlsVerify bool
 
 			syncRegistryConfig := sync.RegistryConfig{
-				URL:       srcBaseURL,
+				URLs:      []string{srcBaseURL},
 				TLSVerify: &tlsVerify,
 				CertDir:   "",
 				OnDemand:  false,
@@ -1813,6 +1817,80 @@ func TestSyncConfigRules(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(resp.StatusCode(), ShouldEqual, 404)
 		})
+	})
+}
+
+func TestMultipleURLs(t *testing.T) {
+	Convey("Verify sync feature", t, func() {
+		updateDuration, _ := time.ParseDuration("30m")
+
+		sctlr, srcBaseURL, srcDir, _, srcClient := startUpstreamServer(false, false)
+		defer os.RemoveAll(srcDir)
+
+		defer func() {
+			sctlr.Shutdown()
+		}()
+
+		regex := ".*"
+		semver := true
+		var tlsVerify bool
+
+		syncRegistryConfig := sync.RegistryConfig{
+			Content: []sync.Content{
+				{
+					Prefix: testImage,
+					Tags: &sync.Tags{
+						Regex:  &regex,
+						Semver: &semver,
+					},
+				},
+			},
+			URLs:         []string{"badURL", "http://invalid.invalid/invalid/", srcBaseURL},
+			PollInterval: updateDuration,
+			TLSVerify:    &tlsVerify,
+			CertDir:      "",
+		}
+
+		syncConfig := &sync.Config{Registries: []sync.RegistryConfig{syncRegistryConfig}}
+
+		dc, destBaseURL, destDir, destClient := startDownstreamServer(false, syncConfig)
+		defer os.RemoveAll(destDir)
+
+		defer func() {
+			dc.Shutdown()
+		}()
+
+		var srcTagsList TagsList
+		var destTagsList TagsList
+
+		resp, _ := srcClient.R().Get(srcBaseURL + "/v2/" + testImage + "/tags/list")
+		So(resp, ShouldNotBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		err := json.Unmarshal(resp.Body(), &srcTagsList)
+		if err != nil {
+			panic(err)
+		}
+
+		for {
+			resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/tags/list")
+			if err != nil {
+				panic(err)
+			}
+
+			err = json.Unmarshal(resp.Body(), &destTagsList)
+			if err != nil {
+				panic(err)
+			}
+
+			if len(destTagsList.Tags) > 0 {
+				break
+			}
+
+			time.Sleep(500 * time.Millisecond)
+		}
+
+		So(destTagsList, ShouldResemble, srcTagsList)
 	})
 }
 
@@ -1861,7 +1939,7 @@ func TestSyncSignatures(t *testing.T) {
 					},
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
 			CertDir:      "",
@@ -1909,11 +1987,14 @@ func TestSyncSignatures(t *testing.T) {
 			panic(err)
 		}
 
+		time.Sleep(1 * time.Second)
+
 		// notation verify the image
 		image := fmt.Sprintf("localhost:%s/%s:%s", destPort, repoName, "1.0")
 		cmd := exec.Command("notation", "verify", "--cert", "good", "--plain-http", image)
 		out, err := cmd.CombinedOutput()
 		So(err, ShouldBeNil)
+
 		msg := string(out)
 		So(msg, ShouldNotBeEmpty)
 		So(strings.Contains(msg, "verification failure"), ShouldBeFalse)
@@ -1970,9 +2051,10 @@ func TestSyncSignatures(t *testing.T) {
 		// 	panic(err)
 		// }
 
-		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+		// sync on demand
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + repoName + "/manifests/1.0")
 		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, 404)
+		So(resp.StatusCode(), ShouldEqual, 200)
 
 		for _, blob := range nm.Blobs {
 			srcBlobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
@@ -1986,9 +2068,14 @@ func TestSyncSignatures(t *testing.T) {
 			So(err, ShouldBeNil)
 		}
 
-		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+		// // remove already synced image
+		// err = os.RemoveAll(path.Join(destDir, repoName))
+		// So(err, ShouldBeNil)
+
+		// sync on demand
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + repoName + "/manifests/1.0")
 		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, 404)
+		So(resp.StatusCode(), ShouldEqual, 200)
 
 		// clean
 		for _, blob := range nm.Blobs {
@@ -2018,9 +2105,14 @@ func TestSyncSignatures(t *testing.T) {
 			So(err, ShouldBeNil)
 		}
 
-		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+		// remove already synced image
+		err = os.RemoveAll(path.Join(destDir, repoName))
 		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, 404)
+
+		// sync on demand
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + repoName + "/manifests/1.0")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
 
 		for _, blob := range cm.Layers {
 			srcBlobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
@@ -2028,15 +2120,19 @@ func TestSyncSignatures(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			destBlobPath := path.Join(destDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
-			err = os.Remove(destBlobPath)
-			So(err, ShouldBeNil)
+
 			err = os.MkdirAll(destBlobPath, 0o000)
 			So(err, ShouldBeNil)
 		}
 
-		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+		// remove already synced image
+		err = os.RemoveAll(path.Join(destDir, repoName))
 		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, 404)
+
+		// sync on demand
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + repoName + "/manifests/1.0")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
 
 		for _, blob := range cm.Layers {
 			destBlobPath := path.Join(destDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
@@ -2052,23 +2148,33 @@ func TestSyncSignatures(t *testing.T) {
 		err = os.Chmod(srcConfigBlobPath, 0o000)
 		So(err, ShouldBeNil)
 
-		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+		// remove already synced image
+		err = os.RemoveAll(path.Join(destDir, repoName))
 		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, 404)
+
+		// sync on demand
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + repoName + "/manifests/1.0")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
 
 		err = os.Chmod(srcConfigBlobPath, 0o755)
 		So(err, ShouldBeNil)
 
 		destConfigBlobPath := path.Join(destDir, repoName, "blobs", string(cm.Config.Digest.Algorithm()),
 			cm.Config.Digest.Hex())
-		err = os.Remove(destConfigBlobPath)
-		So(err, ShouldBeNil)
+		// err = os.Remove(destConfigBlobPath)
+		// So(err, ShouldBeNil)
 		err = os.MkdirAll(destConfigBlobPath, 0o000)
 		So(err, ShouldBeNil)
 
-		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+		// remove already synced image
+		err = os.RemoveAll(path.Join(destDir, repoName))
 		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, 404)
+
+		// sync on demand
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + repoName + "/manifests/1.0")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
 	})
 }
 
@@ -2097,7 +2203,7 @@ func TestSyncError(t *testing.T) {
 					},
 				},
 			},
-			URL:          srcBaseURL,
+			URLs:         []string{srcBaseURL},
 			PollInterval: updateDuration,
 			TLSVerify:    &tlsVerify,
 			CertDir:      "",
@@ -2154,7 +2260,7 @@ func TestSyncSignaturesOnDemand(t *testing.T) {
 		var tlsVerify bool
 
 		syncRegistryConfig := sync.RegistryConfig{
-			URL:       srcBaseURL,
+			URLs:      []string{srcBaseURL},
 			TLSVerify: &tlsVerify,
 			CertDir:   "",
 			OnDemand:  true,
@@ -2214,7 +2320,8 @@ func TestSyncSignaturesOnDemand(t *testing.T) {
 		err = json.Unmarshal(mResp.Body(), &cm)
 		So(err, ShouldBeNil)
 
-		// trigger error on config blob
+		// trigger errors on cosign blobs
+		// trigger error on cosign config blob
 		srcConfigBlobPath := path.Join(srcDir, repoName, "blobs", string(cm.Config.Digest.Algorithm()),
 			cm.Config.Digest.Hex())
 		err = os.Chmod(srcConfigBlobPath, 0o000)
@@ -2227,7 +2334,29 @@ func TestSyncSignaturesOnDemand(t *testing.T) {
 		// sync on demand
 		resp, err = resty.R().Get(destBaseURL + "/v2/" + repoName + "/manifests/1.0")
 		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, 404)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		// trigger error on cosign layer blob
+		srcSignatureBlobPath := path.Join(srcDir, repoName, "blobs", string(cm.Layers[0].Digest.Algorithm()),
+			cm.Layers[0].Digest.Hex())
+
+		err = os.Chmod(srcConfigBlobPath, 0o755)
+		So(err, ShouldBeNil)
+
+		err = os.Chmod(srcSignatureBlobPath, 0o000)
+		So(err, ShouldBeNil)
+
+		// remove already synced image
+		err = os.RemoveAll(path.Join(destDir, repoName))
+		So(err, ShouldBeNil)
+
+		// sync on demand
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + repoName + "/manifests/1.0")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		err = os.Chmod(srcSignatureBlobPath, 0o755)
+		So(err, ShouldBeNil)
 	})
 }
 


### PR DESCRIPTION
…ly one, closes #343

Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
