### PR TITLE
Add read-only tests, mixed read-only tests, mixed write-only tests and mixed read-write tests for zb binary

### DIFF
--- a/.github/workflows/cluster.yaml
+++ b/.github/workflows/cluster.yaml
@@ -136,7 +136,7 @@ jobs:
             ./bin/zot-linux-amd64 serve test/cluster/config-minio3.json &
             sleep 10
             # run zb
-            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+            bin/zb-linux-amd64 -c 10 -n 50 -o ci-cd http://localhost:8080
         env:
           AWS_ACCESS_KEY_ID: minioadmin
           AWS_SECRET_ACCESS_KEY: minioadmin

--- a/cmd/zb/helper.go
+++ b/cmd/zb/helper.go
@@ -1,0 +1,908 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os"
+	"path"
+	"time"
+
+	"github.com/google/uuid"
+	imeta "github.com/opencontainers/image-spec/specs-go"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"gopkg.in/resty.v1"
+	"zotregistry.io/zot/errors"
+	"zotregistry.io/zot/pkg/test"
+)
+
+func deleteTestRepo(repos []string, url string, client *resty.Client) error {
+	for _, repo := range repos {
+		resp, err := client.R().Delete((fmt.Sprintf("%s/v2/%s/", url, repo)))
+		if err != nil {
+			return err
+		}
+
+		// request specific check
+		statusCode := resp.StatusCode()
+		if statusCode != http.StatusAccepted {
+			return errors.ErrUnknownCode
+		}
+	}
+
+	return nil
+}
+
+func pullAndCollect(url string, repos []string, manifestItem manifestStruct,
+	config testConfig, client *resty.Client, statsCh chan statsRecord) []string {
+	manifestHash := manifestItem.manifestHash
+	manifestBySizeHash := manifestItem.manifestBySizeHash
+
+	func() {
+		start := time.Now()
+
+		var isConnFail, isErr bool
+
+		var statusCode int
+
+		var latency time.Duration
+
+		defer func() {
+			// send a stats record
+			statsCh <- statsRecord{
+				latency:    latency,
+				statusCode: statusCode,
+				isConnFail: isConnFail,
+				isErr:      isErr,
+			}
+		}()
+
+		if config.mixedSize {
+			smallSizeIdx := 0
+			mediumSizeIdx := 1
+			largeSizeIdx := 2
+
+			idx := flipFunc(config.probabilityRange)
+
+			switch idx {
+			case smallSizeIdx:
+				statusRequests["1MB"]++
+			case mediumSizeIdx:
+				statusRequests["10MB"]++
+			case largeSizeIdx:
+				statusRequests["100MB"]++
+			}
+
+			manifestHash = manifestBySizeHash[idx]
+		}
+
+		for repo, manifestTag := range manifestHash {
+			manifestLoc := fmt.Sprintf("%s/v2/%s/manifests/%s", url, repo, manifestTag)
+
+			// check manifest
+			resp, err := client.R().
+				SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+				Head(manifestLoc)
+
+			latency = time.Since(start)
+
+			if err != nil {
+				isConnFail = true
+
+				return
+			}
+
+			// request specific check
+			statusCode = resp.StatusCode()
+			if statusCode != http.StatusOK {
+				isErr = true
+
+				return
+			}
+
+			// send request and get the manifest
+			resp, err = client.R().
+				SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+				Get(manifestLoc)
+
+			latency = time.Since(start)
+
+			if err != nil {
+				isConnFail = true
+
+				return
+			}
+
+			// request specific check
+			statusCode = resp.StatusCode()
+			if statusCode != http.StatusOK {
+				isErr = true
+
+				return
+			}
+
+			manifestBody := resp.Body()
+
+			// file copy simulation
+			_, err = io.Copy(ioutil.Discard, bytes.NewReader(manifestBody))
+
+			latency = time.Since(start)
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			var pulledManifest ispec.Manifest
+
+			err = json.Unmarshal(manifestBody, &pulledManifest)
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// check config
+			configDigest := pulledManifest.Config.Digest
+			configLoc := fmt.Sprintf("%s/v2/%s/blobs/%s", url, repo, configDigest)
+			resp, err = client.R().Head(configLoc)
+
+			latency = time.Since(start)
+
+			if err != nil {
+				isConnFail = true
+
+				return
+			}
+
+			// request specific check
+			statusCode = resp.StatusCode()
+			if statusCode != http.StatusOK {
+				isErr = true
+
+				return
+			}
+
+			// send request and get the config
+			resp, err = client.R().Get(configLoc)
+
+			latency = time.Since(start)
+
+			if err != nil {
+				isConnFail = true
+
+				return
+			}
+
+			// request specific check
+			statusCode = resp.StatusCode()
+			if statusCode != http.StatusOK {
+				isErr = true
+
+				return
+			}
+
+			configBody := resp.Body()
+
+			// file copy simulation
+			_, err = io.Copy(ioutil.Discard, bytes.NewReader(configBody))
+
+			latency = time.Since(start)
+
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			// download blobs
+			for _, layer := range pulledManifest.Layers {
+				blobDigest := layer.Digest
+				blobLoc := fmt.Sprintf("%s/v2/%s/blobs/%s", url, repo, blobDigest)
+
+				// check blob
+				resp, err := client.R().Head(blobLoc)
+
+				latency = time.Since(start)
+
+				if err != nil {
+					isConnFail = true
+
+					return
+				}
+
+				// request specific check
+				statusCode = resp.StatusCode()
+				if statusCode != http.StatusOK {
+					isErr = true
+
+					return
+				}
+
+				// send request and get response the blob
+				resp, err = client.R().Get(blobLoc)
+
+				latency = time.Since(start)
+
+				if err != nil {
+					isConnFail = true
+
+					return
+				}
+
+				// request specific check
+				statusCode = resp.StatusCode()
+				if statusCode != http.StatusOK {
+					isErr = true
+
+					return
+				}
+
+				blobBody := resp.Body()
+
+				// file copy simulation
+				_, err = io.Copy(ioutil.Discard, bytes.NewReader(blobBody))
+				if err != nil {
+					log.Fatal(err)
+				}
+			}
+		}
+	}()
+
+	return repos
+}
+
+func pushMonolithImage(workdir, url, trepo string, repos []string, size int,
+	client *resty.Client) (map[string]string, []string, error) {
+	var statusCode int
+
+	// key: repository name. value: manifest name
+	manifestHash := make(map[string]string)
+
+	ruid, err := uuid.NewUUID()
+	if err != nil {
+		return nil, repos, err
+	}
+
+	var repo string
+
+	if trepo != "" {
+		repo = trepo + "/" + ruid.String()
+	} else {
+		repo = ruid.String()
+	}
+
+	repos = append(repos, repo)
+
+	// upload blob
+	resp, err := client.R().Post(fmt.Sprintf("%s/v2/%s/blobs/uploads/", url, repo))
+	if err != nil {
+		return nil, repos, err
+	}
+
+	// request specific check
+	statusCode = resp.StatusCode()
+	if statusCode != http.StatusAccepted {
+		return nil, repos, errors.ErrUnknownCode
+	}
+
+	loc := test.Location(url, resp)
+	blob := path.Join(workdir, fmt.Sprintf("%d.blob", size))
+
+	fhandle, err := os.OpenFile(blob, os.O_RDONLY, defaultFilePerms)
+	if err != nil {
+		return nil, repos, err
+	}
+
+	defer fhandle.Close()
+
+	// stream the entire blob
+	digest := blobHash[blob]
+
+	resp, err = client.R().
+		SetContentLength(true).
+		SetQueryParam("digest", digest.String()).
+		SetHeader("Content-Length", fmt.Sprintf("%d", size)).
+		SetHeader("Content-Type", "application/octet-stream").SetBody(fhandle).Put(loc)
+
+	if err != nil {
+		return nil, repos, err
+	}
+
+	// request specific check
+	statusCode = resp.StatusCode()
+	if statusCode != http.StatusCreated {
+		return nil, repos, errors.ErrUnknownCode
+	}
+
+	// upload image config blob
+	resp, err = client.R().
+		Post(fmt.Sprintf("%s/v2/%s/blobs/uploads/", url, repo))
+
+	if err != nil {
+		return nil, repos, err
+	}
+
+	// request specific check
+	statusCode = resp.StatusCode()
+	if statusCode != http.StatusAccepted {
+		return nil, repos, errors.ErrUnknownCode
+	}
+
+	loc = test.Location(url, resp)
+	cblob, cdigest := test.GetRandomImageConfig()
+	resp, err = client.R().
+		SetContentLength(true).
+		SetHeader("Content-Length", fmt.Sprintf("%d", len(cblob))).
+		SetHeader("Content-Type", "application/octet-stream").
+		SetQueryParam("digest", cdigest.String()).
+		SetBody(cblob).
+		Put(loc)
+
+	if err != nil {
+		return nil, repos, err
+	}
+
+	// request specific check
+	statusCode = resp.StatusCode()
+	if statusCode != http.StatusCreated {
+		return nil, repos, errors.ErrUnknownCode
+	}
+
+	// create a manifest
+	manifest := ispec.Manifest{
+		Versioned: imeta.Versioned{
+			SchemaVersion: defaultSchemaVersion,
+		},
+		Config: ispec.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    cdigest,
+			Size:      int64(len(cblob)),
+		},
+		Layers: []ispec.Descriptor{
+			{
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    digest,
+				Size:      int64(size),
+			},
+		},
+	}
+
+	content, err := json.MarshalIndent(&manifest, "", "\t")
+	if err != nil {
+		return nil, repos, err
+	}
+
+	manifestTag := fmt.Sprintf("tag%d", size)
+
+	// finish upload
+	resp, err = client.R().
+		SetContentLength(true).
+		SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+		SetBody(content).
+		Put(fmt.Sprintf("%s/v2/%s/manifests/%s", url, repo, manifestTag))
+
+	if err != nil {
+		return nil, repos, err
+	}
+
+	// request specific check
+	statusCode = resp.StatusCode()
+	if statusCode != http.StatusCreated {
+		return nil, repos, errors.ErrUnknownCode
+	}
+
+	manifestHash[repo] = manifestTag
+
+	return manifestHash, repos, nil
+}
+
+func pushMonolithAndCollect(workdir, url, trepo string, count int,
+	repos []string, config testConfig, client *resty.Client,
+	statsCh chan statsRecord) []string {
+	func() {
+		start := time.Now()
+
+		var isConnFail, isErr bool
+
+		var statusCode int
+
+		var latency time.Duration
+
+		defer func() {
+			// send a stats record
+			statsCh <- statsRecord{
+				latency:    latency,
+				statusCode: statusCode,
+				isConnFail: isConnFail,
+				isErr:      isErr,
+			}
+		}()
+
+		ruid, err := uuid.NewUUID()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var repo string
+
+		if trepo != "" {
+			repo = trepo + "/" + ruid.String()
+		} else {
+			repo = ruid.String()
+		}
+
+		repos = append(repos, repo)
+
+		// create a new upload
+		resp, err := client.R().
+			Post(fmt.Sprintf("%s/v2/%s/blobs/uploads/", url, repo))
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusAccepted {
+			isErr = true
+
+			return
+		}
+
+		loc := test.Location(url, resp)
+
+		var size int
+
+		if config.mixedSize {
+			idx := flipFunc(config.probabilityRange)
+			smallSizeIdx := 0
+			mediumSizeIdx := 1
+			largeSizeIdx := 2
+
+			switch idx {
+			case smallSizeIdx:
+				size = smallBlob
+				statusRequests["1MB"]++
+			case mediumSizeIdx:
+				size = mediumBlob
+				statusRequests["10MB"]++
+			case largeSizeIdx:
+				size = largeBlob
+				statusRequests["100MB"]++
+			default:
+				size = config.size
+			}
+		} else {
+			size = config.size
+		}
+
+		blob := path.Join(workdir, fmt.Sprintf("%d.blob", size))
+
+		fhandle, err := os.OpenFile(blob, os.O_RDONLY, defaultFilePerms)
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		defer fhandle.Close()
+
+		// stream the entire blob
+		digest := blobHash[blob]
+
+		resp, err = client.R().
+			SetContentLength(true).
+			SetHeader("Content-Length", fmt.Sprintf("%d", size)).
+			SetHeader("Content-Type", "application/octet-stream").
+			SetQueryParam("digest", digest.String()).
+			SetBody(fhandle).
+			Put(loc)
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusCreated {
+			isErr = true
+
+			return
+		}
+
+		// upload image config blob
+		resp, err = client.R().
+			Post(fmt.Sprintf("%s/v2/%s/blobs/uploads/", url, repo))
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusAccepted {
+			isErr = true
+
+			return
+		}
+
+		loc = test.Location(url, resp)
+		cblob, cdigest := test.GetRandomImageConfig()
+		resp, err = client.R().
+			SetContentLength(true).
+			SetHeader("Content-Length", fmt.Sprintf("%d", len(cblob))).
+			SetHeader("Content-Type", "application/octet-stream").
+			SetQueryParam("digest", cdigest.String()).
+			SetBody(cblob).
+			Put(loc)
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusCreated {
+			isErr = true
+
+			return
+		}
+
+		// create a manifest
+		manifest := ispec.Manifest{
+			Versioned: imeta.Versioned{
+				SchemaVersion: defaultSchemaVersion,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    cdigest,
+				Size:      int64(len(cblob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    digest,
+					Size:      int64(size),
+				},
+			},
+		}
+
+		content, err := json.MarshalIndent(&manifest, "", "\t")
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		manifestTag := fmt.Sprintf("tag%d", count)
+
+		resp, err = client.R().
+			SetContentLength(true).
+			SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+			SetBody(content).
+			Put(fmt.Sprintf("%s/v2/%s/manifests/%s", url, repo, manifestTag))
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusCreated {
+			isErr = true
+
+			return
+		}
+	}()
+
+	return repos
+}
+
+func pushChunkAndCollect(workdir, url, trepo string, count int,
+	repos []string, config testConfig, client *resty.Client,
+	statsCh chan statsRecord) []string {
+	func() {
+		start := time.Now()
+
+		var isConnFail, isErr bool
+
+		var statusCode int
+
+		var latency time.Duration
+
+		defer func() {
+			// send a stats record
+			statsCh <- statsRecord{
+				latency:    latency,
+				statusCode: statusCode,
+				isConnFail: isConnFail,
+				isErr:      isErr,
+			}
+		}()
+
+		ruid, err := uuid.NewUUID()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var repo string
+
+		if trepo != "" {
+			repo = trepo + "/" + ruid.String()
+		} else {
+			repo = ruid.String()
+		}
+
+		repos = append(repos, repo)
+
+		// create a new upload
+		resp, err := client.R().
+			Post(fmt.Sprintf("%s/v2/%s/blobs/uploads/", url, repo))
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusAccepted {
+			isErr = true
+
+			return
+		}
+
+		loc := test.Location(url, resp)
+
+		var size int
+
+		if config.mixedSize {
+			idx := flipFunc(config.probabilityRange)
+			smallSizeIdx := 0
+			mediumSizeIdx := 1
+			largeSizeIdx := 2
+
+			switch idx {
+			case smallSizeIdx:
+				size = smallBlob
+				statusRequests["1MB"]++
+			case mediumSizeIdx:
+				size = mediumBlob
+				statusRequests["10MB"]++
+			case largeSizeIdx:
+				size = largeBlob
+				statusRequests["100MB"]++
+
+			default:
+				size = config.size
+			}
+		} else {
+			size = config.size
+		}
+
+		blob := path.Join(workdir, fmt.Sprintf("%d.blob", size))
+
+		fhandle, err := os.OpenFile(blob, os.O_RDONLY, defaultFilePerms)
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		defer fhandle.Close()
+
+		digest := blobHash[blob]
+
+		// upload blob
+		resp, err = client.R().
+			SetContentLength(true).
+			SetHeader("Content-Type", "application/octet-stream").
+			SetBody(fhandle).
+			Patch(loc)
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		loc = test.Location(url, resp)
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusAccepted {
+			isErr = true
+
+			return
+		}
+
+		// finish upload
+		resp, err = client.R().
+			SetContentLength(true).
+			SetHeader("Content-Length", fmt.Sprintf("%d", size)).
+			SetHeader("Content-Type", "application/octet-stream").
+			SetQueryParam("digest", digest.String()).
+			Put(loc)
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusCreated {
+			isErr = true
+
+			return
+		}
+
+		// upload image config blob
+		resp, err = client.R().
+			Post(fmt.Sprintf("%s/v2/%s/blobs/uploads/", url, repo))
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusAccepted {
+			isErr = true
+
+			return
+		}
+
+		loc = test.Location(url, resp)
+		cblob, cdigest := test.GetRandomImageConfig()
+		resp, err = client.R().
+			SetContentLength(true).
+			SetHeader("Content-Type", "application/octet-stream").
+			SetBody(fhandle).
+			Patch(loc)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusAccepted {
+			isErr = true
+
+			return
+		}
+
+		// upload blob
+		resp, err = client.R().
+			SetContentLength(true).
+			SetHeader("Content-Type", "application/octet-stream").
+			SetBody(cblob).
+			Patch(loc)
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		loc = test.Location(url, resp)
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusAccepted {
+			isErr = true
+
+			return
+		}
+
+		// finish upload
+		resp, err = client.R().
+			SetContentLength(true).
+			SetHeader("Content-Length", fmt.Sprintf("%d", len(cblob))).
+			SetHeader("Content-Type", "application/octet-stream").
+			SetQueryParam("digest", cdigest.String()).
+			Put(loc)
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusCreated {
+			isErr = true
+
+			return
+		}
+
+		// create a manifest
+		manifest := ispec.Manifest{
+			Versioned: imeta.Versioned{
+				SchemaVersion: defaultSchemaVersion,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    cdigest,
+				Size:      int64(len(cblob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    digest,
+					Size:      int64(size),
+				},
+			},
+		}
+
+		content, err := json.Marshal(manifest)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		manifestTag := fmt.Sprintf("tag%d", count)
+
+		// finish upload
+		resp, err = client.R().
+			SetContentLength(true).
+			SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+			SetBody(content).
+			Put(fmt.Sprintf("%s/v2/%s/manifests/%s", url, repo, manifestTag))
+
+		latency = time.Since(start)
+
+		if err != nil {
+			isConnFail = true
+
+			return
+		}
+
+		// request specific check
+		statusCode = resp.StatusCode()
+		if statusCode != http.StatusCreated {
+			isErr = true
+
+			return
+		}
+	}()
+
+	return repos
+}

--- a/cmd/zb/main.go
+++ b/cmd/zb/main.go
@@ -63,7 +63,7 @@ func NewPerfRootCmd() *cobra.Command {
 		"Output format of test results: stdout (default), json, ci-cd")
 
 	// "version"
-	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "show the version and exit")
+	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Show the version and exit")
 
 	return rootCmd
 }

--- a/cmd/zb/main_test.go
+++ b/cmd/zb/main_test.go
@@ -1,4 +1,4 @@
-package main //nolint:testpackage // separate binary
+package main // nolint:testpackage // separate binary
 
 import (
 	"testing"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
