### PR TITLE
storage: return errors instead of panics

### DIFF
--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -47,6 +47,11 @@ type BearerConfig struct {
 	Cert    string
 }
 
+type RatelimitConfig struct {
+	Rate  int
+	Burst int
+}
+
 type HTTPConfig struct {
 	Address          string
 	Port             string
@@ -54,8 +59,9 @@ type HTTPConfig struct {
 	Auth             *AuthConfig
 	RawAccessControl map[string]interface{} `mapstructure:"accessControl,omitempty"`
 	Realm            string
-	AllowReadAccess  bool `mapstructure:",omitempty"`
-	ReadOnly         bool `mapstructure:",omitempty"`
+	AllowReadAccess  bool             `mapstructure:",omitempty"`
+	ReadOnly         bool             `mapstructure:",omitempty"`
+	Ratelimit        *RatelimitConfig `mapstructure:",omitempty"`
 }
 
 type LDAPConfig struct {

--- a/pkg/storage/storage_fs.go
+++ b/pkg/storage/storage_fs.go
@@ -843,12 +843,16 @@ func (is *ImageStoreFS) PutBlobChunkStreamed(repo string, uuid string, body io.R
 		DefaultFilePerms,
 	)
 	if err != nil {
-		is.log.Fatal().Err(err).Msg("failed to open file")
+		is.log.Error().Err(err).Msg("failed to open file")
+
+		return -1, err
 	}
 	defer file.Close()
 
 	if _, err := file.Seek(0, io.SeekEnd); err != nil {
-		is.log.Fatal().Err(err).Msg("failed to seek file")
+		is.log.Error().Err(err).Msg("failed to seek file")
+
+		return -1, err
 	}
 
 	n, err := io.Copy(file, body)
@@ -884,12 +888,16 @@ func (is *ImageStoreFS) PutBlobChunk(repo string, uuid string, from int64, to in
 		DefaultFilePerms,
 	)
 	if err != nil {
-		is.log.Fatal().Err(err).Msg("failed to open file")
+		is.log.Error().Err(err).Msg("failed to open file")
+
+		return -1, err
 	}
 	defer file.Close()
 
 	if _, err := file.Seek(from, io.SeekStart); err != nil {
-		is.log.Fatal().Err(err).Msg("failed to seek file")
+		is.log.Error().Err(err).Msg("failed to seek file")
+
+		return -1, err
 	}
 
 	n, err := io.Copy(file, body)


### PR DESCRIPTION
Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

#359 


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
