### PR TITLE
Fix scrub command crash

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -15,6 +15,7 @@ import (
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
+	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/storage"
 )
 
@@ -121,6 +122,7 @@ func newScrubCmd(conf *config.Config) *cobra.Command {
 			} else {
 				// server is down
 				ctlr := api.NewController(conf)
+				ctlr.Metrics = monitoring.NewMetricsServer(false, ctlr.Log)
 
 				if err := ctlr.InitImageStore(); err != nil {
 					panic(err)


### PR DESCRIPTION

**What type of PR is this?**
bug

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
Scrub command fails/crashes because metrics server not defined (needed after we added storage lock latency metrics)


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:
`
midgard@ubuntu:~/work/rchincha/zot$ bin/zot scrub examples/config-test.json 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x93baf5]

goroutine 1 [running]:
zotregistry.io/zot/pkg/extensions/monitoring.ObserveStorageLockLatency({0x0, 0x0}, 0x2eb726eb, {0xc0003d12b0, 0x8}, {0x1ed39e9, 0x5})
	zotregistry.io/zot/pkg/extensions/monitoring/extension.go:196 +0xb5
zotregistry.io/zot/pkg/storage.(*ImageStoreFS).RUnlock(0xc000382140, 0xc001fd7a88)
	zotregistry.io/zot/pkg/storage/storage_fs.go:159 +0x91
zotregistry.io/zot/pkg/storage.(*ImageStoreFS).GetRepositories(0xc000382140)
	zotregistry.io/zot/pkg/storage/storage_fs.go:342 +0x251
zotregistry.io/zot/pkg/storage.StoreController.CheckAllBlobsIntegrity({{0x23ed580, 0xc000382140}, 0x0})
	zotregistry.io/zot/pkg/storage/scrub.go:56 +0x1c3
zotregistry.io/zot/pkg/cli.newScrubCmd.func1(0xc000362780, {0xc0005a3810, 0x1, 0x1})
	zotregistry.io/zot/pkg/cli/root.go:129 +0x18b
github.com/spf13/cobra.(*Command).execute(0xc000362780, {0xc0005a37e0, 0x1, 0x1})
	github.com/spf13/cobra@v1.2.1/command.go:860 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0xc00027d400)
	github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
	zotregistry.io/zot/cmd/zot/main.go:10 +0x1e
midgard@ubuntu:~/work/rchincha/zot$ 
midgard@ubuntu:~/work/rchincha/zot$ 
midgard@ubuntu:~/work/rchincha/zot$ 
midgard@ubuntu:~/work/rchincha/zot$ bin/zot-minimal scrub examples/config-test.json 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x9b0f70]

goroutine 1 [running]:
zotregistry.io/zot/pkg/extensions/monitoring.ObserveStorageLockLatency({0x0, 0x0}, 0x25e49a0, {0xc00039f600, 0x8}, {0x11a1850, 0x5})
	zotregistry.io/zot/pkg/extensions/monitoring/minimal.go:517 +0x1f0
zotregistry.io/zot/pkg/storage.(*ImageStoreFS).RUnlock(0xc000208500, 0xc00199fa88)
	zotregistry.io/zot/pkg/storage/storage_fs.go:159 +0x91
zotregistry.io/zot/pkg/storage.(*ImageStoreFS).GetRepositories(0xc000208500)
	zotregistry.io/zot/pkg/storage/storage_fs.go:342 +0x251
zotregistry.io/zot/pkg/storage.StoreController.CheckAllBlobsIntegrity({{0x14b4780, 0xc000208500}, 0x0})
	zotregistry.io/zot/pkg/storage/scrub.go:56 +0x1c3
zotregistry.io/zot/pkg/cli.newScrubCmd.func1(0xc00063c280, {0xc00024eaa0, 0x1, 0x1})
	zotregistry.io/zot/pkg/cli/root.go:129 +0x18b
github.com/spf13/cobra.(*Command).execute(0xc00063c280, {0xc00024ea60, 0x1, 0x1})
	github.com/spf13/cobra@v1.2.1/command.go:860 +0x5f8
github.com/spf13/cobra.(*Command).ExecuteC(0xc000191900)
	github.com/spf13/cobra@v1.2.1/command.go:974 +0x3bc
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.2.1/command.go:902
main.main()
	zotregistry.io/zot/cmd/zot/main.go:10 +0x1e
midgard@ubuntu:~/work/rchincha/zot$ 
`


**Testing done on this change**:
Run 'make test'

**Automation added to e2e**:
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
