### PR TITLE
search: graphql api to give detailed repo info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/opencontainers/umoci v0.4.8-0.20210922062158-e60a0cc726e6
 	github.com/oras-project/artifacts-spec v1.0.0-draft.1
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
+	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/rs/zerolog v1.26.0
@@ -271,7 +272,6 @@ require (
 	github.com/owenrumney/squealer v0.2.28 // indirect
 	github.com/pelletier/go-toml v1.9.4 // indirect
 	github.com/pierrec/lz4 v2.6.1+incompatible // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.31.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/pkg/extensions/search/models_gen.go
+++ b/pkg/extensions/search/models_gen.go
@@ -44,10 +44,26 @@ type ImgResultForFixedCve struct {
 	Tags []*TagInfo `json:"Tags"`
 }
 
+type LayerInfo struct {
+	Size   *string `json:"Size"`
+	Digest *string `json:"Digest"`
+}
+
+type ManifestInfo struct {
+	Digest   *string      `json:"Digest"`
+	Tag      *string      `json:"Tag"`
+	IsSigned *bool        `json:"IsSigned"`
+	Layers   []*LayerInfo `json:"Layers"`
+}
+
 type PackageInfo struct {
 	Name             *string `json:"Name"`
 	InstalledVersion *string `json:"InstalledVersion"`
 	FixedVersion     *string `json:"FixedVersion"`
+}
+
+type RepoInfo struct {
+	Manifests []*ManifestInfo `json:"Manifests"`
 }
 
 type TagInfo struct {

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -50,10 +50,27 @@ type ImageInfo {
      Labels: String
 }
 
+type RepoInfo {
+     Manifests: [ManifestInfo]
+}
+
+type ManifestInfo {
+     Digest: String
+     Tag: String
+     IsSigned: Boolean
+     Layers: [LayerInfo]
+}
+
+type LayerInfo {
+     Size: String # Int64 is not supported.
+     Digest: String
+}
+
 type Query {
   CVEListForImage(image: String!) :CVEResultForImage 
   ImageListForCVE(id: String!) :[ImgResultForCVE]
   ImageListWithCVEFixed(id: String!, image: String!) :ImgResultForFixedCVE
   ImageListForDigest(id: String!) :[ImgResultForDigest]
   ImageListWithLatestTag:[ImageInfo]
+  ExpandedRepoInfo(repo: String!):RepoInfo
 }


### PR DESCRIPTION
- DetailedRepoInfo graphql api returns detailed repo info given name.
- Each repo contains its manifests info.
- Each manifest entry contains digest, signature, tag and layers info
- Each layer info containes digest, size.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
