### PR TITLE
sync processor

### DIFF
--- a/pkg/extensions/sync/process.go
+++ b/pkg/extensions/sync/process.go
@@ -1,0 +1,69 @@
+package sync
+
+import (
+	"context"
+	"sync"
+)
+
+type SyncProcessor interface {
+	Get(image string)
+}
+
+type syncProcessor struct {
+	wgWorkers sync.WaitGroup
+	fetchCh   chan syncImageReq
+	is        *storage.imgStore
+	log       log
+}
+
+type syncImageReq struct {
+	image string
+}
+
+// Example: sp := NewSyncProcessor(ctx, wg, is, 16, log)
+// sp.Get("repo/image:tag") <- blocks only if channel is full, else returns
+
+func NewSyncProcessor(ctx context.Context, wg sync.WaitGroup, is *imageStore, workers int, log log) {
+	sp := &syncProcessor{fetchCh: make(chan syncImageReq, workers), is: is, log: log}
+	go sp.demux(ctx)
+	return sp
+}
+
+// before calling this method, we expect the caller to have first checked if the image is already present
+// also make sure no locks held because we write to a channel and it can block if full
+func (sp *syncProcessor) Get(image string) {
+	sp.fetchCh <- syncImageReq{image: image}
+}
+
+// you will need a way to stop this thread, so maybe pass a cancellable context to this, plus that shutdown wg
+func (sp *syncProcessor) demux(ctx context.Context) {
+	sp.log("starting the sync processor")
+
+	for {
+		select {
+		case work := <-sp.fetchCh:
+			image := work.image
+			if ImageAlreadyPresent(image) {
+				// image already downloaded in a worker, so no need to do it again
+				continue
+			}
+
+			sp.wgWorkers.Add(1)
+			go sp.worker(ctx, image)
+
+		case <-ctx.Done():
+			// a cancel received, so this thread is done - won't pick up any new requests
+			wgWorkers.Wait()
+			wg.Done()
+		}
+	}
+}
+
+func (sp *syncProcess) worker(ctx context.Context) {
+	sp.log("downloading image <image>")
+
+	// download image
+
+	// signal done
+	sp.wgWorkers.Done()
+}


### PR DESCRIPTION
Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
