### PR TITLE
ci/cd: restore part of github workflow for PRs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -13,6 +13,14 @@ jobs:
   build-test:
     name: Build and test ZOT
     runs-on: ubuntu-latest
+    steps:
+      - name: Run build and test
+        timeout-minutes: 60
+        run: |
+            echo "job deprecated"
+  build-test-arch:
+    name: Build and test ZOT
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         os: [linux, darwin]
@@ -30,10 +38,8 @@ jobs:
         uses: actions/setup-go@v2
         with:
           go-version: 1.17.x
-
       - name: Check out source code
         uses: actions/checkout@v1
-
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
@@ -46,7 +52,6 @@ jobs:
           curl -Lo notation.tar.gz https://github.com/notaryproject/notation/releases/download/v0.7.1-alpha.1/notation_0.7.1-alpha.1_linux_amd64.tar.gz
           sudo tar xvzf notation.tar.gz -C /usr/bin notation
           go get github.com/wadey/gocovmerge
-
       - name: Run build and test
         timeout-minutes: 60
         run: |
@@ -63,10 +68,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: fake
           OS: ${{ matrix.os }}
           ARCH: ${{ matrix.arch }}
-
       - name: Upload code coverage
         uses: codecov/codecov-action@v1
-
       - if: github.event_name == 'release' && github.event.action == 'published'
         name: Publish artifacts on releases
         uses: svenstaro/upload-release-action@v2


### PR DESCRIPTION
Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

ci/cd bug

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

Whenever github workflows are changed, somehow PRs seem to keep the stale jobs. Adding a placeholder "deprecated" job to keep PRs happy.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
