### PR TITLE
ci/cd: fix image upload pipeline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ RUN echo '{\n\
 # Stage 2: Final image with nothing but certs, binary, and default config file
 # ---
 FROM scratch AS final
+ARG OS
+ARG ARCH
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/project-zot/zot/bin/zot-$OS-$ARCH /usr/bin/zot
 COPY --from=builder /go/src/github.com/project-zot/zot/config.json /etc/zot/config.json

--- a/Dockerfile-minimal
+++ b/Dockerfile-minimal
@@ -26,6 +26,8 @@ RUN echo '{\n\
 # Stage 2: Final image with nothing but certs, binary, and default config file
 # ---
 FROM scratch AS final
+ARG OS
+ARG ARCH
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/src/github.com/project-zot/zot/bin/zot-$OS-$ARCH-minimal /usr/bin/zot
 COPY --from=builder /go/src/github.com/project-zot/zot/config.json /etc/zot/config.json

--- a/Dockerfile-zb
+++ b/Dockerfile-zb
@@ -14,5 +14,7 @@ RUN make COMMIT=$COMMIT OS=$OS ARCH=$ARCH clean bench
 # Stage 2: Final image with nothing but certs, binary, and default config file
 # ---
 FROM scratch AS final
+ARG OS
+ARG ARCH
 COPY --from=builder /go/src/github.com/project-zot/zot/bin/zb-$OS-$ARCH /usr/bin/zb
 ENTRYPOINT ["/usr/bin/zb"]

--- a/Dockerfile-zxp
+++ b/Dockerfile-zxp
@@ -27,6 +27,8 @@ RUN echo '{\n\
 # Stage 2: Final image with nothing but binary and default config file
 # ---
 FROM scratch AS final
+ARG OS
+ARG ARCH
 COPY --from=builder /go/src/github.com/project-zot/zot/bin/zxp-$OS-$ARCH /zxp
 COPY --from=builder /go/src/github.com/project-zot/zot/config.json /etc/zxp/config.json
 ENTRYPOINT ["/zxp"]


### PR DESCRIPTION
Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

ci/cd bug


<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

Our docker files are two-stage and OS/ARCH args are not passed into the second stage, failing the binary copy.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
