### PR TITLE
routes: changes required to do browser authentication

### DIFF
--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -64,6 +64,7 @@ type RatelimitConfig struct {
 type HTTPConfig struct {
 	Address          string
 	Port             string
+	AllowOrigin      string // comma separated
 	TLS              *TLSConfig
 	Auth             *AuthConfig
 	RawAccessControl map[string]interface{} `mapstructure:"accessControl,omitempty"`

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -57,6 +57,10 @@ func NewRouteHandler(c *Controller) *RouteHandler {
 	return rh
 }
 
+func allowedMethods(method string) []string {
+	return []string{http.MethodOptions, method}
+}
+
 func (rh *RouteHandler) SetupRoutes() {
 	rh.c.Router.Use(AuthHandler(rh.c))
 	// authz is being enabled because authn is found
@@ -68,11 +72,11 @@ func (rh *RouteHandler) SetupRoutes() {
 	prefixedRouter := rh.c.Router.PathPrefix(RoutePrefix).Subrouter()
 	{
 		prefixedRouter.HandleFunc(fmt.Sprintf("/{name:%s}/tags/list", NameRegexp.String()),
-			rh.ListTags).Methods("GET")
+			rh.ListTags).Methods(allowedMethods("GET")...)
 		prefixedRouter.HandleFunc(fmt.Sprintf("/{name:%s}/manifests/{reference}", NameRegexp.String()),
-			rh.CheckManifest).Methods("HEAD")
+			rh.CheckManifest).Methods(allowedMethods("HEAD")...)
 		prefixedRouter.HandleFunc(fmt.Sprintf("/{name:%s}/manifests/{reference}", NameRegexp.String()),
-			rh.GetManifest).Methods("GET")
+			rh.GetManifest).Methods(allowedMethods("GET")...)
 		prefixedRouter.HandleFunc(fmt.Sprintf("/{name:%s}/manifests/{reference}", NameRegexp.String()),
 			rh.UpdateManifest).Methods("PUT")
 		prefixedRouter.HandleFunc(fmt.Sprintf("/{name:%s}/manifests/{reference}", NameRegexp.String()),
@@ -94,9 +98,9 @@ func (rh *RouteHandler) SetupRoutes() {
 		prefixedRouter.HandleFunc(fmt.Sprintf("/{name:%s}/blobs/uploads/{session_id}", NameRegexp.String()),
 			rh.DeleteBlobUpload).Methods("DELETE")
 		prefixedRouter.HandleFunc("/_catalog",
-			rh.ListRepositories).Methods("GET")
+			rh.ListRepositories).Methods(allowedMethods("GET")...)
 		prefixedRouter.HandleFunc("/",
-			rh.CheckVersionSupport).Methods("GET")
+			rh.CheckVersionSupport).Methods(allowedMethods("GET")...)
 	}
 
 	// support for oras artifact reference types (alpha 1) - image signature use case

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -96,7 +96,7 @@ func SetupRoutes(config *config.Config, router *mux.Router, storeController stor
 			resConfig = search.GetResolverConfig(log, storeController, false)
 		}
 
-		router.PathPrefix("/query").Methods("GET", "POST").
+		router.PathPrefix("/query").Methods("GET", "POST", "OPTIONS").
 			Handler(gqlHandler.NewDefaultServer(search.NewExecutableSchema(resConfig)))
 	}
 


### PR DESCRIPTION
whenever we make a request that contains header apart from CORS allowed header, browser sends a preflight request
and in response accept *Access-Control-Allow-Headers*.

preflight request is in form of OPTIONS method, added new http handler func to set headers
and returns HTTP status ok in case of OPTIONS method.

in case of authorization, request contains authorization header
added authorization header in Access-Control-Allow-Headers list

added AllowOrigin field in HTTPConfig this field value is set to Access-Control-Allow-Origin header and will give zot adminstrator to limit incoming request.

Signed-off-by: Shivam Mishra <shimish2@cisco.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
