### PR TITLE
tls: restrict tls cipher suites

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -182,8 +182,16 @@ func (c *Controller) Run() error {
 			}
 
 			server.TLSConfig = &tls.Config{
-				ClientAuth:               clientAuth,
-				ClientCAs:                caCertPool,
+				ClientAuth: clientAuth,
+				ClientCAs:  caCertPool,
+				CipherSuites: []uint16{
+					tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+					tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+					tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+				},
 				PreferServerCipherSuites: true,
 				MinVersion:               tls.VersionTLS12,
 			}


### PR DESCRIPTION
golang will not turn them off by default:
https://github.com/golang/go/issues/13385

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

Restrict cipher suites to TLS 1.2 only.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
