### PR TITLE
remove linger go.sum entries to fix dependabot alert

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -2385,8 +2385,6 @@ github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041/go.mod h1:N5mDOms
 github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/shurcooL/vfsgen v0.0.0-20180121065927-ffb13db8def0/go.mod h1:TrYk7fJVaAttu97ZZKrO9UbRa8izdowaMIZcxYMbVaw=
-github.com/sigstore/cosign v1.3.1 h1:booDYHEVPQfe1TIrCcTJ3LZCJk1bLzoumbdvaQ3eH0o=
-github.com/sigstore/cosign v1.3.1/go.mod h1:Op66Y4LNtFLhtptpbSzxnSTikWsBthTXoKLMApFTcu4=
 github.com/sigstore/cosign v1.5.2 h1:YMVIjSLQ+6fL8m3deqLcg7aRqGbU/U6sJvcU0aT4fSM=
 github.com/sigstore/cosign v1.5.2/go.mod h1:USeA+jISR3H86hfgsTn1UJYKC9mgEE7/o+dJ7sk63MY=
 github.com/sigstore/fulcio v0.1.2-0.20210831152525-42f7422734bb h1:smRYK5Ii+6MzPPz6yisB65v2Pam5oHPOTLDlxyM3qYY=


### PR DESCRIPTION
Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug/cleanup

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

CVE-2022-23649: fix dependabot alert


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
