### PR TITLE
conformance: fix cross-mount behavior when 'from' is missing

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2665,7 +2665,7 @@ func TestCrossRepoMount(t *testing.T) {
 			SetBasicAuth(username, passphrase).SetQueryParams(params).
 			Post(baseURL + "/v2/zot-mount-test/blobs/uploads/")
 		So(err, ShouldBeNil)
-		So(postResponse.StatusCode(), ShouldEqual, http.StatusMethodNotAllowed)
+		So(postResponse.StatusCode(), ShouldEqual, http.StatusAccepted)
 
 		params = make(map[string]string)
 		params["from"] = "zot-cve-test"
@@ -3902,7 +3902,7 @@ func TestRouteFailures(t *testing.T) {
 			resp = response.Result()
 			defer resp.Body.Close()
 			So(resp, ShouldNotBeNil)
-			So(resp.StatusCode, ShouldEqual, http.StatusMethodNotAllowed)
+			So(resp.StatusCode, ShouldEqual, http.StatusAccepted)
 		})
 
 		Convey("Get blob upload", func() {

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -716,13 +716,6 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 			return
 		}
 
-		from, ok := request.URL.Query()["from"]
-		if !ok || len(from) != 1 {
-			response.WriteHeader(http.StatusMethodNotAllowed)
-
-			return
-		}
-
 		// zot does not support cross mounting directly and do a workaround creating using hard link.
 		// check blob looks for actual path (name+mountDigests[0]) first then look for cache and
 		// if found in cache, will do hard link and if fails we will start new upload.


### PR DESCRIPTION
fixes issue #442

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

issue #442 

**What does this PR do / Why do we need it**:

'from' query param is not support, so conform per spec.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
