### PR TITLE
Proof of concept for running blackbox tests using bats test framework

### DIFF
--- a/.github/workflows/blackbox.yaml
+++ b/.github/workflows/blackbox.yaml
@@ -1,0 +1,51 @@
+name: Run blackbox tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-blackbox-tests:
+    name: Build and test ZOT
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [linux]
+        arch: [amd64]
+    steps:
+      - name: Install go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17.x
+      - name: Check out source code
+        uses: actions/checkout@v1
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          go get -u github.com/swaggo/swag/cmd/swag
+          go mod download
+          sudo apt-get update
+          sudo apt install snapd jq curl skopeo
+          git clone https://github.com/bats-core/bats-core.git
+          cd bats-core
+          sudo ./install.sh /usr/local
+      - name: Build binaries
+        run: |
+          echo "Building for $OS:$ARCH"
+          cd $GITHUB_WORKSPACE
+          make OS=$OS ARCH=$ARCH binary binary-minimal cli
+        env:
+          OS: ${{ matrix.os }}
+          ARCH: ${{ matrix.arch }}
+      - name: Execute blackbox tests
+        run: |
+          echo "Running tests for $OS:$ARCH"
+          cd $GITHUB_WORKSPACE
+          make OS=$OS ARCH=$ARCH blackbox-tests
+        env:
+          OS: ${{ matrix.os }}
+          ARCH: ${{ matrix.arch }}

--- a/Makefile
+++ b/Makefile
@@ -186,3 +186,11 @@ binary-stacker:
 .PHONY: image
 image:
 	${CONTAINER_RUNTIME} build ${BUILD_ARGS} -f Dockerfile -t zot:latest .
+
+.PHONY: blackbox-tests
+blackbox-tests:
+	bats --trace --print-output-on-failure test/blackbox
+
+.PHONY: blackbox-tests-verbose
+blackbox-tests-verbose:
+	bats --trace --verbose-run --print-output-on-failure --show-output-of-passing-tests test/blackbox

--- a/test/blackbox/helpers.bash
+++ b/test/blackbox/helpers.bash
@@ -1,0 +1,61 @@
+ROOT_DIR=$(git rev-parse --show-toplevel)
+TEST_DATA_DIR=${ROOT_DIR}/test/data/
+OS="${OS:-linux}"
+ARCH="${ARCH:-amd64}"
+ZOT_MIN_PATH=${ROOT_DIR}/bin/zot-${OS}-${ARCH}-minimal
+
+if [ ! -f ${ZOT_MIN_PATH} ]; then
+    echo "you need to build ${ZOT_MIN_PATH} before running the tests"
+    exit 1
+fi
+
+if [ ! command -v curl &> /dev/null ]; then
+    echo "you need to install curl as a prerequisite to running the tests"
+    exit 1
+fi
+
+if [ ! command -v jq &> /dev/null ]; then
+    echo "you need to install jq as a prerequisite to running the tests"
+    exit 1
+fi
+
+if [ ! command -v skopeo &> /dev/null ]; then
+    echo "you need to install skopeo as a prerequisite to running the tests"
+    exit 1
+fi
+
+mkdir -p ${TEST_DATA_DIR}
+
+function zot_serve() {
+    local zot_path=${1}
+    local config_file=${2}
+    local pid_dir=${3}
+    ${zot_path} serve ${config_file} &
+    echo $! > ${pid_dir}/zot.pid
+}
+
+function zot_stop() {
+    local pid_dir=${1}
+    kill $(cat ${pid_dir}/zot.pid)
+    rm ${pid_dir}/zot.pid
+}
+
+function setup_zot_minimal_file_level() {
+    local config_file=${1}
+    zot_serve ${ZOT_MIN_PATH} ${config_file} ${BATS_FILE_TMPDIR}
+}
+
+function teardown_zot_file_level() {
+    zot_stop ${BATS_FILE_TMPDIR}
+}
+
+function wait_zot_reachable() {
+    zot_url=${1}
+    curl --connect-timeout 3 \
+        --max-time 3 \
+        --retry 10 \
+        --retry-delay 0 \
+        --retry-max-time 60 \
+        --retry-connrefused \
+        ${zot_url}
+}

--- a/test/blackbox/upload.bats
+++ b/test/blackbox/upload.bats
@@ -1,0 +1,45 @@
+load helpers
+
+function setup_file() {
+    # Download test data
+    skopeo --insecure-policy copy docker://public.ecr.aws/t0x7q1g8/centos:7 oci:${TEST_DATA_DIR}/zot-test:0.0.1
+    skopeo --insecure-policy copy docker://public.ecr.aws/t0x7q1g8/centos:8 oci:${TEST_DATA_DIR}/zot-cve-test:0.0.1
+    # Setup zot server
+    local zot_root_dir=${BATS_FILE_TMPDIR}/zot
+    local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
+    mkdir -p ${zot_root_dir}
+    cat > ${zot_config_file}<<EOF
+{
+    "version": "0.1.0-dev",
+    "storage": {
+        "rootDirectory": "${zot_root_dir}"
+    },
+    "http": {
+        "address": "0.0.0.0",
+        "port": "8080",
+        "ReadOnly": false
+    },
+    "log": {
+        "level": "debug"
+    }
+}
+EOF
+    setup_zot_minimal_file_level ${zot_config_file}
+    wait_zot_reachable "http://127.0.0.1:8080/v2/_catalog"
+}
+
+function teardown_file() {
+    local zot_root_dir=${BATS_FILE_TMPDIR}/zot
+    teardown_zot_file_level
+    rm -rf ${zot_root_dir}
+}
+
+@test "upload image" {
+    run skopeo --insecure-policy copy --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/zot-test:0.0.1 \
+        docker://127.0.0.1:8080/zot-test:0.0.1
+    [ "$status" -eq 0 ]
+    run curl http://127.0.0.1:8080/v2/_catalog
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.repositories[]') = '"zot-test"' ]
+}


### PR DESCRIPTION
**What type of PR is this?**
build

**Which issue does this PR fix**:
Lately the amount of shell code present in the makefile or the GH workflows has been growing, and the main reason is we need to do some black box testing using separate binaries (notation, openssl, curl, maybe zb).
Ideally we should organize this code into tests with a consistent architecture.

**What does this PR do / Why do we need it**:
POC for using the bats test framework for black box testing using shell commands.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
