### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -109,11 +109,7 @@ func TestRunAlreadyRunningServer(t *testing.T) {
 
 		ctlr := api.NewController(conf)
 
-		globalDir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(globalDir)
+		globalDir := t.TempDir()
 
 		ctlr.Config.Storage.RootDirectory = globalDir
 
@@ -137,7 +133,7 @@ func TestRunAlreadyRunningServer(t *testing.T) {
 			_ = ctlr.Server.Shutdown(ctx)
 		}()
 
-		err = ctlr.Run()
+		err := ctlr.Run()
 		So(err, ShouldNotBeNil)
 	})
 }
@@ -253,12 +249,7 @@ func TestHtpasswdSingleCred(t *testing.T) {
 					},
 				}
 				ctlr := api.NewController(conf)
-				dir, err := ioutil.TempDir("", "oci-repo-test")
-				if err != nil {
-					panic(err)
-				}
-				defer os.RemoveAll(dir)
-				ctlr.Config.Storage.RootDirectory = dir
+				ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 				go startServer(ctlr)
 				defer stopServer(ctlr)
@@ -308,12 +299,7 @@ func TestHtpasswdTwoCreds(t *testing.T) {
 					},
 				}
 				ctlr := api.NewController(conf)
-				dir, err := ioutil.TempDir("", "oci-repo-test")
-				if err != nil {
-					panic(err)
-				}
-				defer os.RemoveAll(dir)
-				ctlr.Config.Storage.RootDirectory = dir
+				ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 				go startServer(ctlr)
 				defer stopServer(ctlr)
@@ -364,12 +350,7 @@ func TestHtpasswdFiveCreds(t *testing.T) {
 				},
 			}
 			ctlr := api.NewController(conf)
-			dir, err := ioutil.TempDir("", "oci-repo-test")
-			if err != nil {
-				panic(err)
-			}
-			defer os.RemoveAll(dir)
-			ctlr.Config.Storage.RootDirectory = dir
+			ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 			go startServer(ctlr)
 			defer stopServer(ctlr)
@@ -402,12 +383,7 @@ func TestRatelimit(t *testing.T) {
 			Rate: &rate,
 		}
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -443,12 +419,7 @@ func TestRatelimit(t *testing.T) {
 			},
 		}
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -485,12 +456,7 @@ func TestRatelimit(t *testing.T) {
 			},
 		}
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -526,12 +492,7 @@ func TestBasicAuth(t *testing.T) {
 			},
 		}
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -565,13 +526,7 @@ func TestInterruptedBlobUpload(t *testing.T) {
 		conf.HTTP.Port = port
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -805,17 +760,8 @@ func TestMultipleInstance(t *testing.T) {
 		err := ctlr.Run()
 		So(err, ShouldEqual, errors.ErrImgStoreNotFound)
 
-		globalDir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(globalDir)
-
-		subDir, err := ioutil.TempDir("", "oci-sub-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(subDir)
+		globalDir := t.TempDir()
+		subDir := t.TempDir()
 
 		ctlr.Config.Storage.RootDirectory = globalDir
 		subPathMap := make(map[string]config.StorageConfig)
@@ -848,17 +794,8 @@ func TestMultipleInstance(t *testing.T) {
 			},
 		}
 		ctlr := api.NewController(conf)
-		globalDir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(globalDir)
-
-		subDir, err := ioutil.TempDir("", "oci-sub-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(subDir)
+		globalDir := t.TempDir()
+		subDir := t.TempDir()
 
 		ctlr.Config.Storage.RootDirectory = globalDir
 		subPathMap := make(map[string]config.StorageConfig)
@@ -916,12 +853,7 @@ func TestTLSWithBasicAuth(t *testing.T) {
 		}
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -982,12 +914,7 @@ func TestTLSWithBasicAuthAllowReadAccess(t *testing.T) {
 		conf.HTTP.AllowReadAccess = true
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -1042,12 +969,7 @@ func TestTLSMutualAuth(t *testing.T) {
 		}
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -1115,12 +1037,7 @@ func TestTLSMutualAuthAllowReadAccess(t *testing.T) {
 		conf.HTTP.AllowReadAccess = true
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -1201,12 +1118,7 @@ func TestTLSMutualAndBasicAuth(t *testing.T) {
 		}
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -1284,12 +1196,7 @@ func TestTLSMutualAndBasicAuthAllowReadAccess(t *testing.T) {
 		conf.HTTP.AllowReadAccess = true
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -1443,12 +1350,7 @@ func TestBasicAuthWithLDAP(t *testing.T) {
 			},
 		}
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -1532,10 +1434,7 @@ func TestBearerAuth(t *testing.T) {
 			},
 		}
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -1699,10 +1598,7 @@ func TestBearerAuthWithAllowReadAccess(t *testing.T) {
 		}
 		conf.HTTP.AllowReadAccess = true
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -1931,12 +1827,8 @@ func TestAuthorizationWithBasicAuth(t *testing.T) {
 		}
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		err = test.CopyFiles("../../test/data", dir)
+		dir := t.TempDir()
+		err := test.CopyFiles("../../test/data", dir)
 		if err != nil {
 			panic(err)
 		}
@@ -2459,12 +2351,7 @@ func TestHTTPReadOnly(t *testing.T) {
 					},
 				}
 				ctlr := api.NewController(conf)
-				dir, err := ioutil.TempDir("", "oci-repo-test")
-				if err != nil {
-					panic(err)
-				}
-				defer os.RemoveAll(dir)
-				ctlr.Config.Storage.RootDirectory = dir
+				ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 				go startServer(ctlr)
 				defer stopServer(ctlr)
@@ -2476,7 +2363,7 @@ func TestHTTPReadOnly(t *testing.T) {
 				So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 
 				// with creds, any modifications should still fail on read-only mode
-				resp, err = resty.R().SetBasicAuth(user, password).
+				resp, err := resty.R().SetBasicAuth(user, password).
 					Post(baseURL + "/v2/" + AuthorizedNamespace + "/blobs/uploads/")
 				So(err, ShouldBeNil)
 				So(resp, ShouldNotBeNil)
@@ -2510,16 +2397,12 @@ func TestCrossRepoMount(t *testing.T) {
 
 		ctlr := api.NewController(conf)
 
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
+		dir := t.TempDir()
 
-		err = test.CopyFiles("../../test/data", dir)
+		err := test.CopyFiles("../../test/data", dir)
 		if err != nil {
 			panic(err)
 		}
-		defer os.RemoveAll(dir)
 		ctlr.Config.Storage.RootDirectory = dir
 
 		go startServer(ctlr)
@@ -2694,16 +2577,12 @@ func TestCrossRepoMount(t *testing.T) {
 
 		ctlr := api.NewController(conf)
 
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
+		dir := t.TempDir()
 
-		err = test.CopyFiles("../../test/data", dir)
+		err := test.CopyFiles("../../test/data", dir)
 		if err != nil {
 			panic(err)
 		}
-		defer os.RemoveAll(dir)
 
 		ctlr.Config.Storage.RootDirectory = dir
 		ctlr.Config.Storage.Dedupe = false
@@ -2836,32 +2715,9 @@ func TestParallelRequests(t *testing.T) {
 
 	ctlr := api.NewController(conf)
 
-	dir, err := ioutil.TempDir("", "oci-repo-test")
-	if err != nil {
-		panic(err)
-	}
-
-	t.Cleanup(func() {
-		os.RemoveAll(dir)
-	})
-
-	firstSubDir, err := ioutil.TempDir("", "oci-sub-dir")
-	if err != nil {
-		panic(err)
-	}
-
-	t.Cleanup(func() {
-		os.RemoveAll(firstSubDir)
-	})
-
-	secondSubDir, err := ioutil.TempDir("", "oci-sub-dir")
-	if err != nil {
-		panic(err)
-	}
-
-	t.Cleanup(func() {
-		os.RemoveAll(secondSubDir)
-	})
+	dir := t.TempDir()
+	firstSubDir := t.TempDir()
+	secondSubDir := t.TempDir()
 
 	subPaths := make(map[string]config.StorageConfig)
 
@@ -3079,22 +2935,14 @@ func TestHardLink(t *testing.T) {
 
 		ctlr := api.NewController(conf)
 
-		dir, err := ioutil.TempDir("", "hard-link-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
-		err = os.Chmod(dir, 0o400)
+		err := os.Chmod(dir, 0o400)
 		if err != nil {
 			panic(err)
 		}
 
-		subDir, err := ioutil.TempDir("", "sub-hardlink-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(subDir)
+		subDir := t.TempDir()
 
 		err = os.Chmod(subDir, 0o400)
 		if err != nil {
@@ -3135,11 +2983,7 @@ func TestImageSignatures(t *testing.T) {
 		conf.HTTP.Port = port
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 		ctlr.Config.Storage.RootDirectory = dir
 		go func(controller *api.Controller) {
 			// this blocks
@@ -3235,9 +3079,7 @@ func TestImageSignatures(t *testing.T) {
 			cwd, err := os.Getwd()
 			So(err, ShouldBeNil)
 			defer func() { _ = os.Chdir(cwd) }()
-			tdir, err := ioutil.TempDir("", "cosign")
-			So(err, ShouldBeNil)
-			defer os.RemoveAll(tdir)
+			tdir := t.TempDir()
 			_ = os.Chdir(tdir)
 
 			// generate a keypair
@@ -3321,9 +3163,7 @@ func TestImageSignatures(t *testing.T) {
 			cwd, err := os.Getwd()
 			So(err, ShouldBeNil)
 			defer func() { _ = os.Chdir(cwd) }()
-			tdir, err := ioutil.TempDir("", "notation")
-			So(err, ShouldBeNil)
-			defer os.RemoveAll(tdir)
+			tdir := t.TempDir()
 			_ = os.Chdir(tdir)
 
 			// "notation" (notaryv2) doesn't yet support exported apis, so use the binary instead
@@ -3474,12 +3314,7 @@ func TestRouteFailures(t *testing.T) {
 		conf.HTTP.Port = port
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 		ctlr.Config.Storage.Commit = true
 
 		go startServer(ctlr)
@@ -4061,11 +3896,7 @@ func TestStorageCommit(t *testing.T) {
 		conf.HTTP.Port = port
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 		ctlr.Config.Storage.RootDirectory = dir
 		ctlr.Config.Storage.Commit = true
 

--- a/pkg/cli/client_test.go
+++ b/pkg/cli/client_test.go
@@ -69,12 +69,7 @@ func TestTLSWithAuth(t *testing.T) {
 		}
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 		go func() {
 			// this blocks
 			if err := ctlr.Run(); err != nil {
@@ -166,12 +161,7 @@ func TestTLSWithoutAuth(t *testing.T) {
 		}
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 		go func() {
 			// this blocks
 			if err := ctlr.Run(); err != nil {
@@ -234,12 +224,7 @@ func TestTLSWithoutAuth(t *testing.T) {
 		}
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 		go func() {
 			// this blocks
 			if err := ctlr.Run(); err != nil {
@@ -297,12 +282,7 @@ func TestTLSBadCerts(t *testing.T) {
 		}
 
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 		go func() {
 			// this blocks
 			if err := ctlr.Run(); err != nil {

--- a/pkg/cli/cve_cmd_test.go
+++ b/pkg/cli/cve_cmd_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
@@ -291,17 +290,12 @@ func TestServerCVEResponse(t *testing.T) {
 	conf := config.New()
 	conf.HTTP.Port = port
 
-	dir, err := ioutil.TempDir("", "oci-repo-test")
+	dir := t.TempDir()
+
+	err := test.CopyFiles("../../test/data/zot-cve-test", path.Join(dir, "zot-cve-test"))
 	if err != nil {
 		panic(err)
 	}
-
-	err = test.CopyFiles("../../test/data/zot-cve-test", path.Join(dir, "zot-cve-test"))
-	if err != nil {
-		panic(err)
-	}
-
-	defer os.RemoveAll(dir)
 
 	conf.Storage.RootDirectory = dir
 	cveConfig := &extconf.CVEConfig{

--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -291,13 +291,7 @@ func TestServerResponse(t *testing.T) {
 			Search: &extconf.SearchConfig{Enable: &defaultVal},
 		}
 		ctlr := api.NewController(conf)
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-
-		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
 		go func(controller *api.Controller) {
 			// this blocks
 			if err := controller.Run(); err != nil {
@@ -329,7 +323,7 @@ func TestServerResponse(t *testing.T) {
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
 			cmd.SetArgs(args)
-			err = cmd.Execute()
+			err := cmd.Execute()
 			So(err, ShouldBeNil)
 			space := regexp.MustCompile(`\s+`)
 			str := space.ReplaceAllString(buff.String(), " ")
@@ -348,7 +342,7 @@ func TestServerResponse(t *testing.T) {
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
 			cmd.SetArgs(args)
-			err = cmd.Execute()
+			err := cmd.Execute()
 			So(err, ShouldBeNil)
 			space := regexp.MustCompile(`\s+`)
 			str := space.ReplaceAllString(buff.String(), " ")
@@ -373,7 +367,7 @@ func TestServerResponse(t *testing.T) {
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
 			cmd.SetArgs(args)
-			err = cmd.Execute()
+			err := cmd.Execute()
 			So(err, ShouldBeNil)
 			space := regexp.MustCompile(`\s+`)
 			str := space.ReplaceAllString(buff.String(), " ")
@@ -411,7 +405,7 @@ func TestServerResponse(t *testing.T) {
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
 			cmd.SetArgs(args)
-			err = cmd.Execute()
+			err := cmd.Execute()
 			So(err, ShouldBeNil)
 			space := regexp.MustCompile(`\s+`)
 			str := space.ReplaceAllString(buff.String(), " ")
@@ -452,7 +446,7 @@ func TestServerResponse(t *testing.T) {
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
 			cmd.SetArgs(args)
-			err = cmd.Execute()
+			err := cmd.Execute()
 			So(err, ShouldNotBeNil)
 			actual := buff.String()
 			So(actual, ShouldContainSubstring, "unknown")

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -398,12 +398,7 @@ func TestScrub(t *testing.T) {
 			config.HTTP.Port = port
 			controller := api.NewController(config)
 
-			dir, err := ioutil.TempDir("", "scrub-test")
-			if err != nil {
-				panic(err)
-			}
-
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			controller.Config.Storage.RootDirectory = dir
 			go func(controller *api.Controller) {
@@ -480,11 +475,7 @@ func TestScrub(t *testing.T) {
 		Convey("bad index.json", func(c C) {
 			port := GetFreePort()
 
-			dir, err := ioutil.TempDir("", "scrub-test")
-			if err != nil {
-				panic(err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			repoName := "badIndex"
 

--- a/pkg/compliance/v1_0_0/check_test.go
+++ b/pkg/compliance/v1_0_0/check_test.go
@@ -2,7 +2,6 @@ package v1_0_0_test
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"testing"
@@ -25,7 +24,7 @@ var (
 )
 
 func TestWorkflows(t *testing.T) {
-	ctrl, randomPort := startServer()
+	ctrl, randomPort := startServer(t)
 	defer stopServer(ctrl)
 
 	storageInfo := []string{defaultDir, firstDir, secondDir}
@@ -38,7 +37,7 @@ func TestWorkflows(t *testing.T) {
 }
 
 func TestWorkflowsOutputJSON(t *testing.T) {
-	ctrl, randomPort := startServer()
+	ctrl, randomPort := startServer(t)
 	defer stopServer(ctrl)
 
 	storageInfo := []string{defaultDir, firstDir, secondDir}
@@ -52,7 +51,9 @@ func TestWorkflowsOutputJSON(t *testing.T) {
 }
 
 // start local server on random open port.
-func startServer() (*api.Controller, string) {
+func startServer(t *testing.T) (*api.Controller, string) {
+	t.Helper()
+
 	port := GetFreePort()
 	baseURL := GetBaseURL(port)
 	conf := config.New()
@@ -60,25 +61,13 @@ func startServer() (*api.Controller, string) {
 	conf.HTTP.Port = port
 	ctrl := api.NewController(conf)
 
-	dir, err := ioutil.TempDir("", "oci-repo-test")
-	if err != nil {
-		panic(err)
-	}
-
+	dir := t.TempDir()
 	defaultDir = dir
 
-	firstSubDir, err := ioutil.TempDir("", "oci-repo-test")
-	if err != nil {
-		panic(err)
-	}
-
+	firstSubDir := t.TempDir()
 	firstDir = firstSubDir
 
-	secondSubDir, err := ioutil.TempDir("", "oci-repo-test")
-	if err != nil {
-		panic(err)
-	}
-
+	secondSubDir := t.TempDir()
 	secondDir = secondSubDir
 
 	subPaths := make(map[string]config.StorageConfig)

--- a/pkg/exporter/api/controller_test.go
+++ b/pkg/exporter/api/controller_test.go
@@ -8,10 +8,8 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -85,8 +83,7 @@ func TestNewExporter(t *testing.T) {
 		exporterPort := GetFreePort()
 		serverPort := GetFreePort()
 		exporterConfig.Exporter.Port = exporterPort
-		dir, _ := ioutil.TempDir("", "metrics")
-		exporterConfig.Exporter.Metrics.Path = strings.TrimPrefix(dir, "/tmp/")
+		exporterConfig.Exporter.Metrics.Path = strings.TrimPrefix(t.TempDir(), "/tmp/")
 		exporterConfig.Server.Port = serverPort
 		exporterController := api.NewController(exporterConfig)
 
@@ -126,9 +123,7 @@ func TestNewExporter(t *testing.T) {
 				serverController := zotapi.NewController(servercConfig)
 				So(serverController, ShouldNotBeNil)
 
-				dir, err := ioutil.TempDir("", "exporter-test")
-				So(err, ShouldBeNil)
-				defer os.RemoveAll(dir)
+				dir := t.TempDir()
 				serverController.Config.Storage.RootDirectory = dir
 				go func(c *zotapi.Controller) {
 					// this blocks

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -5,9 +5,7 @@ package monitoring_test
 
 import (
 	"context"
-	"io/ioutil"
 	"net/http"
-	"os"
 	"path"
 	"testing"
 	"time"
@@ -28,11 +26,7 @@ func TestExtensionMetrics(t *testing.T) {
 		conf := config.New()
 		conf.HTTP.Port = port
 
-		rootDir, err := ioutil.TempDir("", "metrics-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(rootDir)
+		rootDir := t.TempDir()
 
 		conf.Storage.RootDirectory = rootDir
 		conf.Extensions = &extconf.ExtensionConfig{}
@@ -61,7 +55,7 @@ func TestExtensionMetrics(t *testing.T) {
 		monitoring.IncDownloadCounter(ctlr.Metrics, "alpine")
 		monitoring.IncUploadCounter(ctlr.Metrics, "alpine")
 
-		err = test.CopyFiles("../../../test/data/zot-test", path.Join(rootDir, "alpine"))
+		err := test.CopyFiles("../../../test/data/zot-test", path.Join(rootDir, "alpine"))
 		if err != nil {
 			panic(err)
 		}
@@ -88,13 +82,7 @@ func TestExtensionMetrics(t *testing.T) {
 		conf := config.New()
 		conf.HTTP.Port = port
 
-		rootDir, err := ioutil.TempDir("", "metrics-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(rootDir)
-
-		conf.Storage.RootDirectory = rootDir
+		conf.Storage.RootDirectory = t.TempDir()
 		conf.Extensions = &extconf.ExtensionConfig{}
 		var disabled bool
 		conf.Extensions.Metrics = &extconf.MetricsConfig{Enable: &disabled}

--- a/pkg/extensions/search/common/common_test.go
+++ b/pkg/extensions/search/common/common_test.go
@@ -6,7 +6,6 @@ package common_test
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -66,22 +65,17 @@ type ImageInfo struct {
 	Labels      string
 }
 
-func testSetup() error {
-	dir, err := ioutil.TempDir("", "search_test")
-	if err != nil {
-		return err
-	}
+func testSetup(t *testing.T) error {
+	t.Helper()
+	dir := t.TempDir()
 
-	subDir, err := ioutil.TempDir("", "sub_search_test")
-	if err != nil {
-		return err
-	}
+	subDir := t.TempDir()
 
 	rootDir = dir
 
 	subRootDir = subDir
 
-	err = CopyFiles("../../../../test/data", rootDir)
+	err := CopyFiles("../../../../test/data", rootDir)
 	if err != nil {
 		return err
 	}
@@ -184,7 +178,7 @@ func TestImageFormat(t *testing.T) {
 
 func TestLatestTagSearchHTTP(t *testing.T) {
 	Convey("Test latest image search by timestamp", t, func() {
-		err := testSetup()
+		err := testSetup(t)
 		if err != nil {
 			panic(err)
 		}
@@ -322,7 +316,7 @@ func TestLatestTagSearchHTTP(t *testing.T) {
 
 func TestExpandedRepoInfo(t *testing.T) {
 	Convey("Test expanded repo info", t, func() {
-		err := testSetup()
+		err := testSetup(t)
 		if err != nil {
 			panic(err)
 		}
@@ -512,17 +506,9 @@ func TestUtilsMethod(t *testing.T) {
 
 		log := log.NewLogger("debug", "")
 
-		rootDir, err := ioutil.TempDir("", "common_utils_test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(rootDir)
+		rootDir := t.TempDir()
 
-		subRootDir, err := ioutil.TempDir("", "common_utils_test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(subRootDir)
+		subRootDir := t.TempDir()
 
 		metrics := monitoring.NewMetricsServer(false, log)
 		defaultStore := storage.NewImageStore(rootDir, false, storage.DefaultGCDelay, false, false, log, metrics)

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -325,23 +325,9 @@ func makeTestFile(fileName string, content string) error {
 func TestMultipleStoragePath(t *testing.T) {
 	Convey("Test multiple storage path", t, func() {
 		// Create temporary directory
-		firstRootDir, err := ioutil.TempDir("", "util_test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(firstRootDir)
-
-		secondRootDir, err := ioutil.TempDir("", "util_test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(secondRootDir)
-
-		thirdRootDir, err := ioutil.TempDir("", "util_test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(thirdRootDir)
+		firstRootDir := t.TempDir()
+		secondRootDir := t.TempDir()
+		thirdRootDir := t.TempDir()
 
 		log := log.NewLogger("debug", "")
 		metrics := monitoring.NewMetricsServer(false, log)
@@ -628,19 +614,11 @@ func TestCVEConfig(t *testing.T) {
 
 		ctlr := api.NewController(conf)
 
-		firstDir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
+		firstDir := t.TempDir()
 
-		secondDir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(firstDir)
-		defer os.RemoveAll(secondDir)
+		secondDir := t.TempDir()
 
-		err = CopyFiles("../../../../test/data", path.Join(secondDir, "a"))
+		err := CopyFiles("../../../../test/data", path.Join(secondDir, "a"))
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/extensions/search/digest/digest_test.go
+++ b/pkg/extensions/search/digest/digest_test.go
@@ -342,13 +342,11 @@ func TestDigestSearchHTTPSubPaths(t *testing.T) {
 func TestDigestSearchDisabled(t *testing.T) {
 	Convey("Test disabling image search", t, func() {
 		var disabled bool
-		dir, err := ioutil.TempDir("", "digest_test")
-		So(err, ShouldBeNil)
 		port := GetFreePort()
 		baseURL := GetBaseURL(port)
 		conf := config.New()
 		conf.HTTP.Port = port
-		conf.Storage.RootDirectory = dir
+		conf.Storage.RootDirectory = t.TempDir()
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: &extconf.SearchConfig{Enable: &disabled},
 		}

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -43,12 +43,8 @@ type AuditLog struct {
 
 func TestAuditLogMessages(t *testing.T) {
 	Convey("Make a new controller", t, func() {
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
-		err = CopyFiles("../../test/data", dir)
+		dir := t.TempDir()
+		err := CopyFiles("../../test/data", dir)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -1,8 +1,6 @@
 package storage_test
 
 import (
-	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -14,10 +12,7 @@ import (
 
 func TestCache(t *testing.T) {
 	Convey("Make a new cache", t, func() {
-		dir, err := ioutil.TempDir("", "cache_test")
-		So(err, ShouldBeNil)
-		So(dir, ShouldNotBeEmpty)
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		log := log.NewLogger("debug", "")
 		So(log, ShouldNotBeNil)

--- a/pkg/storage/scrub_test.go
+++ b/pkg/storage/scrub_test.go
@@ -25,12 +25,7 @@ const (
 )
 
 func TestCheckAllBlobsIntegrity(t *testing.T) {
-	dir, err := ioutil.TempDir("", "scrub-test")
-	if err != nil {
-		panic(err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	log := log.NewLogger("debug", "")
 
@@ -40,7 +35,7 @@ func TestCheckAllBlobsIntegrity(t *testing.T) {
 
 	Convey("Scrub only one repo", t, func(c C) {
 		// initialize repo
-		err = imgStore.InitRepo(repoName)
+		err := imgStore.InitRepo(repoName)
 		So(err, ShouldBeNil)
 		ok := imgStore.DirExists(path.Join(imgStore.RootDir(), repoName))
 		So(ok, ShouldBeTrue)

--- a/pkg/storage/storage_fs_test.go
+++ b/pkg/storage/storage_fs_test.go
@@ -30,12 +30,7 @@ const (
 )
 
 func TestStorageFSAPIs(t *testing.T) {
-	dir, err := ioutil.TempDir("", "oci-repo-test")
-	if err != nil {
-		panic(err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	log := log.Logger{Logger: zerolog.New(os.Stdout)}
 	metrics := monitoring.NewMetricsServer(false, log)
@@ -167,12 +162,7 @@ func TestStorageFSAPIs(t *testing.T) {
 }
 
 func TestDedupeLinks(t *testing.T) {
-	dir, err := ioutil.TempDir("", "oci-repo-test")
-	if err != nil {
-		panic(err)
-	}
-
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	log := log.Logger{Logger: zerolog.New(os.Stdout)}
 	metrics := monitoring.NewMetricsServer(false, log)
@@ -308,11 +298,7 @@ func TestDedupe(t *testing.T) {
 		})
 
 		Convey("Valid ImageStore", func() {
-			dir, err := ioutil.TempDir("", "oci-repo-test")
-			if err != nil {
-				panic(err)
-			}
-			defer os.RemoveAll(dir)
+			dir := t.TempDir()
 
 			log := log.Logger{Logger: zerolog.New(os.Stdout)}
 			metrics := monitoring.NewMetricsServer(false, log)
@@ -326,11 +312,7 @@ func TestDedupe(t *testing.T) {
 // nolint: gocyclo
 func TestNegativeCases(t *testing.T) {
 	Convey("Invalid root dir", t, func(c C) {
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
@@ -342,17 +324,13 @@ func TestNegativeCases(t *testing.T) {
 	})
 
 	Convey("Invalid init repo", t, func(c C) {
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
 		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
 
-		err = os.Chmod(dir, 0o000) // remove all perms
+		err := os.Chmod(dir, 0o000) // remove all perms
 		if err != nil {
 			panic(err)
 		}
@@ -381,11 +359,7 @@ func TestNegativeCases(t *testing.T) {
 	})
 
 	Convey("Invalid validate repo", t, func(c C) {
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
@@ -394,7 +368,7 @@ func TestNegativeCases(t *testing.T) {
 		So(imgStore, ShouldNotBeNil)
 		So(imgStore.InitRepo("test"), ShouldBeNil)
 
-		err = os.MkdirAll(path.Join(dir, "invalid-test"), 0o755)
+		err := os.MkdirAll(path.Join(dir, "invalid-test"), 0o755)
 		So(err, ShouldBeNil)
 
 		err = os.Chmod(path.Join(dir, "invalid-test"), 0o000) // remove all perms
@@ -499,11 +473,7 @@ func TestNegativeCases(t *testing.T) {
 		_, err := ilfs.GetImageTags("test")
 		So(err, ShouldNotBeNil)
 
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
@@ -526,11 +496,7 @@ func TestNegativeCases(t *testing.T) {
 		_, _, _, err := ilfs.GetImageManifest("test", "")
 		So(err, ShouldNotBeNil)
 
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
@@ -571,11 +537,7 @@ func TestNegativeCases(t *testing.T) {
 	})
 
 	Convey("Invalid new blob upload", t, func(c C) {
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
@@ -584,7 +546,7 @@ func TestNegativeCases(t *testing.T) {
 		So(imgStore, ShouldNotBeNil)
 		So(imgStore.InitRepo("test"), ShouldBeNil)
 
-		err = os.Chmod(path.Join(dir, "test", ".uploads"), 0o000)
+		err := os.Chmod(path.Join(dir, "test", ".uploads"), 0o000)
 		if err != nil {
 			panic(err)
 		}
@@ -621,6 +583,12 @@ func TestNegativeCases(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
+		t.Cleanup(func() {
+			err = os.Chmod(path.Join(dir, "test", ".uploads"), 0o700)
+			if err != nil {
+				panic(err)
+			}
+		})
 
 		content := []byte("test-data3")
 		buf := bytes.NewBuffer(content)
@@ -633,11 +601,7 @@ func TestNegativeCases(t *testing.T) {
 	})
 
 	Convey("Invalid dedupe scenarios", t, func() {
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
@@ -710,14 +674,10 @@ func TestNegativeCases(t *testing.T) {
 	})
 
 	Convey("DirExists call with a filename as argument", t, func(c C) {
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		filePath := path.Join(dir, "file.txt")
-		err = ioutil.WriteFile(filePath, []byte("some dummy file content"), 0o644) //nolint: gosec
+		err := ioutil.WriteFile(filePath, []byte("some dummy file content"), 0o644) //nolint: gosec
 		if err != nil {
 			panic(err)
 		}
@@ -748,14 +708,10 @@ func TestHardLink(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 	Convey("Test that ValidateHardLink returns error if rootDir is a file", t, func() {
-		dir, err := ioutil.TempDir("", "storage-hard-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		filePath := path.Join(dir, "file.txt")
-		err = ioutil.WriteFile(filePath, []byte("some dummy file content"), 0o644) //nolint: gosec
+		err := ioutil.WriteFile(filePath, []byte("some dummy file content"), 0o644) //nolint: gosec
 		if err != nil {
 			panic(err)
 		}
@@ -764,13 +720,9 @@ func TestHardLink(t *testing.T) {
 		So(err, ShouldNotBeNil)
 	})
 	Convey("Test if filesystem supports hardlink", t, func() {
-		dir, err := ioutil.TempDir("", "storage-hard-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
-		err = storage.ValidateHardLink(dir)
+		err := storage.ValidateHardLink(dir)
 		So(err, ShouldBeNil)
 
 		err = ioutil.WriteFile(path.Join(dir, "hardtest.txt"), []byte("testing hard link code"), 0o644) //nolint: gosec
@@ -782,6 +734,13 @@ func TestHardLink(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
+		// Allow hardtest.txt to be cleaned up by t.TempDir()
+		t.Cleanup(func() {
+			err = os.Chmod(dir, 0o700)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
 
 		err = os.Link(path.Join(dir, "hardtest.txt"), path.Join(dir, "duphardtest.txt"))
 		So(err, ShouldNotBeNil)
@@ -795,9 +754,7 @@ func TestHardLink(t *testing.T) {
 
 func TestInjectWriteFile(t *testing.T) {
 	Convey("writeFile with commit", t, func() {
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
@@ -827,9 +784,7 @@ func TestInjectWriteFile(t *testing.T) {
 	})
 
 	Convey("writeFile without commit", t, func() {
-		dir, err := ioutil.TempDir("", "oci-repo-test")
-		So(err, ShouldBeNil)
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
@@ -844,12 +799,7 @@ func TestInjectWriteFile(t *testing.T) {
 
 func TestGarbageCollect(t *testing.T) {
 	Convey("Repo layout", t, func(c C) {
-		dir, err := ioutil.TempDir("", "oci-gc-test")
-		if err != nil {
-			panic(err)
-		}
-
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -6,7 +6,6 @@ import (
 	_ "crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -111,12 +110,7 @@ func TestStorageAPIs(t *testing.T) {
 				store, imgStore, _ = createObjectsStore(testDir)
 				defer cleanupStorage(store, testDir)
 			} else {
-				dir, err := ioutil.TempDir("", "oci-repo-test")
-				if err != nil {
-					panic(err)
-				}
-
-				defer os.RemoveAll(dir)
+				dir := t.TempDir()
 
 				log := log.Logger{Logger: zerolog.New(os.Stdout)}
 				metrics := monitoring.NewMetricsServer(false, log)
@@ -686,25 +680,9 @@ func TestStorageHandler(t *testing.T) {
 				defer cleanupStorage(thirdStorageDriver, thirdRootDir)
 			} else {
 				// Create temporary directory
-				var err error
-
-				firstRootDir, err = ioutil.TempDir("", "util_test")
-				if err != nil {
-					panic(err)
-				}
-				defer os.RemoveAll(firstRootDir)
-
-				secondRootDir, err = ioutil.TempDir("", "util_test")
-				if err != nil {
-					panic(err)
-				}
-				defer os.RemoveAll(secondRootDir)
-
-				thirdRootDir, err = ioutil.TempDir("", "util_test")
-				if err != nil {
-					panic(err)
-				}
-				defer os.RemoveAll(thirdRootDir)
+				firstRootDir = t.TempDir()
+				secondRootDir = t.TempDir()
+				thirdRootDir = t.TempDir()
 
 				log := log.NewLogger("debug", "")
 

--- a/pkg/test/common_test.go
+++ b/pkg/test/common_test.go
@@ -19,56 +19,40 @@ func TestCopyFiles(t *testing.T) {
 		So(err, ShouldNotBeNil)
 	})
 	Convey("destDir is a file", t, func() {
-		dir, err := ioutil.TempDir("", "copy-files-test")
+		dir := t.TempDir()
+
+		err := test.CopyFiles("../../test/data", dir)
 		if err != nil {
 			panic(err)
 		}
 
-		err = test.CopyFiles("../../test/data", dir)
-		if err != nil {
-			panic(err)
-		}
-
-		defer os.RemoveAll(dir)
 		err = test.CopyFiles(dir, "/etc/passwd")
 		So(err, ShouldNotBeNil)
 	})
 	Convey("sourceDir does not have read permissions", t, func() {
-		dir, err := ioutil.TempDir("", "copy-files-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
-		err = os.Chmod(dir, 0o300)
+		err := os.Chmod(dir, 0o300)
 		So(err, ShouldBeNil)
 
 		err = test.CopyFiles(dir, os.TempDir())
 		So(err, ShouldNotBeNil)
 	})
 	Convey("sourceDir has a subfolder that does not have read permissions", t, func() {
-		dir, err := ioutil.TempDir("", "copy-files-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		sdir := "subdir"
-		err = os.Mkdir(path.Join(dir, sdir), 0o300)
+		err := os.Mkdir(path.Join(dir, sdir), 0o300)
 		So(err, ShouldBeNil)
 
 		err = test.CopyFiles(dir, os.TempDir())
 		So(err, ShouldNotBeNil)
 	})
 	Convey("sourceDir has a file that does not have read permissions", t, func() {
-		dir, err := ioutil.TempDir("", "copy-files-test")
-		if err != nil {
-			panic(err)
-		}
-		defer os.RemoveAll(dir)
+		dir := t.TempDir()
 
 		filePath := path.Join(dir, "file.txt")
-		err = ioutil.WriteFile(filePath, []byte("some dummy file content"), 0o644) //nolint: gosec
+		err := ioutil.WriteFile(filePath, []byte("some dummy file content"), 0o644) //nolint: gosec
 		if err != nil {
 			panic(err)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

cleanup

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:

This PR does not break upgrades or downgrades.

**Does this change require updates to the CNI daemonset config files to work?**:

No.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

No.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
