### PR TITLE
[cloud usecase] zot cli should not download manifests when listing images

### DIFF
--- a/golangcilint.yaml
+++ b/golangcilint.yaml
@@ -50,6 +50,7 @@ linters-settings:
       - github.com/containers/image/v5
       - github.com/opencontainers/image-spec
       - github.com/open-policy-agent/opa
+      - github.com/vektah/gqlparser/v2
       - go.opentelemetry.io/otel
       - go.opentelemetry.io/otel/exporters/otlp
       - go.opentelemetry.io/otel/metric

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -283,16 +284,12 @@ func (p *requestsPool) doJob(ctx context.Context, job *manifestJob) {
 
 	image := &imageStruct{}
 	image.verbose = *job.config.verbose
-	image.Name = job.imageName
-	image.Tags = []tags{
-		{
-			Name:         job.tagName,
-			Digest:       digest,
-			Size:         size,
-			ConfigDigest: configDigest,
-			Layers:       layers,
-		},
-	}
+	image.RepoName = job.imageName
+	image.Tag = job.tagName
+	image.Digest = digest
+	image.Size = strconv.Itoa(int(size))
+	image.ConfigDigest = configDigest
+	image.Layers = layers
 
 	str, err := image.string(*job.config.outputFormat)
 	if err != nil {

--- a/pkg/cli/client_test.go
+++ b/pkg/cli/client_test.go
@@ -20,6 +20,7 @@ import (
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"
+	extConf "zotregistry.io/zot/pkg/extensions/config"
 	"zotregistry.io/zot/pkg/test"
 )
 
@@ -67,6 +68,11 @@ func TestTLSWithAuth(t *testing.T) {
 			Cert:   ServerCert,
 			Key:    ServerKey,
 			CACert: CACert,
+		}
+
+		enable := true
+		conf.Extensions = &extConf.ExtensionConfig{
+			Search: &extConf.SearchConfig{Enable: &enable},
 		}
 
 		ctlr := api.NewController(conf)
@@ -159,6 +165,11 @@ func TestTLSWithoutAuth(t *testing.T) {
 			Cert:   ServerCert,
 			Key:    ServerKey,
 			CACert: CACert,
+		}
+
+		enable := true
+		conf.Extensions = &extConf.ExtensionConfig{
+			Search: &extConf.SearchConfig{Enable: &enable},
 		}
 
 		ctlr := api.NewController(conf)

--- a/pkg/cli/cve_cmd.go
+++ b/pkg/cli/cve_cmd.go
@@ -4,13 +4,18 @@
 package cli
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/url"
 	"os"
 	"path"
 
 	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
+	"gopkg.in/resty.v1"
 	zotErrors "zotregistry.io/zot/errors"
+	"zotregistry.io/zot/pkg/api/constants"
 )
 
 func NewCveCommand(searchService SearchService) *cobra.Command {
@@ -68,7 +73,8 @@ func NewCveCommand(searchService SearchService) *cobra.Command {
 			}
 
 			spin := spinner.New(spinner.CharSets[39], spinnerDuration, spinner.WithWriter(cmd.ErrOrStderr()))
-			spin.Prefix = fmt.Sprintf("Fetching from %s.. ", servURL)
+			spin.Prefix = fmt.Sprintf("Fetching from %s..", servURL)
+			spin.Suffix = "\n\b"
 
 			verbose = false
 
@@ -112,7 +118,7 @@ func NewCveCommand(searchService SearchService) *cobra.Command {
 
 func setupCveFlags(cveCmd *cobra.Command, variables cveFlagVariables) {
 	variables.searchCveParams["imageName"] = cveCmd.Flags().StringP("image", "I", "", "List CVEs by IMAGENAME[:TAG]")
-	variables.searchCveParams["cvid"] = cveCmd.Flags().StringP("cve-id", "i", "", "List images affected by a CVE")
+	variables.searchCveParams["cveID"] = cveCmd.Flags().StringP("cve-id", "i", "", "List images affected by a CVE")
 
 	cveCmd.Flags().StringVar(variables.servURL, "url", "", "Specify zot server URL if config-name is not mentioned")
 	cveCmd.Flags().StringVarP(variables.user, "user", "u", "", `User Credentials of `+
@@ -131,8 +137,80 @@ type cveFlagVariables struct {
 	fixedFlag       *bool
 }
 
+type field struct {
+	Name string `json:"name"`
+}
+
+type schemaList struct {
+	Data struct {
+		Schema struct {
+			QueryType struct {
+				Fields []field `json:"fields"`
+			} `json:"queryType"` //nolint:tagliatelle // graphQL schema
+		} `json:"__schema"` //nolint:tagliatelle // graphQL schema
+	} `json:"data"`
+}
+
+func containsGQLQuery(queryList []field, query string) bool {
+	for _, q := range queryList {
+		if q.Name == query {
+			return true
+		}
+	}
+
+	return false
+}
+
+func checkExtEndPoint(serverURL string) bool {
+	client := resty.New()
+
+	extEndPoint, err := combineServerAndEndpointURL(serverURL, fmt.Sprintf("%s%s",
+		constants.RoutePrefix, constants.ExtOciDiscoverPrefix))
+	if err != nil {
+		return false
+	}
+
+	// nolint: gosec
+	resp, err := client.R().Get(extEndPoint)
+	if err != nil || resp.StatusCode() != http.StatusOK {
+		return false
+	}
+
+	searchEndPoint, _ := combineServerAndEndpointURL(serverURL, constants.ExtSearchPrefix)
+
+	query := `
+        {
+            __schema() {
+                queryType {
+                    fields {
+                        name
+                    }
+                }
+            }
+        }`
+
+	resp, err = client.R().Get(searchEndPoint + "?query=" + url.QueryEscape(query))
+	if err != nil || resp.StatusCode() != http.StatusOK {
+		return false
+	}
+
+	queryList := &schemaList{}
+
+	_ = json.Unmarshal(resp.Body(), queryList)
+
+	return containsGQLQuery(queryList.Data.Schema.QueryType.Fields, "ImageList")
+}
+
 func searchCve(searchConfig searchConfig) error {
-	for _, searcher := range getCveSearchers() {
+	var searchers []searcher
+
+	if checkExtEndPoint(*searchConfig.servURL) {
+		searchers = getCveSearchersGQL()
+	} else {
+		searchers = getCveSearchers()
+	}
+
+	for _, searcher := range searchers {
 		found, err := searcher.search(searchConfig)
 		if found {
 			if err != nil {

--- a/pkg/cli/image_cmd.go
+++ b/pkg/cli/image_cmd.go
@@ -129,7 +129,15 @@ func setupImageFlags(imageCmd *cobra.Command, searchImageParams map[string]*stri
 }
 
 func searchImage(searchConfig searchConfig) error {
-	for _, searcher := range getImageSearchers() {
+	var searchers []searcher
+
+	if checkExtEndPoint(*searchConfig.servURL) {
+		searchers = getImageSearchersGQL()
+	} else {
+		searchers = getImageSearchers()
+	}
+
+	for _, searcher := range searchers {
 		found, err := searcher.search(searchConfig)
 		if found {
 			if err != nil {

--- a/pkg/extensions/search/common/common.go
+++ b/pkg/extensions/search/common/common.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-	"path"
 	"sort"
 	"strings"
 	"time"
@@ -23,14 +22,6 @@ type TagInfo struct {
 	Name      string
 	Digest    string
 	Timestamp time.Time
-}
-
-func GetImageRepoPath(image string, storeController storage.StoreController) string {
-	rootDir := GetRootDir(image, storeController)
-
-	repo := GetRepo(image)
-
-	return path.Join(rootDir, repo)
 }
 
 func GetRootDir(image string, storeController storage.StoreController) string {

--- a/pkg/extensions/search/common/common_test.go
+++ b/pkg/extensions/search/common/common_test.go
@@ -97,7 +97,7 @@ type RepoSummary struct {
 	Platforms   []OsArch     `json:"platforms"`
 	Vendors     []string     `json:"vendors"`
 	Score       int          `json:"score"`
-	NewestTag   ImageSummary `json:"newestTag"`
+	NewestImage ImageSummary `json:"newestImage"`
 }
 
 type LayerSummary struct {
@@ -126,8 +126,8 @@ type ErrorGQL struct {
 }
 
 type ImageInfo struct {
-	Name        string
-	Latest      string
+	RepoName    string
+	Tag         string
 	LastUpdated time.Time
 	Description string
 	Licenses    string
@@ -377,7 +377,7 @@ func TestLatestTagSearchHTTP(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, 422)
 
-		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){Name%20Latest}}")
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){RepoName%20Tag}}")
 		So(resp, ShouldNotBeNil)
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
@@ -388,9 +388,9 @@ func TestLatestTagSearchHTTP(t *testing.T) {
 		So(len(responseStruct.ImgListWithLatestTag.Images), ShouldEqual, 4)
 
 		images := responseStruct.ImgListWithLatestTag.Images
-		So(images[0].Latest, ShouldEqual, "0.0.1")
+		So(images[0].Tag, ShouldEqual, "0.0.1")
 
-		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){Name%20Latest}}")
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){RepoName%20Tag}}")
 		So(resp, ShouldNotBeNil)
 		So(err, ShouldBeNil)
 
@@ -399,7 +399,7 @@ func TestLatestTagSearchHTTP(t *testing.T) {
 			panic(err)
 		}
 
-		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){Name%20Latest}}")
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){RepoName%20Tag}}")
 		So(resp, ShouldNotBeNil)
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
@@ -423,7 +423,7 @@ func TestLatestTagSearchHTTP(t *testing.T) {
 			panic(err)
 		}
 
-		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){Name%20Latest}}")
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){RepoName%20Tag}}")
 		So(resp, ShouldNotBeNil)
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
@@ -434,7 +434,7 @@ func TestLatestTagSearchHTTP(t *testing.T) {
 			panic(err)
 		}
 
-		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){Name%20Latest}}")
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){RepoName%20Tag}}")
 		So(resp, ShouldNotBeNil)
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
@@ -444,7 +444,7 @@ func TestLatestTagSearchHTTP(t *testing.T) {
 			panic(err)
 		}
 
-		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){Name%20Latest}}")
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){RepoName%20Tag}}")
 		So(resp, ShouldNotBeNil)
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
@@ -455,7 +455,7 @@ func TestLatestTagSearchHTTP(t *testing.T) {
 			panic(err)
 		}
 
-		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){Name%20Latest}}")
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query={ImageListWithLatestTag(){RepoName%20Tag}}")
 		So(resp, ShouldNotBeNil)
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
@@ -532,7 +532,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		So(responseStruct.ExpandedRepoInfo.RepoInfo.Summary.Name, ShouldEqual, "zot-cve-test")
 		So(responseStruct.ExpandedRepoInfo.RepoInfo.Summary.Score, ShouldEqual, -1)
 
-		query = "{ExpandedRepoInfo(repo:\"zot-cve-test\"){Manifests%20{Digest%20IsSigned%20Tag%20Layers%20{Size%20Digest}}}}"
+		query = "{ExpandedRepoInfo(repo:\"zot-cve-test\"){Images%20{Digest%20IsSigned%20Tag%20Layers%20{Size%20Digest}}}}"
 
 		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + query)
 		So(resp, ShouldNotBeNil)
@@ -543,10 +543,10 @@ func TestExpandedRepoInfo(t *testing.T) {
 
 		err = json.Unmarshal(resp.Body(), responseStruct)
 		So(err, ShouldBeNil)
-		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Manifests), ShouldNotEqual, 0)
-		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Manifests[0].Layers), ShouldNotEqual, 0)
+		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Images), ShouldNotEqual, 0)
+		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Images[0].Layers), ShouldNotEqual, 0)
 		found := false
-		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.Manifests {
+		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.Images {
 			if m.Digest == "63a795ca90aa6e7cca60941e826810a4cd0a2e73ea02bf458241df2a5c973e29" {
 				found = true
 				So(m.IsSigned, ShouldEqual, false)
@@ -564,10 +564,10 @@ func TestExpandedRepoInfo(t *testing.T) {
 
 		err = json.Unmarshal(resp.Body(), responseStruct)
 		So(err, ShouldBeNil)
-		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Manifests), ShouldNotEqual, 0)
-		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Manifests[0].Layers), ShouldNotEqual, 0)
+		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Images), ShouldNotEqual, 0)
+		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Images[0].Layers), ShouldNotEqual, 0)
 		found = false
-		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.Manifests {
+		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.Images {
 			if m.Digest == "63a795ca90aa6e7cca60941e826810a4cd0a2e73ea02bf458241df2a5c973e29" {
 				found = true
 				So(m.IsSigned, ShouldEqual, true)
@@ -575,14 +575,14 @@ func TestExpandedRepoInfo(t *testing.T) {
 		}
 		So(found, ShouldEqual, true)
 
-		query = "{ExpandedRepoInfo(repo:\"\"){Manifests%20{Digest%20Tag%20IsSigned%20Layers%20{Size%20Digest}}}}"
+		query = "{ExpandedRepoInfo(repo:\"\"){Images%20{Digest%20Tag%20IsSigned%20Layers%20{Size%20Digest}}}}"
 
 		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + query)
 		So(resp, ShouldNotBeNil)
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
-		query = "{ExpandedRepoInfo(repo:\"zot-test\"){Manifests%20{Digest%20Tag%20IsSigned%20Layers%20{Size%20Digest}}}}"
+		query = "{ExpandedRepoInfo(repo:\"zot-test\"){Images%20{Digest%20Tag%20IsSigned%20Layers%20{Size%20Digest}}}}"
 		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + query)
 		So(resp, ShouldNotBeNil)
 		So(err, ShouldBeNil)
@@ -590,10 +590,10 @@ func TestExpandedRepoInfo(t *testing.T) {
 
 		err = json.Unmarshal(resp.Body(), responseStruct)
 		So(err, ShouldBeNil)
-		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Manifests), ShouldNotEqual, 0)
-		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Manifests[0].Layers), ShouldNotEqual, 0)
+		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Images), ShouldNotEqual, 0)
+		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Images[0].Layers), ShouldNotEqual, 0)
 		found = false
-		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.Manifests {
+		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.Images {
 			if m.Digest == "2bacca16b9df395fc855c14ccf50b12b58d35d468b8e7f25758aff90f89bf396" {
 				found = true
 				So(m.IsSigned, ShouldEqual, false)
@@ -611,10 +611,10 @@ func TestExpandedRepoInfo(t *testing.T) {
 
 		err = json.Unmarshal(resp.Body(), responseStruct)
 		So(err, ShouldBeNil)
-		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Manifests), ShouldNotEqual, 0)
-		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Manifests[0].Layers), ShouldNotEqual, 0)
+		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Images), ShouldNotEqual, 0)
+		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.Images[0].Layers), ShouldNotEqual, 0)
 		found = false
-		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.Manifests {
+		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.Images {
 			if m.Digest == "2bacca16b9df395fc855c14ccf50b12b58d35d468b8e7f25758aff90f89bf396" {
 				found = true
 				So(m.IsSigned, ShouldEqual, true)
@@ -832,7 +832,7 @@ func TestGlobalSearch(t *testing.T) {
       					}
       					Vendors
 						Score
-						NewestTag {
+						NewestImage {
 							RepoName
 							Tag
 							LastUpdated
@@ -911,14 +911,14 @@ func TestGlobalSearch(t *testing.T) {
 			So(repo.Vendors[0], ShouldEqual, image.Vendor)
 			So(repo.Platforms[0].Os, ShouldEqual, image.Platform.Os)
 			So(repo.Platforms[0].Arch, ShouldEqual, image.Platform.Arch)
-			So(repo.NewestTag.RepoName, ShouldEqual, image.RepoName)
-			So(repo.NewestTag.Tag, ShouldEqual, image.Tag)
-			So(repo.NewestTag.LastUpdated, ShouldEqual, image.LastUpdated)
-			So(repo.NewestTag.Size, ShouldEqual, image.Size)
-			So(repo.NewestTag.IsSigned, ShouldEqual, image.IsSigned)
-			So(repo.NewestTag.Vendor, ShouldEqual, image.Vendor)
-			So(repo.NewestTag.Platform.Os, ShouldEqual, image.Platform.Os)
-			So(repo.NewestTag.Platform.Arch, ShouldEqual, image.Platform.Arch)
+			So(repo.NewestImage.RepoName, ShouldEqual, image.RepoName)
+			So(repo.NewestImage.Tag, ShouldEqual, image.Tag)
+			So(repo.NewestImage.LastUpdated, ShouldEqual, image.LastUpdated)
+			So(repo.NewestImage.Size, ShouldEqual, image.Size)
+			So(repo.NewestImage.IsSigned, ShouldEqual, image.IsSigned)
+			So(repo.NewestImage.Vendor, ShouldEqual, image.Vendor)
+			So(repo.NewestImage.Platform.Os, ShouldEqual, image.Platform.Os)
+			So(repo.NewestImage.Platform.Arch, ShouldEqual, image.Platform.Arch)
 		}
 
 		// GetRepositories fail

--- a/pkg/extensions/search/common/oci_layout.go
+++ b/pkg/extensions/search/common/oci_layout.go
@@ -43,11 +43,11 @@ type BaseOciLayoutUtils struct {
 }
 
 type RepoInfo struct {
-	Manifests []Manifest `json:"manifests"`
-	Summary   RepoSummary
+	Summary RepoSummary
+	Images  []Image `json:"images"`
 }
 
-type Manifest struct {
+type Image struct {
 	Tag      string  `json:"tag"`
 	Digest   string  `json:"digest"`
 	IsSigned bool    `json:"isSigned"`
@@ -358,7 +358,7 @@ func (olu BaseOciLayoutUtils) GetExpandedRepoInfo(name string) (RepoInfo, error)
 	// made up of all manifests, configs and image layers
 	repoSize := int64(0)
 
-	manifests := make([]Manifest, 0)
+	manifests := make([]Image, 0)
 
 	tagsInfo, err := olu.GetImageTagsWithTimestamp(name)
 	if err != nil {
@@ -376,7 +376,7 @@ func (olu BaseOciLayoutUtils) GetExpandedRepoInfo(name string) (RepoInfo, error)
 	repoVendors := make([]string, 0, len(manifestList))
 
 	for _, man := range manifestList {
-		manifestInfo := Manifest{}
+		manifestInfo := Image{}
 
 		manifestInfo.Digest = man.Digest.Encoded()
 
@@ -441,7 +441,7 @@ func (olu BaseOciLayoutUtils) GetExpandedRepoInfo(name string) (RepoInfo, error)
 		manifests = append(manifests, manifestInfo)
 	}
 
-	repo.Manifests = manifests
+	repo.Images = manifests
 
 	lastUpdate, err := olu.GetRepoLastUpdated(name)
 	if err != nil {

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -46,23 +46,14 @@ type CveResult struct {
 	ImgList ImgList `json:"data"`
 }
 
-type ImgWithFixedCVE struct {
-	ImgResults ImgResults `json:"data"`
-}
-
 //nolint:tagliatelle // graphQL schema
-type ImgResults struct {
-	ImgResultForFixedCVE ImgResultForFixedCVE `json:"ImgResultForFixedCVE"`
+type ImgListWithCVEFixed struct {
+	Images []ImageInfo `json:"ImageListWithCVEFixed"`
 }
 
-//nolint:tagliatelle // graphQL schema
-type ImgResultForFixedCVE struct {
-	Tags []TagInfo `json:"Tags"`
-}
-
-type TagInfo struct {
-	Name      string
-	Timestamp time.Time
+type ImageInfo struct {
+	RepoName    string
+	LastUpdated time.Time
 }
 
 //nolint:tagliatelle // graphQL schema
@@ -470,24 +461,24 @@ func TestCVESearch(t *testing.T) {
 
 		cvid := cveResult.ImgList.CVEResultForImage.CVEList[0].ID
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-test\"){Tags{Name%20Timestamp}}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-test\"){RepoName%20LastUpdated}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
-		var imgFixedCVEResult ImgWithFixedCVE
-		err = json.Unmarshal(resp.Body(), &imgFixedCVEResult)
+		var imgListWithCVEFixed ImgListWithCVEFixed
+		err = json.Unmarshal(resp.Body(), &imgListWithCVEFixed)
 		So(err, ShouldBeNil)
-		So(len(imgFixedCVEResult.ImgResults.ImgResultForFixedCVE.Tags), ShouldEqual, 0)
+		So(len(imgListWithCVEFixed.Images), ShouldEqual, 0)
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-cve-test\"){Tags{Name%20Timestamp}}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-cve-test\"){RepoName%20LastUpdated}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
-		err = json.Unmarshal(resp.Body(), &imgFixedCVEResult)
+		err = json.Unmarshal(resp.Body(), &imgListWithCVEFixed)
 		So(err, ShouldBeNil)
-		So(len(imgFixedCVEResult.ImgResults.ImgResultForFixedCVE.Tags), ShouldEqual, 0)
+		So(len(imgListWithCVEFixed.Images), ShouldEqual, 0)
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-test\"){Tags{Name%20Timestamp}}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-test\"){RepoName%20LastUpdated}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
@@ -504,7 +495,7 @@ func TestCVESearch(t *testing.T) {
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-squashfs-noindex\"){Tags{Name%20Timestamp}}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-squashfs-noindex\"){RepoName%20LastUpdated}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
@@ -512,7 +503,7 @@ func TestCVESearch(t *testing.T) {
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-squashfs-invalid-index\"){Tags{Name%20Timestamp}}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-squashfs-invalid-index\"){RepoName%20LastUpdated}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
@@ -520,11 +511,11 @@ func TestCVESearch(t *testing.T) {
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-squashfs-noblob\"){Tags{Name%20Timestamp}}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-squashfs-noblob\"){RepoName%20LastUpdated}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-squashfs-test\"){Tags{Name%20Timestamp}}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-squashfs-test\"){RepoName%20LastUpdated}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
@@ -532,7 +523,7 @@ func TestCVESearch(t *testing.T) {
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-squashfs-invalid-blob\"){Tags{Name%20Timestamp}}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListWithCVEFixed(id:\"" + cvid + "\",image:\"zot-squashfs-invalid-blob\"){RepoName%20LastUpdated}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
@@ -544,7 +535,7 @@ func TestCVESearch(t *testing.T) {
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListForCVE(id:\"CVE-201-20482\"){Name%20Tags}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListForCVE(id:\"CVE-201-20482\"){RepoName%20Tag}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 
@@ -585,11 +576,11 @@ func TestCVESearch(t *testing.T) {
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 422)
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListForCVE(tet:\"CVE-2018-20482\"){Name%20Tags}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListForCVE(tet:\"CVE-2018-20482\"){RepoName%20Tag}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 422)
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageistForCVE(id:\"CVE-2018-20482\"){Name%20Tags}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageistForCVE(id:\"CVE-2018-20482\"){RepoName%20Tag}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 422)
 
@@ -601,7 +592,7 @@ func TestCVESearch(t *testing.T) {
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 422)
 
-		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListForCVE(id:\"" + cvid + "\"){Name%20Tags}}")
+		resp, _ = resty.R().SetBasicAuth(username, passphrase).Get(baseURL + constants.ExtSearchPrefix + "?query={ImageListForCVE(id:\"" + cvid + "\"){RepoName%20Tag}}")
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, 200)
 	})

--- a/pkg/extensions/search/cve/models.go
+++ b/pkg/extensions/search/cve/models.go
@@ -2,6 +2,8 @@
 package cveinfo
 
 import (
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/opencontainers/go-digest"
 	"github.com/urfave/cli/v2"
 	"zotregistry.io/zot/pkg/extensions/search/common"
 	"zotregistry.io/zot/pkg/log"
@@ -24,4 +26,10 @@ type CveTrivyController struct {
 type TrivyCtx struct {
 	Input string
 	Ctx   *cli.Context
+}
+
+type ImageInfoByCVE struct {
+	Tag      string
+	Digest   digest.Digest
+	Manifest v1.Manifest
 }

--- a/pkg/extensions/search/gql_generated/models_gen.go
+++ b/pkg/extensions/search/gql_generated/models_gen.go
@@ -25,58 +25,28 @@ type GlobalSearchResult struct {
 	Layers []*LayerSummary `json:"Layers"`
 }
 
-type ImageInfo struct {
-	Name        *string    `json:"Name"`
-	Latest      *string    `json:"Latest"`
-	LastUpdated *time.Time `json:"LastUpdated"`
-	Description *string    `json:"Description"`
-	Licenses    *string    `json:"Licenses"`
-	Vendor      *string    `json:"Vendor"`
-	Size        *string    `json:"Size"`
-	Labels      *string    `json:"Labels"`
-}
-
 type ImageSummary struct {
-	RepoName    *string    `json:"RepoName"`
-	Tag         *string    `json:"Tag"`
-	LastUpdated *time.Time `json:"LastUpdated"`
-	IsSigned    *bool      `json:"IsSigned"`
-	Size        *string    `json:"Size"`
-	Platform    *OsArch    `json:"Platform"`
-	Vendor      *string    `json:"Vendor"`
-	Score       *int       `json:"Score"`
-}
-
-type ImgResultForCve struct {
-	Name *string   `json:"Name"`
-	Tags []*string `json:"Tags"`
-}
-
-type ImgResultForDigest struct {
-	Name *string   `json:"Name"`
-	Tags []*string `json:"Tags"`
-}
-
-type ImgResultForFixedCve struct {
-	Tags []*TagInfo `json:"Tags"`
-}
-
-type LayerInfo struct {
-	Size   *string `json:"Size"`
-	Digest *string `json:"Digest"`
+	RepoName      *string         `json:"RepoName"`
+	Tag           *string         `json:"Tag"`
+	Digest        *string         `json:"Digest"`
+	ConfigDigest  *string         `json:"ConfigDigest"`
+	LastUpdated   *time.Time      `json:"LastUpdated"`
+	IsSigned      *bool           `json:"IsSigned"`
+	Size          *string         `json:"Size"`
+	Platform      *OsArch         `json:"Platform"`
+	Vendor        *string         `json:"Vendor"`
+	Score         *int            `json:"Score"`
+	DownloadCount *int            `json:"DownloadCount"`
+	Layers        []*LayerSummary `json:"Layers"`
+	Description   *string         `json:"Description"`
+	Licenses      *string         `json:"Licenses"`
+	Labels        *string         `json:"Labels"`
 }
 
 type LayerSummary struct {
 	Size   *string `json:"Size"`
 	Digest *string `json:"Digest"`
 	Score  *int    `json:"Score"`
-}
-
-type ManifestInfo struct {
-	Digest   *string      `json:"Digest"`
-	Tag      *string      `json:"Tag"`
-	IsSigned *bool        `json:"IsSigned"`
-	Layers   []*LayerInfo `json:"Layers"`
 }
 
 type OsArch struct {
@@ -91,22 +61,19 @@ type PackageInfo struct {
 }
 
 type RepoInfo struct {
-	Manifests []*ManifestInfo `json:"Manifests"`
-	Summary   *RepoSummary    `json:"Summary"`
+	Images  []*ImageSummary `json:"Images"`
+	Summary *RepoSummary    `json:"Summary"`
 }
 
 type RepoSummary struct {
-	Name        *string       `json:"Name"`
-	LastUpdated *time.Time    `json:"LastUpdated"`
-	Size        *string       `json:"Size"`
-	Platforms   []*OsArch     `json:"Platforms"`
-	Vendors     []*string     `json:"Vendors"`
-	Score       *int          `json:"Score"`
-	NewestTag   *ImageSummary `json:"NewestTag"`
-}
-
-type TagInfo struct {
-	Name      *string    `json:"Name"`
-	Digest    *string    `json:"Digest"`
-	Timestamp *time.Time `json:"Timestamp"`
+	Name          *string       `json:"Name"`
+	LastUpdated   *time.Time    `json:"LastUpdated"`
+	Size          *string       `json:"Size"`
+	Platforms     []*OsArch     `json:"Platforms"`
+	Vendors       []*string     `json:"Vendors"`
+	Score         *int          `json:"Score"`
+	NewestImage   *ImageSummary `json:"NewestImage"`
+	DownloadCount *int          `json:"DownloadCount"`
+	StarCount     *int          `json:"StarCount"`
+	IsBookmarked  *bool         `json:"IsBookmarked"`
 }

--- a/pkg/extensions/search/resolver_test.go
+++ b/pkg/extensions/search/resolver_test.go
@@ -139,7 +139,7 @@ func TestGlobalSearch(t *testing.T) {
 			mockOlum := mocks.OciLayoutUtilsMock{
 				GetExpandedRepoInfoFn: func(name string) (common.RepoInfo, error) {
 					return common.RepoInfo{
-						Manifests: []common.Manifest{
+						Images: []common.Image{
 							{
 								Tag: "latest",
 								Layers: []common.Layer{

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -1,123 +1,91 @@
 scalar Time
 
 type CVEResultForImage {
-     Tag: String 
-     CVEList: [CVE]
+    Tag: String 
+    CVEList: [CVE]
 }
 
 type CVE {
-     Id: String 
-     Title: String
-     Description: String
-     Severity: String
-     PackageList: [PackageInfo]
+    Id: String 
+    Title: String
+    Description: String
+    Severity: String
+    PackageList: [PackageInfo]
 }
 
 type PackageInfo {
-     Name: String 
-     InstalledVersion: String 
-     FixedVersion: String 
-}
-
-type ImgResultForCVE {
-     Name: String 
-     Tags: [String]
-}
-
-type ImgResultForFixedCVE {
-     Tags: [TagInfo]
-}
-
-type ImgResultForDigest {
-     Name: String
-     Tags: [String]
-}
-
-type TagInfo {
-     Name: String
-     Digest: String
-     Timestamp: Time
-}
-
-type ImageInfo {
-     Name: String
-     Latest: String
-     LastUpdated: Time
-     Description: String
-     Licenses: String
-     Vendor: String
-     Size: String
-     Labels: String
+    Name: String 
+    InstalledVersion: String 
+    FixedVersion: String 
 }
 
 type RepoInfo {
-     Manifests: [ManifestInfo]
-     Summary: RepoSummary
-}
-
-type ManifestInfo {
-     Digest: String
-     Tag: String
-     IsSigned: Boolean
-     Layers: [LayerInfo]
-}
-
-type LayerInfo {
-     Size: String # Int64 is not supported.
-     Digest: String
+    Images: [ImageSummary]
+    Summary: RepoSummary
 }
 
 # Search results in all repos/images/layers
 # There will be other more structures for more detailed information
 type GlobalSearchResult {
-     Images: [ImageSummary]
-     Repos: [RepoSummary]
-     Layers: [LayerSummary]
+    Images: [ImageSummary]
+    Repos: [RepoSummary]
+    Layers: [LayerSummary]
 }
 
 # Brief on a specific image to be used in queries returning a list of images
 # We define an image as a pairing or a repo and a tag belonging to that repo
 type ImageSummary {
-     RepoName: String
-     Tag: String
-     LastUpdated: Time
-     IsSigned: Boolean
-     Size: String
-     Platform: OsArch
-     Vendor: String
-     Score: Int
+    RepoName: String
+    Tag: String
+    Digest: String
+    ConfigDigest: String
+    LastUpdated: Time
+    IsSigned: Boolean
+    Size: String
+    Platform: OsArch
+    Vendor: String
+    Score: Int
+    DownloadCount: Int
+    Layers: [LayerSummary]
+    Description: String
+    Licenses: String
+    Labels: String
 }
 
 # Brief on a specific repo to be used in queries returning a list of repos
 type RepoSummary {
-     Name: String
-     LastUpdated: Time
-     Size: String
-     Platforms: [OsArch]
-     Vendors: [String]
-     Score: Int
-     NewestTag: ImageSummary
+    Name: String
+    LastUpdated: Time
+    Size: String
+    Platforms: [OsArch]
+    Vendors: [String]
+    Score: Int
+    NewestImage: ImageSummary
+    DownloadCount: Int
+    StarCount: Int
+    IsBookmarked: Boolean
 }
 
 # Currently the same as LayerInfo, we can refactor later
 # For detailed information on the layer a ImageListForDigest call can be made
 type LayerSummary {
-     Size: String # Int64 is not supported.
-     Digest: String
-     Score: Int
+    Size: String  # Int64 is not supported.
+    Digest: String
+    Score: Int
 }
 
 type OsArch {
-     Os: String
-     Arch: String
+    Os: String
+    Arch: String
 }
 
 type Query {
-  CVEListForImage(image: String!) :CVEResultForImage 
-  ImageListForCVE(id: String!) :[ImgResultForCVE]
-  ImageListWithCVEFixed(id: String!, image: String!) :ImgResultForFixedCVE
-  ImageListForDigest(id: String!) :[ImgResultForDigest]
-  ImageListWithLatestTag:[ImageInfo]
-  ExpandedRepoInfo(repo: String!):RepoInfo
-  GlobalSearch(query: String!): GlobalSearchResult
+    CVEListForImage(image: String!): CVEResultForImage!
+    ImageListForCVE(id: String!): [ImageSummary!]
+    ImageListWithCVEFixed(id: String!, image: String!): [ImageSummary!]
+    ImageListForDigest(id: String!): [ImageSummary!]
+    ImageListWithLatestTag: [ImageSummary!]
+    ImageList(repo: String!): [ImageSummary!]
+    ExpandedRepoInfo(repo: String!): RepoInfo!
+    GlobalSearch(query: String!): GlobalSearchResult!
 }


### PR DESCRIPTION
Signed-off-by: Roxana Nemulescu <roxana.nemulescu@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
