### PR TITLE
fix dependabot alert

### DIFF
--- a/examples/config-allextensions.json
+++ b/examples/config-allextensions.json
@@ -1,5 +1,5 @@
 {
-	"distSpecVersion": "1.0.0",
+	"distSpecVersion": "1.0.1",
 	"storage": {
 		"rootDirectory": "/tmp/zot"
 	},

--- a/examples/config-bearer-auth.json
+++ b/examples/config-bearer-auth.json
@@ -1,5 +1,5 @@
 {
-  "distSpecVersion":"1.0.0",
+  "distSpecVersion":"1.0.1",
   "storage":{
     "rootDirectory":"/tmp/zot"
   },

--- a/examples/config-commit.json
+++ b/examples/config-commit.json
@@ -1,5 +1,5 @@
 {
-    "distSpecVersion": "1.0.0",
+    "distSpecVersion": "1.0.1",
     "storage": {
         "rootDirectory": "/tmp/zot",
         "commit": true

--- a/examples/config-conformance.json
+++ b/examples/config-conformance.json
@@ -1,5 +1,5 @@
 {
-  "distSpecVersion":"1.0.0",
+  "distSpecVersion":"1.0.1",
   "storage":{
     "rootDirectory":"/tmp/zot",
     "gc": false,

--- a/examples/config-cve.json
+++ b/examples/config-cve.json
@@ -1,5 +1,5 @@
 {
-    "distSpecVersion": "1.0.0",
+    "distSpecVersion": "1.0.1",
     "storage": {
         "rootDirectory": "/tmp/zot"
     },

--- a/examples/config-example.json
+++ b/examples/config-example.json
@@ -1,5 +1,5 @@
 {
-  "distSpecVersion":"1.0.0",
+  "distSpecVersion":"1.0.1",
   "storage":{
     "rootDirectory":"/tmp/zot"
   },

--- a/examples/config-gc.json
+++ b/examples/config-gc.json
@@ -1,5 +1,5 @@
 {
-    "distSpecVersion": "1.0.0",
+    "distSpecVersion": "1.0.1",
     "storage": {
         "rootDirectory": "/tmp/zot",
         "gc": true,

--- a/examples/config-metrics.json
+++ b/examples/config-metrics.json
@@ -1,5 +1,5 @@
 {
-    "distSpecVersion": "1.0.0",
+    "distSpecVersion": "1.0.1",
     "storage": {
         "rootDirectory": "/tmp/zot"
     },

--- a/examples/config-minimal.json
+++ b/examples/config-minimal.json
@@ -1,5 +1,5 @@
 {
-    "distSpecVersion": "1.0.0",
+    "distSpecVersion": "1.0.1",
     "storage": {
         "rootDirectory": "/tmp/zot"
     },

--- a/examples/config-multiple-cve.json
+++ b/examples/config-multiple-cve.json
@@ -1,5 +1,5 @@
 {
-    "distSpecVersion": "1.0.0",
+    "distSpecVersion": "1.0.1",
     "storage": {
         "rootDirectory": "/tmp/zot",
         "dedupe": true,

--- a/examples/config-multiple.json
+++ b/examples/config-multiple.json
@@ -1,5 +1,5 @@
 {
-    "distSpecVersion": "1.0.0",
+    "distSpecVersion": "1.0.1",
     "storage": {
         "rootDirectory": "/tmp/zot",
         "dedupe": true,

--- a/examples/config-policy.json
+++ b/examples/config-policy.json
@@ -1,5 +1,5 @@
 {
-  "distSpecVersion": "1.0.0",
+  "distSpecVersion": "1.0.1",
   "storage": {
     "rootDirectory": "/tmp/zot"
   },

--- a/examples/config-ratelimit.json
+++ b/examples/config-ratelimit.json
@@ -1,5 +1,5 @@
 {
-    "distSpecVersion": "1.0.0",
+    "distSpecVersion": "1.0.1",
     "storage": {
         "rootDirectory": "/tmp/zot"
     },

--- a/examples/config-s3.json
+++ b/examples/config-s3.json
@@ -1,5 +1,5 @@
 {
-    "distSpecVersion": "1.0.0",
+    "distSpecVersion": "1.0.1",
     "storage": {
         "rootDirectory": "/zot",
         "storageDriver": {

--- a/examples/config-sync.json
+++ b/examples/config-sync.json
@@ -1,5 +1,5 @@
 {
-	"distSpecVersion":"1.0.0",
+	"distSpecVersion":"1.0.1",
 	"storage":{
 		"rootDirectory":"/tmp/zot"
 	},

--- a/examples/config-test.json
+++ b/examples/config-test.json
@@ -1,5 +1,5 @@
 {
-  "distSpecVersion":"1.0.0",
+  "distSpecVersion":"1.0.1",
   "storage":{
     "rootDirectory":"/tmp/zot"
   },

--- a/examples/config-tls.json
+++ b/examples/config-tls.json
@@ -1,5 +1,5 @@
 {
-  "distSpecVersion":"1.0.0",
+  "distSpecVersion":"1.0.1",
   "storage":{
     "rootDirectory":"/tmp/zot"
   },

--- a/go.mod
+++ b/go.mod
@@ -286,7 +286,7 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/oklog/ulid v1.3.1 // indirect
 	github.com/open-policy-agent/opa v0.37.0 // indirect
-	github.com/opencontainers/distribution-spec v1.0.0
+	github.com/opencontainers/distribution-spec v1.0.1
 	github.com/opencontainers/runc v1.1.0 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2023,8 +2023,8 @@ github.com/open-policy-agent/opa v0.32.0/go.mod h1:5sJdtc+1/U8zy/j30njpQl6u9rM4M
 github.com/open-policy-agent/opa v0.35.0/go.mod h1:xEmekKlk6/c+so5HF9wtPnGPXDfBuBsrMGhSHOHEF+U=
 github.com/open-policy-agent/opa v0.37.0 h1:OUXB+RAcxQpmXeNW2BN1wYzQQvVCPF1T9zv+QXGr9Wg=
 github.com/open-policy-agent/opa v0.37.0/go.mod h1:xX3NUCZuXK8f0CNhFQvhm4495mZLptf94pIkWRLaFqo=
-github.com/opencontainers/distribution-spec v1.0.0 h1:3qi5mXdKrXCacBYm8y46okmGmCR0pSgfaEd2/T0QXWE=
-github.com/opencontainers/distribution-spec v1.0.0/go.mod h1:copR2flp+jTEvQIFMb6MIx45OkrxzqyjszPDT3hx/5Q=
+github.com/opencontainers/distribution-spec v1.0.1 h1:hT6tF6uKZAQh+HH3BrJqn7/xHhMoDHzahIg4KxD2DqM=
+github.com/opencontainers/distribution-spec v1.0.1/go.mod h1:copR2flp+jTEvQIFMb6MIx45OkrxzqyjszPDT3hx/5Q=
 github.com/opencontainers/go-digest v0.0.0-20170106003457-a6d0ee40d420/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=


### PR DESCRIPTION
https://github.com/project-zot/zot/security/dependabot/10

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

bug

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

Fix a dependabot alert triggered by distribution spec version in go.mod


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
