### PR TITLE
Separate make targets that require elevated privileges

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -62,6 +62,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           if [[ $OS == "linux" && $ARCH == "amd64" ]]; then
             make OS=$OS ARCH=$ARCH
+            sudo env "PATH=$PATH" make privileged-test
           else
             make OS=$OS ARCH=$ARCH binary binary-minimal binary-debug cli bench exporter-minimal
           fi

--- a/pkg/cli/client_elevated_test.go
+++ b/pkg/cli/client_elevated_test.go
@@ -1,0 +1,123 @@
+//go:build extended && needprivileges
+// +build extended,needprivileges
+
+package cli //nolint:testpackage
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/resty.v1"
+	"zotregistry.io/zot/pkg/api"
+	"zotregistry.io/zot/pkg/api/config"
+)
+
+func TestElevatedPrivilegesTLSNewControllerPrivilegedCert(t *testing.T) {
+	Convey("Privileged certs - Make a new controller", t, func() {
+		cmd := exec.Command("mkdir", "-p", "/etc/containers/certs.d/127.0.0.1:8089/") // nolint: gosec
+		_, err := cmd.Output()
+		if err != nil {
+			panic(err)
+		}
+
+		defer exec.Command("rm", "-rf", "/etc/containers/certs.d/127.0.0.1:8089/")
+
+		wd, _ := os.Getwd()
+		os.Chdir("../../test/data")
+
+		clientGlob, _ := filepath.Glob("client.*")
+		caGlob, _ := filepath.Glob("ca.*")
+
+		for _, file := range clientGlob {
+			cmd = exec.Command("cp", file, "/etc/containers/certs.d/127.0.0.1:8089/")
+			res, err := cmd.CombinedOutput()
+			if err != nil {
+				panic(string(res))
+			}
+		}
+
+		for _, file := range caGlob {
+			cmd = exec.Command("cp", file, "/etc/containers/certs.d/127.0.0.1:8089/")
+			res, err := cmd.CombinedOutput()
+			if err != nil {
+				panic(string(res))
+			}
+		}
+
+		allGlob, _ := filepath.Glob("/etc/containers/certs.d/127.0.0.1:8089/*.key")
+
+		for _, file := range allGlob {
+			cmd = exec.Command("chmod", "a=rwx", file)
+			res, err := cmd.CombinedOutput()
+			if err != nil {
+				panic(string(res))
+			}
+		}
+
+		os.Chdir(wd)
+
+		caCert, err := ioutil.ReadFile(CACert)
+		So(err, ShouldBeNil)
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCert)
+
+		resty.SetTLSClientConfig(&tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12})
+		defer func() { resty.SetTLSClientConfig(nil) }()
+		conf := config.New()
+		conf.HTTP.Port = SecurePort2
+		conf.HTTP.TLS = &config.TLSConfig{
+			Cert:   ServerCert,
+			Key:    ServerKey,
+			CACert: CACert,
+		}
+
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
+		go func() {
+			// this blocks
+			if err := ctlr.Run(context.Background()); err != nil {
+				return
+			}
+		}()
+
+		// wait till ready
+		for {
+			_, err := resty.R().Get(BaseURL2)
+			if err == nil {
+				break
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		defer func() {
+			ctx := context.Background()
+			_ = ctlr.Server.Shutdown(ctx)
+		}()
+
+		Convey("Certs in privileged path", func() {
+			configPath := makeConfigFile(
+				fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s/v2/_catalog","showspinner":false}]}`,
+					BaseSecureURL2))
+			defer os.Remove(configPath)
+
+			args := []string{"imagetest"}
+			imageCmd := NewImageCommand(new(searchService))
+			imageBuff := bytes.NewBufferString("")
+			imageCmd.SetOut(imageBuff)
+			imageCmd.SetErr(imageBuff)
+			imageCmd.SetArgs(args)
+			err := imageCmd.Execute()
+			So(err, ShouldBeNil)
+		})
+	})
+}

--- a/pkg/cli/client_test.go
+++ b/pkg/cli/client_test.go
@@ -206,62 +206,6 @@ func TestTLSWithoutAuth(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 	})
-
-	Convey("Privileged certs - Make a new controller", t, func() {
-		caCert, err := ioutil.ReadFile(CACert)
-		So(err, ShouldBeNil)
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCert)
-
-		resty.SetTLSClientConfig(&tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12})
-		defer func() { resty.SetTLSClientConfig(nil) }()
-		conf := config.New()
-		conf.HTTP.Port = SecurePort2
-		conf.HTTP.TLS = &config.TLSConfig{
-			Cert:   ServerCert,
-			Key:    ServerKey,
-			CACert: CACert,
-		}
-
-		ctlr := api.NewController(conf)
-		ctlr.Config.Storage.RootDirectory = t.TempDir()
-		go func() {
-			// this blocks
-			if err := ctlr.Run(context.Background()); err != nil {
-				return
-			}
-		}()
-
-		// wait till ready
-		for {
-			_, err := resty.R().Get(BaseURL2)
-			if err == nil {
-				break
-			}
-			time.Sleep(100 * time.Millisecond)
-		}
-
-		defer func() {
-			ctx := context.Background()
-			_ = ctlr.Server.Shutdown(ctx)
-		}()
-
-		Convey("Certs in privileged path", func() {
-			configPath := makeConfigFile(
-				fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s/v2/_catalog","showspinner":false}]}`,
-					BaseSecureURL2))
-			defer os.Remove(configPath)
-
-			args := []string{"imagetest"}
-			imageCmd := NewImageCommand(new(searchService))
-			imageBuff := bytes.NewBufferString("")
-			imageCmd.SetOut(imageBuff)
-			imageCmd.SetErr(imageBuff)
-			imageCmd.SetArgs(args)
-			err := imageCmd.Execute()
-			So(err, ShouldBeNil)
-		})
-	})
 }
 
 func TestTLSBadCerts(t *testing.T) {

--- a/pkg/storage/storage_fs_elevated_test.go
+++ b/pkg/storage/storage_fs_elevated_test.go
@@ -1,0 +1,97 @@
+//go:build needprivileges
+// +build needprivileges
+
+package storage_test
+
+import (
+	"bytes"
+	_ "crypto/sha256"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+
+	godigest "github.com/opencontainers/go-digest"
+	"github.com/rs/zerolog"
+	. "github.com/smartystreets/goconvey/convey"
+	"zotregistry.io/zot/pkg/extensions/monitoring"
+	"zotregistry.io/zot/pkg/log"
+	"zotregistry.io/zot/pkg/storage"
+)
+
+func TestElevatedPrivilegesInvalidDedupe(t *testing.T) {
+	Convey("Invalid dedupe scenarios", t, func() {
+		dir := t.TempDir()
+
+		log := log.Logger{Logger: zerolog.New(os.Stdout)}
+		metrics := monitoring.NewMetricsServer(false, log)
+		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+
+		upload, err := imgStore.NewBlobUpload("dedupe1")
+		So(err, ShouldBeNil)
+		So(upload, ShouldNotBeEmpty)
+
+		content := []byte("test-data3")
+		buf := bytes.NewBuffer(content)
+		buflen := buf.Len()
+		digest := godigest.FromBytes(content)
+		blob, err := imgStore.PutBlobChunkStreamed("dedupe1", upload, buf)
+		So(err, ShouldBeNil)
+		So(blob, ShouldEqual, buflen)
+
+		blobDigest1 := strings.Split(digest.String(), ":")[1]
+		So(blobDigest1, ShouldNotBeEmpty)
+
+		err = imgStore.FinishBlobUpload("dedupe1", upload, buf, digest.String())
+		So(err, ShouldBeNil)
+		So(blob, ShouldEqual, buflen)
+
+		// Create a file at the same place where FinishBlobUpload will create
+		err = imgStore.InitRepo("dedupe2")
+		So(err, ShouldBeNil)
+
+		err = os.MkdirAll(path.Join(dir, "dedupe2", "blobs/sha256"), 0o755)
+		if err != nil {
+			panic(err)
+		}
+
+		err = ioutil.WriteFile(path.Join(dir, "dedupe2", "blobs/sha256", blobDigest1), content, 0o755) // nolint: gosec
+		if err != nil {
+			panic(err)
+		}
+
+		upload, err = imgStore.NewBlobUpload("dedupe2")
+		So(err, ShouldBeNil)
+		So(upload, ShouldNotBeEmpty)
+
+		content = []byte("test-data3")
+		buf = bytes.NewBuffer(content)
+		buflen = buf.Len()
+		digest = godigest.FromBytes(content)
+		blob, err = imgStore.PutBlobChunkStreamed("dedupe2", upload, buf)
+		So(err, ShouldBeNil)
+		So(blob, ShouldEqual, buflen)
+
+		cmd := exec.Command("chattr", "+i", path.Join(dir, "dedupe2", "blobs/sha256", blobDigest1)) // nolint: gosec
+		_, err = cmd.Output()
+		if err != nil {
+			panic(err)
+		}
+
+		err = imgStore.FinishBlobUpload("dedupe2", upload, buf, digest.String())
+		So(err, ShouldNotBeNil)
+		So(blob, ShouldEqual, buflen)
+
+		cmd = exec.Command("chattr", "-i", path.Join(dir, "dedupe2", "blobs/sha256", blobDigest1)) // nolint: gosec
+		_, err = cmd.Output()
+		if err != nil {
+			panic(err)
+		}
+
+		err = imgStore.FinishBlobUpload("dedupe2", upload, buf, digest.String())
+		So(err, ShouldBeNil)
+		So(blob, ShouldEqual, buflen)
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
#459 

**What does this PR do / Why do we need it**:
This PR separates the tests that need some sort of privileged execution from the ones that don't by use of new make targets.
This allows running without needing privileges or when they are not available.
Additionally, this PR will now make tests run on every platform (make test was only run on linux && amd64).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
