### PR TITLE
Added imagestore regulator to limit the maximum concurrent go routines,

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -84,6 +84,14 @@ to wasted storage, and background garbage collection can be enabled with:
         "gc": true,
 ```
 
+When the registry is backed by a filesystem and is under heavy load it can
+reach maximum file descriptor limit, and it will get "too many open files" error.
+Maximum go routines which can use the storage can be configured with:
+
+```
+        "maxThreads": 4096,
+```
+
 It is also possible to store and serve images from multiple filesystems with
 their own repository paths, dedupe and garbage collection settings with:
 

--- a/examples/config-example.json
+++ b/examples/config-example.json
@@ -1,7 +1,8 @@
 {
   "distSpecVersion":"1.0.1",
   "storage":{
-    "rootDirectory":"/tmp/zot"
+    "rootDirectory":"/tmp/zot",
+    "maxThreads": 4096
   },
   "http": {
     "address":"127.0.0.1",

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -25,6 +25,7 @@ type StorageConfig struct {
 	Dedupe        bool
 	Commit        bool
 	GCDelay       time.Duration
+	MaxThreads    uint64
 	StorageDriver map[string]interface{} `mapstructure:",omitempty"`
 }
 
@@ -100,6 +101,7 @@ type GlobalStorageConfig struct {
 	Commit        bool
 	GCDelay       time.Duration
 	RootDirectory string
+	MaxThreads    uint64
 	StorageDriver map[string]interface{} `mapstructure:",omitempty"`
 	SubPaths      map[string]StorageConfig
 }

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -237,7 +237,8 @@ func (c *Controller) InitImageStore() error {
 		var defaultStore storage.ImageStore
 		if len(c.Config.Storage.StorageDriver) == 0 {
 			defaultStore = storage.NewImageStore(c.Config.Storage.RootDirectory,
-				c.Config.Storage.GC, c.Config.Storage.GCDelay, c.Config.Storage.Dedupe, c.Config.Storage.Commit, c.Log, c.Metrics)
+				c.Config.Storage.GC, c.Config.Storage.GCDelay, c.Config.Storage.Dedupe, c.Config.Storage.Commit,
+				c.Config.Storage.MaxThreads, c.Log, c.Metrics)
 		} else {
 			storeName := fmt.Sprintf("%v", c.Config.Storage.StorageDriver["name"])
 			if storeName != storage.S3StorageDriverName {
@@ -290,7 +291,8 @@ func (c *Controller) InitImageStore() error {
 
 				if len(storageConfig.StorageDriver) == 0 {
 					subImageStore[route] = storage.NewImageStore(storageConfig.RootDirectory,
-						storageConfig.GC, storageConfig.GCDelay, storageConfig.Dedupe, storageConfig.Commit, c.Log, c.Metrics)
+						storageConfig.GC, storageConfig.GCDelay, storageConfig.Dedupe,
+						storageConfig.Commit, storageConfig.MaxThreads, c.Log, c.Metrics)
 				} else {
 					storeName := fmt.Sprintf("%v", storageConfig.StorageDriver["name"])
 					if storeName != storage.S3StorageDriverName {

--- a/pkg/extensions/search/common/common_test.go
+++ b/pkg/extensions/search/common/common_test.go
@@ -126,7 +126,7 @@ func TestImageFormat(t *testing.T) {
 		dbDir := "../../../../test/data"
 
 		metrics := monitoring.NewMetricsServer(false, log)
-		defaultStore := storage.NewImageStore(dbDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+		defaultStore := storage.NewImageStore(dbDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 		storeController := storage.StoreController{DefaultStore: defaultStore}
 		olu := common.NewOciLayoutUtils(storeController, log)
 
@@ -511,9 +511,9 @@ func TestUtilsMethod(t *testing.T) {
 		subRootDir := t.TempDir()
 
 		metrics := monitoring.NewMetricsServer(false, log)
-		defaultStore := storage.NewImageStore(rootDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+		defaultStore := storage.NewImageStore(rootDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
-		subStore := storage.NewImageStore(subRootDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+		subStore := storage.NewImageStore(subRootDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
 		subStoreMap := make(map[string]storage.ImageStore)
 

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -91,7 +91,7 @@ func testSetup() error {
 	log := log.NewLogger("debug", "")
 	metrics := monitoring.NewMetricsServer(false, log)
 
-	storeController := storage.StoreController{DefaultStore: storage.NewImageStore(dir, false, storage.DefaultGCDelay, false, false, log, metrics)}
+	storeController := storage.StoreController{DefaultStore: storage.NewImageStore(dir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)}
 
 	layoutUtils := common.NewOciLayoutUtils(storeController, log)
 
@@ -334,11 +334,11 @@ func TestMultipleStoragePath(t *testing.T) {
 		metrics := monitoring.NewMetricsServer(false, log)
 
 		// Create ImageStore
-		firstStore := storage.NewImageStore(firstRootDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+		firstStore := storage.NewImageStore(firstRootDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
-		secondStore := storage.NewImageStore(secondRootDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+		secondStore := storage.NewImageStore(secondRootDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
-		thirdStore := storage.NewImageStore(thirdRootDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+		thirdStore := storage.NewImageStore(thirdRootDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
 		storeController := storage.StoreController{}
 

--- a/pkg/extensions/search/digest/digest_test.go
+++ b/pkg/extensions/search/digest/digest_test.go
@@ -98,7 +98,7 @@ func testSetup() error {
 	log := log.NewLogger("debug", "")
 	metrics := monitoring.NewMetricsServer(false, log)
 	storeController := storage.StoreController{
-		DefaultStore: storage.NewImageStore(rootDir, false, storage.DefaultGCDelay, false, false, log, metrics),
+		DefaultStore: storage.NewImageStore(rootDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics),
 	}
 
 	digestInfo = digestinfo.NewDigestInfo(storeController, log)

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -61,7 +61,7 @@ func TestInjectSyncUtils(t *testing.T) {
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
 
-		imageStore := storage.NewImageStore(t.TempDir(), false, storage.DefaultGCDelay, false, false, log, metrics)
+		imageStore := storage.NewImageStore(t.TempDir(), false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
 		injected = test.InjectFailure(0)
 		_, _, err = getLocalImageRef(imageStore, testImage, testImageTag)
@@ -151,7 +151,7 @@ func TestSyncInternal(t *testing.T) {
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
 
-		imageStore := storage.NewImageStore(t.TempDir(), false, storage.DefaultGCDelay, false, false, log, metrics)
+		imageStore := storage.NewImageStore(t.TempDir(), false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
 		err := os.Chmod(imageStore.RootDir(), 0o000)
 		So(err, ShouldBeNil)
@@ -287,7 +287,7 @@ func TestSyncInternal(t *testing.T) {
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
 
-		imageStore := storage.NewImageStore(storageDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+		imageStore := storage.NewImageStore(storageDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
 		repoRefStr := fmt.Sprintf("%s/%s", host, testImage)
 		repoRef, err := parseRepositoryReference(repoRefStr)
@@ -350,7 +350,7 @@ func TestSyncInternal(t *testing.T) {
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
 
-		imageStore := storage.NewImageStore(storageDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+		imageStore := storage.NewImageStore(storageDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
 		storeController := storage.StoreController{}
 		storeController.DefaultStore = imageStore
@@ -371,7 +371,7 @@ func TestSyncInternal(t *testing.T) {
 			panic(err)
 		}
 
-		testImageStore := storage.NewImageStore(testRootDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+		testImageStore := storage.NewImageStore(testRootDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 		manifestContent, _, _, err := testImageStore.GetImageManifest(testImage, testImageTag)
 		So(err, ShouldBeNil)
 

--- a/pkg/extensions/sync/utils.go
+++ b/pkg/extensions/sync/utils.go
@@ -445,7 +445,7 @@ func pushSyncedLocalImage(repo, tag, localCachePath string,
 	imageStore := storeController.GetImageStore(repo)
 
 	metrics := monitoring.NewMetricsServer(false, log)
-	cacheImageStore := storage.NewImageStore(localCachePath, false, storage.DefaultGCDelay, false, false, log, metrics)
+	cacheImageStore := storage.NewImageStore(localCachePath, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
 	manifestContent, _, _, err := cacheImageStore.GetImageManifest(repo, tag)
 	if err != nil {

--- a/pkg/storage/regulator.go
+++ b/pkg/storage/regulator.go
@@ -1,0 +1,240 @@
+package storage
+
+import (
+	"io"
+	"sync"
+	"time"
+
+	"github.com/opencontainers/go-digest"
+	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
+)
+
+type regulator struct {
+	imageStore ImageStore
+	*sync.Cond
+
+	available uint64
+}
+
+/* NewRegulator wraps ImageStore in order to regulate concurrent calls
+to ImageStore, useful for filesystem storage which can reach maximum open file descriptors. */
+func NewRegulator(imageStore ImageStore, limit uint64) ImageStore {
+	return &regulator{
+		imageStore: imageStore,
+		Cond:       sync.NewCond(&sync.Mutex{}),
+		available:  limit,
+	}
+}
+
+func (r *regulator) enter() {
+	r.L.Lock()
+	for r.available == 0 {
+		// limit reach
+		r.Wait()
+	}
+	r.available--
+	r.L.Unlock()
+}
+
+func (r *regulator) exit() {
+	r.L.Lock()
+	// signal waiting go routines
+	r.Signal()
+	r.available++
+	r.L.Unlock()
+}
+
+func (r *regulator) DirExists(d string) bool {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.DirExists(d)
+}
+
+func (r *regulator) RootDir() string {
+	return r.imageStore.RootDir()
+}
+
+func (r *regulator) RLock(lockStart *time.Time) {
+	r.imageStore.RLock(lockStart)
+}
+
+func (r *regulator) RUnlock(lockStart *time.Time) {
+	r.imageStore.RUnlock(lockStart)
+}
+
+func (r *regulator) Lock(lockStart *time.Time) {
+	r.imageStore.Lock(lockStart)
+}
+
+func (r *regulator) Unlock(lockStart *time.Time) {
+	r.imageStore.Unlock(lockStart)
+}
+
+func (r *regulator) InitRepo(repo string) error {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.InitRepo(repo)
+}
+
+func (r *regulator) ValidateRepo(repo string) (bool, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.ValidateRepo(repo)
+}
+
+func (r *regulator) GetRepositories() ([]string, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.GetRepositories()
+}
+
+func (r *regulator) GetImageTags(repo string) ([]string, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.GetImageTags(repo)
+}
+
+func (r *regulator) GetImageManifest(repo, reference string) ([]byte, string, string, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.GetImageManifest(repo, reference)
+}
+
+func (r *regulator) PutImageManifest(repo, reference, mediatype string, body []byte) (string, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.PutImageManifest(repo, reference, mediatype, body)
+}
+
+func (r *regulator) DeleteImageManifest(repo, reference string) error {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.DeleteImageManifest(repo, reference)
+}
+
+func (r *regulator) BlobUploadPath(repo, uuid string) string {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.BlobUploadPath(repo, uuid)
+}
+
+func (r *regulator) NewBlobUpload(repo string) (string, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.NewBlobUpload(repo)
+}
+
+func (r *regulator) GetBlobUpload(repo string, uuid string) (int64, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.GetBlobUpload(repo, uuid)
+}
+
+func (r *regulator) PutBlobChunkStreamed(repo, uuid string, body io.Reader) (int64, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.PutBlobChunkStreamed(repo, uuid, body)
+}
+
+func (r *regulator) PutBlobChunk(repo, uuid string, from, to int64, body io.Reader) (int64, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.PutBlobChunk(repo, uuid, from, to, body)
+}
+
+func (r *regulator) BlobUploadInfo(repo, uuid string) (int64, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.BlobUploadInfo(repo, uuid)
+}
+
+func (r *regulator) FinishBlobUpload(repo, uuid string, body io.Reader, digest string) error {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.FinishBlobUpload(repo, uuid, body, digest)
+}
+
+func (r *regulator) FullBlobUpload(repo string, body io.Reader, digest string) (string, int64, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.FullBlobUpload(repo, body, digest)
+}
+
+func (r *regulator) DedupeBlob(src string, dstDigest digest.Digest, dst string) error {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.DedupeBlob(src, dstDigest, dst)
+}
+
+func (r *regulator) DeleteBlobUpload(repo, uuid string) error {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.DeleteBlobUpload(repo, uuid)
+}
+
+func (r *regulator) BlobPath(repo string, digest digest.Digest) string {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.BlobPath(repo, digest)
+}
+
+func (r *regulator) CheckBlob(repo, digest string) (bool, int64, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.CheckBlob(repo, digest)
+}
+
+func (r *regulator) GetBlob(repo, digest, mediaType string) (io.Reader, int64, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.GetBlob(repo, digest, mediaType)
+}
+
+func (r *regulator) DeleteBlob(repo, digest string) error {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.DeleteBlob(repo, digest)
+}
+
+func (r *regulator) GetIndexContent(repo string) ([]byte, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.GetIndexContent(repo)
+}
+
+func (r *regulator) GetBlobContent(repo, digest string) ([]byte, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.GetBlobContent(repo, digest)
+}
+
+func (r *regulator) GetReferrers(repo, digest, mediaType string) ([]artifactspec.Descriptor, error) {
+	r.enter()
+	defer r.exit()
+
+	return r.imageStore.GetReferrers(repo, digest, mediaType)
+}

--- a/pkg/storage/scrub_test.go
+++ b/pkg/storage/scrub_test.go
@@ -31,7 +31,7 @@ func TestCheckAllBlobsIntegrity(t *testing.T) {
 
 	metrics := monitoring.NewMetricsServer(false, log)
 
-	imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+	imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 
 	Convey("Scrub only one repo", t, func(c C) {
 		// initialize repo

--- a/pkg/storage/storage_fs_test.go
+++ b/pkg/storage/storage_fs_test.go
@@ -34,7 +34,7 @@ func TestStorageFSAPIs(t *testing.T) {
 
 	log := log.Logger{Logger: zerolog.New(os.Stdout)}
 	metrics := monitoring.NewMetricsServer(false, log)
-	imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+	imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 
 	Convey("Repo layout", t, func(c C) {
 		repoName := "test"
@@ -166,7 +166,7 @@ func TestDedupeLinks(t *testing.T) {
 
 	log := log.Logger{Logger: zerolog.New(os.Stdout)}
 	metrics := monitoring.NewMetricsServer(false, log)
-	imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+	imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 
 	Convey("Dedupe", t, func(c C) {
 		// manifest1
@@ -302,7 +302,7 @@ func TestDedupe(t *testing.T) {
 
 			log := log.Logger{Logger: zerolog.New(os.Stdout)}
 			metrics := monitoring.NewMetricsServer(false, log)
-			il := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+			il := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 
 			So(il.DedupeBlob("", "", ""), ShouldNotBeNil)
 		})
@@ -317,9 +317,9 @@ func TestNegativeCases(t *testing.T) {
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
 
-		So(storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics), ShouldNotBeNil)
+		So(storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics), ShouldNotBeNil)
 		if os.Geteuid() != 0 {
-			So(storage.NewImageStore("/deadBEEF", true, storage.DefaultGCDelay, true, true, log, metrics), ShouldBeNil)
+			So(storage.NewImageStore("/deadBEEF", true, storage.DefaultGCDelay, true, true, 0, log, metrics), ShouldBeNil)
 		}
 	})
 
@@ -328,7 +328,7 @@ func TestNegativeCases(t *testing.T) {
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
-		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 
 		err := os.Chmod(dir, 0o000) // remove all perms
 		if err != nil {
@@ -363,7 +363,7 @@ func TestNegativeCases(t *testing.T) {
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
-		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 
 		So(imgStore, ShouldNotBeNil)
 		So(imgStore.InitRepo("test"), ShouldBeNil)
@@ -477,7 +477,7 @@ func TestNegativeCases(t *testing.T) {
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
-		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 
 		So(imgStore, ShouldNotBeNil)
 		So(imgStore.InitRepo("test"), ShouldBeNil)
@@ -500,7 +500,7 @@ func TestNegativeCases(t *testing.T) {
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
-		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 
 		So(imgStore, ShouldNotBeNil)
 		So(imgStore.InitRepo("test"), ShouldBeNil)
@@ -541,7 +541,7 @@ func TestNegativeCases(t *testing.T) {
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
-		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 
 		So(imgStore, ShouldNotBeNil)
 		So(imgStore.InitRepo("test"), ShouldBeNil)
@@ -605,7 +605,7 @@ func TestNegativeCases(t *testing.T) {
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
-		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 
 		upload, err := imgStore.NewBlobUpload("dedupe1")
 		So(err, ShouldBeNil)
@@ -758,7 +758,7 @@ func TestInjectWriteFile(t *testing.T) {
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
-		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 
 		Convey("Failure path1", func() {
 			injected := test.InjectFailure(0)
@@ -788,7 +788,7 @@ func TestInjectWriteFile(t *testing.T) {
 
 		log := log.Logger{Logger: zerolog.New(os.Stdout)}
 		metrics := monitoring.NewMetricsServer(false, log)
-		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, false, log, metrics)
+		imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, false, 0, log, metrics)
 
 		Convey("Failure path not reached", func() {
 			err := imgStore.InitRepo("repo1")
@@ -805,7 +805,7 @@ func TestGarbageCollect(t *testing.T) {
 		metrics := monitoring.NewMetricsServer(false, log)
 
 		Convey("Garbage collect with default/long delay", func() {
-			imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+			imgStore := storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 			repoName := "gc-long"
 
 			upload, err := imgStore.NewBlobUpload(repoName)
@@ -871,7 +871,7 @@ func TestGarbageCollect(t *testing.T) {
 		})
 
 		Convey("Garbage collect with short delay", func() {
-			imgStore := storage.NewImageStore(dir, true, 1*time.Second, true, true, log, metrics)
+			imgStore := storage.NewImageStore(dir, true, 1*time.Second, true, true, 0, log, metrics)
 			repoName := "gc-short"
 
 			// upload orphan blob

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -114,7 +114,7 @@ func TestStorageAPIs(t *testing.T) {
 
 				log := log.Logger{Logger: zerolog.New(os.Stdout)}
 				metrics := monitoring.NewMetricsServer(false, log)
-				imgStore = storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, log, metrics)
+				imgStore = storage.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, 0, log, metrics)
 			}
 
 			Convey("Repo layout", t, func(c C) {
@@ -689,11 +689,11 @@ func TestStorageHandler(t *testing.T) {
 				metrics := monitoring.NewMetricsServer(false, log)
 
 				// Create ImageStore
-				firstStore = storage.NewImageStore(firstRootDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+				firstStore = storage.NewImageStore(firstRootDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
-				secondStore = storage.NewImageStore(secondRootDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+				secondStore = storage.NewImageStore(secondRootDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 
-				thirdStore = storage.NewImageStore(thirdRootDir, false, storage.DefaultGCDelay, false, false, log, metrics)
+				thirdStore = storage.NewImageStore(thirdRootDir, false, storage.DefaultGCDelay, false, false, 0, log, metrics)
 			}
 
 			Convey("Test storage handler", t, func() {


### PR DESCRIPTION
in order the avoid 'maximum open files' error

Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
4. Ensure your change works on existing clusters after upgrade.
5. If your mounting any new file or directory, make sure its not opening up any security attack vector for aws-vpc-cni-k8s modules.
6. If AWS apis are invoked, document the call rate in the description section.
7. If EC2 Metadata apis are invoked, ensure to handle stale information returned from metadata.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs from IPAMD/CNI showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades. Has updating a running cluster been tested?**:


**Does this change require updates to the CNI daemonset config files to work?**:
<!--
If this change does not work with a "kubectl patch" of the image tag, please explain why.
-->

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
