### PR TITLE
Refactor the push/pull tests to use the bats test framework

### DIFF
--- a/test/blackbox/helpers.bash
+++ b/test/blackbox/helpers.bash
@@ -1,0 +1,74 @@
+ROOT_DIR=$(git rev-parse --show-toplevel)
+TEST_DATA_DIR=${ROOT_DIR}/test/data/
+OS="${OS:-linux}"
+ARCH="${ARCH:-amd64}"
+ZOT_PATH=${ROOT_DIR}/bin/zot-${OS}-${ARCH}
+
+mkdir -p ${TEST_DATA_DIR}
+
+function verify_prerequisites {
+    if [ ! -f ${BATS_RUN_TMPDIR}/.firstrun ]; then
+        env | grep proxy >&3
+        touch ${BATS_RUN_TMPDIR}/.firstrun
+    fi
+
+    if [ ! -f ${ZOT_PATH} ]; then
+        echo "you need to build ${ZOT_PATH} before running the tests" >&3
+        return 1
+    fi
+
+    if [ ! command -v curl &> /dev/null ]; then
+        echo "you need to install curl as a prerequisite to running the tests" >&3
+        return 1
+    fi
+
+    if [ ! command -v jq &> /dev/null ]; then
+        echo "you need to install jq as a prerequisite to running the tests" >&3
+        return 1
+    fi
+
+    if [ ! command -v skopeo &> /dev/null ]; then
+        echo "you need to install skopeo as a prerequisite to running the tests" >&3
+        return 1
+    fi
+
+    if [ ! command -v oras &> /dev/null ]; then
+        echo "you need to install oras as a prerequisite to running the tests" >&3
+        return 1
+    fi
+    return 0
+}
+
+function zot_serve() {
+    local zot_path=${1}
+    local config_file=${2}
+    local pid_dir=${3}
+    ${zot_path} serve ${config_file} &
+    echo $! > ${pid_dir}/zot.pid
+}
+
+function zot_stop() {
+    local pid_dir=${1}
+    kill $(cat ${pid_dir}/zot.pid)
+    rm ${pid_dir}/zot.pid
+}
+
+function setup_zot_file_level() {
+    local config_file=${1}
+    zot_serve ${ZOT_PATH} ${config_file} ${BATS_FILE_TMPDIR}
+}
+
+function teardown_zot_file_level() {
+    zot_stop ${BATS_FILE_TMPDIR}
+}
+
+function wait_zot_reachable() {
+    zot_url=${1}
+    curl --connect-timeout 3 \
+        --max-time 3 \
+        --retry 10 \
+        --retry-delay 0 \
+        --retry-max-time 60 \
+        --retry-connrefused \
+        ${zot_url}
+}

--- a/test/blackbox/pushpull.bats
+++ b/test/blackbox/pushpull.bats
@@ -1,0 +1,81 @@
+load helpers
+
+function setup_file() {
+    # Verify prerequisites are available
+    if ! verify_prerequisites; then
+        exit 1
+    fi
+    # Download test data to folder common for the entire suite, not just this file
+    skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.17 oci:${TEST_DATA_DIR}/golang:1.17
+    # Setup zot server
+    local zot_root_dir=${BATS_FILE_TMPDIR}/zot
+    local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
+    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
+    mkdir -p ${zot_root_dir}
+    mkdir -p ${oci_data_dir}
+    cat > ${zot_config_file}<<EOF
+{
+    "distSpecVersion": "1.0.1",
+    "storage": {
+        "rootDirectory": "${zot_root_dir}"
+    },
+    "http": {
+        "address": "0.0.0.0",
+        "port": "8080",
+        "ReadOnly": false
+    },
+    "log": {
+        "level": "debug"
+    }
+}
+EOF
+    setup_zot_file_level ${zot_config_file}
+    wait_zot_reachable "http://127.0.0.1:8080/v2/_catalog"
+}
+
+function teardown_file() {
+    local zot_root_dir=${BATS_FILE_TMPDIR}/zot
+    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
+    teardown_zot_file_level
+    rm -rf ${zot_root_dir}
+    rm -rf ${oci_data_dir}
+}
+
+@test "push image" {
+    run skopeo --insecure-policy copy --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/golang:1.17 \
+        docker://127.0.0.1:8080/golang:1.17
+    [ "$status" -eq 0 ]
+    run curl http://127.0.0.1:8080/v2/_catalog
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.repositories[]') = '"golang"' ]
+    run curl http://127.0.0.1:8080/v2/golang/tags/list
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.17"' ]
+}
+
+@test "pull image" {
+    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
+    run skopeo --insecure-policy copy --src-tls-verify=false \
+        docker://127.0.0.1:8080/golang:1.17 \
+        oci:${oci_data_dir}/golang:1.17
+    [ "$status" -eq 0 ]
+    run cat ${BATS_FILE_TMPDIR}/oci/golang/index.json
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.manifests[].annotations."org.opencontainers.image.ref.name"') = '"1.17"' ]
+}
+
+@test "push oras artifact" {
+    echo "{\"name\":\"foo\",\"value\":\"bar\"}" > config.json
+    echo "hello world" > artifact.txt
+    oras push 127.0.0.1:8080/hello-artifact:v2 \
+        --manifest-config config.json:application/vnd.acme.rocket.config.v1+json artifact.txt:text/plain -d -v
+	rm -f artifact.txt
+    rm -f config.json
+}
+
+@test "pull oras artifact" {
+    oras pull 127.0.0.1:8080/hello-artifact:v2 -d -v -a
+    grep -q "hello world" artifact.txt
+    rm -f artifact.txt
+}


### PR DESCRIPTION
This is a follow up to #444.

Signed-off-by: Andrei Aaron <andaaron@cisco.com>

**What type of PR is this?**
cleanup
build

**What does this PR do / Why do we need it**:
See #444, this PR migrates the tests in the makefile to the bats test framework.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
