### PR TITLE
Reduce downloads by grouping .sync dirs for all images in the same repo

### DIFF
--- a/pkg/extensions/sync/on_demand.go
+++ b/pkg/extensions/sync/on_demand.go
@@ -309,7 +309,12 @@ func syncRun(regCfg RegistryConfig, localRepo, remoteRepo, tag string, utils syn
 		}
 	}
 
-	localImageRef, localCachePath, err := getLocalImageRef(utils.imageStore, localRepo, tag)
+	localCachePath, err := getLocalCachePath(utils.imageStore, localRepo)
+	if err != nil {
+		log.Error().Err(err).Msgf("couldn't get localCachePath for %s", localRepo)
+	}
+
+	localImageRef, err := getLocalImageRef(localCachePath, localRepo, tag)
 	if err != nil {
 		log.Error().Err(err).Msgf("couldn't obtain a valid image reference for reference %s/%s:%s",
 			localCachePath, localRepo, tag)

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -3295,8 +3295,8 @@ func TestSyncOnlyDiff(t *testing.T) {
 				case <-done:
 					return
 				default:
-					_, err := os.ReadDir(path.Join(destDir, testImage, ".sync"))
-					if err == nil {
+					fileList, _ := os.ReadDir(path.Join(destDir, testImage, ".sync"))
+					if len(fileList) > 0 {
 						isPopulated = true
 					}
 					time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
**What type of PR is this?**

enhancement

**Which issue does this PR fix**:

#480 #479

**What does this PR do / Why do we need it**:
This PR checks the existence of the blob before it being uploaded to the local imageStore, and only does so if it's not present.
Also, When syncing a repo with multiple images/tags, sync would create a local directory for each image, downloading the same blobs over and over again. This PR makes sync use the same folder per sync session, to massively reduce redownloading.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
