### PR TITLE
update metrics/Dockerfile to match current binary name format

### DIFF
--- a/examples/metrics/Dockerfile
+++ b/examples/metrics/Dockerfile
@@ -30,11 +30,11 @@ RUN echo '{\n\
 # ---
 # Stage 2: Final image with nothing but certs, binary, and default config file
 # ---
-FROM scratch AS final
+FROM gcr.io/distroless/base AS final
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /go/src/github.com/project-zot/zot/bin/zot /zot
+COPY --from=builder /go/src/github.com/project-zot/zot/bin/zot-linux-amd64 /usr/bin/zot
 COPY --from=builder /go/src/github.com/project-zot/zot/config.json /etc/zot/config.json
-ENTRYPOINT ["/zot"]
+ENTRYPOINT ["/usr/bin/zot"]
 EXPOSE 5000
 VOLUME ["/var/lib/registry"]
 CMD ["serve", "/etc/zot/config.json"]

--- a/examples/metrics/Dockerfile-minimal
+++ b/examples/metrics/Dockerfile-minimal
@@ -22,11 +22,11 @@ RUN echo '{\n\
 # ---
 # Stage 2: Final image with nothing but certs, binary, and default config file
 # ---
-FROM scratch AS final
+FROM gcr.io/distroless/base AS final
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=builder /go/src/github.com/project-zot/zot/bin/zot-minimal /zot
+COPY --from=builder /go/src/github.com/project-zot/zot/bin/zot-linux-amd64-minimal /usr/bin/zot
 COPY --from=builder /go/src/github.com/project-zot/zot/config.json /etc/zot/config.json
-ENTRYPOINT ["/zot"]
+ENTRYPOINT ["/usr/bin/zot"]
 EXPOSE 5050
 VOLUME ["/var/lib/registry"]
 CMD ["serve", "/etc/zot/config.json"]

--- a/examples/metrics/Dockerfile-zxp
+++ b/examples/metrics/Dockerfile-zxp
@@ -23,9 +23,9 @@ RUN echo '{\n\
 # ---
 # Stage 2: Final image with nothing but binary and default config file
 # ---
-FROM scratch AS final
-COPY --from=builder /go/src/github.com/project-zot/zot/bin/zxp /zxp
+FROM gcr.io/distroless/base AS final
+COPY --from=builder /go/src/github.com/project-zot/zot/bin/zxp-linux-amd64 /usr/bin/zxp
 COPY --from=builder /go/src/github.com/project-zot/zot/config.json /etc/zxp/config.json
-ENTRYPOINT ["/zxp"]
+ENTRYPOINT ["/usr/bin/zxp"]
 EXPOSE 5051
 CMD ["config", "/etc/zxp/config.json"]


### PR DESCRIPTION
Signed-off-by: Andreea-Lupu <andreealupu1470@yahoo.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
After changing the name format of the binary(ex zot-$OS-$ARCH) trying to build images using metrics/Dockerfile doesn't work anymore because of name mismatch. This PR fixes this issue by updating the name of the binary to current format.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
