### PR TITLE
s3: added logic for deduping blobs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -308,13 +308,15 @@ zot also supports different storage drivers for each subpath.
 
 ### Specifying S3 credentials
 
-There are multiple ways to specify S3 credentials:
-
 - Config file: 
 
 ```
+    "storage": {
+        "rootDirectory": "/tmp/zot",  # local path used to store dedupe cache database
+        "dedupe": true,
         "storageDriver": {
             "name": "s3",
+            "rootdirectory": "/zot",  # this is a prefix that is applied to all S3 keys to allow you to segment data in your bucket if necessary.
             "region": "us-east-2",
             "bucket": "zot-storage",
             "secure": true,
@@ -323,6 +325,8 @@ There are multiple ways to specify S3 credentials:
             "secretkey": "<YOUR_SECRET_ACCESS_KEY>"
         }
 ```
+
+There are multiple ways to specify S3 credentials besides config file:
 
 - Environment variables:
 

--- a/examples/config-s3.json
+++ b/examples/config-s3.json
@@ -1,9 +1,11 @@
 {
     "distSpecVersion": "1.0.1-dev",
     "storage": {
-        "rootDirectory": "/zot",
+        "rootDirectory": "/tmp/zot",
+        "dedupe": true,
         "storageDriver": {
             "name": "s3",
+            "rootdirectory": "/zot",
             "region": "us-east-2",
             "bucket": "zot-storage",
             "secure": true,
@@ -11,9 +13,11 @@
         },
         "subPaths": {
             "/a": {
-                "rootDirectory": "/zot-a",
+                "rootDirectory": "/tmp/zot1",
+                "dedupe": false,
                 "storageDriver": {
                     "name": "s3",
+                    "rootdirectory": "/zot-a",
                     "region": "us-east-2",
                     "bucket": "zot-storage",
                     "secure": true,
@@ -21,9 +25,11 @@
                 }
             },
             "/b": {
-                "rootDirectory": "/zot-b",
+                "rootDirectory": "/tmp/zot2",
+                "dedupe": true,
                 "storageDriver": {
                     "name": "s3",
+                    "rootdirectory": "/zot-b",
                     "region": "us-east-2",
                     "bucket": "zot-storage",
                     "secure": true,
@@ -31,9 +37,11 @@
                 }
             },
             "/c": {
-                "rootDirectory": "/zot-c",
+                "rootDirectory": "/tmp/zot3",
+                "dedupe": true,
                 "storageDriver": {
                     "name": "s3",
+                    "rootdirectory": "/zot-c",
                     "region": "us-east-2",
                     "bucket": "zot-storage",
                     "secure": false,

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -151,8 +151,8 @@ func TestObjectStorageController(t *testing.T) {
 		conf := config.New()
 		conf.HTTP.Port = port
 		storageDriverParams := map[string]interface{}{
-			"rootDir": "zot",
-			"name":    storage.S3StorageDriverName,
+			"rootdirectory": "zot",
+			"name":          storage.S3StorageDriverName,
 		}
 		conf.Storage.StorageDriver = storageDriverParams
 		ctlr := api.NewController(conf)
@@ -174,7 +174,7 @@ func TestObjectStorageController(t *testing.T) {
 		endpoint := os.Getenv("S3MOCK_ENDPOINT")
 
 		storageDriverParams := map[string]interface{}{
-			"rootDir":        "zot",
+			"rootdirectory":  "zot",
 			"name":           storage.S3StorageDriverName,
 			"region":         "us-east-2",
 			"bucket":         bucket,
@@ -206,7 +206,7 @@ func TestObjectStorageControllerSubPaths(t *testing.T) {
 		endpoint := os.Getenv("S3MOCK_ENDPOINT")
 
 		storageDriverParams := map[string]interface{}{
-			"rootDir":        "zot",
+			"rootdirectory":  "zot",
 			"name":           storage.S3StorageDriverName,
 			"region":         "us-east-2",
 			"bucket":         bucket,

--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -17,9 +17,9 @@ func TestCache(t *testing.T) {
 		log := log.NewLogger("debug", "")
 		So(log, ShouldNotBeNil)
 
-		So(storage.NewCache("/deadBEEF", "cache_test", log), ShouldBeNil)
+		So(storage.NewCache("/deadBEEF", "cache_test", true, log), ShouldBeNil)
 
-		cache := storage.NewCache(dir, "cache_test", log)
+		cache := storage.NewCache(dir, "cache_test", true, log)
 		So(cache, ShouldNotBeNil)
 
 		val, err := cache.GetBlob("key")

--- a/pkg/storage/s3/storage.go
+++ b/pkg/storage/s3/storage.go
@@ -8,9 +8,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -27,11 +27,13 @@ import (
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	zlog "zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"
+	"zotregistry.io/zot/pkg/test"
 )
 
 const (
-	RLOCK  = "RLock"
-	RWLOCK = "RWLock"
+	RLOCK       = "RLock"
+	RWLOCK      = "RWLock"
+	CacheDBName = "s3_cache"
 )
 
 // ObjectStorage provides the image storage operations.
@@ -46,6 +48,8 @@ type ObjectStorage struct {
 	// see: https://github.com/distribution/distribution/blob/main/registry/storage/driver/s3-aws/s3.go#L545
 	multiPartUploads sync.Map
 	metrics          monitoring.MetricServer
+	cache            *storage.Cache
+	dedupe           bool
 }
 
 func (is *ObjectStorage) RootDir() string {
@@ -62,7 +66,7 @@ func (is *ObjectStorage) DirExists(d string) bool {
 
 // NewObjectStorage returns a new image store backed by cloud storages.
 // see https://github.com/docker/docker.github.io/tree/master/registry/storage-drivers
-func NewImageStore(rootDir string, gc bool, gcDelay time.Duration, dedupe, commit bool,
+func NewImageStore(rootDir string, cacheDir string, gc bool, gcDelay time.Duration, dedupe, commit bool,
 	log zlog.Logger, metrics monitoring.MetricServer,
 	store driver.StorageDriver,
 ) storage.ImageStore {
@@ -74,6 +78,19 @@ func NewImageStore(rootDir string, gc bool, gcDelay time.Duration, dedupe, commi
 		log:              log.With().Caller().Logger(),
 		multiPartUploads: sync.Map{},
 		metrics:          metrics,
+		dedupe:           dedupe,
+	}
+
+	cachePath := path.Join(cacheDir, CacheDBName+storage.DBExtensionName)
+
+	if dedupe {
+		imgStore.cache = storage.NewCache(cacheDir, CacheDBName, false, log)
+	} else {
+		// if dedupe was used in previous runs use it to serve blobs correctly
+		if _, err := os.Stat(cachePath); err == nil {
+			log.Info().Str("cache path", cachePath).Msg("found cache database")
+			imgStore.cache = storage.NewCache(cacheDir, CacheDBName, false, log)
+		}
 	}
 
 	return imgStore
@@ -197,13 +214,9 @@ func (is *ObjectStorage) ValidateRepo(name string) (bool, error) {
 	}
 
 	for _, file := range files {
-		f, err := is.store.Stat(context.Background(), file)
+		_, err := is.store.Stat(context.Background(), file)
 		if err != nil {
 			return false, err
-		}
-
-		if strings.HasSuffix(file, "blobs") && !f.IsDir() {
-			return false, nil
 		}
 
 		filename, err := filepath.Rel(dir, file)
@@ -923,11 +936,20 @@ func (is *ObjectStorage) FinishBlobUpload(repo, uuid string, body io.Reader, dig
 	is.Lock(&lockLatency)
 	defer is.Unlock(&lockLatency)
 
-	if err := is.store.Move(context.Background(), src, dst); err != nil {
-		is.log.Error().Err(err).Str("src", src).Str("dstDigest", dstDigest.String()).
-			Str("dst", dst).Msg("unable to finish blob")
+	if is.dedupe && is.cache != nil {
+		if err := is.DedupeBlob(src, dstDigest, dst); err != nil {
+			is.log.Error().Err(err).Str("src", src).Str("dstDigest", dstDigest.String()).
+				Str("dst", dst).Msg("unable to dedupe blob")
 
-		return err
+			return err
+		}
+	} else {
+		if err := is.store.Move(context.Background(), src, dst); err != nil {
+			is.log.Error().Err(err).Str("src", src).Str("dstDigest", dstDigest.String()).
+				Str("dst", dst).Msg("unable to finish blob")
+
+			return err
+		}
 	}
 
 	is.multiPartUploads.Delete(src)
@@ -994,17 +1016,104 @@ func (is *ObjectStorage) FullBlobUpload(repo string, body io.Reader, digest stri
 
 	dst := is.BlobPath(repo, dstDigest)
 
-	if err := is.store.Move(context.Background(), src, dst); err != nil {
-		is.log.Error().Err(err).Str("src", src).Str("dstDigest", dstDigest.String()).
-			Str("dst", dst).Msg("unable to finish blob")
+	if is.dedupe && is.cache != nil {
+		if err := is.DedupeBlob(src, dstDigest, dst); err != nil {
+			is.log.Error().Err(err).Str("src", src).Str("dstDigest", dstDigest.String()).
+				Str("dst", dst).Msg("unable to dedupe blob")
 
-		return "", -1, err
+			return "", -1, err
+		}
+	} else {
+		if err := is.store.Move(context.Background(), src, dst); err != nil {
+			is.log.Error().Err(err).Str("src", src).Str("dstDigest", dstDigest.String()).
+				Str("dst", dst).Msg("unable to finish blob")
+
+			return "", -1, err
+		}
 	}
 
 	return uuid, int64(nbytes), nil
 }
 
 func (is *ObjectStorage) DedupeBlob(src string, dstDigest godigest.Digest, dst string) error {
+retry:
+	is.log.Debug().Str("src", src).Str("dstDigest", dstDigest.String()).Str("dst", dst).Msg("dedupe: enter")
+
+	dstRecord, err := is.cache.GetBlob(dstDigest.String())
+	if err := test.Error(err); err != nil && !errors.Is(err, zerr.ErrCacheMiss) {
+		is.log.Error().Err(err).Str("blobPath", dst).Msg("dedupe: unable to lookup blob record")
+
+		return err
+	}
+
+	if dstRecord == "" {
+		// cache record doesn't exist, so first disk and cache entry for this digest
+		if err := is.cache.PutBlob(dstDigest.String(), dst); err != nil {
+			is.log.Error().Err(err).Str("blobPath", dst).Msg("dedupe: unable to insert blob record")
+
+			return err
+		}
+
+		// move the blob from uploads to final dest
+		if err := is.store.Move(context.Background(), src, dst); err != nil {
+			is.log.Error().Err(err).Str("src", src).Str("dst", dst).Msg("dedupe: unable to rename blob")
+
+			return err
+		}
+
+		is.log.Debug().Str("src", src).Str("dst", dst).Msg("dedupe: rename")
+	} else {
+		// cache record exists, but due to GC and upgrades from older versions,
+		// disk content and cache records may go out of sync
+		_, err := is.store.Stat(context.Background(), dstRecord)
+		if err != nil {
+			is.log.Error().Err(err).Str("blobPath", dstRecord).Msg("dedupe: unable to stat")
+			// the actual blob on disk may have been removed by GC, so sync the cache
+			err := is.cache.DeleteBlob(dstDigest.String(), dstRecord)
+			if err = test.Error(err); err != nil {
+				// nolint:lll
+				is.log.Error().Err(err).Str("dstDigest", dstDigest.String()).Str("dst", dst).Msg("dedupe: unable to delete blob record")
+
+				return err
+			}
+
+			goto retry
+		}
+
+		fileInfo, err := is.store.Stat(context.Background(), dst)
+		if err != nil && !errors.As(err, &driver.PathNotFoundError{}) {
+			is.log.Error().Err(err).Str("blobPath", dstRecord).Msg("dedupe: unable to stat")
+
+			return err
+		}
+
+		if dstRecord == dst {
+			is.log.Warn().Msg("FOUND equal dsts")
+		}
+
+		// prevent overwrite original blob
+		if fileInfo == nil && dstRecord != dst {
+			// put empty file so that we are compliant with oci layout, this will act as a deduped blob
+			err = is.store.PutContent(context.Background(), dst, []byte{})
+			if err != nil {
+				is.log.Error().Err(err).Str("blobPath", dstRecord).Msg("dedupe: unable to write empty file")
+
+				return err
+			}
+		} else {
+			is.log.Warn().Msg("prevent overwrite")
+		}
+
+		// remove temp blobupload
+		if err := is.store.Delete(context.Background(), src); err != nil {
+			is.log.Error().Err(err).Str("src", src).Msg("dedupe: unable to remove blob")
+
+			return err
+		}
+
+		is.log.Debug().Str("src", src).Msg("dedupe: remove")
+	}
+
 	return nil
 }
 
@@ -1041,24 +1150,81 @@ func (is *ObjectStorage) CheckBlob(repo, digest string) (bool, int64, error) {
 
 	blobPath := is.BlobPath(repo, dgst)
 
-	is.RLock(&lockLatency)
-	defer is.RUnlock(&lockLatency)
+	if is.dedupe && is.cache != nil {
+		is.Lock(&lockLatency)
+		defer is.Unlock(&lockLatency)
+	} else {
+		is.RLock(&lockLatency)
+		defer is.RUnlock(&lockLatency)
+	}
 
 	binfo, err := is.store.Stat(context.Background(), blobPath)
-	if err != nil {
-		var perr driver.PathNotFoundError
-		if errors.As(err, &perr) {
-			return false, -1, zerr.ErrBlobNotFound
-		}
+	if err == nil && binfo.Size() > 0 {
+		is.log.Debug().Str("blob path", blobPath).Msg("blob path found")
 
-		is.log.Error().Err(err).Str("blob", blobPath).Msg("failed to stat blob")
+		return true, binfo.Size(), nil
+	}
+	// otherwise is a 'deduped' blob (empty file)
+
+	// Check blobs in cache
+	dstRecord, err := is.checkCacheBlob(digest)
+	if err != nil {
+		is.log.Error().Err(err).Str("digest", digest).Msg("cache: not found")
+
+		return false, -1, zerr.ErrBlobNotFound
+	}
+
+	// If found copy to location
+	blobSize, err := is.copyBlob(repo, blobPath, dstRecord)
+	if err != nil {
+		return false, -1, zerr.ErrBlobNotFound
+	}
+
+	// put deduped blob in cache
+	if err := is.cache.PutBlob(digest, blobPath); err != nil {
+		is.log.Error().Err(err).Str("blobPath", blobPath).Msg("dedupe: unable to insert blob record")
 
 		return false, -1, err
 	}
 
-	is.log.Debug().Str("blob path", blobPath).Msg("blob path found")
+	return true, blobSize, nil
+}
 
-	return true, binfo.Size(), nil
+func (is *ObjectStorage) checkCacheBlob(digest string) (string, error) {
+	if is.cache == nil {
+		return "", zerr.ErrBlobNotFound
+	}
+
+	dstRecord, err := is.cache.GetBlob(digest)
+	if err != nil {
+		return "", err
+	}
+
+	is.log.Debug().Str("digest", digest).Str("dstRecord", dstRecord).Msg("cache: found dedupe record")
+
+	return dstRecord, nil
+}
+
+func (is *ObjectStorage) copyBlob(repo string, blobPath string, dstRecord string) (int64, error) {
+	if err := is.initRepo(repo); err != nil {
+		is.log.Error().Err(err).Str("repo", repo).Msg("unable to initialize an empty repo")
+
+		return -1, err
+	}
+
+	if err := is.store.PutContent(context.Background(), blobPath, []byte{}); err != nil {
+		is.log.Error().Err(err).Str("blobPath", blobPath).Str("link", dstRecord).Msg("dedupe: unable to link")
+
+		return -1, zerr.ErrBlobNotFound
+	}
+
+	// return original blob with content instead of the deduped one (blobPath)
+	binfo, err := is.store.Stat(context.Background(), dstRecord)
+	if err == nil {
+		return binfo.Size(), nil
+	}
+
+	return -1, zerr.ErrBlobNotFound
 }
 
 // GetBlob returns a stream to read the blob.
@@ -1090,6 +1256,36 @@ func (is *ObjectStorage) GetBlob(repo, digest, mediaType string) (io.Reader, int
 		is.log.Error().Err(err).Str("blob", blobPath).Msg("failed to open blob")
 
 		return nil, -1, err
+	}
+
+	// is a 'deduped' blob
+	if binfo.Size() == 0 && is.cache != nil {
+		// Check blobs in cache
+		dstRecord, err := is.checkCacheBlob(digest)
+		if err == nil {
+			binfo, err := is.store.Stat(context.Background(), dstRecord)
+			if err != nil {
+				is.log.Error().Err(err).Str("blob", dstRecord).Msg("failed to stat blob")
+
+				// the actual blob on disk may have been removed by GC, so sync the cache
+				if err := is.cache.DeleteBlob(digest, dstRecord); err != nil {
+					is.log.Error().Err(err).Str("dstDigest", digest).Str("dst", dstRecord).Msg("dedupe: unable to delete blob record")
+
+					return nil, -1, err
+				}
+
+				return nil, -1, zerr.ErrBlobNotFound
+			}
+
+			blobReader, err := is.store.Reader(context.Background(), dstRecord, 0)
+			if err != nil {
+				is.log.Error().Err(err).Str("blob", dstRecord).Msg("failed to open blob")
+
+				return nil, -1, err
+			}
+
+			return blobReader, binfo.Size(), nil
+		}
 	}
 
 	return blobReader, binfo.Size(), nil
@@ -1156,6 +1352,44 @@ func (is *ObjectStorage) DeleteBlob(repo, digest string) error {
 		is.log.Error().Err(err).Str("blob", blobPath).Msg("failed to stat blob")
 
 		return zerr.ErrBlobNotFound
+	}
+
+	if is.cache != nil {
+		dstRecord, err := is.cache.GetBlob(digest)
+		if err != nil && !errors.Is(err, zerr.ErrCacheMiss) {
+			is.log.Error().Err(err).Str("blobPath", dstRecord).Msg("dedupe: unable to lookup blob record")
+
+			return err
+		}
+
+		// remove cache entry and move blob contents to the next candidate if there is any
+		if err := is.cache.DeleteBlob(digest, blobPath); err != nil {
+			is.log.Error().Err(err).Str("digest", digest).Str("blobPath", blobPath).Msg("unable to remove blob path from cache")
+
+			return err
+		}
+
+		// if the deleted blob is one with content
+		if dstRecord == blobPath {
+			// get next candidate
+			dstRecord, err := is.cache.GetBlob(digest)
+			if err != nil && !errors.Is(err, zerr.ErrCacheMiss) {
+				is.log.Error().Err(err).Str("blobPath", dstRecord).Msg("dedupe: unable to lookup blob record")
+
+				return err
+			}
+
+			// if we have a new candidate move the blob content to it
+			if dstRecord != "" {
+				if err := is.store.Move(context.Background(), blobPath, dstRecord); err != nil {
+					is.log.Error().Err(err).Str("blobPath", blobPath).Msg("unable to remove blob path")
+
+					return err
+				}
+
+				return nil
+			}
+		}
 	}
 
 	if err := is.store.Delete(context.Background(), blobPath); err != nil {

--- a/pkg/storage/storage_fs.go
+++ b/pkg/storage/storage_fs.go
@@ -129,7 +129,7 @@ func NewImageStore(rootDir string, gc bool, gcDelay time.Duration, dedupe, commi
 	}
 
 	if dedupe {
-		imgStore.cache = NewCache(rootDir, "cache", log)
+		imgStore.cache = NewCache(rootDir, "cache", true, log)
 	}
 
 	if gc {

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -42,7 +42,7 @@ func skipIt(t *testing.T) {
 	}
 }
 
-func createObjectsStore(rootDir string) (driver.StorageDriver, storage.ImageStore, error) {
+func createObjectsStore(rootDir string, cacheDir string) (driver.StorageDriver, storage.ImageStore, error) {
 	bucket := "zot-storage-test"
 	endpoint := os.Getenv("S3MOCK_ENDPOINT")
 	storageDriverParams := map[string]interface{}{
@@ -51,6 +51,8 @@ func createObjectsStore(rootDir string) (driver.StorageDriver, storage.ImageStor
 		"region":         "us-east-2",
 		"bucket":         bucket,
 		"regionendpoint": endpoint,
+		"accesskey":      "minioadmin",
+		"secretkey":      "minioadmin",
 		"secure":         false,
 		"skipverify":     false,
 	}
@@ -71,7 +73,7 @@ func createObjectsStore(rootDir string) (driver.StorageDriver, storage.ImageStor
 	log := log.Logger{Logger: zerolog.New(os.Stdout)}
 	metrics := monitoring.NewMetricsServer(false, log)
 
-	il := s3.NewImageStore(rootDir, false, storage.DefaultGCDelay, false, false, log, metrics, store)
+	il := s3.NewImageStore(rootDir, cacheDir, false, storage.DefaultGCDelay, true, false, log, metrics, store)
 
 	return store, il, err
 }
@@ -105,9 +107,10 @@ func TestStorageAPIs(t *testing.T) {
 				}
 
 				testDir := path.Join("/oci-repo-test", uuid.String())
+				tdir := t.TempDir()
 
 				var store driver.StorageDriver
-				store, imgStore, _ = createObjectsStore(testDir)
+				store, imgStore, _ = createObjectsStore(testDir, tdir)
 				defer cleanupStorage(store, testDir)
 			} else {
 				dir := t.TempDir()
@@ -676,15 +679,15 @@ func TestStorageHandler(t *testing.T) {
 				var thirdStorageDriver driver.StorageDriver
 
 				firstRootDir = "/util_test1"
-				firstStorageDriver, firstStore, _ = createObjectsStore(firstRootDir)
+				firstStorageDriver, firstStore, _ = createObjectsStore(firstRootDir, t.TempDir())
 				defer cleanupStorage(firstStorageDriver, firstRootDir)
 
 				secondRootDir = "/util_test2"
-				secondStorageDriver, secondStore, _ = createObjectsStore(secondRootDir)
+				secondStorageDriver, secondStore, _ = createObjectsStore(secondRootDir, t.TempDir())
 				defer cleanupStorage(secondStorageDriver, secondRootDir)
 
 				thirdRootDir = "/util_test3"
-				thirdStorageDriver, thirdStore, _ = createObjectsStore(thirdRootDir)
+				thirdStorageDriver, thirdStore, _ = createObjectsStore(thirdRootDir, t.TempDir())
 				defer cleanupStorage(thirdStorageDriver, thirdRootDir)
 			} else {
 				// Create temporary directory

--- a/test/cluster/config-minio.json
+++ b/test/cluster/config-minio.json
@@ -1,11 +1,12 @@
 {
-    "distSpecVersion": "1.0.0",
+    "distSpecVersion": "1.0.1",
     "storage": {
-        "rootDirectory": "/zot",
+        "rootDirectory": "/tmp/zot",
         "gc": false,
         "dedupe": false,
         "storageDriver": {
             "name": "s3",
+            "rootdirectory": "/zot",
             "region": "us-east-2",
             "bucket": "zot-storage",
             "regionendpoint": "http://localhost:9000",


### PR DESCRIPTION
Because s3 doesn't support hard links we store duplicated blobs
as empty files. When the original blob is deleted its content is
moved to the the next duplicated blob and so on.

Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
