### PR TITLE
Add flag to CheckBlob function to make duplicate blob linking optional

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -556,7 +556,7 @@ func (rh *RouteHandler) CheckBlob(response http.ResponseWriter, request *http.Re
 		return
 	}
 
-	ok, blen, err := imgStore.CheckBlob(name, digest)
+	ok, blen, err := imgStore.CheckBlob(name, digest, false)
 	if err != nil {
 		if errors.Is(err, zerr.ErrBadBlobDigest) { //nolint:gocritic // errorslint conflicts with gocritic:IfElseChain
 			WriteJSON(response,
@@ -732,7 +732,7 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 		// zot does not support cross mounting directly and do a workaround creating using hard link.
 		// check blob looks for actual path (name+mountDigests[0]) first then look for cache and
 		// if found in cache, will do hard link and if fails we will start new upload.
-		_, _, err := imgStore.CheckBlob(name, mountDigests[0])
+		_, _, err := imgStore.CheckBlob(name, mountDigests[0], true)
 		if err != nil {
 			upload, err := imgStore.NewBlobUpload(name)
 			if err != nil {

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -522,7 +522,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 		_, _, err = imgStore.FullBlobUpload(testImage, bytes.NewBuffer([]byte{}), "inexistent")
 		So(err, ShouldNotBeNil)
 
-		_, _, err = imgStore.CheckBlob(testImage, digest.String())
+		_, _, err = imgStore.CheckBlob(testImage, digest.String(), true)
 		So(err, ShouldNotBeNil)
 	})
 

--- a/pkg/storage/s3/storage.go
+++ b/pkg/storage/s3/storage.go
@@ -1027,7 +1027,7 @@ func (is *ObjectStorage) BlobPath(repo string, digest godigest.Digest) string {
 }
 
 // CheckBlob verifies a blob and returns true if the blob is correct.
-func (is *ObjectStorage) CheckBlob(repo string, digest string) (bool, int64, error) {
+func (is *ObjectStorage) CheckBlob(repo string, digest string, linkIfDupe bool) (bool, int64, error) {
 	var lockLatency time.Time
 
 	dgst, err := godigest.Parse(digest)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -38,7 +38,7 @@ type ImageStore interface {
 	DedupeBlob(src string, dstDigest digest.Digest, dst string) error
 	DeleteBlobUpload(repo string, uuid string) error
 	BlobPath(repo string, digest digest.Digest) string
-	CheckBlob(repo string, digest string) (bool, int64, error)
+	CheckBlob(repo string, digest string, linkIfDupe bool) (bool, int64, error)
 	GetBlob(repo string, digest string, mediaType string) (io.Reader, int64, error)
 	DeleteBlob(repo string, digest string) error
 	GetIndexContent(repo string) ([]byte, error)

--- a/pkg/storage/storage_fs_test.go
+++ b/pkg/storage/storage_fs_test.go
@@ -63,7 +63,7 @@ func TestStorageFSAPIs(t *testing.T) {
 			_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest.String())
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err := imgStore.CheckBlob("test", cdigest.String())
+			hasBlob, _, err := imgStore.CheckBlob("test", cdigest.String(), false)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -188,7 +188,7 @@ func TestDedupeLinks(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		_, _, err = imgStore.CheckBlob("dedupe1", digest.String())
+		_, _, err = imgStore.CheckBlob("dedupe1", digest.String(), true)
 		So(err, ShouldBeNil)
 
 		_, _, err = imgStore.GetBlob("dedupe1", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
@@ -198,7 +198,7 @@ func TestDedupeLinks(t *testing.T) {
 		_, clen, err := imgStore.FullBlobUpload("dedupe1", bytes.NewReader(cblob), cdigest.String())
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
-		hasBlob, _, err := imgStore.CheckBlob("dedupe1", cdigest.String())
+		hasBlob, _, err := imgStore.CheckBlob("dedupe1", cdigest.String(), true)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -244,7 +244,7 @@ func TestDedupeLinks(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		_, _, err = imgStore.CheckBlob("dedupe2", digest.String())
+		_, _, err = imgStore.CheckBlob("dedupe2", digest.String(), true)
 		So(err, ShouldBeNil)
 
 		_, _, err = imgStore.GetBlob("dedupe2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
@@ -254,7 +254,7 @@ func TestDedupeLinks(t *testing.T) {
 		_, clen, err = imgStore.FullBlobUpload("dedupe2", bytes.NewReader(cblob), cdigest.String())
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
-		hasBlob, _, err = imgStore.CheckBlob("dedupe2", cdigest.String())
+		hasBlob, _, err = imgStore.CheckBlob("dedupe2", cdigest.String(), true)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -758,7 +758,7 @@ func TestGarbageCollect(t *testing.T) {
 			_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest.String())
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest.String())
+			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -785,14 +785,14 @@ func TestGarbageCollect(t *testing.T) {
 			_, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest, manifestBuf)
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
 			err = imgStore.DeleteImageManifest(repoName, digest.String())
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 		})
@@ -845,7 +845,7 @@ func TestGarbageCollect(t *testing.T) {
 			_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest.String())
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest.String())
+			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -872,11 +872,11 @@ func TestGarbageCollect(t *testing.T) {
 			_, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest, manifestBuf)
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, odigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repoName, odigest.String(), true)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -886,7 +886,7 @@ func TestGarbageCollect(t *testing.T) {
 			err = imgStore.DeleteImageManifest(repoName, digest.String())
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String(), true)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 		})
@@ -924,7 +924,7 @@ func TestGarbageCollect(t *testing.T) {
 			_, clen, err := imgStore.FullBlobUpload(repo1Name, bytes.NewReader(cblob), cdigest.String())
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err := imgStore.CheckBlob(repo1Name, cdigest.String())
+			hasBlob, _, err := imgStore.CheckBlob(repo1Name, cdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -950,14 +950,14 @@ func TestGarbageCollect(t *testing.T) {
 			_, err = imgStore.PutImageManifest(repo1Name, tag, ispec.MediaTypeImageManifest, manifestBuf)
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repo1Name, tdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo1Name, tdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
 			// sleep so past GC timeout
 			time.Sleep(10 * time.Second)
 
-			hasBlob, _, err = imgStore.CheckBlob(repo1Name, tdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo1Name, tdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -986,7 +986,7 @@ func TestGarbageCollect(t *testing.T) {
 			_, clen, err = imgStore.FullBlobUpload(repo2Name, bytes.NewReader(cblob), cdigest.String())
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err = imgStore.CheckBlob(repo2Name, cdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo2Name, cdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1012,7 +1012,7 @@ func TestGarbageCollect(t *testing.T) {
 			_, err = imgStore.PutImageManifest(repo2Name, tag, ispec.MediaTypeImageManifest, manifestBuf)
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repo2Name, bdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo2Name, bdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1041,7 +1041,7 @@ func TestGarbageCollect(t *testing.T) {
 			_, clen, err = imgStore.FullBlobUpload(repo2Name, bytes.NewReader(cblob), cdigest.String())
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err = imgStore.CheckBlob(repo2Name, cdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo2Name, cdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1070,7 +1070,7 @@ func TestGarbageCollect(t *testing.T) {
 
 			// original blob should exist
 
-			hasBlob, _, err = imgStore.CheckBlob(repo2Name, tdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo2Name, tdigest.String(), true)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -164,6 +164,18 @@ func TestStorageAPIs(t *testing.T) {
 					So(err, ShouldBeNil)
 					So(n, ShouldEqual, len(body))
 					So(upload, ShouldNotBeEmpty)
+
+					Convey("Test for blob in different repo", func() {
+						hasBlob, _, _ := imgStore.CheckBlob("another", digest.String(), false)
+						So(hasBlob, ShouldBeTrue)
+						createdDir := imgStore.DirExists(path.Join(imgStore.RootDir(), "another"))
+						So(createdDir, ShouldBeFalse)
+
+						hasBlob, _, _ = imgStore.CheckBlob("yet-another", digest.String(), true)
+						So(hasBlob, ShouldBeTrue)
+						createdDir = imgStore.DirExists(path.Join(imgStore.RootDir(), "yet-another"))
+						So(createdDir, ShouldBeTrue)
+					})
 				})
 
 				Convey("New blob upload", func() {
@@ -227,7 +239,7 @@ func TestStorageAPIs(t *testing.T) {
 						err = imgStore.FinishBlobUpload("test", upload, buf, digest.String())
 						So(err, ShouldBeNil)
 
-						_, _, err = imgStore.CheckBlob("test", digest.String())
+						_, _, err = imgStore.CheckBlob("test", digest.String(), false)
 						So(err, ShouldBeNil)
 
 						_, _, err = imgStore.GetBlob("test", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
@@ -266,7 +278,7 @@ func TestStorageAPIs(t *testing.T) {
 							_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest.String())
 							So(err, ShouldBeNil)
 							So(clen, ShouldEqual, len(cblob))
-							hasBlob, _, err := imgStore.CheckBlob("test", cdigest.String())
+							hasBlob, _, err := imgStore.CheckBlob("test", cdigest.String(), false)
 							So(err, ShouldBeNil)
 							So(hasBlob, ShouldEqual, true)
 
@@ -334,7 +346,7 @@ func TestStorageAPIs(t *testing.T) {
 							So(len(tags), ShouldEqual, 2)
 
 							// We deleted only one tag, make sure blob should not be removed.
-							hasBlob, _, err = imgStore.CheckBlob("test", digest.String())
+							hasBlob, _, err = imgStore.CheckBlob("test", digest.String(), false)
 							So(err, ShouldBeNil)
 							So(hasBlob, ShouldEqual, true)
 
@@ -347,7 +359,7 @@ func TestStorageAPIs(t *testing.T) {
 							So(len(tags), ShouldEqual, 0)
 
 							// All tags/references are deleted, blob should not be present in disk.
-							hasBlob, _, err = imgStore.CheckBlob("test", digest.String())
+							hasBlob, _, err = imgStore.CheckBlob("test", digest.String(), true)
 							So(err, ShouldNotBeNil)
 							So(hasBlob, ShouldEqual, false)
 
@@ -410,7 +422,7 @@ func TestStorageAPIs(t *testing.T) {
 						err = imgStore.FinishBlobUpload("test", bupload, buf, digest.String())
 						So(err, ShouldBeNil)
 
-						_, _, err = imgStore.CheckBlob("test", digest.String())
+						_, _, err = imgStore.CheckBlob("test", digest.String(), true)
 						So(err, ShouldBeNil)
 
 						_, _, err = imgStore.GetBlob("test", "inexistent", "application/vnd.oci.image.layer.v1.tar+gzip")
@@ -434,7 +446,7 @@ func TestStorageAPIs(t *testing.T) {
 							_, _, err := imgStore.FullBlobUpload("test", bytes.NewBuffer([]byte{}), "inexistent")
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.CheckBlob("test", "inexistent")
+							_, _, err = imgStore.CheckBlob("test", "inexistent", true)
 							So(err, ShouldNotBeNil)
 						})
 
@@ -454,7 +466,7 @@ func TestStorageAPIs(t *testing.T) {
 							_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest.String())
 							So(err, ShouldBeNil)
 							So(clen, ShouldEqual, len(cblob))
-							hasBlob, _, err := imgStore.CheckBlob("test", cdigest.String())
+							hasBlob, _, err := imgStore.CheckBlob("test", cdigest.String(), true)
 							So(err, ShouldBeNil)
 							So(hasBlob, ShouldEqual, true)
 
@@ -548,7 +560,7 @@ func TestStorageAPIs(t *testing.T) {
 					_, clen, err := imgStore.FullBlobUpload("replace", bytes.NewReader(cblob), cdigest.String())
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
-					hasBlob, _, err := imgStore.CheckBlob("replace", cdigest.String())
+					hasBlob, _, err := imgStore.CheckBlob("replace", cdigest.String(), true)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -598,7 +610,7 @@ func TestStorageAPIs(t *testing.T) {
 					_, clen, err = imgStore.FullBlobUpload("replace", bytes.NewReader(cblob), cdigest.String())
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
-					hasBlob, _, err = imgStore.CheckBlob("replace", cdigest.String())
+					hasBlob, _, err = imgStore.CheckBlob("replace", cdigest.String(), true)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**Which issue does this PR fix**:

#511 

**What does this PR do / Why do we need it**:

Adds a `linkIfDupe` flag to the [`ImageStore.CheckBlob`](https://github.com/daviesian/zot/blob/dupe-blob-link-fix/pkg/storage/storage_fs.go#L1235) function, preventing it from linking to a blob found elsewhere unless required. This stops `HEAD` requests (testing for the existence of a blob) from polluting the storage directory.

It may make more sense to split `CheckBlob` into two separate functions - `CheckBlob` (with no side effects) and `EnsureRepoExists` (which creates the repo directory and copies duplicate blobs if necessary). Happy to do this instead if someone more familiar with the codebase thinks this would be better!

**Testing done on this change**:

Failing test added then verified passing. Several other tests were already failing for me on `main`, but this change did not affect their results.

**Automation added to e2e**:

None

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:

No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
