### PR TITLE
build: fix base image in stacker files

### DIFF
--- a/stacker-conformance.yaml
+++ b/stacker-conformance.yaml
@@ -38,7 +38,7 @@ build:
 "${{REPO_NAME:zot}}":
   from:
     type: docker
-    url: docker://gcr.io/distroless/base
+    url: docker://alpine:3
   import:
     - stacker://build/go/src/github.com/project-zot/zot/bin/zot-${{OS}}-${{ARCH}}
     - stacker://build/go/src/github.com/project-zot/zot/config.json

--- a/stacker-zb.yaml
+++ b/stacker-zb.yaml
@@ -19,7 +19,7 @@ build:
 "${{REPO_NAME:zb}}":
   from:
     type: docker
-    url: docker://gcr.io/distroless/base
+    url: docker://alpine:3
   import:
     - stacker://build/go/src/github.com/project-zot/zot/bin/zb-${{OS}}-${{ARCH}}
   run: |

--- a/stacker-zxp.yaml
+++ b/stacker-zxp.yaml
@@ -37,7 +37,7 @@ build:
 "${{REPO_NAME:zxp}}":
   from:
     type: docker
-    url: docker://gcr.io/distroless/base
+    url: docker://alpine:3
   import:
     - stacker://build/go/src/github.com/project-zot/zot/bin/zxp-${{OS}}-${{ARCH}}
     - stacker://build/go/src/github.com/project-zot/zot/config.json

--- a/stacker.yaml
+++ b/stacker.yaml
@@ -36,7 +36,7 @@ build:
 "${{REPO_NAME:zot}}":
   from:
     type: docker
-    url: docker://gcr.io/distroless/base
+    url: docker://alpine:3
   import:
     - stacker://build/go/src/github.com/project-zot/zot/bin/zot-${{OS}}-${{ARCH}}${{EXT:}}
     - stacker://build/go/src/github.com/project-zot/zot/config.json


### PR DESCRIPTION
Revert 058bbb94c68afbe3311e1c38bf094e5af7e79766
Use alpine:3

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

bug

**Which issue does this PR fix**:

stacker builds are broken in the final step since distroless and how we package using stacker are incompatible.


**What does this PR do / Why do we need it**:

Final container image builds are broken.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
