### PR TITLE
add endpoints field in ext discover api

### DIFF
--- a/pkg/api/constants/extensions.go
+++ b/pkg/api/constants/extensions.go
@@ -5,5 +5,5 @@ const (
 	ExtCatalogPrefix     = "/_catalog"
 	ExtOciDiscoverPrefix = "/_oci/ext/discover"
 	// zot specific extensions.
-	ExtSearchPrefix = RoutePrefix + "/_search"
+	ExtSearchPrefix = RoutePrefix + "/_zot/ext/search"
 )

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -4854,6 +4854,11 @@ func TestDistSpecExtensions(t *testing.T) {
 		err = json.Unmarshal(resp.Body(), &extensionList)
 		So(err, ShouldBeNil)
 		So(len(extensionList.Extensions), ShouldEqual, 1)
+		So(len(extensionList.Extensions[0].Endpoints), ShouldEqual, 1)
+		So(extensionList.Extensions[0].Name, ShouldEqual, "zot")
+		So(extensionList.Extensions[0].URL, ShouldContainSubstring, "_zot.md")
+		So(extensionList.Extensions[0].Description, ShouldNotBeEmpty)
+		So(extensionList.Extensions[0].Endpoints[0], ShouldEqual, constants.RoutePrefix+constants.ExtSearchPrefix)
 	})
 
 	Convey("start minimal zot server", t, func(c C) {

--- a/pkg/extensions/_zot.md
+++ b/pkg/extensions/_zot.md
@@ -1,0 +1,12 @@
+`zot` [extension](#references)
+===
+
+`zot` extension has following components accessible under `/v2/_zot` endpoint.
+
+Component | Endpoint | Description
+--- | --- | ---
+[`search`](search/search.md) | `/v2/_zot/ext/search` | efficient and enhanced registry search capabilities using graphQL backend
+
+
+# References
+[1] https://github.com/opencontainers/distribution-spec/tree/main/extensions

--- a/pkg/extensions/extensions.go
+++ b/pkg/extensions/extensions.go
@@ -112,11 +112,12 @@ func EnableScrubExtension(config *config.Config, storeController storage.StoreCo
 	}
 }
 
-func getExtension(name, url, description string) distext.Extension {
+func getExtension(name, url, description string, endpoints []string) distext.Extension {
 	return distext.Extension{
 		Name:        name,
 		URL:         url,
 		Description: description,
+		Endpoints:   endpoints,
 	}
 }
 
@@ -126,9 +127,10 @@ func GetExtensions(config *config.Config) distext.ExtensionList {
 	extensions := make([]distext.Extension, 0)
 
 	if config.Extensions != nil && config.Extensions.Search != nil {
-		searchExt := getExtension("search",
-			"https://github.com/project-zot/zot/tree/main/pkg/extensions/search/_search.md",
-			"search extension to provide various search feature e.g cve")
+		endpoints := []string{fmt.Sprintf("%s%s", constants.RoutePrefix, constants.ExtSearchPrefix)}
+		searchExt := getExtension("zot",
+			"https://github.com/project-zot/zot/tree/main/pkg/extensions/_zot.md",
+			"zot extension provide various components e.g search that provides various search capabilities", endpoints)
 
 		extensions = append(extensions, searchExt)
 	}

--- a/pkg/extensions/search/search.md
+++ b/pkg/extensions/search/search.md
@@ -1,12 +1,7 @@
-`search` extension
-===
+# `search` 
 
-`search` extension provides efficient and enhanced registry search capabilities using graphQL backend.
-
-
-Table of Contents
-===
-
+`search` component provides efficient and enhanced registry search capabilities using graphQL backend.
+	
 | Supported queries | Input | Ouput | Description | graphQL query |
 | --- | --- | --- | --- | --- |
 | [Search images by digest](#search-images-by-digest) | digest | image list | Search all repositories in the registry and return list of images that matches given digest (manifest, config or layers) | ImageListForDigest |
@@ -92,7 +87,7 @@ curl -X POST -H "Content-Type: application/json" --data '{ "query": "{ CVEListFo
 			}]
 			}
 		}
-    }
+	}
 ```
 # List images not affected by a given CVE id
 
@@ -189,6 +184,3 @@ curl -X POST -H "Content-Type: application/json" --data '{ "query": "{ ExpandedR
 	}
 }
 ```
-
-# References
-[1] https://github.com/opencontainers/distribution-spec/tree/main/extensions


### PR DESCRIPTION
distribution spec extension discover api has endpoints field required.

https://github.com/opencontainers/distribution-spec/blob/main/extensions/_oci.md#extensions-property-descriptions

Signed-off-by: Shivam Mishra <shimish2@cisco.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
