### PR TITLE
auth: Added API key support,

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ https://zotregistry.io
   * TLS mutual authentication
   * HTTP *Basic* (local _htpasswd_ and LDAP)
   * HTTP *Bearer* token
+  * [API keys](README_APIkeys.md)
 * Supports Identity-Based Access Control
 * Supports live modifications on the config file while zot is running (Authorization config only)
 * Doesn't require _root_ privileges

--- a/README_APIkeys.md
+++ b/README_APIkeys.md
@@ -1,0 +1,83 @@
+# API keys
+
+Zot allows authentication for REST API calls using your API key as an alternative to your password.
+
+* User can create/revoke/regenerate his API key.
+
+* Each user has only one API key at a time.
+
+* Can not be retrieve, it is shown to the user only the first time is created/regenerated.
+
+* An API key has the same rights as the user who generated it.
+
+* Admin can revoke a user API key.
+
+* Admin can revoke all API keys.
+
+
+## API keys REST API
+
+
+### Create API Key
+**Description**: Create an API key for the current user. Returns an error if API key already exists - use regenerate API key instead.
+
+**Usage**: POST /api/security/apiKey
+
+**Produces**: application/json
+
+**Sample input**:
+```
+POST /api/security/apiKey
+```
+
+**Sample output**:
+```
+{
+    "apiKey": "3OloposOtVFyCMrT+cXmCAScmVMPrSYXkWIjiyDCXsY="
+}
+```
+
+### Regenerate API Key
+**Description**: Regenerate an API key for the current user
+
+**Usage**: PUT /api/security/apiKey
+
+**Produces**: application/json
+
+**Sample input**:
+```
+PUT /api/security/apiKey
+```
+
+**Sample output**:
+
+```
+{
+    "apiKey": "3OloposOtVFyCMrT+cXmCAScmVMPrSYXkWIjiyDCXsY="
+}
+```
+
+### Revoke API Key
+**Description**: Revokes the current user's API key
+
+**Usage**: DELETE /api/security/apiKey
+
+**Produces**: application/json
+
+### Revoke User API Key
+**Description**: Revokes the API key of another user
+
+**Security**: Requires a privileged user (Admin only)
+
+**Usage**: DELETE /api/security/apiKey/{username} 
+
+**Produces**: application/json
+
+### Revoke All API Keys
+**Description**: Revokes all API keys currently defined in the system
+
+**Security**: Requires a privileged user (Admin only)
+
+**Usage**: DELETE /api/security/apiKey?deleteAll={0/1}
+
+**Produces**: application/json

--- a/examples/README.md
+++ b/examples/README.md
@@ -179,6 +179,16 @@ Should authentication fail, to prevent automated attacks, a delayed response can
       "failDelay": 5
 ```
 
+#### API keys
+
+Use it to activate API keys, boltdb database is stored in root directory
+
+```
+  "http": {
+    "auth": {
+      "apikeys": true
+```
+
 ## Identity-based Authorization
 
 Allowing actions on one or more repository paths can be tied to user

--- a/examples/config-example.json
+++ b/examples/config-example.json
@@ -26,7 +26,8 @@
       "htpasswd": {
         "path": "test/data/htpasswd"
       },
-      "failDelay": 5
+      "failDelay": 5,
+      "apikeys": true
     },
     "allowReadAccess": false
   },

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/google/go-containerregistry v0.9.0
 	github.com/google/uuid v1.3.0
-	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/json-iterator/go v1.1.12
 	github.com/minio/sha256-simd v1.0.0
@@ -57,6 +56,7 @@ require (
 require github.com/open-policy-agent/opa v0.37.0 // indirect
 
 require (
+	github.com/gorilla/handlers v1.5.1
 	github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220217185014-dd38b7ed8a99
 	github.com/sigstore/cosign v1.9.0
 	github.com/swaggo/http-swagger v1.2.8

--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -192,6 +192,13 @@ func AuthzHandler(ctlr *Controller) mux.MiddlewareFunc {
 
 			ctx := acCtrlr.getContext(username, request)
 
+			// bypass authz for /api/ endpoint used for API keys, but with context to know if current user is admin
+			if strings.Contains(request.RequestURI, "/api/") {
+				next.ServeHTTP(response, request.WithContext(ctx))
+
+				return
+			}
+
 			// will return only repos on which client is authorized to read
 			if request.RequestURI == fmt.Sprintf("%s%s", constants.RoutePrefix, constants.ExtCatalogPrefix) {
 				next.ServeHTTP(response, request.WithContext(ctx))

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -42,6 +42,7 @@ type AuthConfig struct {
 	HTPasswd  AuthHTPasswd
 	LDAP      *LDAPConfig
 	Bearer    *BearerConfig
+	APIKeys   bool `mapstructure:",omitempty"`
 }
 
 type BearerConfig struct {
@@ -60,6 +61,7 @@ type RatelimitConfig struct {
 	Methods []MethodRatelimitConfig `mapstructure:",omitempty"`
 }
 
+// nolint: maligned
 type HTTPConfig struct {
 	Address          string
 	Port             string

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -35,6 +35,7 @@ const (
 	DENIED
 	UNSUPPORTED
 	INVALID_INDEX
+	APIKEY_EXISTS
 )
 
 func (e ErrorCode) String() string {
@@ -55,6 +56,7 @@ func (e ErrorCode) String() string {
 		DENIED:                "DENIED",
 		UNSUPPORTED:           "UNSUPPORTED",
 		INVALID_INDEX:         "INVALID_INDEX",
+		APIKEY_EXISTS:         "APIKEY_EXISTS",
 	}
 
 	return errMap[e]
@@ -158,6 +160,11 @@ func NewError(code ErrorCode, detail ...interface{}) Error { //nolint: interface
 		INVALID_INDEX: {
 			Message:     "Invalid format of index.json file of the repo",
 			Description: "index.json file does not contain data in json format",
+		},
+
+		APIKEY_EXISTS: {
+			Message:     "API key already exists",
+			Description: "API key for this username already exists, use regenerate API key instead",
 		},
 	}
 

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -14,7 +14,7 @@ import (
 const (
 	BlobsCache              = "blobs"
 	DBExtensionName         = ".db"
-	dbCacheLockCheckTimeout = 10 * time.Second
+	DBCacheLockCheckTimeout = 10 * time.Second
 )
 
 type Cache struct {
@@ -24,15 +24,10 @@ type Cache struct {
 	useRelPaths bool // weather or not to use relative paths, should be true for filesystem and false for s3
 }
 
-// Blob is a blob record.
-type Blob struct {
-	Path string
-}
-
 func NewCache(rootDir string, name string, useRelPaths bool, log zlog.Logger) *Cache {
 	dbPath := path.Join(rootDir, name+DBExtensionName)
 	dbOpts := &bbolt.Options{
-		Timeout:      dbCacheLockCheckTimeout,
+		Timeout:      DBCacheLockCheckTimeout,
 		FreelistType: bbolt.FreelistArrayType,
 	}
 

--- a/pkg/storage/database/database.go
+++ b/pkg/storage/database/database.go
@@ -1,0 +1,185 @@
+package database
+
+import (
+	"path"
+	"strings"
+
+	"go.etcd.io/bbolt"
+	"zotregistry.io/zot/errors"
+	zlog "zotregistry.io/zot/pkg/log"
+	"zotregistry.io/zot/pkg/storage"
+	"zotregistry.io/zot/pkg/test"
+)
+
+type Database interface {
+	Put(key, value string) error
+	Get(key string) (string, error)
+	Has(key string) bool
+	Delete(key string) error
+	DeleteAll() error
+}
+
+// key:value store
+type DB struct {
+	bucket  string
+	rootDir string
+	db      *bbolt.DB
+	log     zlog.Logger
+}
+
+func New(rootDir string, name string, bucket string, log zlog.Logger) (*DB, error) {
+	dbPath := path.Join(rootDir, name+storage.DBExtensionName)
+	dbOpts := &bbolt.Options{
+		Timeout:      storage.DBCacheLockCheckTimeout,
+		FreelistType: bbolt.FreelistArrayType,
+	}
+
+	database, err := bbolt.Open(dbPath, 0o600, dbOpts) //nolint:gomnd
+	if err != nil {
+		log.Error().Err(err).Str("dbPath", dbPath).Msg("unable to create cache db")
+
+		return nil, err
+	}
+
+	if err := database.Update(func(tx *bbolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists([]byte(bucket)); err != nil {
+			// this is a serious failure
+			log.Error().Err(err).Str("dbPath", dbPath).Msg("unable to create a root bucket")
+
+			return err
+		}
+
+		return nil
+	}); err != nil {
+		// something went wrong
+		log.Error().Err(err).Msg("unable to create a database")
+
+		return nil, err
+	}
+
+	return &DB{rootDir: rootDir, bucket: bucket, log: log, db: database}, nil
+}
+
+func (db *DB) Put(key, value string) error {
+	if value == "" || key == "" {
+		db.log.Error().Err(errors.ErrEmptyValue).Str("key", key).Str("value", value).Msg("empty key/value provided")
+
+		return errors.ErrEmptyValue
+	}
+
+	if err := test.Error(db.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(db.bucket))
+		if bucket == nil {
+			// this is a serious failure
+			err := errors.ErrCacheRootBucket
+			db.log.Error().Err(err).Str("bucket", db.bucket).Msg("unable to access root bucket")
+
+			return err
+		}
+
+		return bucket.Put([]byte(key), []byte(value))
+	})); err != nil {
+		db.log.Error().Err(err).Str("bucket", db.bucket).Str("key", key).Str("value", value).Msg("unable to put record")
+
+		return err
+	}
+
+	return nil
+}
+
+func (db *DB) Get(key string) (string, error) {
+	var value strings.Builder
+
+	if err := test.Error(db.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(db.bucket))
+		if bucket == nil {
+			// this is a serious failure
+			err := errors.ErrCacheRootBucket
+			db.log.Error().Err(err).Str("bucket", db.bucket).Msg("unable to access root bucket")
+
+			return err
+		}
+
+		v := bucket.Get([]byte(key))
+		value.Write(v)
+
+		return nil
+	})); err != nil {
+		return "", err
+	}
+
+	return value.String(), nil
+}
+
+func (db *DB) Has(key string) bool {
+	if err := db.db.View(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(db.bucket))
+		if bucket == nil {
+			// this is a serious failure
+			err := errors.ErrCacheRootBucket
+			db.log.Error().Err(err).Msg("unable to access root bucket")
+
+			return err
+		}
+
+		if bucket.Get([]byte(key)) == nil {
+			return errors.ErrCacheMiss
+		}
+
+		return nil
+	}); err != nil {
+		return false
+	}
+
+	return true
+}
+
+func (db *DB) Delete(key string) error {
+	if err := test.Error(db.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(db.bucket))
+		if bucket == nil {
+			// this is a serious failure
+			err := errors.ErrCacheRootBucket
+			db.log.Error().Err(err).Str("bucket", db.bucket).Msg("unable to access root bucket")
+
+			return err
+		}
+
+		return bucket.Delete([]byte(key))
+	})); err != nil {
+		db.log.Error().Err(err).Str("bucket", db.bucket).Msg("unable to delete a keys")
+
+		return err
+	}
+
+	return nil
+}
+
+func (db *DB) DeleteAll() error {
+	if err := test.Error(db.db.Update(func(tx *bbolt.Tx) error {
+		bucket := tx.Bucket([]byte(db.bucket))
+		if bucket == nil {
+			// this is a serious failure
+			err := errors.ErrCacheRootBucket
+			db.log.Error().Err(err).Str("bucket", db.bucket).Msg("unable to access root bucket")
+
+			return err
+		}
+
+		err := bucket.ForEach(func(k, v []byte) error {
+			return bucket.Delete(k)
+		})
+
+		return err
+	})); err != nil {
+		db.log.Error().Err(err).Str("bucket", db.bucket).Msg("unable to delete all keys")
+
+		return err
+	}
+
+	return nil
+}
+
+func (db *DB) Close() error {
+	return db.db.Close()
+}

--- a/pkg/storage/database/database_internal_test.go
+++ b/pkg/storage/database/database_internal_test.go
@@ -1,0 +1,42 @@
+package database
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"zotregistry.io/zot/pkg/log"
+)
+
+func TestDatabaseNilBucket(t *testing.T) {
+	Convey("Make a new database", t, func() {
+		dir := t.TempDir()
+
+		log := log.NewLogger("debug", "")
+		So(log, ShouldNotBeNil)
+
+		_, err := New("/deadBEEF", "db_test", "db_test", log)
+		So(err, ShouldNotBeNil)
+
+		store, err := New(dir, "db_test", "db_test", log)
+		So(err, ShouldBeNil)
+		So(store, ShouldNotBeNil)
+
+		store.bucket = "unknown"
+
+		exists := store.Has("key")
+		So(exists, ShouldBeFalse)
+
+		err = store.Put("key", "value")
+		So(err, ShouldNotBeNil)
+
+		val, err := store.Get("key")
+		So(err, ShouldNotBeNil)
+		So(val, ShouldBeEmpty)
+
+		err = store.Delete("key")
+		So(err, ShouldNotBeNil)
+
+		err = store.DeleteAll()
+		So(err, ShouldNotBeNil)
+	})
+}

--- a/pkg/storage/database/database_test.go
+++ b/pkg/storage/database/database_test.go
@@ -1,0 +1,115 @@
+package database_test
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"zotregistry.io/zot/errors"
+	"zotregistry.io/zot/pkg/log"
+	"zotregistry.io/zot/pkg/storage/database"
+	"zotregistry.io/zot/pkg/test"
+)
+
+func TestDatabase(t *testing.T) {
+	Convey("Make a new database", t, func() {
+		dir := t.TempDir()
+
+		log := log.NewLogger("debug", "")
+		So(log, ShouldNotBeNil)
+
+		store, err := database.New(dir, "db_test", "db_test", log)
+		So(err, ShouldBeNil)
+		So(store, ShouldNotBeNil)
+
+		exists := store.Has("key")
+		So(exists, ShouldBeFalse)
+
+		err = store.Put("", "")
+		So(err, ShouldEqual, errors.ErrEmptyValue)
+
+		err = store.Put("key", "value")
+		So(err, ShouldBeNil)
+
+		exists = store.Has("key")
+		So(exists, ShouldBeTrue)
+
+		val, err := store.Get("key")
+		So(err, ShouldBeNil)
+		So(val, ShouldNotBeEmpty)
+
+		err = store.Delete("bogusKey")
+		So(err, ShouldBeNil)
+
+		err = store.Delete("key")
+		So(err, ShouldBeNil)
+
+		err = store.Put("key1", "value1")
+		So(err, ShouldBeNil)
+
+		err = store.Put("key2", "value2")
+		So(err, ShouldBeNil)
+
+		// check deleteAll actually deletes all keys
+		err = store.DeleteAll()
+		So(err, ShouldBeNil)
+
+		val, err = store.Get("key1")
+		So(err, ShouldBeNil)
+		So(val, ShouldBeEmpty)
+
+		val, err = store.Get("key2")
+		So(err, ShouldBeNil)
+		So(val, ShouldBeEmpty)
+
+		err = store.Close()
+		So(err, ShouldBeNil)
+
+		// trigger timeout error, open an already opened db
+		_, err = database.New(dir, "db_test", "", log)
+		So(err, ShouldNotBeNil)
+
+		// trigger empty bucket name error
+		_, err = database.New(dir, "db_test", "", log)
+		So(err, ShouldNotBeNil)
+
+		err = store.Close()
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestInjectDatabaseErrs(t *testing.T) {
+	Convey("Make a new database", t, func() {
+		dir := t.TempDir()
+
+		log := log.NewLogger("debug", "")
+		So(log, ShouldNotBeNil)
+
+		store, err := database.New(dir, "db_test", "db_test", log)
+		So(err, ShouldBeNil)
+		So(store, ShouldNotBeNil)
+
+		injected := test.InjectFailure(0)
+		if injected {
+			_, err = store.Get("key1")
+			So(err, ShouldNotBeNil)
+		}
+
+		injected = test.InjectFailure(0)
+		if injected {
+			err = store.Put("key", "value")
+			So(err, ShouldNotBeNil)
+		}
+
+		injected = test.InjectFailure(0)
+		if injected {
+			err = store.Delete("key")
+			So(err, ShouldNotBeNil)
+		}
+
+		injected = test.InjectFailure(0)
+		if injected {
+			err = store.DeleteAll()
+			So(err, ShouldNotBeNil)
+		}
+	})
+}


### PR DESCRIPTION
only one key per user which is visible only at creation time
user can generate/revoke/regenerate his api key
admin can revoke a user api key or all keys

closes #528

Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
