### PR TITLE
Blob upload location should strip query parameters

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -35,6 +35,7 @@ import (
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"
 	"zotregistry.io/zot/pkg/test" // nolint: goimports
+
 	// as required by swaggo.
 	_ "zotregistry.io/zot/swagger"
 )
@@ -759,7 +760,10 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 				return
 			}
 
-			response.Header().Set("Location", path.Join(request.URL.String(), upload))
+			u := request.URL
+			u.Path = path.Join(u.Path, upload)
+			u.RawQuery = ""
+			response.Header().Set("Location", u.String())
 			response.Header().Set("Range", "bytes=0-0")
 			response.WriteHeader(http.StatusAccepted)
 


### PR DESCRIPTION
Signed-off-by: Brandon Mitchell <git@bmitch.net>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
bug

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Fixes #573

**What does this PR do / Why do we need it**:
The url response when a mount query is seen includes the mount query with the upload location appended, which is not valid for uploading a blob.

**If an issue # is not available please add repro steps and logs showing the issue**:
See #573

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

I manually tested this. (Wanted to add a unit test, but got lost in the packages being used.)

```
$ regctl artifact put -f sbom.json localhost:5207/sbom -v debug
DEBU[0000] regclient initialized                         VCSRef=0e8ba98e23a78839b7d514bbc7ab1cbf3a6e1fbd-dirty VCSTag=
DEBU[0000] http req                                      method=POST url="http://localhost:5207/v2/sbom/blobs/uploads/?mount=sha256%3A44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a" withAuth=false
DEBU[0000] Received put URL                              digest="{ 2 sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a [] map[] [] <nil>}" err="<nil>" location=/v2/sbom/blobs/uploads/97285b56-00ad-415b-9523-e1b66ff0cdcf putURL="http://localhost:5207/v2/sbom/blobs/uploads/97285b56-00ad-415b-9523-e1b66ff0cdcf" target="localhost:5207/sbom:latest"
DEBU[0000] http req                                      method=PUT url="http://localhost:5207/v2/sbom/blobs/uploads/97285b56-00ad-415b-9523-e1b66ff0cdcf?digest=sha256%3A44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a" withAuth=false 
DEBU[0000] http req                                      method=HEAD url="http://localhost:5207/v2/sbom/blobs/sha256:3c581b946b9d591324779f4c9ffa8bc9c7a5d1bd92a87c39b29c4e9da5ab0809" withAuth=false
DEBU[0000] Request failed                                Status="Not Found" URL="http://localhost:5207/v2/sbom/blobs/sha256:3c581b946b9d591324779f4c9ffa8bc9c7a5d1bd92a87c39b29c4e9da5ab0809"
DEBU[0000] http req                                      method=POST url="http://localhost:5207/v2/sbom/blobs/uploads/?mount=sha256%3A3c581b946b9d591324779f4c9ffa8bc9c7a5d1bd92a87c39b29c4e9da5ab0809" withAuth=false
DEBU[0000] Received put URL                              digest="{ 12499 sha256:3c581b946b9d591324779f4c9ffa8bc9c7a5d1bd92a87c39b29c4e9da5ab0809 [] map[] [] <nil>}" err="<nil>" location=/v2/sbom/blobs/uploads/738159f6-fb5f-4e2c-a34a-e0ca02e12e12 putURL="http://localhost:5207/v2/sbom/blobs/uploads/738159f6-fb5f-4e2c-a34a-e0ca02e12e12" target="localhost:5207/sbom:latest"
DEBU[0000] http req                                      method=PUT url="http://localhost:5207/v2/sbom/blobs/uploads/738159f6-fb5f-4e2c-a34a-e0ca02e12e12?digest=sha256%3A3c581b946b9d591324779f4c9ffa8bc9c7a5d1bd92a87c39b29c4e9da5ab0809" withAuth=false             
DEBU[0000] http req                                      method=PUT url="http://localhost:5207/v2/sbom/manifests/latest" withAuth=false
```


**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
