### PR TITLE
deprecation: allowReadAccess and ReadOnly

### DIFF
--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -49,3 +49,6 @@ jobs:
       - name: Run scrub tests
         run: |
             make bats-scrub
+      - name: Run anonymous-push-pull tests
+        run: |
+            make anonymous-push-pull

--- a/Makefile
+++ b/Makefile
@@ -315,3 +315,7 @@ fuzz-all:
 	rm -rf test-data; \
 	bash test/scripts/fuzzAll.sh ${fuzztime}; \
 	rm -rf pkg/storage/testdata; \
+
+.PHONY: anonymous-push-pull
+anonymous-push-pull: binary check-skopeo $(BATS)
+	$(BATS) --trace --print-output-on-failure test/blackbox/anonymous_policiy.bats

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -54,4 +54,5 @@ var (
 	ErrSyncSignatureNotFound   = errors.New("sync: couldn't find any upstream notary/cosign signatures")
 	ErrSyncSignature           = errors.New("sync: couldn't get upstream notary/cosign signatures")
 	ErrImageLintAnnotations    = errors.New("routes: lint checks failed")
+	ErrParsingAuthHeader       = errors.New("auth: failed parsing authorization header")
 )

--- a/examples/README.md
+++ b/examples/README.md
@@ -49,13 +49,6 @@ Additionally, TLS configuration can be specified with:
         },
 ```
 
-The registry can be deployed as a read-only service with:
-
-```
-        "ReadOnly": false
-    },
-```
-
 ## Storage
 
 Configure storage with:
@@ -209,7 +202,8 @@ create/update/delete can not be used without 'read' action, make sure read is al
           "actions": ["read", "create", "update"]
         }
       ],
-      "defaultPolicy": ["read", "create"]                      # default policy which is applied for all users => so all users can read/create repositories
+      "defaultPolicy": ["read", "create"],                     # default policy which is applied for authenticated users, other than "charlie"=> so these users can read/create repositories
+      "anonymousPolicy": ["read]                               # anonymous policy which is applied for unauthenticated users => so they can read repositories
     },
     "tmp/**": {                                                # matches all repos under tmp/ recursively
       "defaultPolicy": ["read", "create", "update"]            # so all users have read/create/update on all repos under tmp/ eg: tmp/infra/repo

--- a/examples/config-anonymous-authz.json
+++ b/examples/config-anonymous-authz.json
@@ -9,25 +9,25 @@
     "realm": "zot",
     "accessControl": {
       "**": {
-        "defaultPolicy": [
+        "anonymousPolicy": [
           "read",
           "create"
         ]
       },
       "tmp/**": {
-        "defaultPolicy": [
+        "anonymousPolicy": [
           "read",
           "create",
           "update"
         ]
       },
       "infra/**": {
-        "defaultPolicy": [
+        "anonymousPolicy": [
           "read"
         ]
       },
       "repos2/repo": {
-        "defaultPolicy": [
+        "anonymousPolicy": [
           "read"
         ]
       }

--- a/examples/config-bench.json
+++ b/examples/config-bench.json
@@ -5,8 +5,7 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080",
-        "ReadOnly": false
+        "port": "8080"
     },
     "log": {
         "level": "debug",

--- a/examples/config-commit.json
+++ b/examples/config-commit.json
@@ -6,8 +6,7 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080",
-        "ReadOnly": false
+        "port": "8080"
     },
     "log": {
         "level": "debug"

--- a/examples/config-example.json
+++ b/examples/config-example.json
@@ -27,8 +27,7 @@
         "path": "test/data/htpasswd"
       },
       "failDelay": 5
-    },
-    "allowReadAccess": false
+    }
   },
   "log": {
     "level": "debug",

--- a/examples/config-example.yaml
+++ b/examples/config-example.yaml
@@ -1,7 +1,6 @@
 distspecversion: 1.0.1-dev
 http:
   address: 127.0.0.1
-  allowreadaccess: false
   auth:
     faildelay: 5
     htpasswd:

--- a/examples/config-gc.json
+++ b/examples/config-gc.json
@@ -7,8 +7,7 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080",
-        "ReadOnly": false
+        "port": "8080"
     },
     "log": {
         "level": "debug"

--- a/examples/config-lint.json
+++ b/examples/config-lint.json
@@ -5,8 +5,7 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080",
-        "ReadOnly": false
+        "port": "8080"
     },
     "log": {
         "level": "debug"

--- a/examples/config-minimal.json
+++ b/examples/config-minimal.json
@@ -5,8 +5,7 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080",
-        "ReadOnly": false
+        "port": "8080"
     },
     "log": {
         "level": "debug"

--- a/examples/config-multiple-cve.json
+++ b/examples/config-multiple-cve.json
@@ -21,8 +21,7 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "5000",
-        "ReadOnly": false
+        "port": "5000"
     },
     "log": {
         "level": "debug"

--- a/examples/config-multiple.json
+++ b/examples/config-multiple.json
@@ -21,8 +21,7 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "5000",
-        "ReadOnly": false
+        "port": "5000"
     },
     "log": {
         "level": "debug"

--- a/examples/config-policy.json
+++ b/examples/config-policy.json
@@ -15,6 +15,7 @@
     },
     "accessControl": {
       "**": {
+        "anonymousPolicy": ["read"],
         "policies": [
           {
             "users": [

--- a/examples/config-ratelimit.json
+++ b/examples/config-ratelimit.json
@@ -6,7 +6,6 @@
     "http": {
         "address": "127.0.0.1",
         "port": "8080",
-        "ReadOnly": false,
         "Ratelimit": {
             "Rate": 10,
             "Methods": [

--- a/examples/config-s3.json
+++ b/examples/config-s3.json
@@ -52,8 +52,7 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080",
-        "ReadOnly": false
+        "port": "8080"
     },
     "log": {
         "level": "debug"

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -68,8 +68,6 @@ type HTTPConfig struct {
 	Auth             *AuthConfig
 	RawAccessControl map[string]interface{} `mapstructure:"accessControl,omitempty"`
 	Realm            string
-	AllowReadAccess  bool             `mapstructure:",omitempty"`
-	ReadOnly         bool             `mapstructure:",omitempty"`
 	Ratelimit        *RatelimitConfig `mapstructure:",omitempty"`
 }
 
@@ -112,8 +110,9 @@ type AccessControlConfig struct {
 type Repositories map[string]PolicyGroup
 
 type PolicyGroup struct {
-	Policies      []Policy
-	DefaultPolicy []string
+	Policies        []Policy
+	DefaultPolicy   []string
+	AnonymousPolicy []string
 }
 
 type Policy struct {
@@ -193,8 +192,11 @@ func (c *Config) LoadAccessControlConfig(viperInstance *viper.Viper) error {
 		}
 
 		defaultPolicy := viperInstance.GetStringSlice(fmt.Sprintf("http::accessControl::%s::defaultPolicy", policy))
-		policyGroup.Policies = policies
 		policyGroup.DefaultPolicy = defaultPolicy
+
+		anonymousPolicy := viperInstance.GetStringSlice(fmt.Sprintf("http::accessControl::%s::anonymousPolicy", policy))
+		policyGroup.Policies = policies
+		policyGroup.AnonymousPolicy = anonymousPolicy
 		c.AccessControl.Repositories[policy] = policyGroup
 	}
 

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -190,7 +190,8 @@ func (c *Controller) Run(reloadCtx context.Context) error {
 
 		if c.Config.HTTP.TLS.CACert != "" {
 			clientAuth := tls.VerifyClientCertIfGiven
-			if (c.Config.HTTP.Auth == nil || c.Config.HTTP.Auth.HTPasswd.Path == "") && !c.Config.HTTP.AllowReadAccess {
+			if (c.Config.HTTP.Auth == nil || c.Config.HTTP.Auth.HTPasswd.Path == "") &&
+				!anonymousPolicyExists(c.Config.AccessControl) {
 				clientAuth = tls.RequireAndVerifyClientCert
 			}
 

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -140,13 +140,11 @@ func (rh *RouteHandler) CheckVersionSupport(response http.ResponseWriter, reques
 	response.Header().Set(constants.DistAPIVersion, "registry/2.0")
 	// NOTE: compatibility workaround - return this header in "allowed-read" mode to allow for clients to
 	// work correctly
-	if rh.c.Config.HTTP.AllowReadAccess {
-		if rh.c.Config.HTTP.Auth != nil {
-			if rh.c.Config.HTTP.Auth.Bearer != nil {
-				response.Header().Set("WWW-Authenticate", fmt.Sprintf("bearer realm=%s", rh.c.Config.HTTP.Auth.Bearer.Realm))
-			} else {
-				response.Header().Set("WWW-Authenticate", fmt.Sprintf("basic realm=%s", rh.c.Config.HTTP.Realm))
-			}
+	if rh.c.Config.HTTP.Auth != nil {
+		if rh.c.Config.HTTP.Auth.Bearer != nil {
+			response.Header().Set("WWW-Authenticate", fmt.Sprintf("bearer realm=%s", rh.c.Config.HTTP.Auth.Bearer.Realm))
+		} else {
+			response.Header().Set("WWW-Authenticate", fmt.Sprintf("basic realm=%s", rh.c.Config.HTTP.Realm))
 		}
 	}
 

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -174,14 +174,14 @@ func TestVerify(t *testing.T) {
 		So(func() { _ = cli.NewServerRootCmd().Execute() }, ShouldNotPanic)
 	})
 
-	Convey("Test verify default authorization", t, func(c C) {
+	Convey("Test verify anonymous authorization", t, func(c C) {
 		tmpfile, err := ioutil.TempFile("", "zot-test*.json")
 		So(err, ShouldBeNil)
 		defer os.Remove(tmpfile.Name()) // clean up
 		content := []byte(`{"storage":{"rootDirectory":"/tmp/zot"},
 		 					"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
-							 "accessControl":{"**":{"defaultPolicy": ["read", "create"]},
-							 "/repo":{"defaultPolicy": ["read", "create"]}
+							 "accessControl":{"**":{"anonymousPolicy": ["read", "create"]},
+							 "/repo":{"anonymousPolicy": ["read", "create"]}
 							 }}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)
@@ -198,7 +198,7 @@ func TestVerify(t *testing.T) {
 		content := []byte(`{"storage":{"rootDirectory":"/tmp/zot"},
 		 					"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							 "accessControl":{"**":{"defaultPolicy": ["read", "create"]},
-							 "/repo":{"defaultPolicy": ["read", "create"]},
+							 "/repo":{"anonymousPolicy": ["read", "create"]},
 							 "adminPolicy":{"users":["admin"],
 							 "actions":["read","create","update","delete"]}
 							 }}}`)
@@ -217,7 +217,7 @@ func TestVerify(t *testing.T) {
 		content := []byte(`{"storage":{"rootDirectory":"/tmp/zot"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"accessControl":{"**":{"defaultPolicy": ["read", "create"]},
-							"/repo":{"defaultPolicy": ["read", "create"]},
+							"/repo":{"anonymousPolicy": ["read", "create"]},
 							"/repo2":{"policies": [{
 								 "users": ["charlie"],
 								 "actions": ["read", "create", "update"]}]}
@@ -289,7 +289,7 @@ func TestVerify(t *testing.T) {
 		content := []byte(`{"storage":{"rootDirectory":"/tmp/zot"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1},
-							"accessControl":{"[":{"policies":[],"defaultPolicy":[]}}}}`)
+							"accessControl":{"[":{"policies":[],"anonymousPolicy":[]}}}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)
 		err = tmpfile.Close()
@@ -339,7 +339,7 @@ func TestVerify(t *testing.T) {
 		So(err, ShouldBeNil)
 		defer os.Remove(tmpfile.Name()) // clean up
 		content := []byte(`{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot"},
-							"http": {"url": "127.0.0.1", "port": "8080", "ReadOnly": false},
+							"http": {"url": "127.0.0.1", "port": "8080"},
 							"log": {"level": "debug"}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)
@@ -355,7 +355,7 @@ func TestVerify(t *testing.T) {
 		defer os.Remove(tmpfile.Name()) // clean up
 		content := []byte(`{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot"},
 							"http": {"auth": {"ldap": {"address": "ldap", "userattribute": "uid"}},
-							"address": "127.0.0.1", "port": "8080", "ReadOnly": false},
+							"address": "127.0.0.1", "port": "8080"},
 							"log": {"level": "debug"}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)
@@ -371,7 +371,7 @@ func TestVerify(t *testing.T) {
 		defer os.Remove(tmpfile.Name()) // clean up
 		content := []byte(`{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot"},
 							"http": {"auth": {"ldap": {"basedn": "ou=Users,dc=example,dc=org", "userattribute": "uid"}},
-							"address": "127.0.0.1", "port": "8080", "ReadOnly": false},
+							"address": "127.0.0.1", "port": "8080"},
 							"log": {"level": "debug"}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)
@@ -387,7 +387,7 @@ func TestVerify(t *testing.T) {
 		defer os.Remove(tmpfile.Name()) // clean up
 		content := []byte(`{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot"},
 							"http": {"auth": {"ldap": {"basedn": "ou=Users,dc=example,dc=org", "address": "ldap"}},
-							"address": "127.0.0.1", "port": "8080", "ReadOnly": false},
+							"address": "127.0.0.1", "port": "8080"},
 							"log": {"level": "debug"}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)
@@ -402,7 +402,7 @@ func TestVerify(t *testing.T) {
 		So(err, ShouldBeNil)
 		defer os.Remove(tmpfile.Name()) // clean up
 		content := []byte(`{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot"},
-							"http": {"address": "127.0.0.1", "port": "8080", "ReadOnly": false},
+							"http": {"address": "127.0.0.1", "port": "8080"},
 							"log": {"level": "debug"}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)
@@ -503,7 +503,7 @@ func TestGC(t *testing.T) {
 			defer os.Remove(file.Name())
 
 			content := []byte(`{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot",
-			"gc": false}, "http": {"address": "127.0.0.1", "port": "8080", "ReadOnly": false},
+			"gc": false}, "http": {"address": "127.0.0.1", "port": "8080"},
 			"log": {"level": "debug"}}`)
 
 			err = ioutil.WriteFile(file.Name(), content, 0o600)

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -807,7 +807,7 @@ func TestConfigReloader(t *testing.T) {
 		}()
 
 		content := fmt.Sprintf(`{"distSpecVersion": "0.1.0-dev", "storage": {"rootDirectory": "%s"},
-		"http": {"address": "127.0.0.1", "port": "%s", "ReadOnly": false},
+		"http": {"address": "127.0.0.1", "port": "%s"},
 		"log": {"level": "debug", "output": "%s"}}`, destDir, destPort, logFile.Name())
 
 		cfgfile, err := ioutil.TempFile("", "zot-test*.json")

--- a/test/blackbox/anonymous_policiy.bats
+++ b/test/blackbox/anonymous_policiy.bats
@@ -1,0 +1,91 @@
+load helpers_pushpull
+
+function setup_file() {
+    # Verify prerequisites are available
+    if ! verify_prerequisites; then
+        exit 1
+    fi
+
+    # Download test data to folder common for the entire suite, not just this file
+    skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.18 oci:${TEST_DATA_DIR}/golang:1.18
+    # Setup zot server
+    local zot_root_dir=${BATS_FILE_TMPDIR}/zot
+    local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
+    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
+    local htpasswordFile=${BATS_FILE_TMPDIR}/htpasswd
+    mkdir -p ${zot_root_dir}
+    mkdir -p ${oci_data_dir}
+    echo 'test:$2a$10$EIIoeCnvsIDAJeDL4T1sEOnL2fWOvsq7ACZbs3RT40BBBXg.Ih7V.' >> ${htpasswordFile}
+    cat > ${zot_config_file}<<EOF
+{
+    "distSpecVersion": "1.0.1",
+    "storage": {
+        "rootDirectory": "${zot_root_dir}"
+    },
+    "http": {
+        "address": "127.0.0.1",
+        "port": "8080",
+        "auth": {
+            "htpasswd": {
+                "path": "${htpasswordFile}"
+            }
+        },
+        "accessControl": {
+            "**": {
+                "anonymousPolicy": ["read"],
+                "policies": [
+                    {
+                        "users": [
+                            "test"
+                        ],
+                        "actions": [
+                            "read",
+                            "create",
+                            "update"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "log": {
+        "level": "debug"
+    }
+}
+EOF
+    git -C ${BATS_FILE_TMPDIR} clone https://github.com/project-zot/helm-charts.git
+    setup_zot_file_level ${zot_config_file}
+    wait_zot_reachable "http://127.0.0.1:8080/v2/_catalog"   
+}
+
+function teardown_file() {
+    local zot_root_dir=${BATS_FILE_TMPDIR}/zot
+    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
+    teardown_zot_file_level
+    rm -rf ${zot_root_dir}
+    rm -rf ${oci_data_dir}
+}
+
+
+@test "push image user policy" {
+    run skopeo --insecure-policy copy --dest-creds test:test --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/golang:1.18 \
+        docker://127.0.0.1:8080/golang:1.18
+    [ "$status" -eq 0 ]
+}
+
+
+@test "pull image anonymous policy" {
+    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
+    run skopeo --insecure-policy copy --src-tls-verify=false \
+        docker://127.0.0.1:8080/golang:1.18 \
+        oci:${oci_data_dir}/golang:1.18
+    [ "$status" -eq 0 ]
+}
+
+@test "push image anonymous policy" {
+    run skopeo --insecure-policy copy --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/golang:1.18 \
+        docker://127.0.0.1:8080/golang:1.18
+    [ "$status" -eq 1 ]
+}

--- a/test/blackbox/cve.bats
+++ b/test/blackbox/cve.bats
@@ -21,8 +21,7 @@ function setup_file() {
     },
     "http": {
         "address": "0.0.0.0",
-        "port": "8080",
-        "ReadOnly": false
+        "port": "8080"
     },
     "log": {
         "level": "debug"

--- a/test/blackbox/metrics.bats
+++ b/test/blackbox/metrics.bats
@@ -25,8 +25,7 @@ function setup_file() {
     },
     "http": {
         "address": "0.0.0.0",
-        "port": "8080",
-        "ReadOnly": false
+        "port": "8080"
     },
     "log": {
         "level": "debug",

--- a/test/blackbox/pushpull.bats
+++ b/test/blackbox/pushpull.bats
@@ -21,8 +21,7 @@ function setup_file() {
     },
     "http": {
         "address": "0.0.0.0",
-        "port": "8080",
-        "ReadOnly": false
+        "port": "8080"
     },
     "log": {
         "level": "debug"

--- a/test/blackbox/scrub.bats
+++ b/test/blackbox/scrub.bats
@@ -27,8 +27,7 @@ function setup() {
     },
     "http": {
         "address": "0.0.0.0",
-        "port": "8080",
-        "ReadOnly": false
+        "port": "8080"
     },
     "log": {
         "level": "debug",

--- a/test/blackbox/sync.bats
+++ b/test/blackbox/sync.bats
@@ -25,8 +25,7 @@ function setup_file() {
     },
     "http": {
         "address": "0.0.0.0",
-        "port": "8080",
-        "ReadOnly": false
+        "port": "8080"
     },
     "log": {
         "level": "debug"
@@ -60,8 +59,7 @@ EOF
     },
     "http": {
         "address": "0.0.0.0",
-        "port": "9000",
-        "ReadOnly": false
+        "port": "9000"
     },
     "log": {
         "level": "debug"

--- a/test/cluster/config-minio.json
+++ b/test/cluster/config-minio.json
@@ -16,8 +16,7 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8081",
-        "ReadOnly": false
+        "port": "8081"
     },
     "log": {
         "level": "debug",


### PR DESCRIPTION
Signed-off-by: Nicol Draghici <idraghic@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
resolves: #537 

**What does this PR do / Why do we need it**:
Now that the access control policy feature was added, AllowReadAccess and ReadOnly can be marked as deprecated.
So should be deprecated.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
yes
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
ReadOnly and AllowReadAcces options are removed, AccessControl should be used instead
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
