### PR TITLE
Make rejecting docker manifests more explicit

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -438,7 +438,9 @@ func (rh *RouteHandler) UpdateManifest(response http.ResponseWriter, request *ht
 
 	mediaType := request.Header.Get("Content-Type")
 	if !storage.IsSupportedMediaType(mediaType) {
-		response.WriteHeader(http.StatusUnsupportedMediaType)
+		// response.WriteHeader(http.StatusUnsupportedMediaType)
+		WriteJSON(response, http.StatusUnsupportedMediaType,
+			NewErrorList(NewError(MANIFEST_INVALID, map[string]string{"mediaType": mediaType})))
 
 		return
 	}

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -725,7 +725,7 @@ func (rh *RouteHandler) DeleteBlob(response http.ResponseWriter, request *http.R
 // @Param   name				path    string     true        "repository name"
 // @Success 202 {string} string	"accepted"
 // @Header  202 {string} Location "/v2/{name}/blobs/uploads/{session_id}"
-// @Header  202 {string} Range "bytes=0-0"
+// @Header  202 {string} Range "0-0"
 // @Failure 404 {string} string "not found"
 // @Failure 500 {string} string "internal server error"
 // @Router /v2/{name}/blobs/uploads [post].
@@ -767,7 +767,7 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 			}
 
 			response.Header().Set("Location", getBlobUploadSessionLocation(request.URL, upload))
-			response.Header().Set("Range", "bytes=0-0")
+			response.Header().Set("Range", "0-0")
 			response.WriteHeader(http.StatusAccepted)
 
 			return
@@ -853,7 +853,7 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 	}
 
 	response.Header().Set("Location", getBlobUploadSessionLocation(request.URL, upload))
-	response.Header().Set("Range", "bytes=0-0")
+	response.Header().Set("Range", "0-0")
 	response.WriteHeader(http.StatusAccepted)
 }
 
@@ -866,7 +866,7 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 // @Param   session_id     path    string     true        "upload session_id"
 // @Success 204 {string} string "no content"
 // @Header  202 {string} Location "/v2/{name}/blobs/uploads/{session_id}"
-// @Header  202 {string} Range "bytes=0-128"
+// @Header  202 {string} Range "0-128"
 // @Failure 404 {string} string "not found"
 // @Failure 500 {string} string "internal server error"
 // @Router /v2/{name}/blobs/uploads/{session_id} [get].
@@ -912,7 +912,7 @@ func (rh *RouteHandler) GetBlobUpload(response http.ResponseWriter, request *htt
 	}
 
 	response.Header().Set("Location", getBlobUploadSessionLocation(request.URL, sessionID))
-	response.Header().Set("Range", fmt.Sprintf("bytes=0-%d", size-1))
+	response.Header().Set("Range", fmt.Sprintf("0-%d", size-1))
 	response.WriteHeader(http.StatusNoContent)
 }
 
@@ -925,7 +925,7 @@ func (rh *RouteHandler) GetBlobUpload(response http.ResponseWriter, request *htt
 // @Param   session_id     path    string     true        "upload session_id"
 // @Success 202 {string} string	"accepted"
 // @Header  202 {string} Location "/v2/{name}/blobs/uploads/{session_id}"
-// @Header  202 {string} Range "bytes=0-128"
+// @Header  202 {string} Range "0-128"
 // @Header  200 {object} api.BlobUploadUUID
 // @Failure 400 {string} string "bad request"
 // @Failure 404 {string} string "not found"
@@ -1004,7 +1004,7 @@ func (rh *RouteHandler) PatchBlobUpload(response http.ResponseWriter, request *h
 	}
 
 	response.Header().Set("Location", getBlobUploadSessionLocation(request.URL, sessionID))
-	response.Header().Set("Range", fmt.Sprintf("bytes=0-%d", clen-1))
+	response.Header().Set("Range", fmt.Sprintf("0-%d", clen-1))
 	response.Header().Set("Content-Length", "0")
 	response.Header().Set(constants.BlobUploadUUID, sessionID)
 	response.WriteHeader(http.StatusAccepted)

--- a/pkg/compliance/v1_0_0/check.go
+++ b/pkg/compliance/v1_0_0/check.go
@@ -289,7 +289,7 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			So(resp.StatusCode(), ShouldEqual, http.StatusNoContent)
 			r := resp.Header().Get("Range")
 			So(r, ShouldNotBeEmpty)
-			So(r, ShouldEqual, "bytes="+contentRange)
+			So(r, ShouldEqual, contentRange)
 
 			// write same chunk should fail
 			contentRange = fmt.Sprintf("%d-%d", 0, len(chunk1)-1)
@@ -357,7 +357,7 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			So(resp.StatusCode(), ShouldEqual, http.StatusNoContent)
 			r := resp.Header().Get("Range")
 			So(r, ShouldNotBeEmpty)
-			So(r, ShouldEqual, "bytes="+contentRange)
+			So(r, ShouldEqual, contentRange)
 
 			// write same chunk should fail
 			contentRange = fmt.Sprintf("%d-%d", 0, len(chunk1)-1)

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -186,7 +186,7 @@ var doc = `{
                             },
                             "Range": {
                                 "type": "string",
-                                "description": "bytes=0-0"
+                                "description": "0-0"
                             }
                         }
                     },

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -168,7 +168,7 @@
                             },
                             "Range": {
                                 "type": "string",
-                                "description": "bytes=0-0"
+                                "description": "0-0"
                             }
                         }
                     },
@@ -371,7 +371,7 @@
                             },
                             "Range": {
                                 "type": "string",
-                                "description": "bytes=0-128"
+                                "description": "0-128"
                             }
                         }
                     },

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -206,7 +206,7 @@ paths:
               description: /v2/{name}/blobs/uploads/{session_id}
               type: string
             Range:
-              description: bytes=0-0
+              description: 0-0
               type: string
           schema:
             type: string
@@ -307,7 +307,7 @@ paths:
               description: /v2/{name}/blobs/uploads/{session_id}
               type: string
             Range:
-              description: bytes=0-128
+              description: 0-128
               type: string
           schema:
             type: string


### PR DESCRIPTION
Signed-off-by: Bogdan BIVOLARU <bbivolar@cisco.com>
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
In case we receive an invalid manifest (docker) we used to return 'Unsupported Media Type' HTTP error code 415, without any HTTP body. This adds a HTTP body which spells it out for the user.

**What does this PR do / Why do we need it**:
Makes docker fail with a clear reason, since docker sees an invalid manifest error and retries with a valid OCI manifest format.

**If an issue # is not available please add repro steps and logs showing the issue**:
fixes: #534 

```bash
sudo docker push reg.mydomain2.com:8080/test:test
The push refers to repository [reg.mydomain2.com:8080/test]
65110baad718: Pushing [==================================================>]  1.947MB
0bc0768466af: Retrying in 4 seconds
bebfee1e62da: Pushing [==================================================>]  774.7kB
23f7bd114e4a: Layer already exists
expected integer   # it's unclear if it's successful or an error; it's not clear how to investigate the root cause
```

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```skopeo --debug -v copy --dest-tls-verify=false docker://alpine:3.4 docker://reg.mydomain2.com:8080/test:test```

```bash
sudo dockerd --pidfile /var/run/docker.sock
sudo docker tag alpine:3.4 docker://reg.mydomain2.com/test:test
sudo docker push reg.mydomain2.com:8080/test:test
The push refers to repository [reg.mydomain2.com:8080/test]
65110baad718: Layer already exists
0bc0768466af: Layer already exists
bebfee1e62da: Layer already exists
23f7bd114e4a: Layer already exists
manifest invalid: manifest invalid
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes

Our own compliance tests fail:
```
  * zotregistry.io/zot/pkg/compliance/v1_0_0/check_test.go 
  Line 32:
  Expected: 'bytes=0-23'
  Actual:   '0-23'
  (Should be equal)
  * zotregistry.io/zot/pkg/compliance/v1_0_0/check_test.go 
  Line 32:
  Expected: 'bytes=0-23'
  Actual:   '0-23'
  (Should be equal)
```

```release-note
When receiving a non-OCI compliant manifest, and the HTTP unsupported media code 415 is returned, send a response body with more detailed explanation
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
