### PR TITLE
Fuzzing for local storage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,3 +283,14 @@ bats-metrics: binary check-skopeo $(BATS)
 bats-metrics-verbose: EXTENSIONS=metrics
 bats-metrics-verbose: binary check-skopeo $(BATS)
 	$(BATS) --trace -p --verbose-run --print-output-on-failure --show-output-of-passing-tests test/blackbox/metrics.bats
+
+.PHONY: fuzz-all
+fuzz-all: fuzztime=${1}
+fuzz-all:
+	rm -rf test-data; \
+	rm -rf pkg/storage/testdata; \
+	git clone https://github.com/project-zot/test-data.git; \
+	mv test-data/storage pkg/storage/testdata; \
+	rm -rf test-data; \
+	bash test/scripts/fuzzAll.sh ${fuzztime}; \
+	rm -rf pkg/storage/testdata; \

--- a/README_fuzz.md
+++ b/README_fuzz.md
@@ -1,0 +1,13 @@
+# Fuzzing in Zot
+
+This project makes use of native Go 1.18 fuzzing. An in-depth tutorial for fuzzing in Go can be found [here](https://go.dev/doc/fuzz/).
+As language specifies, fuzz tests are included among unit-tests, inside the the same `*_test.go files`, in the packages they intend to fuzz. See [fuzzing for local storage](pkg/storage/local_test.go)
+
+Zot doesn't store the test data for fuzzing in the same repo, nor it is added before fuzzing with `(*testing.F).Add` . Instead, it is stored in a separate repo called [test-data](https://github.com/project-zot/test-data).
+
+To start fuzzing locally, one can use the Make target [fuzz-all](Makefile) .
+**The default runtime for each fuzz test is 10s**, which can be overriden with the **fuzztime** variable
+```
+make fuzz-all fuzztime=20
+```
+By running this target, testdata for fuzzing gets downloaded from the previously mentioned repo and the fuzzing begins for every fuzz function that is found.

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -191,6 +191,10 @@ func TestStorageAPIs(t *testing.T) {
 						So(err, ShouldNotBeNil)
 						So(bupload, ShouldEqual, -1)
 
+						bupload, err = imgStore.GetBlobUpload("hi", " \255")
+						So(err, ShouldNotBeNil)
+						So(bupload, ShouldEqual, -1)
+
 						bupload, err = imgStore.GetBlobUpload("test", upload)
 						So(err, ShouldBeNil)
 						So(bupload, ShouldBeGreaterThanOrEqualTo, 0)

--- a/test/scripts/fuzzAll.sh
+++ b/test/scripts/fuzzAll.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+fuzzTime=${1:-10}
+
+files=$(grep -r --include='**_test.go' --files-with-matches 'func Fuzz' .)
+
+for file in ${files}
+do
+    funcs=$(grep -oP 'func \K(Fuzz\w*)' $file)
+    for func in ${funcs}
+    do
+        echo "Fuzzing $func in $file"
+        parentDir=$(dirname $file)
+        go test $parentDir -run=$func -fuzz=$func$ -fuzztime=${fuzzTime}s -tags sync,metrics,search,scrub,ui_base,containers_image_openpgp | grep -oP -x '^(?:(?!\blevel\b).)*$'
+    done
+done


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

1. It is meant to introduce fuzzing, using native go fuzzing engine and ~~https://github.com/AdaLogics/go-fuzz-headers~~ to generate data for fuzz tests

**UPDATE**: go-fuzz-headers fails to generate data as go fuzz engine mutates input. go-fuzz-headers requires a specific amount  of bytes, which can't be guaranteed when data is mutated.

2. Fuzz tests require an initial seed corpus, which in Zot's case is cloned right before fuzzing starts from a separate repo https://github.com/project-zot/test-data
3. A Make target was created for running all Fuzz tests sequentially, each for a default period of 10s ( which can be overriden)


**This PR contains fuzz tests for all implementations of storage interface in storage_fs.**
Other parts of code to be covered with fuzz in future-PRs

**What does this PR do / Why do we need it**:
detect code vulnerabilities

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
