### PR TITLE
build: remove swagger install in stacker files

### DIFF
--- a/stacker-conformance.yaml
+++ b/stacker-conformance.yaml
@@ -9,7 +9,6 @@ build:
     export GOPATH='/go'
     export HOME='/root'
     export PATH='/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-    go get -u github.com/swaggo/swag/cmd/swag
     mkdir -p /go/src/github.com/project-zot
     cd /go/src/github.com/project-zot
     git clone /zotcopy zot

--- a/stacker.yaml
+++ b/stacker.yaml
@@ -9,7 +9,6 @@ build:
     export GOPATH='/go'
     export HOME='/root'
     export PATH='/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
-    go get -u github.com/swaggo/swag/cmd/swag
     mkdir -p /go/src/github.com/project-zot
     cd /go/src/github.com/project-zot
     git clone /zotcopy zot


### PR DESCRIPTION
it is currently installed in the Makefile

Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>

No need to install swagger in stacker files, that part is now in the Makefile as a dependency for binaries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
