### PR TITLE
Update automatically helm chart when publish a new release for zot

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -300,3 +300,45 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: 'trivy-results.sarif'
+
+  update-helm-chart:
+    if: github.event_name == 'release' && github.event.action== 'published'
+    name: Update Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: main
+          fetch-depth: '0'
+
+      - name: Checkout project-zot/helm-charts
+        uses: actions/checkout@v2
+        with:
+          repository: project-zot/helm-charts
+          ref: main
+          fetch-depth: '0'
+          token: ${{ secrets.PUSH_TOKEN }}
+          path: ./helm-charts
+
+      - name: Configure Git
+        run: |
+          git config --global user.name 'github-actions'
+          git config --global user.email 'github-actions@users.noreply.github.com'
+      - name: Update appVersion
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.appVersion = "${{ github.event.release.tag_name }}"' 'helm-charts/charts/zot/Chart.yaml'
+      - name: Update image tag
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq -i '.image.tag = "${{ github.event.release.tag_name }}"' 'helm-charts/charts/zot/values.yaml'
+      - name: Update version
+        run: |
+          sudo apt-get install pip
+          pip install pybump
+          pybump bump --file helm-charts/charts/zot/Chart.yaml --level patch
+      - name: Push changes to project-zot/helm-charts
+        run: |
+          cd ./helm-charts
+          git commit -am "Automated update of Helm Chart"
+          git push


### PR DESCRIPTION
Signed-off-by: Andreea-Lupu <andreealupu1470@yahoo.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

When we publish a new release for zot there will be a new tag for our image, so we need to update the value of the "tag" field from our helm chart(from project-zot/helm-charts/charts/zot)

**What does this PR do / Why do we need it**:

 By this PR it will be automatically updated the values of "tag", "apiVersion" and "version" fields from project-zot/helm-charts/charts/zot.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
