### PR TITLE
Fix test data races

### DIFF
--- a/pkg/cli/extensions_test.go
+++ b/pkg/cli/extensions_test.go
@@ -484,7 +484,10 @@ func TestServeSearchEnabled(t *testing.T) {
 					}
 				}`
 
-		data, err := runCLIWithConfig(t.TempDir(), content)
+		tempDir := t.TempDir()
+		data, err := runCLIWithConfig(tempDir, content)
+		// to avoid data race when multiple go routines write to trivy DB instance.
+		WaitTillTrivyDBDownloadStarted(tempDir)
 		So(err, ShouldBeNil)
 		So(data, ShouldContainSubstring,
 			"\"Extensions\":{\"Search\":{\"CVE\":{\"UpdateInterval\":86400000000000},\"Enable\":true},\"Sync\":null,\"Metrics\":null,\"Scrub\":null}") //nolint:lll // gofumpt conflicts with lll
@@ -519,7 +522,10 @@ func TestServeSearchEnabledCVE(t *testing.T) {
 					}
 				}`
 
-		data, err := runCLIWithConfig(t.TempDir(), content)
+		tempDir := t.TempDir()
+		data, err := runCLIWithConfig(tempDir, content)
+		// to avoid data race when multiple go routines write to trivy DB instance.
+		WaitTillTrivyDBDownloadStarted(tempDir)
 		So(err, ShouldBeNil)
 		// Even if in config we specified updateInterval=1h, the minimum interval is 2h
 		So(data, ShouldContainSubstring,
@@ -555,7 +561,10 @@ func TestServeSearchEnabledNoCVE(t *testing.T) {
 				}
 			}`
 
-		data, err := runCLIWithConfig(t.TempDir(), content)
+		tempDir := t.TempDir()
+		data, err := runCLIWithConfig(tempDir, content)
+		// to avoid data race when multiple go routines write to trivy DB instance.
+		WaitTillTrivyDBDownloadStarted(tempDir)
 		So(err, ShouldBeNil)
 		So(data, ShouldContainSubstring,
 			"\"Extensions\":{\"Search\":{\"CVE\":{\"UpdateInterval\":86400000000000},\"Enable\":true},\"Sync\":null,\"Metrics\":null,\"Scrub\":null}") //nolint:lll // gofumpt conflicts with lll

--- a/pkg/cli/extensions_test.go
+++ b/pkg/cli/extensions_test.go
@@ -608,21 +608,19 @@ func runCLIWithConfig(tempDir string, config string) (string, error) {
 	port := GetFreePort()
 	baseURL := GetBaseURL(port)
 
-	logFile, err := ioutil.TempFile("", "zot-log*.txt")
+	logFile, err := ioutil.TempFile(tempDir, "zot-log*.txt")
 	if err != nil {
 		return "", err
 	}
 
 	defer os.Remove(logFile.Name()) // clean up
 
-	cfgfile, err := ioutil.TempFile("", "zot-test*.json")
+	cfgfile, err := ioutil.TempFile(tempDir, "zot-test*.json")
 	if err != nil {
 		return "", err
 	}
 
 	config = fmt.Sprintf(config, tempDir, port, logFile.Name())
-
-	defer os.Remove(cfgfile.Name()) // clean up
 
 	_, err = cfgfile.Write([]byte(config))
 	if err != nil {

--- a/pkg/test/common.go
+++ b/pkg/test/common.go
@@ -140,6 +140,16 @@ func WaitTillServerReady(url string) {
 	}
 }
 
+func WaitTillTrivyDBDownloadStarted(rootDir string) {
+	for {
+		if _, err := os.Stat(path.Join(rootDir, "trivy.db")); err == nil {
+			break
+		}
+
+		time.Sleep(SleepTime)
+	}
+}
+
 // Adapted from https://gist.github.com/dopey/c69559607800d2f2f90b1b1ed4e550fb
 func randomString(n int) string {
 	const letters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-"


### PR DESCRIPTION
config file may get removed before fsnotify starts watching it
make sure the config file gets removed when test ends, closes #608

Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
