### PR TITLE
GetRefferers of any artifactType, not just application/vnd.cncf.notary.v2.signature

### DIFF
--- a/pkg/storage/local.go
+++ b/pkg/storage/local.go
@@ -19,7 +19,6 @@ import (
 	guuid "github.com/gofrs/uuid"
 	"github.com/minio/sha256-simd"
 	"github.com/notaryproject/notation-go-lib"
-	notreg "github.com/notaryproject/notation/pkg/registry"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/umoci"
@@ -1443,7 +1442,7 @@ func (is *ImageStoreLocal) DeleteBlob(repo, digest string) error {
 	return nil
 }
 
-func (is *ImageStoreLocal) GetReferrers(repo, digest, mediaType string) ([]artifactspec.Descriptor, error) {
+func (is *ImageStoreLocal) GetReferrers(repo, digest, artifactType string) ([]artifactspec.Descriptor, error) {
 	var lockLatency time.Time
 
 	dir := path.Join(is.rootDir, repo)
@@ -1509,14 +1508,16 @@ func (is *ImageStoreLocal) GetReferrers(repo, digest, mediaType string) ([]artif
 			return nil, err
 		}
 
-		if mediaType != artManifest.ArtifactType || gdigest != artManifest.Subject.Digest {
+		if artifactType != artManifest.ArtifactType || gdigest != artManifest.Subject.Digest {
 			continue
 		}
 
 		result = append(result, artifactspec.Descriptor{
 			MediaType:    manifest.MediaType,
-			ArtifactType: notreg.ArtifactTypeNotation,
-			Digest:       manifest.Digest, Size: manifest.Size, Annotations: manifest.Annotations,
+			ArtifactType: artManifest.ArtifactType,
+			Digest:       manifest.Digest,
+			Size:         manifest.Size,
+			Annotations:  manifest.Annotations,
 		})
 
 		found = true


### PR DESCRIPTION
fix GetReferrers function to be able to retrieve referrers of any specified artifactType

Even though the route handler filters for anything not of type  application/vnd.cncf.notary.v2.signature, the GetRefferrers function should not overwrite the artifactType and be prepared for other types.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
overwriting artifactType instead of using the one provided as an argument to GetReferrers 

**What does this PR do / Why do we need it**:

Even though the route handler filters for anything not of type  application/vnd.cncf.notary.v2.signature, the GetRefferrers function should not overwrite the artifactType and be prepared for other types.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
