### PR TITLE
RepoSummary has a new attribute NewestTag of type ImageSummary

### DIFF
--- a/pkg/extensions/search/common/oci_layout.go
+++ b/pkg/extensions/search/common/oci_layout.go
@@ -30,7 +30,7 @@ type OciLayoutUtils interface {
 	GetImagePlatform(imageInfo ispec.Image) (string, string)
 	GetImageVendor(imageInfo ispec.Image) string
 	GetImageManifestSize(repo string, manifestDigest godigest.Digest) int64
-	GetRepoLastUpdated(repo string) (time.Time, error)
+	GetRepoLastUpdated(repo string) (TagInfo, error)
 	GetExpandedRepoInfo(name string) (RepoInfo, error)
 	GetImageConfigInfo(repo string, manifestDigest godigest.Digest) (ispec.Image, error)
 }
@@ -323,15 +323,15 @@ func (olu BaseOciLayoutUtils) GetImageConfigSize(repo string, manifestDigest god
 	return imageBlobManifest.Config.Size
 }
 
-func (olu BaseOciLayoutUtils) GetRepoLastUpdated(repo string) (time.Time, error) {
+func (olu BaseOciLayoutUtils) GetRepoLastUpdated(repo string) (TagInfo, error) {
 	tagsInfo, err := olu.GetImageTagsWithTimestamp(repo)
 	if err != nil || len(tagsInfo) == 0 {
-		return time.Time{}, err
+		return TagInfo{}, err
 	}
 
 	latestTag := GetLatestTag(tagsInfo)
 
-	return latestTag.Timestamp, nil
+	return latestTag, nil
 }
 
 func (olu BaseOciLayoutUtils) GetExpandedRepoInfo(name string) (RepoInfo, error) {

--- a/pkg/extensions/search/gql_generated/generated.go
+++ b/pkg/extensions/search/gql_generated/generated.go
@@ -143,6 +143,7 @@ type ComplexityRoot struct {
 	RepoSummary struct {
 		LastUpdated func(childComplexity int) int
 		Name        func(childComplexity int) int
+		NewestTag   func(childComplexity int) int
 		Platforms   func(childComplexity int) int
 		Score       func(childComplexity int) int
 		Size        func(childComplexity int) int
@@ -596,6 +597,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.RepoSummary.Name(childComplexity), true
 
+	case "RepoSummary.NewestTag":
+		if e.complexity.RepoSummary.NewestTag == nil {
+			break
+		}
+
+		return e.complexity.RepoSummary.NewestTag(childComplexity), true
+
 	case "RepoSummary.Platforms":
 		if e.complexity.RepoSummary.Platforms == nil {
 			break
@@ -794,6 +802,7 @@ type RepoSummary {
      Platforms: [OsArch]
      Vendors: [String]
      Score: Int
+     NewestTag: ImageSummary
 }
 
 # Currently the same as LayerInfo, we can refactor later
@@ -1392,6 +1401,8 @@ func (ec *executionContext) fieldContext_GlobalSearchResult_Repos(ctx context.Co
 				return ec.fieldContext_RepoSummary_Vendors(ctx, field)
 			case "Score":
 				return ec.fieldContext_RepoSummary_Score(ctx, field)
+			case "NewestTag":
+				return ec.fieldContext_RepoSummary_NewestTag(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RepoSummary", field.Name)
 		},
@@ -3735,6 +3746,65 @@ func (ec *executionContext) fieldContext_RepoSummary_Score(ctx context.Context, 
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Int does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RepoSummary_NewestTag(ctx context.Context, field graphql.CollectedField, obj *RepoSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RepoSummary_NewestTag(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.NewestTag, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*ImageSummary)
+	fc.Result = res
+	return ec.marshalOImageSummary2ᚖzotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐImageSummary(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RepoSummary_NewestTag(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RepoSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "RepoName":
+				return ec.fieldContext_ImageSummary_RepoName(ctx, field)
+			case "Tag":
+				return ec.fieldContext_ImageSummary_Tag(ctx, field)
+			case "LastUpdated":
+				return ec.fieldContext_ImageSummary_LastUpdated(ctx, field)
+			case "IsSigned":
+				return ec.fieldContext_ImageSummary_IsSigned(ctx, field)
+			case "Size":
+				return ec.fieldContext_ImageSummary_Size(ctx, field)
+			case "Platform":
+				return ec.fieldContext_ImageSummary_Platform(ctx, field)
+			case "Vendor":
+				return ec.fieldContext_ImageSummary_Vendor(ctx, field)
+			case "Score":
+				return ec.fieldContext_ImageSummary_Score(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
 		},
 	}
 	return fc, nil
@@ -6337,6 +6407,10 @@ func (ec *executionContext) _RepoSummary(ctx context.Context, sel ast.SelectionS
 		case "Score":
 
 			out.Values[i] = ec._RepoSummary_Score(ctx, field, obj)
+
+		case "NewestTag":
+
+			out.Values[i] = ec._RepoSummary_NewestTag(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/pkg/extensions/search/gql_generated/models_gen.go
+++ b/pkg/extensions/search/gql_generated/models_gen.go
@@ -95,12 +95,13 @@ type RepoInfo struct {
 }
 
 type RepoSummary struct {
-	Name        *string    `json:"Name"`
-	LastUpdated *time.Time `json:"LastUpdated"`
-	Size        *string    `json:"Size"`
-	Platforms   []*OsArch  `json:"Platforms"`
-	Vendors     []*string  `json:"Vendors"`
-	Score       *int       `json:"Score"`
+	Name        *string       `json:"Name"`
+	LastUpdated *time.Time    `json:"LastUpdated"`
+	Size        *string       `json:"Size"`
+	Platforms   []*OsArch     `json:"Platforms"`
+	Vendors     []*string     `json:"Vendors"`
+	Score       *int          `json:"Score"`
+	NewestTag   *ImageSummary `json:"NewestTag"`
 }
 
 type TagInfo struct {

--- a/pkg/extensions/search/resolver_test.go
+++ b/pkg/extensions/search/resolver_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"strings"
 	"testing"
-	"time"
 
 	godigest "github.com/opencontainers/go-digest"
 	. "github.com/smartystreets/goconvey/convey"
@@ -19,8 +18,8 @@ func TestGlobalSearch(t *testing.T) {
 	Convey("globalSearch", t, func() {
 		Convey("GetRepoLastUpdated fail", func() {
 			mockOlum := mocks.OciLayoutUtilsMock{
-				GetRepoLastUpdatedFn: func(repo string) (time.Time, error) {
-					return time.Time{}, ErrTestError
+				GetRepoLastUpdatedFn: func(repo string) (common.TagInfo, error) {
+					return common.TagInfo{}, ErrTestError
 				},
 			}
 

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -95,6 +95,7 @@ type RepoSummary {
      Platforms: [OsArch]
      Vendors: [String]
      Score: Int
+     NewestTag: ImageSummary
 }
 
 # Currently the same as LayerInfo, we can refactor later

--- a/pkg/test/mocks/oci_mock.go
+++ b/pkg/test/mocks/oci_mock.go
@@ -20,7 +20,7 @@ type OciLayoutUtilsMock struct {
 	GetImageVendorFn            func(imageInfo ispec.Image) string
 	GetImageManifestSizeFn      func(repo string, manifestDigest godigest.Digest) int64
 	GetImageConfigSizeFn        func(repo string, manifestDigest godigest.Digest) int64
-	GetRepoLastUpdatedFn        func(repo string) (time.Time, error)
+	GetRepoLastUpdatedFn        func(repo string) (common.TagInfo, error)
 	GetExpandedRepoInfoFn       func(name string) (common.RepoInfo, error)
 	GetImageConfigInfoFn        func(repo string, manifestDigest godigest.Digest) (ispec.Image, error)
 }
@@ -105,12 +105,12 @@ func (olum OciLayoutUtilsMock) GetImageConfigSize(repo string, manifestDigest go
 	return 0
 }
 
-func (olum OciLayoutUtilsMock) GetRepoLastUpdated(repo string) (time.Time, error) {
+func (olum OciLayoutUtilsMock) GetRepoLastUpdated(repo string) (common.TagInfo, error) {
 	if olum.GetRepoLastUpdatedFn != nil {
 		return olum.GetRepoLastUpdatedFn(repo)
 	}
 
-	return time.Time{}, nil
+	return common.TagInfo{}, nil
 }
 
 func (olum OciLayoutUtilsMock) GetExpandedRepoInfo(name string) (common.RepoInfo, error) {


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
#666

**What does this PR do / Why do we need it**:
ImageListWithLatestTag currently returns a list of ImageInfo objects.
It needs to return consistent results with the API used for Global search as the same information will be used by the UI in the same type or cards.
So we need to update RepoSummary to include the data which right now is present in ImageInfo, but missing from RepoSummary (information on the latest tag in that specific repo).
Will update return type of ImageListWithLatestTag in a later PR (issue tracked in a separate GH issue)

**Testing done on this change**:
Existing and updated automated tests.

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
Yes it contains extra information to be used by zot ui.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Closes #666

Signed-off-by: Andrei Aaron <andaaron@cisco.com>