### PR TITLE
Fix permissions for image sync and stale workflows

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,8 +5,8 @@ on:
 
 permissions:
   contents: read
-  issues: read|write
-  pull-requests: read|write
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:

--- a/.github/workflows/sync-golang-image.yaml
+++ b/.github/workflows/sync-golang-image.yaml
@@ -11,7 +11,7 @@ env:
 
 permissions:
   contents: read
-  packages: read|write
+  packages: write
 
 jobs:
   sync-golang:


### PR DESCRIPTION
Looks like read|write is not a correct value:
https://github.com/project-zot/zot/actions/runs/2743961177
https://github.com/project-zot/zot/actions/runs/2743965531

Write should include both, so let's try to use that.

Signed-off-by: Andrei Aaron <andaaron@cisco.com>
