### PR TITLE
RepoInfo structure now includes new field representing RepoSummary

### DIFF
--- a/pkg/extensions/search/common/common_test.go
+++ b/pkg/extensions/search/common/common_test.go
@@ -517,7 +517,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, 422)
 
-		query := "{ExpandedRepoInfo(repo:\"zot-cve-test\"){Manifests%20{Digest%20IsSigned%20Tag%20Layers%20{Size%20Digest}}}}"
+		query := "{ExpandedRepoInfo(repo:\"zot-cve-test\"){Summary%20{Name%20LastUpdated%20Size%20Platforms%20{Os%20Arch}%20Vendors%20Score}}}" // nolint: lll
 
 		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + query)
 		So(resp, ShouldNotBeNil)
@@ -525,6 +525,21 @@ func TestExpandedRepoInfo(t *testing.T) {
 		So(resp.StatusCode(), ShouldEqual, 200)
 
 		responseStruct := &ExpandedRepoInfoResp{}
+
+		err = json.Unmarshal(resp.Body(), responseStruct)
+		So(err, ShouldBeNil)
+		So(responseStruct.ExpandedRepoInfo.RepoInfo.Summary, ShouldNotBeEmpty)
+		So(responseStruct.ExpandedRepoInfo.RepoInfo.Summary.Name, ShouldEqual, "zot-cve-test")
+		So(responseStruct.ExpandedRepoInfo.RepoInfo.Summary.Score, ShouldEqual, -1)
+
+		query = "{ExpandedRepoInfo(repo:\"zot-cve-test\"){Manifests%20{Digest%20IsSigned%20Tag%20Layers%20{Size%20Digest}}}}"
+
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + query)
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		responseStruct = &ExpandedRepoInfoResp{}
 
 		err = json.Unmarshal(resp.Body(), responseStruct)
 		So(err, ShouldBeNil)

--- a/pkg/extensions/search/gql_generated/generated.go
+++ b/pkg/extensions/search/gql_generated/generated.go
@@ -138,6 +138,7 @@ type ComplexityRoot struct {
 
 	RepoInfo struct {
 		Manifests func(childComplexity int) int
+		Summary   func(childComplexity int) int
 	}
 
 	RepoSummary struct {
@@ -583,6 +584,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.RepoInfo.Manifests(childComplexity), true
 
+	case "RepoInfo.Summary":
+		if e.complexity.RepoInfo.Summary == nil {
+			break
+		}
+
+		return e.complexity.RepoInfo.Summary(childComplexity), true
+
 	case "RepoSummary.LastUpdated":
 		if e.complexity.RepoSummary.LastUpdated == nil {
 			break
@@ -759,6 +767,7 @@ type ImageInfo {
 
 type RepoInfo {
      Manifests: [ManifestInfo]
+     Summary: RepoSummary
 }
 
 type ManifestInfo {
@@ -3241,6 +3250,8 @@ func (ec *executionContext) fieldContext_Query_ExpandedRepoInfo(ctx context.Cont
 			switch field.Name {
 			case "Manifests":
 				return ec.fieldContext_RepoInfo_Manifests(ctx, field)
+			case "Summary":
+				return ec.fieldContext_RepoInfo_Summary(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RepoInfo", field.Name)
 		},
@@ -3494,6 +3505,63 @@ func (ec *executionContext) fieldContext_RepoInfo_Manifests(ctx context.Context,
 				return ec.fieldContext_ManifestInfo_Layers(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ManifestInfo", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RepoInfo_Summary(ctx context.Context, field graphql.CollectedField, obj *RepoInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RepoInfo_Summary(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Summary, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*RepoSummary)
+	fc.Result = res
+	return ec.marshalORepoSummary2ᚖzotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐRepoSummary(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RepoInfo_Summary(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RepoInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			switch field.Name {
+			case "Name":
+				return ec.fieldContext_RepoSummary_Name(ctx, field)
+			case "LastUpdated":
+				return ec.fieldContext_RepoSummary_LastUpdated(ctx, field)
+			case "Size":
+				return ec.fieldContext_RepoSummary_Size(ctx, field)
+			case "Platforms":
+				return ec.fieldContext_RepoSummary_Platforms(ctx, field)
+			case "Vendors":
+				return ec.fieldContext_RepoSummary_Vendors(ctx, field)
+			case "Score":
+				return ec.fieldContext_RepoSummary_Score(ctx, field)
+			case "NewestTag":
+				return ec.fieldContext_RepoSummary_NewestTag(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RepoSummary", field.Name)
 		},
 	}
 	return fc, nil
@@ -6362,6 +6430,10 @@ func (ec *executionContext) _RepoInfo(ctx context.Context, sel ast.SelectionSet,
 		case "Manifests":
 
 			out.Values[i] = ec._RepoInfo_Manifests(ctx, field, obj)
+
+		case "Summary":
+
+			out.Values[i] = ec._RepoInfo_Summary(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/pkg/extensions/search/gql_generated/models_gen.go
+++ b/pkg/extensions/search/gql_generated/models_gen.go
@@ -92,6 +92,7 @@ type PackageInfo struct {
 
 type RepoInfo struct {
 	Manifests []*ManifestInfo `json:"Manifests"`
+	Summary   *RepoSummary    `json:"Summary"`
 }
 
 type RepoSummary struct {

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -52,6 +52,7 @@ type ImageInfo {
 
 type RepoInfo {
      Manifests: [ManifestInfo]
+     Summary: RepoSummary
 }
 
 type ManifestInfo {

--- a/pkg/extensions/search/schema.resolvers.go
+++ b/pkg/extensions/search/schema.resolvers.go
@@ -333,6 +333,31 @@ func (r *queryResolver) ExpandedRepoInfo(ctx context.Context, repo string) (*gql
 
 	manifests := make([]*gql_generated.ManifestInfo, 0)
 
+	summary := &gql_generated.RepoSummary{}
+
+	summary.LastUpdated = &origRepoInfo.Summary.LastUpdated
+	summary.Name = &origRepoInfo.Summary.Name
+	summary.Platforms = []*gql_generated.OsArch{}
+
+	for _, platform := range origRepoInfo.Summary.Platforms {
+		platform := platform
+
+		summary.Platforms = append(summary.Platforms, &gql_generated.OsArch{
+			Os:   &platform.Os,
+			Arch: &platform.Arch,
+		})
+	}
+
+	summary.Size = &origRepoInfo.Summary.Size
+
+	for _, vendor := range origRepoInfo.Summary.Vendors {
+		vendor := vendor
+		summary.Vendors = append(summary.Vendors, &vendor)
+	}
+
+	score := -1 // score not relevant for this query
+	summary.Score = &score
+
 	for _, manifest := range origRepoInfo.Manifests {
 		tag := manifest.Tag
 
@@ -359,6 +384,7 @@ func (r *queryResolver) ExpandedRepoInfo(ctx context.Context, repo string) (*gql
 		manifests = append(manifests, manifestInfo)
 	}
 
+	repoInfo.Summary = summary
 	repoInfo.Manifests = manifests
 
 	return repoInfo, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
ExpandedRepoInfo currently returns RepoInfo that is a list of Manifests.
To comply with the newest UI requirements, a new field called Summary,
referring to RepoSummary structure, was added.

**What does this PR do / Why do we need it**:
UI

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->


This PR closes [#644](https://github.com/project-zot/zot/issues/664)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
