### PR TITLE
replace dependency of tagsInfo with list of manifests

### DIFF
--- a/pkg/extensions/search/common/oci_layout.go
+++ b/pkg/extensions/search/common/oci_layout.go
@@ -33,6 +33,7 @@ type OciLayoutUtils interface {
 	GetRepoLastUpdated(repo string) (TagInfo, error)
 	GetExpandedRepoInfo(name string) (RepoInfo, error)
 	GetImageConfigInfo(repo string, manifestDigest godigest.Digest) (ispec.Image, error)
+	CheckManifestSignature(name string, digest godigest.Digest) bool
 }
 
 // OciLayoutInfo ...
@@ -270,7 +271,7 @@ func (olu BaseOciLayoutUtils) checkCosignSignature(name string, digest godigest.
 // checks if manifest is signed or not
 // checks for notary or cosign signature
 // if cosign signature found it does not looks for notary signature.
-func (olu BaseOciLayoutUtils) checkManifestSignature(name string, digest godigest.Digest) bool {
+func (olu BaseOciLayoutUtils) CheckManifestSignature(name string, digest godigest.Digest) bool {
 	if !olu.checkCosignSignature(name, digest) {
 		return olu.checkNotarySignature(name, digest)
 	}
@@ -395,7 +396,7 @@ func (olu BaseOciLayoutUtils) GetExpandedRepoInfo(name string) (RepoInfo, error)
 			return RepoInfo{}, err
 		}
 
-		manifestInfo.IsSigned = olu.checkManifestSignature(name, man.Digest)
+		manifestInfo.IsSigned = olu.CheckManifestSignature(name, man.Digest)
 
 		manifestSize := olu.GetImageManifestSize(name, man.Digest)
 		olu.Log.Debug().Msg(fmt.Sprintf("%v", man.Digest))

--- a/pkg/test/mocks/oci_mock.go
+++ b/pkg/test/mocks/oci_mock.go
@@ -23,10 +23,11 @@ type OciLayoutUtilsMock struct {
 	GetRepoLastUpdatedFn        func(repo string) (common.TagInfo, error)
 	GetExpandedRepoInfoFn       func(name string) (common.RepoInfo, error)
 	GetImageConfigInfoFn        func(repo string, manifestDigest godigest.Digest) (ispec.Image, error)
+	CheckManifestSignatureFn    func(name string, digest godigest.Digest) bool
 }
 
 func (olum OciLayoutUtilsMock) GetImageManifests(image string) ([]ispec.Descriptor, error) {
-	if olum.GetImageBlobManifestFn != nil {
+	if olum.GetImageManifestsFn != nil {
 		return olum.GetImageManifestsFn(image)
 	}
 
@@ -127,4 +128,12 @@ func (olum OciLayoutUtilsMock) GetImageConfigInfo(repo string, manifestDigest go
 	}
 
 	return ispec.Image{}, nil
+}
+
+func (olum OciLayoutUtilsMock) CheckManifestSignature(name string, digest godigest.Digest) bool {
+	if olum.CheckManifestSignatureFn != nil {
+		return olum.CheckManifestSignatureFn(name, digest)
+	}
+
+	return false
 }


### PR DESCRIPTION
replace dependency of tagsInfo with list of manifests since only the manifest Digest is needed

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
