### PR TITLE
GraphQL: RepoListWithNewestImage to return list of RepoSummary

### DIFF
--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -84,7 +84,7 @@ type Query {
     ImageListForCVE(id: String!): [ImageSummary!]
     ImageListWithCVEFixed(id: String!, image: String!): [ImageSummary!]
     ImageListForDigest(id: String!): [ImageSummary!]
-    ImageListWithLatestTag: [ImageSummary!]
+    RepoListWithNewestImage: [RepoSummary!]!  # Newest based on created timestamp
     ImageList(repo: String!): [ImageSummary!]
     ExpandedRepoInfo(repo: String!): RepoInfo!
     GlobalSearch(query: String!): GlobalSearchResult!

--- a/pkg/extensions/search/schema.resolvers.go
+++ b/pkg/extensions/search/schema.resolvers.go
@@ -287,41 +287,41 @@ func (r *queryResolver) ImageListForDigest(ctx context.Context, id string) ([]*g
 	return imgResultForDigest, nil
 }
 
-// ImageListWithLatestTag is the resolver for the ImageListWithLatestTag field.
-func (r *queryResolver) ImageListWithLatestTag(ctx context.Context) ([]*gql_generated.ImageSummary, error) {
+// RepoListWithNewestImage is the resolver for the RepoListWithNewestImage field.
+func (r *queryResolver) RepoListWithNewestImage(ctx context.Context) ([]*gql_generated.RepoSummary, error) {
 	r.log.Info().Msg("extension api: finding image list")
 
-	imageList := make([]*gql_generated.ImageSummary, 0)
+	repoList := make([]*gql_generated.RepoSummary, 0)
 
 	defaultStore := r.storeController.DefaultStore
 
-	dsImageList, err := r.getImageListWithLatestTag(defaultStore)
+	dsRepoList, err := r.repoListWithNewestImage(ctx, defaultStore)
 	if err != nil {
 		r.log.Error().Err(err).Msg("extension api: error extracting default store image list")
 
-		return imageList, err
+		return repoList, err
 	}
 
-	if len(dsImageList) != 0 {
-		imageList = append(imageList, dsImageList...)
+	if len(dsRepoList) != 0 {
+		repoList = append(repoList, dsRepoList...)
 	}
 
 	subStore := r.storeController.SubStore
 
 	for _, store := range subStore {
-		ssImageList, err := r.getImageListWithLatestTag(store)
+		ssRepoList, err := r.repoListWithNewestImage(ctx, store)
 		if err != nil {
-			r.log.Error().Err(err).Msg("extension api: error extracting default store image list")
+			r.log.Error().Err(err).Msg("extension api: error extracting substore image list")
 
-			return imageList, err
+			return repoList, err
 		}
 
-		if len(ssImageList) != 0 {
-			imageList = append(imageList, ssImageList...)
+		if len(ssRepoList) != 0 {
+			repoList = append(repoList, ssRepoList...)
 		}
 	}
 
-	return imageList, nil
+	return repoList, nil
 }
 
 // ImageList is the resolver for the ImageList field.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
ui

**Which issue does this PR fix**:
#663

**What does this PR do / Why do we need it**:
From #663:

> ImageListWithLatestTag currently returns a list of ImageInfo objects. It needs to return consistent results with the API used for Global search as the same information will be used by the UI in the same type or cards.

Needed schema changes from #696 

<!--
**Testing done on this change**:


**Automation added to e2e**:


**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
-->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
