### PR TITLE
storage: different subpaths can point to same root directory

### DIFF
--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/getlantern/deepcopy"
@@ -142,6 +143,27 @@ func New() *Config {
 		HTTP:            HTTPConfig{Address: "127.0.0.1", Port: "8080", Auth: &AuthConfig{FailDelay: 0}},
 		Log:             &LogConfig{Level: "debug"},
 	}
+}
+
+func (expConfig StorageConfig) ParamsEqual(actConfig StorageConfig) bool {
+	return expConfig.GC == actConfig.GC && expConfig.Dedupe == actConfig.Dedupe &&
+		expConfig.GCDelay == actConfig.GCDelay && expConfig.GCInterval == actConfig.GCInterval
+}
+
+// SameFile compare two files.
+// This method will first do the stat of two file and compare using os.SameFile method.
+func SameFile(str1, str2 string) (bool, error) {
+	sFile, err := os.Stat(str1)
+	if err != nil {
+		return false, err
+	}
+
+	tFile, err := os.Stat(str2)
+	if err != nil {
+		return false, err
+	}
+
+	return os.SameFile(sFile, tFile), nil
 }
 
 // Sanitize makes a sanitized copy of the config removing any secrets.

--- a/pkg/api/config/config_elevated_test.go
+++ b/pkg/api/config/config_elevated_test.go
@@ -1,0 +1,32 @@
+//go:build needprivileges
+// +build needprivileges
+
+package config_test
+
+import (
+	"syscall"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.io/zot/pkg/api/config"
+)
+
+func TestMountConfig(t *testing.T) {
+	Convey("Test config utils mounting same directory", t, func() {
+		// If two dirs are mounting to same location SameFile should be same
+		dir1 := t.TempDir()
+		dir2 := t.TempDir()
+		dir3 := t.TempDir()
+
+		err := syscall.Mount(dir3, dir1, "", syscall.MS_BIND, "")
+		So(err, ShouldBeNil)
+
+		err = syscall.Mount(dir3, dir2, "", syscall.MS_BIND, "")
+		So(err, ShouldBeNil)
+
+		isSame, err := config.SameFile(dir1, dir2)
+		So(err, ShouldBeNil)
+		So(isSame, ShouldBeTrue)
+	})
+}

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -1,0 +1,67 @@
+package config_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"zotregistry.io/zot/pkg/api/config"
+)
+
+func TestConfig(t *testing.T) {
+	Convey("Test config utils", t, func() {
+		firstStorageConfig := config.StorageConfig{
+			GC: true, Dedupe: true,
+			GCDelay: 1 * time.Minute, GCInterval: 1 * time.Hour,
+		}
+		secondStorageConfig := config.StorageConfig{
+			GC: true, Dedupe: true,
+			GCDelay: 1 * time.Minute, GCInterval: 1 * time.Hour,
+		}
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
+
+		firstStorageConfig.GC = false
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeFalse)
+
+		firstStorageConfig.GC = true
+		firstStorageConfig.Dedupe = false
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeFalse)
+
+		firstStorageConfig.Dedupe = true
+		firstStorageConfig.GCDelay = 2 * time.Minute
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeFalse)
+
+		firstStorageConfig.GCDelay = 1 * time.Minute
+		firstStorageConfig.GCInterval = 2 * time.Hour
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeFalse)
+
+		firstStorageConfig.GCInterval = 1 * time.Hour
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
+
+		isSame, err := config.SameFile("test-config", "test")
+		So(err, ShouldNotBeNil)
+		So(isSame, ShouldBeFalse)
+
+		dir1 := t.TempDir()
+
+		isSame, err = config.SameFile(dir1, "test")
+		So(err, ShouldNotBeNil)
+		So(isSame, ShouldBeFalse)
+
+		dir2 := t.TempDir()
+
+		isSame, err = config.SameFile(dir1, dir2)
+		So(err, ShouldBeNil)
+		So(isSame, ShouldBeFalse)
+
+		isSame, err = config.SameFile(dir1, dir1)
+		So(err, ShouldBeNil)
+		So(isSame, ShouldBeTrue)
+	})
+}

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -286,8 +286,6 @@ func TestORAS(t *testing.T) {
 			panic(err)
 		}
 
-		fmt.Println(fileDir)
-
 		srcURL := strings.Join([]string{sctlr.Server.Addr, "/oras-artifact:v2"}, "")
 
 		cmd = exec.Command("oras", "push", "--plain-http", srcURL, "--config",
@@ -1220,7 +1218,9 @@ func TestBasicAuth(t *testing.T) {
 				},
 			}
 
-			destConfig.Storage.RootDirectory = destDir
+			rootDir := t.TempDir()
+
+			destConfig.Storage.RootDirectory = rootDir
 
 			regex := ".*"
 			var semver bool


### PR DESCRIPTION
currently different subpaths can only point to same root directory only
when one of storage config does not enable dedupe.

different subpath should be able to point to same root directory and in
that case their storage config should be same i.e GC,Dedupe, GC delay
and GC interval

Signed-off-by: Shivam Mishra <shimish2@cisco.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
