### PR TITLE
feat: print the port chosen by kernel if port is unspecified

### DIFF
--- a/examples/config-autoport.json
+++ b/examples/config-autoport.json
@@ -1,0 +1,13 @@
+{
+    "distSpecVersion": "1.0.1-dev",
+    "storage": {
+        "rootDirectory": "/tmp/zot"
+    },
+    "http": {
+        "address": "127.0.0.1",
+        "port": "0"
+    },
+    "log": {
+        "level": "debug"
+    }
+}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -170,6 +170,13 @@ func (c *Controller) Run(reloadCtx context.Context) error {
 		return err
 	}
 
+	if c.Config.HTTP.Port == "0" || c.Config.HTTP.Port == "" {
+		chosenAddr := listener.Addr().(*net.TCPAddr)
+		c.Log.Info().Int("port", chosenAddr.Port).IPAddr("address", chosenAddr.IP).Msg(
+			"Port is unspecified. zot will listen on an available port chosen by the kernel.",
+		)
+	}
+
 	if c.Config.HTTP.TLS != nil && c.Config.HTTP.TLS.Key != "" && c.Config.HTTP.TLS.Cert != "" {
 		server.TLSConfig = &tls.Config{
 			CipherSuites: []uint16{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

feature

**Which issue does this PR fix**:

#717

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
```bash 
{"level":"info","params":{"distSpecVersion":"1.0.1-dev","GoVersion":"","Commit":"","BinaryType":"","AccessControl":null,"Storage":{"Dedupe":true,"GC":true,"Commit":false,"GCDelay":3600000000000,"GCInterval":0,"RootDirectory":"/tmp/zot","StorageDriver":null,"SubPaths":null},"HTTP":{"Address":"127.0.0.1","Port":"0","AllowOrigin":"","TLS":null,"Auth":{"FailDelay":0,"HTPasswd":{"Path":""},"LDAP":null,"Bearer":null},"RawAccessControl":null,"Realm":"","Ratelimit":null},"Log":{"Level":"debug","Output":"","Audit":""},"Extensions":null},"goroutine":1,"caller":"/Users/thesayyn/Documents/zot/pkg/api/controller.go:107","time":"2022-08-11T18:06:37.75729+03:00","message":"configuration settings"}
{"level":"info","cpus":8,"max. open files":10240,"goroutine":1,"caller":"/Users/thesayyn/Documents/zot/pkg/api/controller.go:102","time":"2022-08-11T18:06:37.757374+03:00","message":"runtime params"}
{"level":"warn","goroutine":1,"caller":"/Users/thesayyn/Documents/zot/pkg/extensions/extensions_lint_disabled.go:13","time":"2022-08-11T18:06:37.757525+03:00","message":"lint extension is disabled because given zot binary doesn'tinclude this feature please build a binary that does so"}
{"level":"info","port":64680,"address":"127.0.0.1","goroutine":1,"caller":"/Users/thesayyn/Documents/zot/pkg/api/controller.go:175","time":"2022-08-11T18:06:37.80581+03:00","message":"Port is unspecified. zot will listen on an available port chosen by the kernel."}

```
**Automation added to e2e**:


**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Print the port chosen by the kernel when port is unspecified
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
