### PR TITLE
GQL Playground: Added content-type to Access-Control-Allow-Headers

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -78,7 +78,7 @@ func (c *Controller) CORSHandler(response http.ResponseWriter, request *http.Req
 	}
 
 	response.Header().Set("Access-Control-Allow-Methods", "HEAD,GET,POST,OPTIONS")
-	response.Header().Set("Access-Control-Allow-Headers", "Authorization")
+	response.Header().Set("Access-Control-Allow-Headers", "Authorization,content-type")
 }
 
 func DumpRuntimeParams(log log.Logger) {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -269,7 +269,7 @@ func TestHtpasswdSingleCred(t *testing.T) {
 				So(resp, ShouldNotBeNil)
 				So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 
-				header := []string{"Authorization"}
+				header := []string{"Authorization,content-type"}
 
 				resp, _ = resty.R().SetBasicAuth(user, password).Options(baseURL + "/v2/")
 				So(resp, ShouldNotBeNil)


### PR DESCRIPTION
**What type of PR is this?**

fix for feature

**Which issue does this PR fix**:

Part of #606

**What does this PR do / Why do we need it**:

Adds content-type to Access-Control-Allow-Headers to the CORS header function. Needed for the preflight of the GQL playground.

**Will this break upgrades or downgrades?**

Playground won't work on downgrade

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
