### PR TITLE
graphql: Apply authorization on /_search endpoint

### DIFF
--- a/examples/config-tls.json
+++ b/examples/config-tls.json
@@ -8,8 +8,8 @@
     "port": "8080",
     "realm": "zot",
     "tls": {
-      "cert": "test/data/server.cert",
-      "key": "test/data/server.key"
+      "cert": "../../test/data/server.cert",
+      "key": "../../test/data/server.key"
     }
   },
   "log": {

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -34,6 +34,7 @@ import (
 	"zotregistry.io/zot/pkg/api/constants"
 	ext "zotregistry.io/zot/pkg/extensions"
 	"zotregistry.io/zot/pkg/log"
+	localCtx "zotregistry.io/zot/pkg/requestcontext"
 	"zotregistry.io/zot/pkg/storage"
 	"zotregistry.io/zot/pkg/test" // nolint:goimports
 	// as required by swaggo.
@@ -1240,9 +1241,11 @@ func (rh *RouteHandler) ListRepositories(response http.ResponseWriter, request *
 	}
 
 	var repos []string
+	authzCtxKey := localCtx.GetContextKey()
+
 	// get passed context from authzHandler and filter out repos based on permissions
 	if authCtx := request.Context().Value(authzCtxKey); authCtx != nil {
-		acCtx, ok := authCtx.(AccessControlContext)
+		acCtx, ok := authCtx.(localCtx.AccessControlContext)
 		if !ok {
 			response.WriteHeader(http.StatusInternalServerError)
 
@@ -1250,7 +1253,7 @@ func (rh *RouteHandler) ListRepositories(response http.ResponseWriter, request *
 		}
 
 		for _, r := range combineRepoList {
-			if acCtx.isAdmin || matchesRepo(acCtx.globPatterns, r) {
+			if acCtx.IsAdmin || matchesRepo(acCtx.GlobPatterns, r) {
 				repos = append(repos, r)
 			}
 		}

--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -71,8 +71,8 @@ func SetupSearchRoutes(config *config.Config, router *mux.Router, storeControlle
 			resConfig = search.GetResolverConfig(log, storeController, false)
 		}
 
-		router.PathPrefix(constants.ExtSearchPrefix).Methods("OPTIONS", "GET", "POST").
-			Handler(gqlHandler.NewDefaultServer(gql_generated.NewExecutableSchema(resConfig)))
+		graphqlPrefix := router.PathPrefix(constants.ExtSearchPrefix).Methods("OPTIONS", "GET", "POST")
+		graphqlPrefix.Handler(gqlHandler.NewDefaultServer(gql_generated.NewExecutableSchema(resConfig)))
 	}
 }
 

--- a/pkg/extensions/search/schema.resolvers.go
+++ b/pkg/extensions/search/schema.resolvers.go
@@ -454,7 +454,14 @@ func (r *queryResolver) GlobalSearch(ctx context.Context, query string) (*gql_ge
 		return &gql_generated.GlobalSearchResult{}, err
 	}
 
-	repos, images, layers := globalSearch(repoList, name, tag, olu, r.log)
+	availableRepos, err := userAvailableRepos(ctx, repoList)
+	if err != nil {
+		r.log.Error().Err(err).Msg("unable to filter user available repositories")
+
+		return &gql_generated.GlobalSearchResult{}, err
+	}
+
+	repos, images, layers := globalSearch(availableRepos, name, tag, olu, r.log)
 
 	return &gql_generated.GlobalSearchResult{
 		Images: images,

--- a/pkg/requestcontext/context.go
+++ b/pkg/requestcontext/context.go
@@ -1,0 +1,18 @@
+package requestcontext
+
+type Key int
+
+// request-local context key.
+var authzCtxKey = Key(0) // nolint: gochecknoglobals
+
+// pointer needed for use in context.WithValue.
+func GetContextKey() *Key {
+	return &authzCtxKey
+}
+
+// AccessControlContext context passed down to http.Handlers.
+type AccessControlContext struct {
+	GlobPatterns map[string]bool
+	IsAdmin      bool
+	Username     string
+}

--- a/pkg/test/common_test.go
+++ b/pkg/test/common_test.go
@@ -4,14 +4,18 @@
 package test_test
 
 import (
+	"context"
 	"encoding/json"
 	"io/ioutil"
 	"os"
 	"path"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
+	"zotregistry.io/zot/pkg/api"
+	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/test"
 )
 
@@ -121,4 +125,284 @@ func TestGetOciLayoutDigests(t *testing.T) {
 			panic(err)
 		}
 	})
+}
+
+func TestGetImageComponents(t *testing.T) {
+	Convey("Inject failures for unreachable lines", t, func() {
+		injected := test.InjectFailure(0)
+		if injected {
+			_, _, _, err := test.GetImageComponents(100)
+			So(err, ShouldNotBeNil)
+		}
+	})
+	Convey("finishes successfully", t, func() {
+		_, _, _, err := test.GetImageComponents(100)
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestUploadImage(t *testing.T) {
+	Convey("Post request results in an error", t, func() {
+		port := test.GetFreePort()
+		baseURL := test.GetBaseURL(port)
+
+		conf := config.New()
+		conf.HTTP.Port = port
+		conf.Storage.RootDirectory = t.TempDir()
+
+		img := test.Image{
+			Layers: make([][]byte, 10),
+		}
+
+		err := test.UploadImage(img, baseURL, "test")
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Post request status differs from accepted", t, func() {
+		port := test.GetFreePort()
+		baseURL := test.GetBaseURL(port)
+
+		tempDir := t.TempDir()
+		conf := config.New()
+		conf.HTTP.Port = port
+		conf.Storage.RootDirectory = tempDir
+
+		err := os.Chmod(tempDir, 0o400)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ctlr := api.NewController(conf)
+		go startServer(ctlr)
+		defer stopServer(ctlr)
+
+		test.WaitTillServerReady(baseURL)
+
+		img := test.Image{
+			Layers: make([][]byte, 10),
+		}
+
+		err = test.UploadImage(img, baseURL, "test")
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Put request results in an error", t, func() {
+		port := test.GetFreePort()
+		baseURL := test.GetBaseURL(port)
+
+		conf := config.New()
+		conf.HTTP.Port = port
+		conf.Storage.RootDirectory = t.TempDir()
+
+		ctlr := api.NewController(conf)
+		go startServer(ctlr)
+		defer stopServer(ctlr)
+
+		test.WaitTillServerReady(baseURL)
+
+		img := test.Image{
+			Layers: make([][]byte, 10), // invalid format that will result in an error
+			Config: ispec.Image{},
+		}
+
+		err := test.UploadImage(img, baseURL, "test")
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Image uploaded successfully", t, func() {
+		port := test.GetFreePort()
+		baseURL := test.GetBaseURL(port)
+
+		conf := config.New()
+		conf.HTTP.Port = port
+		conf.Storage.RootDirectory = t.TempDir()
+
+		ctlr := api.NewController(conf)
+		go startServer(ctlr)
+		defer stopServer(ctlr)
+
+		test.WaitTillServerReady(baseURL)
+
+		layerBlob := []byte("test")
+
+		img := test.Image{
+			Layers: [][]byte{
+				layerBlob,
+			}, // invalid format that will result in an error
+			Config: ispec.Image{},
+		}
+
+		err := test.UploadImage(img, baseURL, "test")
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Blob upload wrong response status code", t, func() {
+		port := test.GetFreePort()
+		baseURL := test.GetBaseURL(port)
+
+		tempDir := t.TempDir()
+		conf := config.New()
+		conf.HTTP.Port = port
+		conf.Storage.RootDirectory = tempDir
+
+		ctlr := api.NewController(conf)
+		go startServer(ctlr)
+		defer stopServer(ctlr)
+
+		test.WaitTillServerReady(baseURL)
+
+		layerBlob := []byte("test")
+		layerBlobDigest := digest.FromBytes(layerBlob)
+		layerPath := path.Join(tempDir, "test", "blobs", "sha256")
+
+		if _, err := os.Stat(layerPath); os.IsNotExist(err) {
+			err = os.MkdirAll(layerPath, 0o700)
+			if err != nil {
+				t.Fatal(err)
+			}
+			file, err := os.Create(path.Join(layerPath, layerBlobDigest.Encoded()))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = os.Chmod(layerPath, 0o000)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer func() {
+				err = os.Chmod(layerPath, 0o700)
+				if err != nil {
+					t.Fatal(err)
+				}
+				os.RemoveAll(file.Name())
+			}()
+		}
+
+		img := test.Image{
+			Layers: [][]byte{
+				layerBlob,
+			}, // invalid format that will result in an error
+			Config: ispec.Image{},
+		}
+
+		err := test.UploadImage(img, baseURL, "test")
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("CreateBlobUpload wrong response status code", t, func() {
+		port := test.GetFreePort()
+		baseURL := test.GetBaseURL(port)
+
+		tempDir := t.TempDir()
+		conf := config.New()
+		conf.HTTP.Port = port
+		conf.Storage.RootDirectory = tempDir
+
+		ctlr := api.NewController(conf)
+		go startServer(ctlr)
+		defer stopServer(ctlr)
+
+		test.WaitTillServerReady(baseURL)
+
+		layerBlob := []byte("test")
+
+		img := test.Image{
+			Layers: [][]byte{
+				layerBlob,
+			}, // invalid format that will result in an error
+			Config: ispec.Image{},
+		}
+
+		Convey("CreateBlobUpload", func() {
+			injected := test.InjectFailure(2)
+			if injected {
+				err := test.UploadImage(img, baseURL, "test")
+				So(err, ShouldNotBeNil)
+			}
+		})
+		Convey("UpdateBlobUpload", func() {
+			injected := test.InjectFailure(4)
+			if injected {
+				err := test.UploadImage(img, baseURL, "test")
+				So(err, ShouldNotBeNil)
+			}
+		})
+	})
+}
+
+func TestInjectUploadImage(t *testing.T) {
+	Convey("Inject failures for unreachable lines", t, func() {
+		port := test.GetFreePort()
+		baseURL := test.GetBaseURL(port)
+
+		tempDir := t.TempDir()
+		conf := config.New()
+		conf.HTTP.Port = port
+		conf.Storage.RootDirectory = tempDir
+
+		ctlr := api.NewController(conf)
+		go startServer(ctlr)
+		defer stopServer(ctlr)
+
+		test.WaitTillServerReady(baseURL)
+
+		layerBlob := []byte("test")
+		layerPath := path.Join(tempDir, "test", ".uploads")
+
+		if _, err := os.Stat(layerPath); os.IsNotExist(err) {
+			err = os.MkdirAll(layerPath, 0o700)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		img := test.Image{
+			Layers: [][]byte{
+				layerBlob,
+			}, // invalid format that will result in an error
+			Config: ispec.Image{},
+		}
+
+		Convey("first marshal", func() {
+			injected := test.InjectFailure(0)
+			if injected {
+				err := test.UploadImage(img, baseURL, "test")
+				So(err, ShouldNotBeNil)
+			}
+		})
+		Convey("CreateBlobUpload POST call", func() {
+			injected := test.InjectFailure(1)
+			if injected {
+				err := test.UploadImage(img, baseURL, "test")
+				So(err, ShouldNotBeNil)
+			}
+		})
+		Convey("UpdateBlobUpload PUT call", func() {
+			injected := test.InjectFailure(3)
+			if injected {
+				err := test.UploadImage(img, baseURL, "test")
+				So(err, ShouldNotBeNil)
+			}
+		})
+		Convey("second marshal", func() {
+			injected := test.InjectFailure(5)
+			if injected {
+				err := test.UploadImage(img, baseURL, "test")
+				So(err, ShouldNotBeNil)
+			}
+		})
+	})
+}
+
+func startServer(c *api.Controller) {
+	// this blocks
+	ctx := context.Background()
+	if err := c.Run(ctx); err != nil {
+		return
+	}
+}
+
+func stopServer(c *api.Controller) {
+	ctx := context.Background()
+	_ = c.Server.Shutdown(ctx)
 }

--- a/pkg/test/dev.go
+++ b/pkg/test/dev.go
@@ -6,6 +6,7 @@
 package test
 
 import (
+	"net/http"
 	"sync"
 
 	zerr "zotregistry.io/zot/errors"
@@ -34,6 +35,20 @@ func Error(err error) error {
 	}
 
 	return nil
+}
+
+// Used to inject error status codes for coverage purposes.
+// -1 will be returned in case of successful failure injection.
+func ErrStatusCode(status int) int {
+	if !injectedFailure() {
+		if status == http.StatusAccepted || status == http.StatusCreated {
+			return status
+		}
+
+		return 0
+	}
+
+	return -1
 }
 
 /**

--- a/pkg/test/inject_test.go
+++ b/pkg/test/inject_test.go
@@ -59,6 +59,18 @@ func bar() error {
 	return nil
 }
 
+func baz() error {
+	if test.ErrStatusCode(0) != 0 {
+		return errCall1
+	}
+
+	if test.ErrStatusCode(0) != 0 {
+		return errCall2
+	}
+
+	return nil
+}
+
 func alwaysErr() error {
 	return errNotZero
 }
@@ -104,6 +116,22 @@ func TestInject(t *testing.T) {
 			Convey("With skipping", func() {
 				test.InjectFailure(1) // inject a failure but skip first one
 				err := bar()          // should be a failure
+				So(errors.Is(err, errCall1), ShouldBeFalse)
+				So(errors.Is(err, errCall2), ShouldBeTrue)
+			})
+		})
+
+		Convey("Check ErrStatusCode", func() {
+			Convey("Without skipping", func() {
+				test.InjectFailure(0)   // inject a failure
+				err := baz()            // should be a failure
+				So(err, ShouldNotBeNil) // should be a failure
+				So(errors.Is(err, errCall1), ShouldBeTrue)
+			})
+
+			Convey("With skipping", func() {
+				test.InjectFailure(1) // inject a failure but skip first one
+				err := baz()          // should be a failure
 				So(errors.Is(err, errCall1), ShouldBeFalse)
 				So(errors.Is(err, errCall2), ShouldBeTrue)
 			})

--- a/pkg/test/prod.go
+++ b/pkg/test/prod.go
@@ -11,6 +11,10 @@ func Ok(ok bool) bool {
 	return ok
 }
 
+func ErrStatusCode(statusCode int) int {
+	return statusCode
+}
+
 /**
  *
  * Failure injection infrastructure to cover hard-to-reach code paths (nop in production).


### PR DESCRIPTION
- AccessControlContext now resides in a separate package from where it can be imported,
along with the contextKey that will be used to set and retrieve this context value.

- AccessControlContext has a new field called Username, that will be of use for future
implementations in graphQL resolvers.

- GlobalSearch resolver now uses this context to filter repos available to the logged user.

Closes #615

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
using authz context for use on GraphQl resolvers

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
