### PR TITLE
Fix file handlers not being closed after calls to ImageStore.GetBlob

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -655,6 +655,7 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 
 		return
 	}
+	defer repo.Close()
 
 	response.Header().Set("Content-Length", fmt.Sprintf("%d", blen))
 	response.Header().Set(constants.DistContentDigestKey, digest)

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -405,8 +405,8 @@ func TestRoutes(t *testing.T) {
 					"digest": "sha256:7a0437f04f83f084b7ed68ad9c4a4947e12fc4e1b006b38129bac89114ec3621",
 				},
 				&mocks.MockedImageStore{
-					GetBlobFn: func(repo, digest, mediaType string) (io.Reader, int64, error) {
-						return bytes.NewBuffer([]byte("")), 0, zerr.ErrRepoNotFound
+					GetBlobFn: func(repo, digest, mediaType string) (io.ReadCloser, int64, error) {
+						return io.NopCloser(bytes.NewBuffer([]byte(""))), 0, zerr.ErrRepoNotFound
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusNotFound)
@@ -418,8 +418,8 @@ func TestRoutes(t *testing.T) {
 					"digest": "sha256:7a0437f04f83f084b7ed68ad9c4a4947e12fc4e1b006b38129bac89114ec3621",
 				},
 				&mocks.MockedImageStore{
-					GetBlobFn: func(repo, digest, mediaType string) (io.Reader, int64, error) {
-						return bytes.NewBuffer([]byte("")), 0, zerr.ErrBadBlobDigest
+					GetBlobFn: func(repo, digest, mediaType string) (io.ReadCloser, int64, error) {
+						return io.NopCloser(bytes.NewBuffer([]byte(""))), 0, zerr.ErrBadBlobDigest
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusBadRequest)

--- a/pkg/storage/local_test.go
+++ b/pkg/storage/local_test.go
@@ -751,11 +751,14 @@ func FuzzGetBlob(f *testing.F) {
 			t.Error(err)
 		}
 
-		_, _, err = imgStore.GetBlob(repoName, digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		blobReadCloser, _, err := imgStore.GetBlob(repoName, digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
 		if err != nil {
 			if isKnownErr(err) {
 				return
 			}
+			t.Error(err)
+		}
+		if err = blobReadCloser.Close(); err != nil {
 			t.Error(err)
 		}
 	})
@@ -951,7 +954,9 @@ func TestDedupeLinks(t *testing.T) {
 		_, _, err = imgStore.CheckBlob("dedupe1", digest.String())
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.GetBlob("dedupe1", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		blobrc, _, err := imgStore.GetBlob("dedupe1", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		So(err, ShouldBeNil)
+		err = blobrc.Close()
 		So(err, ShouldBeNil)
 
 		cblob, cdigest := test.GetRandomImageConfig()
@@ -1009,7 +1014,9 @@ func TestDedupeLinks(t *testing.T) {
 		_, _, err = imgStore.CheckBlob("dedupe2", digest.String())
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.GetBlob("dedupe2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		blobrc, _, err = imgStore.GetBlob("dedupe2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		So(err, ShouldBeNil)
+		err = blobrc.Close()
 		So(err, ShouldBeNil)
 
 		cblob, cdigest = test.GetRandomImageConfig()

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -866,8 +866,11 @@ func TestS3Dedupe(t *testing.T) {
 		So(checkBlobSize1, ShouldBeGreaterThan, 0)
 		So(err, ShouldBeNil)
 
-		_, getBlobSize1, err := imgStore.GetBlob("dedupe1", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		blobReadCloser, getBlobSize1, err := imgStore.GetBlob("dedupe1", digest.String(),
+			"application/vnd.oci.image.layer.v1.tar+gzip")
 		So(getBlobSize1, ShouldBeGreaterThan, 0)
+		So(err, ShouldBeNil)
+		err = blobReadCloser.Close()
 		So(err, ShouldBeNil)
 
 		cblob, cdigest := test.GetRandomImageConfig()
@@ -928,11 +931,14 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(checkBlobSize2, ShouldBeGreaterThan, 0)
 
-		_, getBlobSize2, err := imgStore.GetBlob("dedupe2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		blobReadCloser, getBlobSize2, err := imgStore.GetBlob("dedupe2", digest.String(),
+			"application/vnd.oci.image.layer.v1.tar+gzip")
 		So(err, ShouldBeNil)
 		So(getBlobSize2, ShouldBeGreaterThan, 0)
 		So(checkBlobSize1, ShouldEqual, checkBlobSize2)
 		So(getBlobSize1, ShouldEqual, getBlobSize2)
+		err = blobReadCloser.Close()
+		So(err, ShouldBeNil)
 
 		cblob, cdigest = test.GetRandomImageConfig()
 		_, clen, err = imgStore.FullBlobUpload("dedupe2", bytes.NewReader(cblob), cdigest.String())
@@ -1039,9 +1045,12 @@ func TestS3Dedupe(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// check that we retrieve the real dedupe2/blob (which is deduped earlier - 0 size) when switching to dedupe false
-			_, getBlobSize2, err = imgStore.GetBlob("dedupe2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+			blobReadCloser, getBlobSize2, err = imgStore.GetBlob("dedupe2", digest.String(),
+				"application/vnd.oci.image.layer.v1.tar+gzip")
 			So(err, ShouldBeNil)
 			So(getBlobSize1, ShouldEqual, getBlobSize2)
+			err = blobReadCloser.Close()
+			So(err, ShouldBeNil)
 
 			_, checkBlobSize2, err := imgStore.CheckBlob("dedupe2", digest.String())
 			So(err, ShouldBeNil)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -39,7 +39,7 @@ type ImageStore interface {
 	DeleteBlobUpload(repo, uuid string) error
 	BlobPath(repo string, digest digest.Digest) string
 	CheckBlob(repo, digest string) (bool, int64, error)
-	GetBlob(repo, digest, mediaType string) (io.Reader, int64, error)
+	GetBlob(repo, digest, mediaType string) (io.ReadCloser, int64, error)
 	DeleteBlob(repo, digest string) error
 	GetIndexContent(repo string) ([]byte, error)
 	GetBlobContent(repo, digest string) ([]byte, error)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -242,7 +242,9 @@ func TestStorageAPIs(t *testing.T) {
 						_, _, err = imgStore.CheckBlob("test", digest.String())
 						So(err, ShouldBeNil)
 
-						_, _, err = imgStore.GetBlob("test", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+						blob, _, err := imgStore.GetBlob("test", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+						So(err, ShouldBeNil)
+						err = blob.Close()
 						So(err, ShouldBeNil)
 
 						manifest := ispec.Manifest{}
@@ -431,7 +433,9 @@ func TestStorageAPIs(t *testing.T) {
 						_, _, err = imgStore.GetBlob("test", "inexistent", "application/vnd.oci.image.layer.v1.tar+gzip")
 						So(err, ShouldNotBeNil)
 
-						_, _, err = imgStore.GetBlob("test", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+						blob, _, err := imgStore.GetBlob("test", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+						So(err, ShouldBeNil)
+						err = blob.Close()
 						So(err, ShouldBeNil)
 
 						blobContent, err := imgStore.GetBlobContent("test", digest.String())

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -30,7 +30,7 @@ type MockedImageStore struct {
 	DeleteBlobUploadFn     func(repo string, uuid string) error
 	BlobPathFn             func(repo string, digest digest.Digest) string
 	CheckBlobFn            func(repo string, digest string) (bool, int64, error)
-	GetBlobFn              func(repo string, digest string, mediaType string) (io.Reader, int64, error)
+	GetBlobFn              func(repo string, digest string, mediaType string) (io.ReadCloser, int64, error)
 	DeleteBlobFn           func(repo string, digest string) error
 	GetIndexContentFn      func(repo string) ([]byte, error)
 	GetBlobContentFn       func(repo, digest string) ([]byte, error)
@@ -230,12 +230,12 @@ func (is MockedImageStore) CheckBlob(repo string, digest string) (bool, int64, e
 	return true, 0, nil
 }
 
-func (is MockedImageStore) GetBlob(repo string, digest string, mediaType string) (io.Reader, int64, error) {
+func (is MockedImageStore) GetBlob(repo string, digest string, mediaType string) (io.ReadCloser, int64, error) {
 	if is.GetBlobFn != nil {
 		return is.GetBlobFn(repo, digest, mediaType)
 	}
 
-	return &io.LimitedReader{}, 0, nil
+	return io.NopCloser(&io.LimitedReader{}), 0, nil
 }
 
 func (is MockedImageStore) DeleteBlobUpload(repo string, digest string) error {


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
This indirectly fixes hitting the FD limit when reading blobs from the disk when using the graphql API

**What does this PR do / Why do we need it**:
Makes sure file handlers are timely closed after reading blobs.

**If an issue # is not available please add repro steps and logs showing the issue**:
Tested changeset in https://github.com/project-zot/zot/pull/457.
The environment had roughly 100 images (4 repos with multiple tags in each, 1042 individual blob files) in storage.
Before the fix, `bin/zli-linux-amd64 images local` used to cause FD limit to be reached when the file handlers for blobs remained open.

**Testing done on this change**:
Repeated the test mentioned above with the patchset cherry-picked on top of https://github.com/project-zot/zot/pull/457, with this change the opened blob files are closed immediately.

Signed-off-by: Andrei Aaron <andaaron@cisco.com>