### PR TITLE
zb: populate images first for the GetCatalog test

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./cache
-          key: ${{ runner.os }}-benchmark
+          key: $${runner.os }}-gen1-benchmark
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1.14.0

--- a/.github/workflows/cluster.yaml
+++ b/.github/workflows/cluster.yaml
@@ -167,7 +167,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./cache
-          key: ${{ runner.os }}-benchmark-stateless-cluster
+          key: $${runner.os }}-gen1-benchmark-stateless-cluster
       # Run `github-action-benchmark` action
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1.14.0


### PR DESCRIPTION
Signed-off-by: Roxana Nemulescu <roxana.nemulescu@gmail.com>

**Which issue does this PR fix**:
GetCatalog() uses empty storage for benchmarking.

**What does this PR do / Why do we need it**:
Populate with mix of many small, medium and large images.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
