### PR TITLE
report listening port when chosen by kernel

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -55,4 +55,5 @@ var (
 	ErrSyncSignature           = errors.New("sync: couldn't get upstream notary/cosign signatures")
 	ErrImageLintAnnotations    = errors.New("routes: lint checks failed")
 	ErrParsingAuthHeader       = errors.New("auth: failed parsing authorization header")
+	ErrBadType                 = errors.New("core: invalid type")
 )

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -143,6 +143,55 @@ func TestRunAlreadyRunningServer(t *testing.T) {
 	})
 }
 
+func TestAutoPortSelection(t *testing.T) {
+	Convey("Run server with specifying a port", t, func() {
+		conf := config.New()
+		conf.HTTP.Port = "0"
+
+		logFile, err := os.CreateTemp("", "zot-log*.txt")
+		So(err, ShouldBeNil)
+		conf.Log.Output = logFile.Name()
+		defer os.Remove(logFile.Name()) // clean up
+
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
+
+		go startServer(ctlr)
+		time.Sleep(1000 * time.Millisecond)
+		defer stopServer(ctlr)
+
+		file, err := os.Open(logFile.Name())
+		So(err, ShouldBeNil)
+		defer file.Close()
+
+		scanner := bufio.NewScanner(file)
+
+		var contents bytes.Buffer
+		start := time.Now()
+
+		for scanner.Scan() {
+			if time.Since(start) < time.Second*30 {
+				t.Logf("Exhausted: Controller did not print the expected log within 30 seconds")
+			}
+			text := scanner.Text()
+			contents.WriteString(text)
+			if strings.Contains(text, "Port unspecified") {
+				break
+			}
+			t.Logf(scanner.Text())
+		}
+		So(scanner.Err(), ShouldBeNil)
+		So(contents.String(), ShouldContainSubstring,
+			"port is unspecified, listening on kernel chosen port",
+		)
+		So(contents.String(), ShouldContainSubstring, "\"address\":\"127.0.0.1\"")
+		So(contents.String(), ShouldContainSubstring, "\"port\":")
+
+		So(ctlr.GetPort(), ShouldBeGreaterThan, 0)
+		So(ctlr.GetPort(), ShouldBeLessThan, 65536)
+	})
+}
+
 func TestObjectStorageController(t *testing.T) {
 	skipIt(t)
 	Convey("Negative make a new object storage controller", t, func() {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -232,6 +233,10 @@ func validateStorageConfig(cfg *config.Config) error {
 }
 
 func validateConfiguration(config *config.Config) error {
+	if err := validateHTTP(config); err != nil {
+		return err
+	}
+
 	if err := validateGC(config); err != nil {
 		return err
 	}
@@ -509,6 +514,21 @@ func validateLDAP(config *config.Config) error {
 
 			return errors.ErrLDAPConfig
 		}
+	}
+
+	return nil
+}
+
+func validateHTTP(config *config.Config) error {
+	if config.HTTP.Port != "" {
+		port, err := strconv.ParseInt(config.HTTP.Port, 10, 64)
+		if err != nil || (port < 0 || port > 65535) {
+			log.Error().Str("port", config.HTTP.Port).Msg("invalid port")
+
+			return errors.ErrBadConfig
+		}
+
+		fmt.Printf("HTTP port %d\n", port)
 	}
 
 	return nil

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -540,6 +540,43 @@ func TestLoadConfig(t *testing.T) {
 		err = cli.LoadConfiguration(config, tmpfile.Name())
 		So(err, ShouldBeNil)
 	})
+
+	Convey("Test HTTP port", t, func() {
+		config := config.New()
+		tmpfile, err := os.CreateTemp("", "zot-test*.json")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpfile.Name())
+
+		content := []byte(`{"storage":{"rootDirectory":"/tmp/zot",
+							"subPaths": {"/a": {"rootDirectory": "/zot-a","dedupe":"true"},
+							"/b": {"rootDirectory": "/zot-a","dedupe":"true"}}},
+							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}}}`)
+		err = os.WriteFile(tmpfile.Name(), content, 0o0600)
+		So(err, ShouldBeNil)
+		err = cli.LoadConfiguration(config, tmpfile.Name())
+		So(err, ShouldBeNil)
+
+		content = []byte(`{"storage":{"rootDirectory":"/tmp/zot",
+							"subPaths": {"/a": {"rootDirectory": "/zot-a","dedupe":"true"},
+							"/b": {"rootDirectory": "/zot-a","dedupe":"true"}}},
+							"http":{"address":"127.0.0.1","port":"-1","realm":"zot",
+							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}}}`)
+		err = os.WriteFile(tmpfile.Name(), content, 0o0600)
+		So(err, ShouldBeNil)
+		err = cli.LoadConfiguration(config, tmpfile.Name())
+		So(err, ShouldNotBeNil)
+
+		content = []byte(`{"storage":{"rootDirectory":"/tmp/zot",
+							"subPaths": {"/a": {"rootDirectory": "/zot-a","dedupe":"true"},
+							"/b": {"rootDirectory": "/zot-a","dedupe":"true"}}},
+							"http":{"address":"127.0.0.1","port":"65536","realm":"zot",
+							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}}}`)
+		err = os.WriteFile(tmpfile.Name(), content, 0o0600)
+		So(err, ShouldBeNil)
+		err = cli.LoadConfiguration(config, tmpfile.Name())
+		So(err, ShouldNotBeNil)
+	})
 }
 
 func TestGC(t *testing.T) {


### PR DESCRIPTION
Based off of the PR by @thesayyn
https://github.com/project-zot/zot/pull/720

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

feature

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

issue #717 

**What does this PR do / Why do we need it**:

Supports kernel-chosen random ports

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
