### PR TITLE
dco: enable DCO checks only on PRs

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -2,7 +2,6 @@
 name: DCO
 on:
   pull_request:
-  push:
     branches:
       - main
 


### PR DESCRIPTION
GitHub allows a "Squash and Merge" model which does an automatic rebase but commit GPG signature is from GitHub. So disable DCO checks only when merging.

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

ci/cd

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
