### PR TITLE
use Created field to get the timestamp of image

### DIFF
--- a/pkg/extensions/search/common/oci_layout.go
+++ b/pkg/extensions/search/common/oci_layout.go
@@ -276,12 +276,12 @@ func (olu BaseOciLayoutUtils) GetImageTagsWithTimestamp(repo string) ([]TagInfo,
 				return tagsInfo, err
 			}
 
-			var timeStamp time.Time
+			timeStamp := *imageInfo.Created
 
-			if len(imageInfo.History) != 0 {
-				timeStamp = *imageInfo.History[0].Created
-			} else {
-				timeStamp = time.Time{}
+			defaultTime := time.Time{}
+
+			if timeStamp == defaultTime && len(imageInfo.History) != 0 {
+				timeStamp = *imageInfo.History[len(imageInfo.History)-1].Created
 			}
 
 			tagsInfo = append(tagsInfo, TagInfo{Name: val, Timestamp: timeStamp, Digest: digest.String()})
@@ -338,12 +338,12 @@ func (olu BaseOciLayoutUtils) CheckManifestSignature(name string, digest godiges
 }
 
 func (olu BaseOciLayoutUtils) GetImageLastUpdated(imageInfo ispec.Image) time.Time {
-	var timeStamp time.Time
+	timeStamp := *imageInfo.Created
 
-	if len(imageInfo.History) != 0 {
-		timeStamp = *imageInfo.History[0].Created
-	} else {
-		timeStamp = time.Time{}
+	defaultTime := time.Time{}
+
+	if timeStamp == defaultTime && len(imageInfo.History) != 0 {
+		timeStamp = *imageInfo.History[len(imageInfo.History)-1].Created
 	}
 
 	return timeStamp


### PR DESCRIPTION
if Created field is not set use last entry of history field present in Image object. Last entry of history list is latest layer entry present in image.

if History field is not set use empty time.Time object.

Closes #821

Signed-off-by: Shivam Mishra <shimish2@cisco.com>

**What type of PR is this?**

bug fix

**Which issue does this PR fix**:
#821 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
