### PR TITLE
Added ability to get docker/podman/skopeo pull commands from ExpandedRepoInfo

### DIFF
--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -66,9 +66,9 @@ func SetupSearchRoutes(config *config.Config, router *mux.Router, storeControlle
 		var resConfig gql_generated.Config
 
 		if config.Extensions.Search.CVE != nil {
-			resConfig = search.GetResolverConfig(log, storeController, true)
+			resConfig = search.GetResolverConfig(log, storeController, true, config.HTTP.Address, config.HTTP.Port)
 		} else {
-			resConfig = search.GetResolverConfig(log, storeController, false)
+			resConfig = search.GetResolverConfig(log, storeController, false, config.HTTP.Address, config.HTTP.Port)
 		}
 
 		graphqlPrefix := router.PathPrefix(constants.ExtSearchPrefix).Methods("OPTIONS", "GET", "POST")

--- a/pkg/extensions/search/gql_generated/generated.go
+++ b/pkg/extensions/search/gql_generated/generated.go
@@ -128,8 +128,9 @@ type ComplexityRoot struct {
 	}
 
 	RepoInfo struct {
-		Images  func(childComplexity int) int
-		Summary func(childComplexity int) int
+		Images       func(childComplexity int) int
+		PullCommands func(childComplexity int) int
+		Summary      func(childComplexity int) int
 	}
 
 	RepoSummary struct {
@@ -604,6 +605,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.RepoInfo.Images(childComplexity), true
 
+	case "RepoInfo.PullCommands":
+		if e.complexity.RepoInfo.PullCommands == nil {
+			break
+		}
+
+		return e.complexity.RepoInfo.PullCommands(childComplexity), true
+
 	case "RepoInfo.Summary":
 		if e.complexity.RepoInfo.Summary == nil {
 			break
@@ -757,6 +765,7 @@ type PackageInfo {
 type RepoInfo {
     Images: [ImageSummary]
     Summary: RepoSummary
+    PullCommands: [String]
 }
 
 # Search results in all repos/images/layers
@@ -3531,6 +3540,8 @@ func (ec *executionContext) fieldContext_Query_ExpandedRepoInfo(ctx context.Cont
 				return ec.fieldContext_RepoInfo_Images(ctx, field)
 			case "Summary":
 				return ec.fieldContext_RepoInfo_Summary(ctx, field)
+			case "PullCommands":
+				return ec.fieldContext_RepoInfo_PullCommands(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RepoInfo", field.Name)
 		},
@@ -4064,6 +4075,47 @@ func (ec *executionContext) fieldContext_RepoInfo_Summary(ctx context.Context, f
 				return ec.fieldContext_RepoSummary_IsBookmarked(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type RepoSummary", field.Name)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RepoInfo_PullCommands(ctx context.Context, field graphql.CollectedField, obj *RepoInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RepoInfo_PullCommands(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PullCommands, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*string)
+	fc.Result = res
+	return ec.marshalOString2ᚕᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RepoInfo_PullCommands(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RepoInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -6942,6 +6994,10 @@ func (ec *executionContext) _RepoInfo(ctx context.Context, sel ast.SelectionSet,
 		case "Summary":
 
 			out.Values[i] = ec._RepoInfo_Summary(ctx, field, obj)
+
+		case "PullCommands":
+
+			out.Values[i] = ec._RepoInfo_PullCommands(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/pkg/extensions/search/gql_generated/models_gen.go
+++ b/pkg/extensions/search/gql_generated/models_gen.go
@@ -82,8 +82,9 @@ type PackageInfo struct {
 }
 
 type RepoInfo struct {
-	Images  []*ImageSummary `json:"Images"`
-	Summary *RepoSummary    `json:"Summary"`
+	Images       []*ImageSummary `json:"Images"`
+	Summary      *RepoSummary    `json:"Summary"`
+	PullCommands []*string       `json:"PullCommands"`
 }
 
 type RepoSummary struct {

--- a/pkg/extensions/search/resolver.go
+++ b/pkg/extensions/search/resolver.go
@@ -32,6 +32,7 @@ type Resolver struct {
 	cveInfo         *cveinfo.CveInfo
 	storeController storage.StoreController
 	digestInfo      *digestinfo.DigestInfo
+	hostAddress, hostPort string
 	log             log.Logger
 }
 
@@ -48,7 +49,7 @@ var (
 )
 
 // GetResolverConfig ...
-func GetResolverConfig(log log.Logger, storeController storage.StoreController, enableCVE bool) gql_generated.Config {
+func GetResolverConfig(log log.Logger, storeController storage.StoreController, enableCVE bool, hostAddress, hostPort string) gql_generated.Config {
 	var cveInfo *cveinfo.CveInfo
 
 	var err error
@@ -62,7 +63,7 @@ func GetResolverConfig(log log.Logger, storeController storage.StoreController, 
 
 	digestInfo := digestinfo.NewDigestInfo(storeController, log)
 
-	resConfig := &Resolver{cveInfo: cveInfo, storeController: storeController, digestInfo: digestInfo, log: log}
+	resConfig := &Resolver{cveInfo: cveInfo, storeController: storeController, digestInfo: digestInfo, log: log, hostAddress: hostAddress, hostPort: hostPort}
 
 	return gql_generated.Config{
 		Resolvers: resConfig, Directives: gql_generated.DirectiveRoot{},

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -22,6 +22,7 @@ type PackageInfo {
 type RepoInfo {
     Images: [ImageSummary]
     Summary: RepoSummary
+    PullCommands: [String]
 }
 
 # Search results in all repos/images/layers

--- a/pkg/extensions/search/schema.resolvers.go
+++ b/pkg/extensions/search/schema.resolvers.go
@@ -462,6 +462,12 @@ func (r *queryResolver) ExpandedRepoInfo(ctx context.Context, repo string) (*gql
 	repoInfo.Summary = summary
 	repoInfo.Images = images
 
+	host := r.hostAddress + ":" + r.hostPort
+	dockerPullCommand := "docker pull " + host + "/" + repo + ":" + *repoInfo.Summary.NewestImage.Tag
+	podmanPullCommand := "podman pull " + host + "/" + repo + ":" + *repoInfo.Summary.NewestImage.Tag
+	skopeoPullCommand := "skopeo copy docker://" + host + "/" + repo + ":" + *repoInfo.Summary.NewestImage.Tag + " docker://artprod.mycompany:port/" + "<DOCKER_REPOSITORY>" + ":" + "<DOCKER_TAG>"
+	repoInfo.PullCommands = []*string{&dockerPullCommand, &podmanPullCommand, &skopeoPullCommand}
+
 	return repoInfo, nil
 }
 


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
#811

**What does this PR do / Why do we need it**:
This adds the ability to retrieve the pull commands that the user can put in the terminal to copy an image to a (local) registry.

**Will this break upgrades or downgrades?**
No

curl --insecure -X POST -H "Content-Type: application/json" -d '{"query":"query{ExpandedRepoInfo(repo:\"alpine\"){PullCommands}}"}' https://localhost:5000/v2/_zot/ext/search


{"data":{"ExpandedRepoInfo":{"PullCommands":["docker pull 127.0.0.1:5000/alpine:latest","podman pull 127.0.0.1:5000/alpine:latest","skopeo copy docker://127.0.0.1:5000/alpine:latest docker://artprod.mycompany:port/<DOCKER_REPOSITORY>:\<DOCKER_TAG>"]}}}

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
