### PR TITLE
Support storing image logos as manifest annotations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -140,6 +140,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/chai2010/webp v1.1.1
 	github.com/cheggaaa/pb/v3 v3.0.3 // indirect
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21 // indirect
 	github.com/clbanning/mxj/v2 v2.5.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -538,6 +538,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chai2010/webp v1.1.1 h1:jTRmEccAJ4MGrhFOrPMpNGIJ/eybIgwKpcACsrTEapk=
+github.com/chai2010/webp v1.1.1/go.mod h1:0XVwvZWdjjdxpUEIf7b9g9VkHFnInUSYujwqTLEuldU=
 github.com/chartmuseum/auth v0.5.0 h1:ENNmoxvjxcR/JR0HrghAEtGQe7hToMNj16+UoS5CK9Y=
 github.com/chartmuseum/auth v0.5.0/go.mod h1:BvoSXHyvbsq+/bbhNgVTDQsModM+HERBTNY5o9Vyrig=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=

--- a/pkg/extensions/lint/lint.go
+++ b/pkg/extensions/lint/lint.go
@@ -4,13 +4,23 @@
 package lint
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
+	"image"
+	_ "image/gif"  // nolint:gci  // imported for the registration of it's decoder func
+	_ "image/jpeg" // nolint:gci // imported for the registration of it's decoder func
+	_ "image/png"  // nolint:gci  // imported for the registration of it's decoder func
 
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"zotregistry.io/zot/pkg/extensions/config"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"
+)
+
+const (
+	logoKey string = "com.zot.logo"
 )
 
 type Linter struct {
@@ -61,6 +71,13 @@ func (linter *Linter) CheckMandatoryAnnotations(repo string, manifestDigest godi
 	manifestAnnotations := manifest.Annotations
 	for annotation := range manifestAnnotations {
 		if _, ok := mandatoryAnnotationsMap[annotation]; ok {
+			if annotation == logoKey {
+				if ok := linter.checkIfLogoAnnotationValid(manifestAnnotations[annotation]); ok {
+					mandatoryAnnotationsMap[annotation] = true
+				}
+
+				continue
+			}
 			mandatoryAnnotationsMap[annotation] = true
 		}
 	}
@@ -88,9 +105,15 @@ func (linter *Linter) CheckMandatoryAnnotations(repo string, manifestDigest godi
 	}
 
 	configAnnotations := imageConfig.Config.Labels
-
 	for annotation := range configAnnotations {
 		if _, ok := mandatoryAnnotationsMap[annotation]; ok {
+			if annotation == logoKey {
+				if ok := linter.checkIfLogoAnnotationValid(configAnnotations[annotation]); ok {
+					mandatoryAnnotationsMap[annotation] = true
+				}
+
+				continue
+			}
 			mandatoryAnnotationsMap[annotation] = true
 		}
 	}
@@ -122,4 +145,35 @@ func getMissingAnnotations(mandatoryAnnotationsMap map[string]bool) []string {
 	}
 
 	return missingAnnotations
+}
+
+func (linter *Linter) checkIfLogoAnnotationValid(annotationVal string) bool {
+	decodedVal, err := base64.StdEncoding.DecodeString(annotationVal)
+	if err != nil {
+		linter.log.Error().Err(err).Msg("unable to decode value")
+
+		return false
+	}
+	imageVal := bytes.NewBuffer(decodedVal)
+
+	logoConf, format, err := image.DecodeConfig(imageVal)
+	if err != nil {
+		linter.log.Error().Err(err).Msg("unable to decode image")
+
+		return false
+	}
+
+	if format != "jpeg" && format != "gif" && format != "png" {
+		linter.log.Error().Msg("encoded logo is of incorrect format, allowed formats are jpeg/png/gif")
+
+		return false
+	}
+
+	if logoConf.Height > 200 || logoConf.Width > 200 {
+		linter.log.Error().Msg("encoded logo is of incorrect size")
+
+		return false
+	}
+
+	return true
 }

--- a/pkg/extensions/search/common/common.go
+++ b/pkg/extensions/search/common/common.go
@@ -19,6 +19,7 @@ const (
 	LabelAnnotationTitle         = "org.label-schema.name"
 	LabelAnnotationDocumentation = "org.label-schema.usage"
 	LabelAnnotationSource        = "org.label-schema.vcs-url"
+	logoKey                      = "com.zot.logo"
 )
 
 type TagInfo struct {
@@ -144,6 +145,7 @@ type ImageAnnotations struct {
 	Source        string
 	Labels        string
 	Vendor        string
+	Logo          string
 }
 
 /* OCI annotation/label with backwards compatibility
@@ -193,6 +195,12 @@ func GetLicenses(annotations map[string]string) string {
 	return licenses
 }
 
+func GetLogo(annotations map[string]string) string {
+	logo := annotations[logoKey]
+
+	return logo
+}
+
 func GetAnnotations(annotations, labels map[string]string) ImageAnnotations {
 	description := GetDescription(annotations)
 	if description == "" {
@@ -229,6 +237,11 @@ func GetAnnotations(annotations, labels map[string]string) ImageAnnotations {
 		vendor = GetVendor(labels)
 	}
 
+	logo := GetLogo(annotations)
+	if logo == "" {
+		logo = GetLogo(labels)
+	}
+
 	return ImageAnnotations{
 		Description:   description,
 		Title:         title,
@@ -237,5 +250,6 @@ func GetAnnotations(annotations, labels map[string]string) ImageAnnotations {
 		Licenses:      licenses,
 		Labels:        categories,
 		Vendor:        vendor,
+		Logo:          logo,
 	}
 }

--- a/pkg/extensions/search/common/model.go
+++ b/pkg/extensions/search/common/model.go
@@ -40,6 +40,7 @@ type ImageSummary struct {
 	History         []LayerHistory            `json:"history"`
 	Layers          []LayerSummary            `json:"layers"`
 	Vulnerabilities ImageVulnerabilitySummary `json:"vulnerabilities"`
+	Logo            string                    `json:"logo"`
 }
 
 type OsArch struct {

--- a/pkg/extensions/search/common/oci_layout.go
+++ b/pkg/extensions/search/common/oci_layout.go
@@ -436,6 +436,7 @@ func (olu BaseOciLayoutUtils) GetExpandedRepoInfo(name string) (RepoInfo, error)
 			Labels:        annotations.Labels,
 			Source:        annotations.Source,
 			Layers:        layers,
+			Logo:          annotations.Logo,
 		}
 
 		imageSummaries = append(imageSummaries, imageSummary)

--- a/pkg/extensions/search/gql_generated/generated.go
+++ b/pkg/extensions/search/gql_generated/generated.go
@@ -82,6 +82,7 @@ type ComplexityRoot struct {
 		LastUpdated     func(childComplexity int) int
 		Layers          func(childComplexity int) int
 		Licenses        func(childComplexity int) int
+		Logo            func(childComplexity int) int
 		Platform        func(childComplexity int) int
 		RepoName        func(childComplexity int) int
 		Score           func(childComplexity int) int
@@ -363,6 +364,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.ImageSummary.Licenses(childComplexity), true
+
+	case "ImageSummary.Logo":
+		if e.complexity.ImageSummary.Logo == nil {
+			break
+		}
+
+		return e.complexity.ImageSummary.Logo(childComplexity), true
 
 	case "ImageSummary.Platform":
 		if e.complexity.ImageSummary.Platform == nil {
@@ -831,6 +839,7 @@ type ImageSummary {
     Documentation: String
     History: [LayerHistory]
     Vulnerabilities: ImageVulnerabilitySummary
+    Logo: String
 }
 
 type ImageVulnerabilitySummary {
@@ -1506,6 +1515,8 @@ func (ec *executionContext) fieldContext_GlobalSearchResult_Images(ctx context.C
 				return ec.fieldContext_ImageSummary_History(ctx, field)
 			case "Vulnerabilities":
 				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
+			case "Logo":
+				return ec.fieldContext_ImageSummary_Logo(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
 		},
@@ -2676,6 +2687,47 @@ func (ec *executionContext) fieldContext_ImageSummary_Vulnerabilities(ctx contex
 	return fc, nil
 }
 
+func (ec *executionContext) _ImageSummary_Logo(ctx context.Context, field graphql.CollectedField, obj *ImageSummary) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_ImageSummary_Logo(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Logo, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_ImageSummary_Logo(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "ImageSummary",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _ImageVulnerabilitySummary_MaxSeverity(ctx context.Context, field graphql.CollectedField, obj *ImageVulnerabilitySummary) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_ImageVulnerabilitySummary_MaxSeverity(ctx, field)
 	if err != nil {
@@ -3325,6 +3377,8 @@ func (ec *executionContext) fieldContext_Query_ImageListForCVE(ctx context.Conte
 				return ec.fieldContext_ImageSummary_History(ctx, field)
 			case "Vulnerabilities":
 				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
+			case "Logo":
+				return ec.fieldContext_ImageSummary_Logo(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
 		},
@@ -3419,6 +3473,8 @@ func (ec *executionContext) fieldContext_Query_ImageListWithCVEFixed(ctx context
 				return ec.fieldContext_ImageSummary_History(ctx, field)
 			case "Vulnerabilities":
 				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
+			case "Logo":
+				return ec.fieldContext_ImageSummary_Logo(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
 		},
@@ -3513,6 +3569,8 @@ func (ec *executionContext) fieldContext_Query_ImageListForDigest(ctx context.Co
 				return ec.fieldContext_ImageSummary_History(ctx, field)
 			case "Vulnerabilities":
 				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
+			case "Logo":
+				return ec.fieldContext_ImageSummary_Logo(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
 		},
@@ -3673,6 +3731,8 @@ func (ec *executionContext) fieldContext_Query_ImageList(ctx context.Context, fi
 				return ec.fieldContext_ImageSummary_History(ctx, field)
 			case "Vulnerabilities":
 				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
+			case "Logo":
+				return ec.fieldContext_ImageSummary_Logo(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
 		},
@@ -3891,6 +3951,8 @@ func (ec *executionContext) fieldContext_Query_DerivedImageList(ctx context.Cont
 				return ec.fieldContext_ImageSummary_History(ctx, field)
 			case "Vulnerabilities":
 				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
+			case "Logo":
+				return ec.fieldContext_ImageSummary_Logo(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
 		},
@@ -3985,6 +4047,8 @@ func (ec *executionContext) fieldContext_Query_BaseImageList(ctx context.Context
 				return ec.fieldContext_ImageSummary_History(ctx, field)
 			case "Vulnerabilities":
 				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
+			case "Logo":
+				return ec.fieldContext_ImageSummary_Logo(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
 		},
@@ -4079,6 +4143,8 @@ func (ec *executionContext) fieldContext_Query_Image(ctx context.Context, field 
 				return ec.fieldContext_ImageSummary_History(ctx, field)
 			case "Vulnerabilities":
 				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
+			case "Logo":
+				return ec.fieldContext_ImageSummary_Logo(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
 		},
@@ -4302,6 +4368,8 @@ func (ec *executionContext) fieldContext_RepoInfo_Images(ctx context.Context, fi
 				return ec.fieldContext_ImageSummary_History(ctx, field)
 			case "Vulnerabilities":
 				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
+			case "Logo":
+				return ec.fieldContext_ImageSummary_Logo(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
 		},
@@ -4700,6 +4768,8 @@ func (ec *executionContext) fieldContext_RepoSummary_NewestImage(ctx context.Con
 				return ec.fieldContext_ImageSummary_History(ctx, field)
 			case "Vulnerabilities":
 				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
+			case "Logo":
+				return ec.fieldContext_ImageSummary_Logo(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
 		},
@@ -6844,6 +6914,10 @@ func (ec *executionContext) _ImageSummary(ctx context.Context, sel ast.Selection
 		case "Vulnerabilities":
 
 			out.Values[i] = ec._ImageSummary_Vulnerabilities(ctx, field, obj)
+
+		case "Logo":
+
+			out.Values[i] = ec._ImageSummary_Logo(ctx, field, obj)
 
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))

--- a/pkg/extensions/search/gql_generated/models_gen.go
+++ b/pkg/extensions/search/gql_generated/models_gen.go
@@ -58,6 +58,7 @@ type ImageSummary struct {
 	Documentation   *string                    `json:"Documentation"`
 	History         []*LayerHistory            `json:"History"`
 	Vulnerabilities *ImageVulnerabilitySummary `json:"Vulnerabilities"`
+	Logo            *string                    `json:"Logo"`
 }
 
 type ImageVulnerabilitySummary struct {

--- a/pkg/extensions/search/resolver.go
+++ b/pkg/extensions/search/resolver.go
@@ -235,6 +235,7 @@ func repoListWithNewestImage(
 					MaxSeverity: &imageCveSummary.MaxSeverity,
 					Count:       &imageCveSummary.Count,
 				},
+				Logo: &annotations.Logo,
 			}
 
 			if manifest.Digest.String() == lastUpdatedTag.Digest {
@@ -424,6 +425,7 @@ func globalSearch(repoList []string, name, tag string, olu common.OciLayoutUtils
 						MaxSeverity: &imageCveSummary.MaxSeverity,
 						Count:       &imageCveSummary.Count,
 					},
+					Logo: &annotations.Logo,
 				}
 
 				if manifest.Digest.String() == lastUpdatedTag.Digest {
@@ -621,6 +623,7 @@ func BuildImageInfo(repo string, tag string, manifestDigest godigest.Digest,
 				Os:   &imageConfig.OS,
 				Arch: &imageConfig.Architecture,
 			},
+			Logo: &annotations.Logo,
 		}
 
 		return imageInfo
@@ -670,6 +673,7 @@ func BuildImageInfo(repo string, tag string, manifestDigest godigest.Digest,
 					Os:   &imageConfig.OS,
 					Arch: &imageConfig.Architecture,
 				},
+				Logo: &annotations.Logo,
 			}
 		}
 
@@ -715,6 +719,7 @@ func BuildImageInfo(repo string, tag string, manifestDigest godigest.Digest,
 			Os:   &imageConfig.OS,
 			Arch: &imageConfig.Architecture,
 		},
+		Logo: &annotations.Logo,
 	}
 
 	return imageInfo

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -55,6 +55,7 @@ type ImageSummary {
     Documentation: String
     History: [LayerHistory]
     Vulnerabilities: ImageVulnerabilitySummary
+    Logo: String
 }
 
 type ImageVulnerabilitySummary {

--- a/pkg/extensions/search/schema.resolvers.go
+++ b/pkg/extensions/search/schema.resolvers.go
@@ -307,6 +307,7 @@ func (r *queryResolver) ExpandedRepoInfo(ctx context.Context, repo string) (*gql
 		Licenses:      &origRepoInfo.Summary.NewestImage.Licenses,
 		Labels:        &origRepoInfo.Summary.NewestImage.Labels,
 		Source:        &origRepoInfo.Summary.NewestImage.Source,
+		Logo:          &origRepoInfo.Summary.NewestImage.Logo,
 	}
 
 	for _, platform := range origRepoInfo.Summary.Platforms {
@@ -333,8 +334,9 @@ func (r *queryResolver) ExpandedRepoInfo(ctx context.Context, repo string) (*gql
 		digest := image.Digest
 		isSigned := image.IsSigned
 		size := image.Size
+		logo := image.Logo
 
-		imageSummary := &gql_generated.ImageSummary{Tag: &tag, Digest: &digest, IsSigned: &isSigned, RepoName: &repo}
+		imageSummary := &gql_generated.ImageSummary{Tag: &tag, Digest: &digest, IsSigned: &isSigned, RepoName: &repo, Logo: &logo}
 
 		layers := make([]*gql_generated.LayerSummary, 0)
 


### PR DESCRIPTION
This commit allows storing base64 encoded logos under image manifest annotations, using com.zot.logo key. Logos have type limitations (only jpeg, png and gif allowed) and a maximum allowed size (200x200 px).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
closes https://github.com/project-zot/zot/issues/806

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
