### PR TITLE
build(swagger): removed swagger requirement from binary-minimal and binary

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -31,7 +31,7 @@ jobs:
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
-          args: --config ./golangcilint.yaml --enable-all --build-tags sync,scrub,search,metrics,ui_base,containers_image_openpgp,lint ./cmd/... ./pkg/...
+          args: --config ./golangcilint.yaml --enable-all --build-tags debug,sync,scrub,search,metrics,ui_base,containers_image_openpgp,lint ./cmd/... ./pkg/...
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/Makefile
+++ b/Makefile
@@ -44,18 +44,18 @@ build-metadata:
 	echo "\n Files: \n"
 	go list -tags $(EXTENSIONS) -f '{{ join .GoFiles "\n" }}' ./... | sort -u
 
+.PHONY: binary-minimal
+binary-minimal: EXTENSIONS=minimal # tag doesn't exist, but we need it to overwrite default value and indicate that we have no extension in build-metadata
+binary-minimal: modcheck build-metadata
+	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-minimal -buildmode=pie -tags containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=minimal -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zot
+
 .PHONY: binary
-binary: modcheck swagger create-name build-metadata
+binary: modcheck create-name build-metadata
 	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH) -buildmode=pie -tags $(EXTENSIONS),containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zot
 
 .PHONY: binary-debug
 binary-debug: modcheck swagger create-name build-metadata
-	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-debug -buildmode=pie -tags $(EXTENSIONS),containers_image_openpgp -v -gcflags all='-N -l' -ldflags "-X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION}" ./cmd/zot
-
-.PHONY: binary-minimal
-binary-minimal: EXTENSIONS=minimal # tag doesn't exist, but we need it to overwrite default value and indicate that we have no extension in build-metadata
-binary-minimal: modcheck swagger build-metadata
-	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-minimal -buildmode=pie -tags containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=minimal -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zot
+	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-debug -buildmode=pie -tags $(EXTENSIONS),debug,containers_image_openpgp -v -gcflags all='-N -l' -ldflags "-X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION}" ./cmd/zot
 
 .PHONY: cli
 cli: modcheck create-name build-metadata

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -2,10 +2,6 @@
 // @version v0.1.0-dev
 // @description APIs for Open Container Initiative Distribution Specification
 
-// @contact.name API Support
-// @contact.url http://www.swagger.io/support
-// @contact.email support@swagger.io
-
 // @license.name Apache 2.0
 // @license.url http://www.apache.org/licenses/LICENSE-2.0.html
 
@@ -29,16 +25,14 @@ import (
 	"github.com/opencontainers/distribution-spec/specs-go/v1/extensions"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
-	httpSwagger "github.com/swaggo/http-swagger"
 	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api/constants"
+	debug "zotregistry.io/zot/pkg/debug/swagger"
 	ext "zotregistry.io/zot/pkg/extensions"
 	"zotregistry.io/zot/pkg/log"
 	localCtx "zotregistry.io/zot/pkg/requestcontext"
 	"zotregistry.io/zot/pkg/storage"
 	"zotregistry.io/zot/pkg/test" // nolint:goimports
-	// as required by swaggo.
-	_ "zotregistry.io/zot/swagger"
 )
 
 type RouteHandler struct {
@@ -113,8 +107,9 @@ func (rh *RouteHandler) SetupRoutes() {
 	rh.c.Router.HandleFunc(fmt.Sprintf("%s/{name:%s}/manifests/{digest}/referrers",
 		constants.ArtifactSpecRoutePrefix, NameRegexp.String()), rh.GetReferrers).Methods("GET")
 
-	// swagger swagger "/swagger/v2/index.html"
-	rh.c.Router.PathPrefix("/swagger/v2/").Methods("GET").Handler(httpSwagger.WrapHandler)
+	// swagger
+	debug.SetupSwaggerRoutes(rh.c.Config, rh.c.Router, rh.c.Log)
+
 	// Setup Extensions Routes
 	if rh.c.Config != nil {
 		if rh.c.Config.Extensions == nil {

--- a/pkg/debug/swagger/swagger.go
+++ b/pkg/debug/swagger/swagger.go
@@ -1,0 +1,24 @@
+//go:build debug
+// +build debug
+
+// @contact.name API Support
+// @contact.url http://www.swagger.io/support
+// @contact.email support@swagger.io
+
+package debug
+
+import (
+	"github.com/gorilla/mux"
+	httpSwagger "github.com/swaggo/http-swagger"
+	"zotregistry.io/zot/pkg/api/config"
+	"zotregistry.io/zot/pkg/log" // nolint:goimports
+	// as required by swaggo.
+	_ "zotregistry.io/zot/swagger"
+)
+
+func SetupSwaggerRoutes(conf *config.Config, router *mux.Router, log log.Logger,
+) {
+	log.Info().Msg("setting up swagger route")
+	// swagger swagger "/swagger/v2/index.html"
+	router.PathPrefix("/swagger/v2/").Methods("GET").Handler(httpSwagger.WrapHandler)
+}

--- a/pkg/debug/swagger/swagger_disabled.go
+++ b/pkg/debug/swagger/swagger_disabled.go
@@ -1,0 +1,23 @@
+//go:build !debug
+// +build !debug
+
+// @contact.name API Support
+// @contact.url http://www.swagger.io/support
+// @contact.email support@swagger.io
+
+package debug
+
+import (
+	"github.com/gorilla/mux"
+	"zotregistry.io/zot/pkg/api/config"
+	"zotregistry.io/zot/pkg/log" // nolint:goimports
+	// as required by swaggo.
+	_ "zotregistry.io/zot/swagger"
+)
+
+func SetupSwaggerRoutes(conf *config.Config, router *mux.Router, log log.Logger,
+) {
+	// swagger swagger "/swagger/v2/index.html"
+	log.Warn().Msg("skipping enabling swagger because given zot binary" +
+		"doesn't include this feature, please build a binary that does so")
+}


### PR DESCRIPTION
Also added the "debug" build tag in the binary-debug Make target

**What type of PR is this?**
cleanup

**What does this PR do / Why do we need it**:
swagger is not needed for the minimal and regular binary builds

Also moved binary-minimal to be the first in the Makefile


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
