### PR TITLE
fix(license-check): also account for another result condition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ check-licenses:
 					echo FAIL; \
 					exit 1; \
 				fi; \
-				echo "$${result}" | egrep -q "missing go.sum entry|no required module provides package|build constraints exclude all|updates to go.mod needed"; \
+				echo "$${result}" | egrep -q "missing go.sum entry|no required module provides package|build constraints exclude all|updates to go.mod needed|non-Go code"; \
 				if [ $$? -eq 0 ]; then \
 					echo UNKNOWN; \
 					break; \


### PR DESCRIPTION
Earlier checks did not report non-golang code dependencies. Now they do, so account for that.

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

bug

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

License checker in ci/cd is stuck otherwise.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
