### PR TITLE
build: add commit hash to Config at build for proper discovery readme

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -153,6 +153,7 @@ jobs:
         with:
           file: 'stacker.yaml'
           build-args: |
+            RELEASE_TAG=${{ github.event.release.tag_name }}
             COMMIT=${{ github.event.release.tag_name }}-${{ github.sha }}
             OS=${{ matrix.os }}
             ARCH=${{ matrix.arch }}
@@ -198,6 +199,7 @@ jobs:
         with:
           file: 'stacker.yaml'
           build-args: |
+            RELEASE_TAG=${{ github.event.release.tag_name }}
             COMMIT=${{ github.event.release.tag_name }}-${{ github.sha }}
             OS=${{ matrix.os }}
             ARCH=${{ matrix.arch }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 export GO111MODULE=on
 TOP_LEVEL=$(shell git rev-parse --show-toplevel)
 COMMIT_HASH=$(shell git describe --always --tags --long)
+COMMIT_LONGHASH=$(shell git rev-parse HEAD)
 GO_VERSION=$(shell go version | awk '{print $$3}')
 COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),$(COMMIT_HASH)-dirty,$(COMMIT_HASH))
 CONTAINER_RUNTIME := $(shell command -v podman 2> /dev/null || echo docker)
@@ -47,15 +48,15 @@ build-metadata:
 .PHONY: binary-minimal
 binary-minimal: EXTENSIONS=minimal # tag doesn't exist, but we need it to overwrite default value and indicate that we have no extension in build-metadata
 binary-minimal: modcheck build-metadata
-	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-minimal -buildmode=pie -tags containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=minimal -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zot
+	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-minimal -buildmode=pie -tags containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.CommitHash=${COMMIT_LONGHASH} -X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=minimal -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zot
 
 .PHONY: binary
 binary: modcheck create-name build-metadata
-	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH) -buildmode=pie -tags $(EXTENSIONS),containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zot
+	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH) -buildmode=pie -tags $(EXTENSIONS),containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.CommitHash=${COMMIT_LONGHASH} -X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zot
 
 .PHONY: binary-debug
 binary-debug: modcheck swagger create-name build-metadata
-	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-debug -buildmode=pie -tags $(EXTENSIONS),debug,containers_image_openpgp -v -gcflags all='-N -l' -ldflags "-X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION}" ./cmd/zot
+	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-debug -buildmode=pie -tags $(EXTENSIONS),debug,containers_image_openpgp -v -gcflags all='-N -l' -ldflags "-X zotregistry.io/zot/pkg/api/config.CommitHash=${COMMIT_LONGHASH} -X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION}" ./cmd/zot
 
 .PHONY: cli
 cli: modcheck create-name build-metadata

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 export GO111MODULE=on
 TOP_LEVEL=$(shell git rev-parse --show-toplevel)
 COMMIT_HASH=$(shell git describe --always --tags --long)
-COMMIT_LONGHASH=$(shell git rev-parse HEAD)
+RELEASE_TAG=$(shell git describe --tags --abbrev=0)
 GO_VERSION=$(shell go version | awk '{print $$3}')
 COMMIT ?= $(if $(shell git status --porcelain --untracked-files=no),$(COMMIT_HASH)-dirty,$(COMMIT_HASH))
 CONTAINER_RUNTIME := $(shell command -v podman 2> /dev/null || echo docker)
@@ -48,15 +48,15 @@ build-metadata:
 .PHONY: binary-minimal
 binary-minimal: EXTENSIONS=minimal # tag doesn't exist, but we need it to overwrite default value and indicate that we have no extension in build-metadata
 binary-minimal: modcheck build-metadata
-	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-minimal -buildmode=pie -tags containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.CommitHash=${COMMIT_LONGHASH} -X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=minimal -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zot
+	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-minimal -buildmode=pie -tags containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.ReleaseTag=${RELEASE_TAG} -X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=minimal -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zot
 
 .PHONY: binary
 binary: modcheck create-name build-metadata
-	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH) -buildmode=pie -tags $(EXTENSIONS),containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.CommitHash=${COMMIT_LONGHASH} -X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zot
+	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH) -buildmode=pie -tags $(EXTENSIONS),containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.ReleaseTag=${RELEASE_TAG} -X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zot
 
 .PHONY: binary-debug
 binary-debug: modcheck swagger create-name build-metadata
-	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-debug -buildmode=pie -tags $(EXTENSIONS),debug,containers_image_openpgp -v -gcflags all='-N -l' -ldflags "-X zotregistry.io/zot/pkg/api/config.CommitHash=${COMMIT_LONGHASH} -X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION}" ./cmd/zot
+	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-debug -buildmode=pie -tags $(EXTENSIONS),debug,containers_image_openpgp -v -gcflags all='-N -l' -ldflags "-X zotregistry.io/zot/pkg/api/config.ReleaseTag=${RELEASE_TAG} -X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION}" ./cmd/zot
 
 .PHONY: cli
 cli: modcheck create-name build-metadata

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -14,6 +14,7 @@ import (
 
 var (
 	Commit     string //nolint: gochecknoglobals
+	CommitHash string //nolint: gochecknoglobals
 	BinaryType string //nolint: gochecknoglobals
 	GoVersion  string //nolint: gochecknoglobals
 )
@@ -125,6 +126,7 @@ type Config struct {
 	DistSpecVersion string `json:"distSpecVersion" mapstructure:"distSpecVersion"`
 	GoVersion       string
 	Commit          string
+	CommitHash      string
 	BinaryType      string
 	AccessControl   *AccessControlConfig
 	Storage         GlobalStorageConfig
@@ -138,6 +140,7 @@ func New() *Config {
 		DistSpecVersion: distspec.Version,
 		GoVersion:       GoVersion,
 		Commit:          Commit,
+		CommitHash:      CommitHash,
 		BinaryType:      BinaryType,
 		Storage:         GlobalStorageConfig{GC: true, GCDelay: storage.DefaultGCDelay, Dedupe: true},
 		HTTP:            HTTPConfig{Address: "127.0.0.1", Port: "8080", Auth: &AuthConfig{FailDelay: 0}},

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	Commit     string //nolint: gochecknoglobals
-	CommitHash string //nolint: gochecknoglobals
+	ReleaseTag string //nolint: gochecknoglobals
 	BinaryType string //nolint: gochecknoglobals
 	GoVersion  string //nolint: gochecknoglobals
 )
@@ -126,7 +126,7 @@ type Config struct {
 	DistSpecVersion string `json:"distSpecVersion" mapstructure:"distSpecVersion"`
 	GoVersion       string
 	Commit          string
-	CommitHash      string
+	ReleaseTag      string
 	BinaryType      string
 	AccessControl   *AccessControlConfig
 	Storage         GlobalStorageConfig
@@ -140,7 +140,7 @@ func New() *Config {
 		DistSpecVersion: distspec.Version,
 		GoVersion:       GoVersion,
 		Commit:          Commit,
-		CommitHash:      CommitHash,
+		ReleaseTag:      ReleaseTag,
 		BinaryType:      BinaryType,
 		Storage:         GlobalStorageConfig{GC: true, GCDelay: storage.DefaultGCDelay, Dedupe: true},
 		HTTP:            HTTPConfig{Address: "127.0.0.1", Port: "8080", Auth: &AuthConfig{FailDelay: 0}},

--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -103,7 +103,7 @@ func GetExtensions(config *config.Config) distext.ExtensionList {
 	if config.Extensions != nil && config.Extensions.Search != nil {
 		endpoints := []string{constants.ExtSearchPrefix}
 		searchExt := getExtension("_zot",
-			"https://github.com/project-zot/zot/tree/main/pkg/extensions/_zot.md",
+			"https://github.com/project-zot/zot/blob/"+config.CommitHash+"/pkg/extensions/_zot.md",
 			"zot registry extension",
 			endpoints)
 

--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -103,8 +103,8 @@ func GetExtensions(config *config.Config) distext.ExtensionList {
 	if config.Extensions != nil && config.Extensions.Search != nil {
 		endpoints := []string{constants.ExtSearchPrefix}
 		searchExt := getExtension("_zot",
-			"https://github.com/project-zot/zot/blob/"+config.CommitHash+"/pkg/extensions/_zot.md",
-			"zot registry extension",
+			"https://github.com/project-zot/zot/blob/"+config.ReleaseTag+"/pkg/extensions/_zot.md",
+			"zot registry extensions",
 			endpoints)
 
 		extensions = append(extensions, searchExt)

--- a/stacker.yaml
+++ b/stacker.yaml
@@ -13,7 +13,7 @@ build:
     cd /go/src/github.com/project-zot
     git clone /zotcopy zot
     cd /go/src/github.com/project-zot/zot
-    make COMMIT=${{COMMIT}} OS=${{OS}} ARCH=${{ARCH}} clean binary${{EXT:}}
+    make COMMIT=${{COMMIT}} OS=${{OS}} ARCH=${{ARCH}} RELEASE_TAG=&{{RELEASE_TAG}} clean binary${{EXT:}}
     cat > config.json << EOF
     {
       "storage":{


### PR DESCRIPTION
**What type of PR is this?**
documentation I think

**Which issue does this PR fix**:
#852

**What does this PR do / Why do we need it**:
This PR gets the commit hash and writes it into the new CommitHash variable in api.Config, which is used in the discovery api to point to the extensions readme link of the used build:

```
curl localhost:5000/v2/_oci/ext/discover
{"extensions":[{"name":"_zot","url":"https://github.com/project-zot/zot/blob/v1.4.3-rc2/pkg/extensions/_zot.md","description":"zot registry extension","endpoints":["/v2/_zot/ext/search"]}]}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
