### PR TITLE
build(tags): rename go build tag ui_base to cli

### DIFF
--- a/.github/workflows/branch-cov.yml
+++ b/.github/workflows/branch-cov.yml
@@ -38,7 +38,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           for i in $(find . -type f \( -name "*.go" -not -name "*_test.go" -not -name "generated.go" \)); do
             echo $i;
-            gobco -test '-tags=sync,search,scrub,metrics,ui_base,containers_image_openpgp' $i;
+            gobco -test '-tags=sync,search,scrub,metrics,cli,containers_image_openpgp' $i;
             gobco -test '-tags=minimal,containers_image_openpgp' $i;
           done
         env:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
         # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
     env:
       CGO_ENABLED: 0
-      GOFLAGS: "-tags=sync,search,scrub,metrics,ui_base,containers_image_openpgp"
+      GOFLAGS: "-tags=sync,search,scrub,metrics,cli,containers_image_openpgp"
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -31,7 +31,7 @@ jobs:
 
           # Optional: golangci-lint command line arguments.
           # args: --issues-exit-code=0
-          args: --config ./golangcilint.yaml --enable-all --build-tags debug,needprivileges,sync,scrub,search,metrics,ui_base,containers_image_openpgp,lint ./cmd/... ./pkg/...
+          args: --config ./golangcilint.yaml --enable-all --build-tags debug,needprivileges,sync,scrub,search,metrics,cli,containers_image_openpgp,lint ./cmd/... ./pkg/...
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ make binary-minimal
 ```
 
 For a zot that includes only the extensions that you specify,
-the available extensions that can be used at the moment are: sync, scrub, metrics, search, ui_base .
+the available extensions that can be used at the moment are: sync, scrub, metrics, search, cli.
 
 NOTES: When multiple extensions are used, they should be enlisted in the above presented order.
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ TESTDATA := $(TOP_LEVEL)/test/data
 OS ?= linux
 ARCH ?= amd64
 BENCH_OUTPUT ?= stdout
-EXTENSIONS ?= sync,search,scrub,metrics,ui_base,lint
+EXTENSIONS ?= sync,search,scrub,metrics,cli,lint
 comma:= ,
 hyphen:= -
 extended-name:=
@@ -59,7 +59,7 @@ binary-debug: modcheck swagger create-name build-metadata
 
 .PHONY: cli
 cli: modcheck create-name build-metadata
-	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zli-$(OS)-$(ARCH) -buildmode=pie -tags $(EXTENSIONS),ui_base,containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zli
+	env CGO_ENABLED=0 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zli-$(OS)-$(ARCH) -buildmode=pie -tags $(EXTENSIONS),cli,containers_image_openpgp -v -trimpath -ldflags "-X zotregistry.io/zot/pkg/api/config.Commit=${COMMIT} -X zotregistry.io/zot/pkg/api/config.BinaryType=$(extended-name) -X zotregistry.io/zot/pkg/api/config.GoVersion=${GO_VERSION} -s -w" ./cmd/zli
 
 .PHONY: bench
 bench: modcheck create-name build-metadata
@@ -280,12 +280,12 @@ bats-sync-verbose: binary binary-minimal check-skopeo $(BATS)
 	$(BATS) --trace -t -x -p --verbose-run --print-output-on-failure --show-output-of-passing-tests test/blackbox/sync.bats
 
 .PHONY: bats-cve
-bats-cve: EXTENSIONS=ui_base
+bats-cve: EXTENSIONS=cli
 bats-cve: binary cli check-skopeo $(BATS)
 	$(BATS) --trace --print-output-on-failure test/blackbox/cve.bats
 
 .PHONY: bats-cve-verbose
-bats-cve-verbose: EXTENSIONS=ui_base
+bats-cve-verbose: EXTENSIONS=cli
 bats-cve-verbose: binary cli check-skopeo $(BATS)
 	$(BATS) --trace -t -x -p --verbose-run --print-output-on-failure --show-output-of-passing-tests test/blackbox/cve.bats
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -1,5 +1,5 @@
-//go:build sync && scrub && metrics && search && ui_base
-// +build sync,scrub,metrics,search,ui_base
+//go:build sync && scrub && metrics && search && cli
+// +build sync,scrub,metrics,search,cli
 
 package api_test
 

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -1,5 +1,5 @@
-//go:build sync && scrub && metrics && search && ui_base && lint
-// +build sync,scrub,metrics,search,ui_base,lint
+//go:build sync && scrub && metrics && search && cli && lint
+// +build sync,scrub,metrics,search,cli,lint
 
 package api_test
 

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -1,5 +1,5 @@
-//go:build ui_base || search
-// +build ui_base search
+//go:build cli || search
+// +build cli search
 
 package cli
 

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -1,5 +1,5 @@
-//go:build search || ui_base
-// +build search ui_base
+//go:build search || cli
+// +build search cli
 
 package cli
 

--- a/pkg/cli/client_elevated_test.go
+++ b/pkg/cli/client_elevated_test.go
@@ -1,5 +1,5 @@
-//go:build ui_base && needprivileges
-// +build ui_base,needprivileges
+//go:build cli && needprivileges
+// +build cli,needprivileges
 
 package cli //nolint:testpackage
 

--- a/pkg/cli/client_test.go
+++ b/pkg/cli/client_test.go
@@ -1,5 +1,5 @@
-//go:build ui_base
-// +build ui_base
+//go:build cli
+// +build cli
 
 package cli //nolint:testpackage
 

--- a/pkg/cli/config_cmd.go
+++ b/pkg/cli/config_cmd.go
@@ -1,5 +1,5 @@
-//go:build search || ui_base
-// +build search ui_base
+//go:build search || cli
+// +build search cli
 
 package cli
 

--- a/pkg/cli/config_cmd_test.go
+++ b/pkg/cli/config_cmd_test.go
@@ -1,5 +1,5 @@
-//go:build ui_base
-// +build ui_base
+//go:build cli
+// +build cli
 
 package cli //nolint:testpackage
 

--- a/pkg/cli/cve_cmd.go
+++ b/pkg/cli/cve_cmd.go
@@ -1,5 +1,5 @@
-//go:build search || ui_base
-// +build search ui_base
+//go:build search || cli
+// +build search cli
 
 package cli
 

--- a/pkg/cli/cve_cmd_test.go
+++ b/pkg/cli/cve_cmd_test.go
@@ -1,5 +1,5 @@
-//go:build ui_base
-// +build ui_base
+//go:build cli
+// +build cli
 
 package cli //nolint:testpackage
 

--- a/pkg/cli/extensions_test.go
+++ b/pkg/cli/extensions_test.go
@@ -1,5 +1,5 @@
-//go:build sync && scrub && metrics && search && ui_base
-// +build sync,scrub,metrics,search,ui_base
+//go:build sync && scrub && metrics && search && cli
+// +build sync,scrub,metrics,search,cli
 
 package cli_test
 

--- a/pkg/cli/image_cmd.go
+++ b/pkg/cli/image_cmd.go
@@ -1,5 +1,5 @@
-//go:build search || ui_base
-// +build search ui_base
+//go:build search || cli
+// +build search cli
 
 package cli
 

--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -1,5 +1,5 @@
-//go:build ui_base
-// +build ui_base
+//go:build cli
+// +build cli
 
 package cli //nolint:testpackage
 

--- a/pkg/cli/minimal.go
+++ b/pkg/cli/minimal.go
@@ -1,5 +1,5 @@
-//go:build !search && !ui_base
-// +build !search,!ui_base
+//go:build !search && !cli
+// +build !search,!cli
 
 package cli
 

--- a/pkg/cli/repo_cmd.go
+++ b/pkg/cli/repo_cmd.go
@@ -1,5 +1,5 @@
-//go:build search || ui_base
-// +build search ui_base
+//go:build search || cli
+// +build search cli
 
 package cli
 

--- a/pkg/cli/searcher.go
+++ b/pkg/cli/searcher.go
@@ -1,5 +1,5 @@
-//go:build search || ui_base
-// +build search ui_base
+//go:build search || cli
+// +build search cli
 
 package cli
 

--- a/pkg/cli/service.go
+++ b/pkg/cli/service.go
@@ -1,5 +1,5 @@
-//go:build ui_base || search
-// +build ui_base search
+//go:build cli || search
+// +build cli search
 
 package cli
 

--- a/pkg/extensions/README.md
+++ b/pkg/extensions/README.md
@@ -27,5 +27,5 @@ package extensions
 
 - with every new extension, you should modify the EXTENSIONS variable in Makefile by adding the new extension. The EXTENSIONS variable represents all extensions and is used in Make targets that require them all (e.g make test).
 
-- the available extensions that can be used at the moment are: <b>sync, scrub, metrics, search, ui_base </b>.
+- the available extensions that can be used at the moment are: <b>sync, scrub, metrics, search, cli </b>.
 NOTE: When multiple extensions are used, they should be enlisted in the above presented order.

--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -1,5 +1,5 @@
-//go:build search || ui_base
-// +build search ui_base
+//go:build search || cli
+// +build search cli
 
 package extensions
 

--- a/pkg/extensions/extension_search_disabled.go
+++ b/pkg/extensions/extension_search_disabled.go
@@ -1,5 +1,5 @@
-//go:build !search && !ui_base
-// +build !search,!ui_base
+//go:build !search && !cli
+// +build !search,!cli
 
 package extensions
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,5 +1,5 @@
-//go:build sync && scrub && metrics && search && ui_base
-// +build sync,scrub,metrics,search,ui_base
+//go:build sync && scrub && metrics && search && cli
+// +build sync,scrub,metrics,search,cli
 
 package log_test
 

--- a/pkg/test/common_test.go
+++ b/pkg/test/common_test.go
@@ -1,5 +1,5 @@
-//go:build sync && scrub && metrics && search && ui_base
-// +build sync,scrub,metrics,search,ui_base
+//go:build sync && scrub && metrics && search && cli
+// +build sync,scrub,metrics,search,cli
 
 package test_test
 

--- a/test/scripts/fuzzAll.sh
+++ b/test/scripts/fuzzAll.sh
@@ -13,6 +13,6 @@ do
     do
         echo "Fuzzing $func in $file"
         parentDir=$(dirname $file)
-        go test $parentDir -run=$func -fuzz=$func$ -fuzztime=${fuzzTime}s -tags sync,metrics,search,scrub,ui_base,containers_image_openpgp | grep -oP -x '^(?:(?!\blevel\b).)*$'
+        go test $parentDir -run=$func -fuzz=$func$ -fuzztime=${fuzzTime}s -tags sync,metrics,search,scrub,cli,containers_image_openpgp | grep -oP -x '^(?:(?!\blevel\b).)*$'
     done
 done


### PR DESCRIPTION
The tag is currently used by the cli build and test files we should keep it independent from future ui work in order to be able to build and test separately

Signed-off-by: Andrei Aaron <andaaron@cisco.com>

**What type of PR is this?**
cleanup
build
ci/cd

**Which issue does this PR fix**:
The tag name ui_base does not reflect its current usage.

**What does this PR do / Why do we need it**:
The tag would conflict with future build tags added for the UI support 

**Testing done on this change**:
GH builds


**Does this PR introduce any user-facing change?**:
Build tag sent to the make target will change in case the user manually selects build tags

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
