### PR TITLE
fix: incorrect path for playground template

### DIFF
--- a/pkg/debug/gqlplayground/gqlplayground.go
+++ b/pkg/debug/gqlplayground/gqlplayground.go
@@ -26,7 +26,7 @@ func SetupGQLPlaygroundRoutes(conf *config.Config, router *mux.Router,
 	log := log.Logger{Logger: l.With().Caller().Timestamp().Logger()}
 	log.Info().Msg("setting up graphql playground route")
 
-	templ, err := template.ParseFS(playgroundHTML, "gqlplayground/index.html.tmpl")
+	templ, err := template.ParseFS(playgroundHTML, "index.html.tmpl")
 	if err != nil {
 		log.Fatal().Err(err)
 	}


### PR DESCRIPTION
**What type of PR is this?**
quickfix

**What does this PR do / Why do we need it**:
Fixes ncorrect path for playground template

**If an issue # is not available please add repro steps and logs showing the issue**:
Accessing the playground endpoint results in a blank page

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
