### PR TITLE
fix(lastUpdated): fix image lastUpdated timestamp logic

### DIFF
--- a/pkg/extensions/search/common/common.go
+++ b/pkg/extensions/search/common/common.go
@@ -75,6 +75,27 @@ func GetImageDirAndTag(imageName string) (string, string) {
 	return imageDir, imageTag
 }
 
+// GetImageLastUpdated This method will return last updated timestamp.
+// The Created timestamp is used, but if it is missing, look at the
+// history field and, if provided, return the timestamp of last entry in history.
+func GetImageLastUpdated(imageInfo ispec.Image) time.Time {
+	timeStamp := imageInfo.Created
+
+	if timeStamp != nil && !timeStamp.IsZero() {
+		return *timeStamp
+	}
+
+	if len(imageInfo.History) > 0 {
+		timeStamp = imageInfo.History[len(imageInfo.History)-1].Created
+	}
+
+	if timeStamp == nil {
+		timeStamp = &time.Time{}
+	}
+
+	return *timeStamp
+}
+
 func GetFixedTags(allTags, vulnerableTags []TagInfo) []TagInfo {
 	sort.Slice(allTags, func(i, j int) bool {
 		return allTags[i].Timestamp.Before(allTags[j].Timestamp)

--- a/pkg/test/mocks/oci_mock.go
+++ b/pkg/test/mocks/oci_mock.go
@@ -1,8 +1,6 @@
 package mocks
 
 import (
-	"time"
-
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -15,7 +13,6 @@ type OciLayoutUtilsMock struct {
 	GetImageBlobManifestFn      func(imageDir string, digest godigest.Digest) (v1.Manifest, error)
 	GetImageInfoFn              func(imageDir string, hash v1.Hash) (ispec.Image, error)
 	GetImageTagsWithTimestampFn func(repo string) ([]common.TagInfo, error)
-	GetImageLastUpdatedFn       func(imageInfo ispec.Image) time.Time
 	GetImagePlatformFn          func(imageInfo ispec.Image) (string, string)
 	GetImageVendorFn            func(imageInfo ispec.Image) string
 	GetImageManifestSizeFn      func(repo string, manifestDigest godigest.Digest) int64
@@ -73,14 +70,6 @@ func (olum OciLayoutUtilsMock) GetImageTagsWithTimestamp(repo string) ([]common.
 	}
 
 	return []common.TagInfo{}, nil
-}
-
-func (olum OciLayoutUtilsMock) GetImageLastUpdated(imageInfo ispec.Image) time.Time {
-	if olum.GetImageLastUpdatedFn != nil {
-		return olum.GetImageLastUpdatedFn(imageInfo)
-	}
-
-	return time.Time{}
 }
 
 func (olum OciLayoutUtilsMock) GetImagePlatform(imageInfo ispec.Image) (string, string) {


### PR DESCRIPTION
The lastUpdated field was picked from the first entry in image history Now it is the created time of the image, or the last entry in image history, if created time is unavailable

Signed-off-by: Andrei Aaron <andaaron@cisco.com>

**What type of PR is this?**
bug

**Which issue does this PR fix**:
lastUpdated was computed based on wrong fields

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
