### PR TITLE
chore(lint): gci to separate zot from other imports

### DIFF
--- a/cmd/zb/helper.go
+++ b/cmd/zb/helper.go
@@ -17,6 +17,7 @@ import (
 	imeta "github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/test"
 )

--- a/cmd/zb/main.go
+++ b/cmd/zb/main.go
@@ -6,6 +6,7 @@ import (
 	distspec "github.com/opencontainers/distribution-spec/specs-go"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+
 	"zotregistry.io/zot/pkg/api/config"
 )
 

--- a/cmd/zb/main_test.go
+++ b/cmd/zb/main_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 )

--- a/cmd/zb/perf.go
+++ b/cmd/zb/perf.go
@@ -20,6 +20,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	godigest "github.com/opencontainers/go-digest"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api/constants"
 )
 

--- a/cmd/zli/main_test.go
+++ b/cmd/zli/main_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/cli"

--- a/cmd/zot/main_test.go
+++ b/cmd/zot/main_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/cli"

--- a/golangcilint.yaml
+++ b/golangcilint.yaml
@@ -32,6 +32,11 @@ linters-settings:
       - w *os.File
       - to int64
       - l *ldap.Conn
+  gci:
+    sections:
+      - standard
+      - default
+      - prefix(zotregistry.io/zot)
   wsl:
     allow-assign-and-anything: true
     enforce-err-cuddling: true
@@ -69,3 +74,4 @@ issues:
       linters:
         - lll
         - varnamelen
+        - gci

--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -14,6 +14,7 @@ import (
 	"github.com/chartmuseum/auth"
 	"github.com/gorilla/mux"
 	"golang.org/x/crypto/bcrypt"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api/config"
 )

--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -9,6 +9,7 @@ import (
 
 	glob "github.com/bmatcuk/doublestar/v4"
 	"github.com/gorilla/mux"
+
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"
 	"zotregistry.io/zot/pkg/common"

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/getlantern/deepcopy"
 	distspec "github.com/opencontainers/distribution-spec/specs-go"
 	"github.com/spf13/viper"
+
 	extconf "zotregistry.io/zot/pkg/extensions/config"
 	"zotregistry.io/zot/pkg/storage"
 )

--- a/pkg/api/config/config_elevated_test.go
+++ b/pkg/api/config/config_elevated_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/api/config"
 )
 

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/api/config"
 )
 

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -18,6 +18,7 @@ import (
 	"github.com/docker/distribution/registry/storage/driver/factory"
 	"github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api/config"
 	ext "zotregistry.io/zot/pkg/extensions"

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/crypto/bcrypt"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"

--- a/pkg/api/errors_test.go
+++ b/pkg/api/errors_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/api"
 )
 

--- a/pkg/api/ldap.go
+++ b/pkg/api/ldap.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-ldap/ldap/v3"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/log"
 )

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -25,6 +25,7 @@ import (
 	"github.com/opencontainers/distribution-spec/specs-go/v1/extensions"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
+
 	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api/constants"
 	gqlPlayground "zotregistry.io/zot/pkg/debug/gqlplayground"

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/mux"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
+
 	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"

--- a/pkg/api/session.go
+++ b/pkg/api/session.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/didip/tollbooth/v6"
 	"github.com/gorilla/mux"
+
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"
 )

--- a/pkg/cli/client_elevated_test.go
+++ b/pkg/cli/client_elevated_test.go
@@ -17,6 +17,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"

--- a/pkg/cli/client_test.go
+++ b/pkg/cli/client_test.go
@@ -16,6 +16,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"

--- a/pkg/cli/config_cmd.go
+++ b/pkg/cli/config_cmd.go
@@ -14,6 +14,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 	"github.com/spf13/cobra"
+
 	zerr "zotregistry.io/zot/errors"
 )
 

--- a/pkg/cli/config_cmd_test.go
+++ b/pkg/cli/config_cmd_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	zotErrors "zotregistry.io/zot/errors"
 )
 

--- a/pkg/cli/config_reloader.go
+++ b/pkg/cli/config_reloader.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/rs/zerolog/log"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 )

--- a/pkg/cli/config_reloader_test.go
+++ b/pkg/cli/config_reloader_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	"golang.org/x/crypto/bcrypt"
+
 	"zotregistry.io/zot/pkg/cli"
 	"zotregistry.io/zot/pkg/test"
 )

--- a/pkg/cli/cve_cmd.go
+++ b/pkg/cli/cve_cmd.go
@@ -14,6 +14,7 @@ import (
 	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
 	"gopkg.in/resty.v1"
+
 	zotErrors "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api/constants"
 )

--- a/pkg/cli/cve_cmd_test.go
+++ b/pkg/cli/cve_cmd_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/spf13/cobra"
 	"gopkg.in/resty.v1"
+
 	zotErrors "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"

--- a/pkg/cli/extensions_test.go
+++ b/pkg/cli/extensions_test.go
@@ -14,6 +14,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/cli"
 	. "zotregistry.io/zot/pkg/test"
 )

--- a/pkg/cli/image_cmd.go
+++ b/pkg/cli/image_cmd.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
+
 	zotErrors "zotregistry.io/zot/errors"
 )
 

--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/spf13/cobra"
 	"gopkg.in/resty.v1"
+
 	zotErrors "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"

--- a/pkg/cli/repo_cmd.go
+++ b/pkg/cli/repo_cmd.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
+
 	zotErrors "zotregistry.io/zot/errors"
 )
 

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/cli"

--- a/pkg/cli/searcher.go
+++ b/pkg/cli/searcher.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+
 	zotErrors "zotregistry.io/zot/errors"
 )
 
@@ -638,14 +639,12 @@ type spinnerState struct {
 	enabled bool
 }
 
-//nolint
 func (spinner *spinnerState) startSpinner() {
 	if spinner.enabled {
 		spinner.spinner.Start()
 	}
 }
 
-//nolint
 func (spinner *spinnerState) stopSpinner() {
 	if spinner.enabled && spinner.spinner.Active() {
 		spinner.spinner.Stop()

--- a/pkg/cli/service.go
+++ b/pkg/cli/service.go
@@ -17,6 +17,7 @@ import (
 	jsoniter "github.com/json-iterator/go"
 	"github.com/olekukonko/tablewriter"
 	"gopkg.in/yaml.v2"
+
 	zotErrors "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api/constants"
 )

--- a/pkg/cli/stress_test.go
+++ b/pkg/cli/stress_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/cli"

--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/common"
 )
 

--- a/pkg/compliance/v1_0_0/check.go
+++ b/pkg/compliance/v1_0_0/check.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/smartystreets/goconvey/convey/reporting"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/constants"
 	"zotregistry.io/zot/pkg/compliance"

--- a/pkg/compliance/v1_0_0/check_test.go
+++ b/pkg/compliance/v1_0_0/check_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/compliance"

--- a/pkg/debug/gqlplayground/gqlplayground.go
+++ b/pkg/debug/gqlplayground/gqlplayground.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"
 	debugCst "zotregistry.io/zot/pkg/debug/constants"

--- a/pkg/debug/gqlplayground/gqlplayground_disabled.go
+++ b/pkg/debug/gqlplayground/gqlplayground_disabled.go
@@ -5,6 +5,7 @@ package debug
 
 import (
 	"github.com/gorilla/mux"
+
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/debug/swagger/swagger.go
+++ b/pkg/debug/swagger/swagger.go
@@ -10,6 +10,7 @@ package debug
 import (
 	"github.com/gorilla/mux"
 	httpSwagger "github.com/swaggo/http-swagger"
+
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/log" //nolint:goimports
 	// as required by swaggo.

--- a/pkg/debug/swagger/swagger_disabled.go
+++ b/pkg/debug/swagger/swagger_disabled.go
@@ -9,6 +9,7 @@ package debug
 
 import (
 	"github.com/gorilla/mux"
+
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/log" //nolint:goimports
 	// as required by swaggo.

--- a/pkg/exporter/api/controller_test.go
+++ b/pkg/exporter/api/controller_test.go
@@ -20,6 +20,7 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	zotapi "zotregistry.io/zot/pkg/api"
 	zotcfg "zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/exporter/api"

--- a/pkg/exporter/api/exporter.go
+++ b/pkg/exporter/api/exporter.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"
 )

--- a/pkg/exporter/cli/cli.go
+++ b/pkg/exporter/cli/cli.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/exporter/api"
 )

--- a/pkg/extensions/extension_metrics.go
+++ b/pkg/extensions/extension_metrics.go
@@ -6,6 +6,7 @@ package extensions
 import (
 	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/extensions/extension_metrics_disabled.go
+++ b/pkg/extensions/extension_metrics_disabled.go
@@ -5,6 +5,7 @@ package extensions
 
 import (
 	"github.com/gorilla/mux"
+
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -9,6 +9,7 @@ import (
 	gqlHandler "github.com/99designs/gqlgen/graphql/handler"
 	"github.com/gorilla/mux"
 	distext "github.com/opencontainers/distribution-spec/specs-go/v1/extensions"
+
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"
 	"zotregistry.io/zot/pkg/extensions/search"

--- a/pkg/extensions/extension_search_disabled.go
+++ b/pkg/extensions/extension_search_disabled.go
@@ -6,6 +6,7 @@ package extensions
 import (
 	"github.com/gorilla/mux"
 	distext "github.com/opencontainers/distribution-spec/specs-go/v1/extensions"
+
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	extconf "zotregistry.io/zot/pkg/extensions/config"

--- a/pkg/extensions/lint/lint-disabled.go
+++ b/pkg/extensions/lint/lint-disabled.go
@@ -5,6 +5,7 @@ package lint
 
 import (
 	godigest "github.com/opencontainers/go-digest"
+
 	"zotregistry.io/zot/pkg/storage"
 )
 

--- a/pkg/extensions/lint/lint.go
+++ b/pkg/extensions/lint/lint.go
@@ -8,6 +8,7 @@ import (
 
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"zotregistry.io/zot/pkg/extensions/config"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/extensions/lint/lint_test.go
+++ b/pkg/extensions/lint/lint_test.go
@@ -16,6 +16,7 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	extconf "zotregistry.io/zot/pkg/extensions/config"

--- a/pkg/extensions/monitoring/extension.go
+++ b/pkg/extensions/monitoring/extension.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/log"
 )

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	extconf "zotregistry.io/zot/pkg/extensions/config"

--- a/pkg/extensions/scrub/scrub_test.go
+++ b/pkg/extensions/scrub/scrub_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	extconf "zotregistry.io/zot/pkg/extensions/config"

--- a/pkg/extensions/search/common/common.go
+++ b/pkg/extensions/search/common/common.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"zotregistry.io/zot/pkg/storage"
 )
 

--- a/pkg/extensions/search/common/common_test.go
+++ b/pkg/extensions/search/common/common_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/sigstore/cosign/cmd/cosign/cli/sign"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"

--- a/pkg/extensions/search/common/oci_layout.go
+++ b/pkg/extensions/search/common/oci_layout.go
@@ -12,6 +12,7 @@ import (
 	notreg "github.com/notaryproject/notation-go/registry"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/extensions/search/cve/cve.go
+++ b/pkg/extensions/search/cve/cve.go
@@ -6,6 +6,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"zotregistry.io/zot/pkg/extensions/search/common"
 	cvemodel "zotregistry.io/zot/pkg/extensions/search/cve/model"
 	"zotregistry.io/zot/pkg/extensions/search/cve/trivy"

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -20,6 +20,7 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"

--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -13,6 +13,7 @@ import (
 	regTypes "github.com/google/go-containerregistry/pkg/v1/types"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/urfave/cli/v2"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/extensions/search/common"
 	cvemodel "zotregistry.io/zot/pkg/extensions/search/cve/model"

--- a/pkg/extensions/search/cve/trivy/scanner_internal_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_internal_test.go
@@ -10,6 +10,7 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/api/config"
 	extconf "zotregistry.io/zot/pkg/extensions/config"
 	"zotregistry.io/zot/pkg/extensions/monitoring"

--- a/pkg/extensions/search/digest/digest.go
+++ b/pkg/extensions/search/digest/digest.go
@@ -6,6 +6,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"zotregistry.io/zot/pkg/extensions/search/common"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/extensions/search/digest/digest_test.go
+++ b/pkg/extensions/search/digest/digest_test.go
@@ -14,6 +14,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"

--- a/pkg/extensions/search/resolver.go
+++ b/pkg/extensions/search/resolver.go
@@ -12,17 +12,18 @@ import (
 	"strings"
 
 	"github.com/99designs/gqlgen/graphql"
-	glob "github.com/bmatcuk/doublestar/v4"            //nolint:gci
-	v1 "github.com/google/go-containerregistry/pkg/v1" //nolint:gci
+	glob "github.com/bmatcuk/doublestar/v4"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/vektah/gqlparser/v2/gqlerror"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/extensions/search/common"
 	cveinfo "zotregistry.io/zot/pkg/extensions/search/cve"
 	digestinfo "zotregistry.io/zot/pkg/extensions/search/digest"
 	"zotregistry.io/zot/pkg/extensions/search/gql_generated"
-	"zotregistry.io/zot/pkg/log" //nolint: gci
+	"zotregistry.io/zot/pkg/log"
 	localCtx "zotregistry.io/zot/pkg/requestcontext"
 	"zotregistry.io/zot/pkg/storage"
 ) // THIS CODE IS A STARTING POINT ONLY. IT WILL NOT BE UPDATED WITH SCHEMA CHANGES.

--- a/pkg/extensions/search/resolver_test.go
+++ b/pkg/extensions/search/resolver_test.go
@@ -14,6 +14,7 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/rs/zerolog"
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/extensions/search/common"
 	"zotregistry.io/zot/pkg/log"

--- a/pkg/extensions/sync/on_demand.go
+++ b/pkg/extensions/sync/on_demand.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/image/v5/signature"
 	"github.com/containers/image/v5/types"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"
 )

--- a/pkg/extensions/sync/signatures.go
+++ b/pkg/extensions/sync/signatures.go
@@ -13,6 +13,7 @@ import (
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"github.com/sigstore/cosign/pkg/oci/remote"
 	"gopkg.in/resty.v1"
+
 	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api/constants"
 	"zotregistry.io/zot/pkg/log"

--- a/pkg/extensions/sync/sync.go
+++ b/pkg/extensions/sync/sync.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/image/v5/types"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"gopkg.in/resty.v1"
+
 	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api/constants"
 	"zotregistry.io/zot/pkg/log"

--- a/pkg/extensions/sync/sync_disabled_test.go
+++ b/pkg/extensions/sync/sync_disabled_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	extconf "zotregistry.io/zot/pkg/extensions/config"

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rs/zerolog"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/sigstore/cosign/pkg/oci/remote"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"

--- a/pkg/extensions/sync/utils.go
+++ b/pkg/extensions/sync/utils.go
@@ -21,6 +21,7 @@ import (
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"github.com/sigstore/cosign/pkg/oci/static"
 	"gopkg.in/resty.v1"
+
 	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/common"
 	"zotregistry.io/zot/pkg/extensions/monitoring"

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rs/zerolog"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/scheduler"
 )

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.etcd.io/bbolt"
+
 	"zotregistry.io/zot/errors"
 	zlog "zotregistry.io/zot/pkg/log"
 )

--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/storage/common.go
+++ b/pkg/storage/common.go
@@ -11,6 +11,7 @@ import (
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"github.com/rs/zerolog"
 	"github.com/sigstore/cosign/pkg/oci/remote"
+
 	zerr "zotregistry.io/zot/errors"
 )
 

--- a/pkg/storage/common_test.go
+++ b/pkg/storage/common_test.go
@@ -10,6 +10,7 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/rs/zerolog"
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -25,6 +25,7 @@ import (
 	"github.com/opencontainers/umoci/oci/casext"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"github.com/rs/zerolog"
+
 	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	zlog "zotregistry.io/zot/pkg/log"

--- a/pkg/storage/local/local_elevated_test.go
+++ b/pkg/storage/local/local_elevated_test.go
@@ -15,6 +15,7 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	"github.com/rs/zerolog"
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -23,6 +23,7 @@ import (
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"github.com/rs/zerolog"
 	. "github.com/smartystreets/goconvey/convey"
+
 	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -23,6 +23,7 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"github.com/rs/zerolog"
+
 	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	zlog "zotregistry.io/zot/pkg/log"

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/rs/zerolog"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"

--- a/pkg/storage/scrub.go
+++ b/pkg/storage/scrub.go
@@ -15,6 +15,7 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/opencontainers/umoci"
 	"github.com/opencontainers/umoci/oci/casext"
+
 	"zotregistry.io/zot/errors"
 )
 

--- a/pkg/storage/scrub_test.go
+++ b/pkg/storage/scrub_test.go
@@ -14,6 +14,7 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
+
 	"zotregistry.io/zot/pkg/scheduler"
 )
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rs/zerolog"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
+
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"

--- a/pkg/test/common_test.go
+++ b/pkg/test/common_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/test"

--- a/pkg/test/inject_test.go
+++ b/pkg/test/inject_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/pkg/test"
 )
 

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/opencontainers/go-digest"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
+
 	"zotregistry.io/zot/pkg/scheduler"
 )
 

--- a/pkg/test/mocks/lint_mock.go
+++ b/pkg/test/mocks/lint_mock.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	godigest "github.com/opencontainers/go-digest"
+
 	"zotregistry.io/zot/pkg/storage"
 )
 

--- a/pkg/test/mocks/oci_mock.go
+++ b/pkg/test/mocks/oci_mock.go
@@ -4,6 +4,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	"zotregistry.io/zot/pkg/extensions/search/common"
 )
 

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -838,7 +838,6 @@ func New() *s {
 	return &s{}
 }
 
-
 func (s *s) ReadDoc() string {
 	sInfo := SwaggerInfo
 	sInfo.Description = strings.Replace(sInfo.Description, "\n", "\\n", -1)

--- a/swagger/docs_test.go
+++ b/swagger/docs_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
+
 	"zotregistry.io/zot/swagger"
 )
 


### PR DESCRIPTION
Signed-off-by: Andrei Aaron <andaaron@cisco.com>

**What type of PR is this?**
cleanup

**Which issue does this PR fix**:
Inconsistency in import statements

**What does this PR do / Why do we need it**:
The linter now verifies zot module imports are in a separate block from 3rd party imports

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
