### PR TITLE
fix(s3): remove tracking multipart uploads

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,14 +36,13 @@ jobs:
         arch: [amd64, arm64]
     services:
       s3mock:
-        image: ghcr.io/project-zot/localstack/localstack:0.13.2
+        image: ghcr.io/project-zot/localstack/localstack:1.2.0
         env:
           SERVICES: s3
         ports:
           - 4563-4599:4563-4599
           - 9090:8080
     steps:
-
       - name: Install go
         uses: actions/setup-go@v3
         with:

--- a/examples/cluster/haproxy.cfg
+++ b/examples/cluster/haproxy.cfg
@@ -37,20 +37,9 @@ defaults
 frontend zot
     bind *:8080
     mode http
-    acl write_methods method POST PATCH DELETE PUT
-    use_backend zot-stick-writes if write_methods
-    default_backend zot-reads
+    default_backend zot-cluster
 
-backend zot-stick-writes
-    mode http
-    balance leastconn
-    stick-table type ip size 1m expire 30m 
-    stick on src
-    server zot1 127.0.0.1:8081 check
-    server zot2 127.0.0.1:8082 check
-    server zot3 127.0.0.1:8083 check
-
-backend zot-reads
+backend zot-cluster
     mode http
     balance roundrobin
     server zot1 127.0.0.1:8081 check

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -637,8 +637,8 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 
 		Convey("Test NewBlobUpload", func(c C) {
 			imgStore = createMockStorage(testDir, tdir, false, &StorageDriverMock{
-				PutContentFn: func(ctx context.Context, path string, content []byte) error {
-					return errS3
+				WriterFn: func(ctx context.Context, path string, isAppend bool) (driver.FileWriter, error) {
+					return nil, errS3
 				},
 			})
 			_, err := imgStore.NewBlobUpload(testImage)
@@ -647,11 +647,21 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 
 		Convey("Test GetBlobUpload", func(c C) {
 			imgStore = createMockStorage(testDir, tdir, false, &StorageDriverMock{
-				StatFn: func(ctx context.Context, path string) (driver.FileInfo, error) {
-					return &FileInfoMock{}, errS3
+				WriterFn: func(ctx context.Context, path string, isAppend bool) (driver.FileWriter, error) {
+					return nil, errS3
 				},
 			})
 			_, err := imgStore.GetBlobUpload(testImage, "uuid")
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Test BlobUploadInfo", func(c C) {
+			imgStore = createMockStorage(testDir, tdir, false, &StorageDriverMock{
+				WriterFn: func(ctx context.Context, path string, isAppend bool) (driver.FileWriter, error) {
+					return nil, errS3
+				},
+			})
+			_, err := imgStore.BlobUploadInfo(testImage, "uuid")
 			So(err, ShouldNotBeNil)
 		})
 
@@ -715,6 +725,16 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			_, err := imgStore.PutBlobChunk(testImage, "uuid", 12, 100, io.NopCloser(strings.NewReader("")))
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Test PutBlobChunk4", func(c C) {
+			imgStore = createMockStorage(testDir, tdir, false, &StorageDriverMock{
+				WriterFn: func(ctx context.Context, path string, isAppend bool) (driver.FileWriter, error) {
+					return &FileWriterMock{}, driver.PathNotFoundError{}
+				},
+			})
+			_, err := imgStore.PutBlobChunk(testImage, "uuid", 0, 100, io.NopCloser(strings.NewReader("")))
 			So(err, ShouldNotBeNil)
 		})
 


### PR DESCRIPTION
Remove sticky sessions from clustering

Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
cleanup
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**What does this PR do / Why do we need it**:
Removes the need of sticky sessions in zot cluster load balancer (haproxy)

**If an issue # is not available please add repro steps and logs showing the issue**:


**Will this break upgrades or downgrades?**
no


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
