### PR TITLE
fix(config): make all extension config consistent

### DIFF
--- a/examples/config-lint.json
+++ b/examples/config-lint.json
@@ -12,7 +12,7 @@
     },
     "extensions": {
         "lint": {
-          "enabled": true,
+          "enable": true,
           "mandatoryAnnotations": ["annot1", "annot2", "annot3"]
           
           }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -6118,7 +6118,7 @@ func TestSearchRoutes(t *testing.T) {
 			defaultVal := true
 
 			searchConfig := &extconf.SearchConfig{
-				Enable: &defaultVal,
+				BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
 			}
 
 			conf.Extensions = &extconf.ExtensionConfig{
@@ -6220,7 +6220,7 @@ func TestDistSpecExtensions(t *testing.T) {
 		defaultVal := true
 
 		searchConfig := &extconf.SearchConfig{
-			Enable: &defaultVal,
+			BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
 		}
 
 		conf.Extensions = &extconf.ExtensionConfig{

--- a/pkg/cli/client_test.go
+++ b/pkg/cli/client_test.go
@@ -72,7 +72,7 @@ func TestTLSWithAuth(t *testing.T) {
 
 		enable := true
 		conf.Extensions = &extConf.ExtensionConfig{
-			Search: &extConf.SearchConfig{Enable: &enable},
+			Search: &extConf.SearchConfig{BaseConfig: extConf.BaseConfig{Enable: &enable}},
 		}
 
 		ctlr := api.NewController(conf)
@@ -169,7 +169,7 @@ func TestTLSWithoutAuth(t *testing.T) {
 
 		enable := true
 		conf.Extensions = &extConf.ExtensionConfig{
-			Search: &extConf.SearchConfig{Enable: &enable},
+			Search: &extConf.SearchConfig{BaseConfig: extConf.BaseConfig{Enable: &enable}},
 		}
 
 		ctlr := api.NewController(conf)

--- a/pkg/cli/cve_cmd_test.go
+++ b/pkg/cli/cve_cmd_test.go
@@ -362,8 +362,8 @@ func TestServerCVEResponseGQL(t *testing.T) {
 	}
 	defaultVal := true
 	searchConfig := &extconf.SearchConfig{
-		CVE:    cveConfig,
-		Enable: &defaultVal,
+		BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+		CVE:        cveConfig,
 	}
 	conf.Extensions = &extconf.ExtensionConfig{
 		Search: searchConfig,
@@ -634,8 +634,8 @@ func TestNegativeServerResponse(t *testing.T) {
 		}
 		defaultVal := false
 		searchConfig := &extconf.SearchConfig{
-			CVE:    cveConfig,
-			Enable: &defaultVal,
+			BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+			CVE:        cveConfig,
 		}
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: searchConfig,
@@ -707,8 +707,8 @@ func TestNegativeServerResponse(t *testing.T) {
 		}
 		defaultVal := true
 		searchConfig := &extconf.SearchConfig{
-			CVE:    cveConfig,
-			Enable: &defaultVal,
+			BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+			CVE:        cveConfig,
 		}
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: searchConfig,
@@ -771,8 +771,8 @@ func TestServerCVEResponse(t *testing.T) {
 	}
 	defaultVal := true
 	searchConfig := &extconf.SearchConfig{
-		CVE:    cveConfig,
-		Enable: &defaultVal,
+		BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+		CVE:        cveConfig,
 	}
 	conf.Extensions = &extconf.ExtensionConfig{
 		Search: searchConfig,

--- a/pkg/cli/extensions_test.go
+++ b/pkg/cli/extensions_test.go
@@ -564,7 +564,7 @@ func TestServeLintExtension(t *testing.T) {
 					},
 					"extensions": {
 						"lint": {
-							"enabled": "true",
+							"enable": "true",
 							"mandatoryAnnotations": ["annot1"]
 						}
 					}
@@ -576,7 +576,7 @@ func TestServeLintExtension(t *testing.T) {
 		So(err, ShouldBeNil)
 		defer os.Remove(logPath) // clean up
 		So(string(data), ShouldContainSubstring,
-			"\"Extensions\":{\"Search\":null,\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":{\"Enabled\":true,\"MandatoryAnnotations\":") //nolint:lll // gofumpt conflicts with lll
+			"\"Extensions\":{\"Search\":null,\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":{\"Enable\":true,\"MandatoryAnnotations\":") //nolint:lll // gofumpt conflicts with lll
 	})
 
 	Convey("lint enabled", t, func(c C) {
@@ -594,7 +594,7 @@ func TestServeLintExtension(t *testing.T) {
 					},
 					"extensions": {
 						"lint": {
-							"enabled": "false"
+							"enable": "false"
 						}
 					}
 				}`
@@ -605,7 +605,7 @@ func TestServeLintExtension(t *testing.T) {
 		So(err, ShouldBeNil)
 		defer os.Remove(logPath) // clean up
 		So(string(data), ShouldContainSubstring,
-			"\"Extensions\":{\"Search\":null,\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":{\"Enabled\":false,\"MandatoryAnnotations\":null}") //nolint:lll // gofumpt conflicts with lll
+			"\"Extensions\":{\"Search\":null,\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":{\"Enable\":false,\"MandatoryAnnotations\":null}") //nolint:lll // gofumpt conflicts with lll
 	})
 }
 
@@ -640,7 +640,7 @@ func TestServeSearchEnabled(t *testing.T) {
 		WaitTillTrivyDBDownloadStarted(tempDir)
 		defer os.Remove(logPath) // clean up
 
-		substring := "\"Extensions\":{\"Search\":{\"CVE\":{\"UpdateInterval\":86400000000000},\"Enable\":true},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
+		substring := "\"Extensions\":{\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":86400000000000}},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
 		found, err := readLogFileAndSearchString(logPath, substring, readLogFileTimeout)
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
@@ -685,7 +685,7 @@ func TestServeSearchEnabledCVE(t *testing.T) {
 		// to avoid data race when multiple go routines write to trivy DB instance.
 		WaitTillTrivyDBDownloadStarted(tempDir)
 
-		substring := "\"Extensions\":{\"Search\":{\"CVE\":{\"UpdateInterval\":3600000000000},\"Enable\":true},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
+		substring := "\"Extensions\":{\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":3600000000000}},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
 		found, err := readLogFileAndSearchString(logPath, substring, readLogFileTimeout)
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
@@ -733,7 +733,7 @@ func TestServeSearchEnabledNoCVE(t *testing.T) {
 		// to avoid data race when multiple go routines write to trivy DB instance.
 		WaitTillTrivyDBDownloadStarted(tempDir)
 
-		substring := "\"Extensions\":{\"Search\":{\"CVE\":{\"UpdateInterval\":86400000000000},\"Enable\":true},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
+		substring := "\"Extensions\":{\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":86400000000000}},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
 		found, err := readLogFileAndSearchString(logPath, substring, readLogFileTimeout)
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
@@ -779,7 +779,7 @@ func TestServeSearchDisabled(t *testing.T) {
 		defer os.Remove(logPath) // clean up
 		dataStr := string(data)
 		So(dataStr, ShouldContainSubstring,
-			"\"Extensions\":{\"Search\":{\"CVE\":{\"UpdateInterval\":10800000000000},\"Enable\":false},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}") //nolint:lll // gofumpt conflicts with lll
+			"\"Extensions\":{\"Search\":{\"Enable\":false,\"CVE\":{\"UpdateInterval\":10800000000000}},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}") //nolint:lll // gofumpt conflicts with lll
 		So(dataStr, ShouldContainSubstring, "CVE config not provided, skipping CVE update")
 		So(dataStr, ShouldNotContainSubstring,
 			"CVE update interval set to too-short interval < 2h, changing update duration to 2 hours and continuing.")

--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -269,7 +269,7 @@ func TestSignature(t *testing.T) {
 		conf.HTTP.Port = port
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = currentDir
@@ -391,7 +391,7 @@ func TestDerivedImageList(t *testing.T) {
 		conf.HTTP.Port = port
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
@@ -485,7 +485,7 @@ func TestBaseImageList(t *testing.T) {
 		conf.HTTP.Port = port
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
@@ -819,7 +819,7 @@ func TestServerResponseGQL(t *testing.T) {
 		conf.HTTP.Port = port
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
@@ -1092,7 +1092,7 @@ func TestServerResponse(t *testing.T) {
 		conf.HTTP.Port = port
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
@@ -1262,8 +1262,8 @@ func TestServerResponseGQLWithoutPermissions(t *testing.T) {
 	}
 	defaultVal := true
 	searchConfig := &extconf.SearchConfig{
-		CVE:    cveConfig,
-		Enable: &defaultVal,
+		BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+		CVE:        cveConfig,
 	}
 	conf.Extensions = &extconf.ExtensionConfig{
 		Search: searchConfig,

--- a/pkg/extensions/config/config.go
+++ b/pkg/extensions/config/config.go
@@ -6,6 +6,11 @@ import (
 	"zotregistry.io/zot/pkg/extensions/sync"
 )
 
+// BaseConfig has params applicable to all extensions.
+type BaseConfig struct {
+	Enable *bool `mapstructure:",omitempty"`
+}
+
 type ExtensionConfig struct {
 	Search  *SearchConfig
 	Sync    *sync.Config
@@ -15,14 +20,14 @@ type ExtensionConfig struct {
 }
 
 type LintConfig struct {
-	Enabled              *bool
+	BaseConfig           `mapstructure:",squash"`
 	MandatoryAnnotations []string
 }
 
 type SearchConfig struct {
+	BaseConfig `mapstructure:",squash"`
 	// CVE search
-	CVE    *CVEConfig
-	Enable *bool
+	CVE *CVEConfig
 }
 
 type CVEConfig struct {
@@ -30,7 +35,7 @@ type CVEConfig struct {
 }
 
 type MetricsConfig struct {
-	Enable     *bool
+	BaseConfig `mapstructure:",squash"`
 	Prometheus *PrometheusConfig
 }
 
@@ -39,6 +44,6 @@ type PrometheusConfig struct {
 }
 
 type ScrubConfig struct {
-	Enable   *bool
-	Interval time.Duration
+	BaseConfig `mapstructure:",squash"`
+	Interval   time.Duration
 }

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -79,7 +79,7 @@ func TestMetricsExtension(t *testing.T) {
 
 		conf.Extensions = &extconf.ExtensionConfig{}
 		conf.Extensions.Metrics = &extconf.MetricsConfig{
-			Enable:     &defaultValue,
+			BaseConfig: extconf.BaseConfig{Enable: &defaultValue},
 			Prometheus: &extconf.PrometheusConfig{},
 		}
 		conf.Log.Level = "info"

--- a/pkg/extensions/lint/lint.go
+++ b/pkg/extensions/lint/lint.go
@@ -33,7 +33,7 @@ func (linter *Linter) CheckMandatoryAnnotations(repo string, manifestDigest godi
 		return true, nil
 	}
 
-	if (linter.config != nil && !*linter.config.Enabled) || len(linter.config.MandatoryAnnotations) == 0 {
+	if (linter.config != nil && !*linter.config.Enable) || len(linter.config.MandatoryAnnotations) == 0 {
 		return true, nil
 	}
 

--- a/pkg/extensions/lint/lint_test.go
+++ b/pkg/extensions/lint/lint_test.go
@@ -48,10 +48,10 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 
 		conf := config.New()
 		conf.HTTP.Port = port
-		enabled := false
+		enable := false
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
-		conf.Extensions.Lint.Enabled = &enabled
+		conf.Extensions.Lint.Enable = &enable
 
 		ctlr := api.NewController(conf)
 		dir := t.TempDir()
@@ -95,11 +95,11 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 
 		conf := config.New()
 		conf.HTTP.Port = port
-		enabled := true
+		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
 
-		conf.Extensions.Lint.Enabled = &enabled
+		conf.Extensions.Lint.Enable = &enable
 
 		ctlr := api.NewController(conf)
 		dir := t.TempDir()
@@ -142,11 +142,11 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 
 		conf := config.New()
 		conf.HTTP.Port = port
-		enabled := true
+		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
 
-		conf.Extensions.Lint.Enabled = &enabled
+		conf.Extensions.Lint.Enable = &enable
 		conf.Extensions.Lint.MandatoryAnnotations = []string{"annotation1", "annotation2", "annotation3"}
 
 		ctlr := api.NewController(conf)
@@ -196,11 +196,11 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 
 		conf := config.New()
 		conf.HTTP.Port = port
-		enabled := true
+		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
 
-		conf.Extensions.Lint.Enabled = &enabled
+		conf.Extensions.Lint.Enable = &enable
 		conf.Extensions.Lint.MandatoryAnnotations = []string{"annotation1", "annotation2", "annotation3"}
 
 		ctlr := api.NewController(conf)
@@ -285,11 +285,11 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 
 		conf := config.New()
 		conf.HTTP.Port = port
-		enabled := true
+		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
 
-		conf.Extensions.Lint.Enabled = &enabled
+		conf.Extensions.Lint.Enable = &enable
 		conf.Extensions.Lint.MandatoryAnnotations = []string{"annotation1", "annotation2", "annotation3"}
 
 		ctlr := api.NewController(conf)
@@ -373,11 +373,11 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 
 		conf := config.New()
 		conf.HTTP.Port = port
-		enabled := true
+		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
 
-		conf.Extensions.Lint.Enabled = &enabled
+		conf.Extensions.Lint.Enable = &enable
 		conf.Extensions.Lint.MandatoryAnnotations = []string{"annotation1", "annotation2", "annotation3"}
 
 		ctlr := api.NewController(conf)
@@ -426,10 +426,10 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 
 		conf := config.New()
 		conf.HTTP.Port = port
-		enabled := true
+		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
-		conf.Extensions.Lint.Enabled = &enabled
+		conf.Extensions.Lint.Enable = &enable
 		conf.Extensions.Lint.MandatoryAnnotations = []string{"annotation1", "annotation2", "annotation3"}
 
 		ctlr := api.NewController(conf)
@@ -477,10 +477,10 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 
 func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 	Convey("Mandatory annotations disabled", t, func() {
-		enabled := false
+		enable := false
 
 		lintConfig := &extconf.LintConfig{
-			Enabled:              &enabled,
+			BaseConfig:           extconf.BaseConfig{Enable: &enable},
 			MandatoryAnnotations: []string{},
 		}
 
@@ -510,10 +510,10 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 	})
 
 	Convey("Mandatory annotations enabled, but no list in config", t, func() {
-		enabled := true
+		enable := true
 
 		lintConfig := &extconf.LintConfig{
-			Enabled:              &enabled,
+			BaseConfig:           extconf.BaseConfig{Enable: &enable},
 			MandatoryAnnotations: []string{},
 		}
 
@@ -543,10 +543,10 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 	})
 
 	Convey("Mandatory annotations verification passing", t, func() {
-		enabled := true
+		enable := true
 
 		lintConfig := &extconf.LintConfig{
-			Enabled:              &enabled,
+			BaseConfig:           extconf.BaseConfig{Enable: &enable},
 			MandatoryAnnotations: []string{"annotation1", "annotation2", "annotation3"},
 		}
 
@@ -607,10 +607,10 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 	})
 
 	Convey("Mandatory annotations incomplete in manifest", t, func() {
-		enabled := true
+		enable := true
 
 		lintConfig := &extconf.LintConfig{
-			Enabled:              &enabled,
+			BaseConfig:           extconf.BaseConfig{Enable: &enable},
 			MandatoryAnnotations: []string{"annotation1", "annotation2", "annotation3"},
 		}
 
@@ -670,10 +670,10 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 	})
 
 	Convey("Mandatory annotations verification passing - more annotations than the mandatory list", t, func() {
-		enabled := true
+		enable := true
 
 		lintConfig := &extconf.LintConfig{
-			Enabled:              &enabled,
+			BaseConfig:           extconf.BaseConfig{Enable: &enable},
 			MandatoryAnnotations: []string{"annotation1", "annotation2", "annotation3"},
 		}
 
@@ -735,10 +735,10 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 	})
 
 	Convey("Cannot unmarshal manifest", t, func() {
-		enabled := true
+		enable := true
 
 		lintConfig := &extconf.LintConfig{
-			Enabled:              &enabled,
+			BaseConfig:           extconf.BaseConfig{Enable: &enable},
 			MandatoryAnnotations: []string{"annotation1", "annotation2", "annotation3"},
 		}
 
@@ -809,10 +809,10 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 	})
 
 	Convey("Cannot get config file", t, func() {
-		enabled := true
+		enable := true
 
 		lintConfig := &extconf.LintConfig{
-			Enabled:              &enabled,
+			BaseConfig:           extconf.BaseConfig{Enable: &enable},
 			MandatoryAnnotations: []string{"annotation1", "annotation2", "annotation3"},
 		}
 

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -33,7 +33,7 @@ func TestExtensionMetrics(t *testing.T) {
 		conf.Extensions = &extconf.ExtensionConfig{}
 		enabled := true
 		conf.Extensions.Metrics = &extconf.MetricsConfig{
-			Enable:     &enabled,
+			BaseConfig: extconf.BaseConfig{Enable: &enabled},
 			Prometheus: &extconf.PrometheusConfig{Path: "/metrics"},
 		}
 
@@ -86,7 +86,7 @@ func TestExtensionMetrics(t *testing.T) {
 		conf.Storage.RootDirectory = t.TempDir()
 		conf.Extensions = &extconf.ExtensionConfig{}
 		var disabled bool
-		conf.Extensions.Metrics = &extconf.MetricsConfig{Enable: &disabled}
+		conf.Extensions.Metrics = &extconf.MetricsConfig{BaseConfig: extconf.BaseConfig{Enable: &disabled}}
 
 		ctlr := api.NewController(conf)
 		So(ctlr, ShouldNotBeNil)

--- a/pkg/extensions/scrub/scrub_test.go
+++ b/pkg/extensions/scrub/scrub_test.go
@@ -51,8 +51,8 @@ func TestScrubExtension(t *testing.T) {
 		conf.Log.Output = logFile.Name()
 		trueValue := true
 		scrubConfig := &extconf.ScrubConfig{
-			Enable:   &trueValue,
-			Interval: 2,
+			BaseConfig: extconf.BaseConfig{Enable: &trueValue},
+			Interval:   2,
 		}
 		conf.Extensions = &extconf.ExtensionConfig{
 			Scrub: scrubConfig,
@@ -111,8 +111,8 @@ func TestScrubExtension(t *testing.T) {
 		conf.Log.Output = logFile.Name()
 		trueValue := true
 		scrubConfig := &extconf.ScrubConfig{
-			Enable:   &trueValue,
-			Interval: 2,
+			BaseConfig: extconf.BaseConfig{Enable: &trueValue},
+			Interval:   2,
 		}
 		conf.Extensions = &extconf.ExtensionConfig{
 			Scrub: scrubConfig,
@@ -178,8 +178,8 @@ func TestScrubExtension(t *testing.T) {
 		conf.Log.Output = logFile.Name()
 		trueValue := true
 		scrubConfig := &extconf.ScrubConfig{
-			Enable:   &trueValue,
-			Interval: 2,
+			BaseConfig: extconf.BaseConfig{Enable: &trueValue},
+			Interval:   2,
 		}
 		conf.Extensions = &extconf.ExtensionConfig{
 			Scrub: scrubConfig,

--- a/pkg/extensions/search/common/common_test.go
+++ b/pkg/extensions/search/common/common_test.go
@@ -284,7 +284,7 @@ func TestRepoListWithNewestImage(t *testing.T) {
 		conf.Storage.RootDirectory = rootDir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		conf.Extensions.Search.CVE = nil
@@ -397,7 +397,7 @@ func TestRepoListWithNewestImage(t *testing.T) {
 		conf.Storage.SubPaths[subpath] = config.StorageConfig{RootDirectory: subRootDir}
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		conf.Extensions.Search.CVE = nil
@@ -563,8 +563,8 @@ func TestRepoListWithNewestImage(t *testing.T) {
 			UpdateInterval: updateDuration,
 		}
 		searchConfig := &extconf.SearchConfig{
-			Enable: &defaultVal,
-			CVE:    cveConfig,
+			BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+			CVE:        cveConfig,
 		}
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: searchConfig,
@@ -604,7 +604,7 @@ func TestRepoListWithNewestImage(t *testing.T) {
 			_ = ctlr.Server.Shutdown(ctx)
 		}()
 
-		substring := "\"Extensions\":{\"Search\":{\"CVE\":{\"UpdateInterval\":3600000000000},\"Enable\":true},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
+		substring := "\"Extensions\":{\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":3600000000000}},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
 		found, err := readFileAndSearchString(logPath, substring, 2*time.Minute)
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
@@ -671,7 +671,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		conf.Storage.RootDirectory = tempDir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		conf.Extensions.Search.CVE = nil
@@ -771,7 +771,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		conf.Storage.SubPaths[subpath] = config.StorageConfig{RootDirectory: subRootDir}
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		conf.Extensions.Search.CVE = nil
@@ -1067,7 +1067,7 @@ func TestDerivedImageList(t *testing.T) {
 	conf.Storage.SubPaths[subpath] = config.StorageConfig{RootDirectory: subRootDir}
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
-		Search: &extconf.SearchConfig{Enable: &defaultVal},
+		Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 	}
 
 	conf.Extensions.Search.CVE = nil
@@ -1385,7 +1385,7 @@ func TestDerivedImageListNoRepos(t *testing.T) {
 		conf.Storage.RootDirectory = t.TempDir()
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		conf.Extensions.Search.CVE = nil
@@ -1482,7 +1482,7 @@ func TestBaseImageList(t *testing.T) {
 	conf.Storage.SubPaths[subpath] = config.StorageConfig{RootDirectory: subRootDir}
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
-		Search: &extconf.SearchConfig{Enable: &defaultVal},
+		Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 	}
 
 	conf.Extensions.Search.CVE = nil
@@ -1900,7 +1900,7 @@ func TestBaseImageListNoRepos(t *testing.T) {
 		conf.Storage.RootDirectory = t.TempDir()
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		conf.Extensions.Search.CVE = nil
@@ -1998,7 +1998,7 @@ func TestGlobalSearch(t *testing.T) {
 		conf.Storage.SubPaths[subpath] = config.StorageConfig{RootDirectory: subRootDir}
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		conf.Extensions.Search.CVE = nil
@@ -2195,8 +2195,8 @@ func TestGlobalSearch(t *testing.T) {
 			UpdateInterval: updateDuration,
 		}
 		searchConfig := &extconf.SearchConfig{
-			Enable: &defaultVal,
-			CVE:    cveConfig,
+			BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+			CVE:        cveConfig,
 		}
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: searchConfig,
@@ -2239,7 +2239,7 @@ func TestGlobalSearch(t *testing.T) {
 		}()
 
 		// Wait for trivy db to download
-		substring := "\"Extensions\":{\"Search\":{\"CVE\":{\"UpdateInterval\":3600000000000},\"Enable\":true},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
+		substring := "\"Extensions\":{\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":3600000000000}},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
 		found, err := readFileAndSearchString(logPath, substring, 2*time.Minute)
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
@@ -2418,7 +2418,7 @@ func TestImageList(t *testing.T) {
 		conf.Storage.RootDirectory = rootDir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		conf.Extensions.Search.CVE = nil
@@ -2490,7 +2490,7 @@ func TestImageList(t *testing.T) {
 		conf.Storage.RootDirectory = tempDir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		conf.Extensions.Search.CVE = nil
@@ -2602,7 +2602,7 @@ func TestBuildImageInfo(t *testing.T) {
 		conf.Storage.RootDirectory = rootDir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		conf.Extensions.Search.CVE = nil
@@ -2789,7 +2789,7 @@ func TestSearchSize(t *testing.T) {
 		conf.HTTP.Port = port
 		tr := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &tr},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &tr}},
 		}
 
 		ctlr := api.NewController(conf)
@@ -2903,7 +2903,7 @@ func TestImageSummary(t *testing.T) {
 
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		conf.Extensions.Search.CVE = nil

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -412,8 +412,8 @@ func TestCVESearch(t *testing.T) {
 		}
 		defaultVal := true
 		searchConfig := &extconf.SearchConfig{
-			Enable: &defaultVal,
-			CVE:    cveConfig,
+			BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+			CVE:        cveConfig,
 		}
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: searchConfig,

--- a/pkg/extensions/search/digest/digest_test.go
+++ b/pkg/extensions/search/digest/digest_test.go
@@ -161,7 +161,7 @@ func TestDigestSearchHTTP(t *testing.T) {
 		conf.Storage.RootDirectory = rootDir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		ctlr := api.NewController(conf)
@@ -312,7 +312,7 @@ func TestDigestSearchHTTPSubPaths(t *testing.T) {
 		conf.HTTP.Port = port
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &defaultVal},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
 		}
 
 		ctlr := api.NewController(conf)
@@ -388,7 +388,7 @@ func TestDigestSearchDisabled(t *testing.T) {
 		conf.HTTP.Port = port
 		conf.Storage.RootDirectory = t.TempDir()
 		conf.Extensions = &extconf.ExtensionConfig{
-			Search: &extconf.SearchConfig{Enable: &disabled},
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &disabled}},
 		}
 
 		ctlr := api.NewController(conf)

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -919,9 +919,9 @@ func TestMandatoryAnnotations(t *testing.T) {
 
 		destConfig.Log.Output = logFile.Name()
 
-		lintEnabled := true
+		lintEnable := true
 		destConfig.Extensions.Lint = &extconf.LintConfig{}
-		destConfig.Extensions.Lint.Enabled = &lintEnabled
+		destConfig.Extensions.Lint.Enable = &lintEnable
 		destConfig.Extensions.Lint.MandatoryAnnotations = []string{"annot1", "annot2", "annot3"}
 
 		dctlr := api.NewController(destConfig)

--- a/test/blackbox/annotations.bats
+++ b/test/blackbox/annotations.bats
@@ -31,7 +31,7 @@ function setup_file() {
                     "enable": "true"
         },
         "lint": {
-                    "enabled": "true",
+                    "enable": "true",
                     "mandatoryAnnotations": ["org.opencontainers.image.licenses", "org.opencontainers.image.vendor"]
         }
     }


### PR DESCRIPTION
Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

cleanup

**What does this PR do / Why do we need it**:

Some extensions (like lint) are not consistent in the config params, so fixing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
