### PR TITLE
fix: flaky scheduler coverage

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -6003,7 +6003,7 @@ func TestPeriodicGC(t *testing.T) {
 		defer stopServer(ctlr)
 		test.WaitTillServerReady(baseURL)
 
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(5000 * time.Millisecond)
 
 		data, err := os.ReadFile(logFile.Name())
 		So(err, ShouldBeNil)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -112,11 +112,24 @@ func (scheduler *Scheduler) RunScheduler(ctx context.Context) {
 
 func (scheduler *Scheduler) pushReadyGenerators() {
 	// iterate through waiting generators list and resubmit those which become ready to run
-	for i, gen := range scheduler.waitingGenerators {
-		if gen.getState() == ready {
-			gen.done = false
-			heap.Push(&scheduler.generators, gen)
-			scheduler.waitingGenerators = append(scheduler.waitingGenerators[:i], scheduler.waitingGenerators[i+1:]...)
+	for {
+		modified := false
+
+		for i, gen := range scheduler.waitingGenerators {
+			if gen.getState() == ready {
+				gen.done = false
+				heap.Push(&scheduler.generators, gen)
+				scheduler.waitingGenerators = append(scheduler.waitingGenerators[:i], scheduler.waitingGenerators[i+1:]...)
+				modified = true
+
+				scheduler.log.Debug().Msg("waiting generator is ready, pushing to ready generators")
+
+				break
+			}
+		}
+
+		if !modified {
+			break
 		}
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
#891

**What does this PR do / Why do we need it**:
Coverage sometimes failed for a function within the scheduler code. There was a range of a slice that was iterated upon and then modified, leading to unexpected behavior. 

Also adds a test to check for the waiting task generator (tested with 150 runs) + fixes a periodic GC test that sometimes failed because it didn't have enough time to execute its async task (ran it 500 times on my machine to ensure it passes consistently)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
