### PR TITLE
fix(storage): deleting manifests with identical digests

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -59,4 +59,5 @@ var (
 	ErrParsingHTTPHeader       = errors.New("routes: invalid HTTP header")
 	ErrBadRange                = errors.New("storage: bad range")
 	ErrBadLayerCount           = errors.New("manifest: layers count doesn't correspond to config history")
+	ErrManifestConflict        = errors.New("manifest: multiple manifests found")
 )

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -527,6 +527,9 @@ func (rh *RouteHandler) DeleteManifest(response http.ResponseWriter, request *ht
 		} else if errors.Is(err, zerr.ErrManifestNotFound) {
 			WriteJSON(response, http.StatusNotFound,
 				NewErrorList(NewError(MANIFEST_UNKNOWN, map[string]string{"reference": reference})))
+		} else if errors.Is(err, zerr.ErrManifestConflict) {
+			WriteJSON(response, http.StatusConflict,
+				NewErrorList(NewError(MANIFEST_INVALID, map[string]string{"reference": reference})))
 		} else if errors.Is(err, zerr.ErrBadManifest) {
 			WriteJSON(response, http.StatusBadRequest,
 				NewErrorList(NewError(UNSUPPORTED, map[string]string{"reference": reference})))

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -559,7 +559,11 @@ func (is *ImageStoreLocal) DeleteImageManifest(repo, reference string) error {
 		return err
 	}
 
-	manifestDesc, found := storage.RemoveManifestDescByReference(&index, reference)
+	manifestDesc, found, err := storage.RemoveManifestDescByReference(&index, reference)
+	if err != nil {
+		return err
+	}
+
 	if !found {
 		return zerr.ErrManifestNotFound
 	}

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -467,7 +467,11 @@ func (is *ObjectStorage) DeleteImageManifest(repo, reference string) error {
 		return err
 	}
 
-	manifestDesc, found := storage.RemoveManifestDescByReference(&index, reference)
+	manifestDesc, found, err := storage.RemoveManifestDescByReference(&index, reference)
+	if err != nil {
+		return err
+	}
+
 	if !found {
 		return zerr.ErrManifestNotFound
 	}


### PR DESCRIPTION
Suppose we push two identical manifests (sharing same digest) but with different tags, then deleting by digest should throw an error otherwise we end up deleting all image tags (with gc) or dangling references (without gc)

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

bug


**What does this PR do / Why do we need it**:

`skopeo delete` given a tag, first resolves to a manifest digest and attempts to delete it. This is dangerous if two or more images share the same digest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
