### PR TITLE
refactor(digests): standardise representation of digests to digest.Digest

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3294,12 +3294,12 @@ func TestCrossRepoMount(t *testing.T) {
 			baseURL, constants.RoutePrefix, constants.Blobs, godigest.SHA256, blob))
 
 		// Check os.SameFile here
-		cachePath := path.Join(ctlr.Config.Storage.RootDirectory, "zot-d-test", "blobs/sha256", dgst.Hex())
+		cachePath := path.Join(ctlr.Config.Storage.RootDirectory, "zot-d-test", "blobs/sha256", dgst.Encoded())
 
 		cacheFi, err := os.Stat(cachePath)
 		So(err, ShouldBeNil)
 
-		linkPath := path.Join(ctlr.Config.Storage.RootDirectory, "zot-mount-test", "blobs/sha256", dgst.Hex())
+		linkPath := path.Join(ctlr.Config.Storage.RootDirectory, "zot-mount-test", "blobs/sha256", dgst.Encoded())
 
 		linkFi, err := os.Stat(linkPath)
 		So(err, ShouldBeNil)
@@ -3318,7 +3318,7 @@ func TestCrossRepoMount(t *testing.T) {
 		So(test.Location(baseURL, postResponse), ShouldEqual, fmt.Sprintf("%s%s/zot-mount1-test/%s/%s:%s",
 			baseURL, constants.RoutePrefix, constants.Blobs, godigest.SHA256, blob))
 
-		linkPath = path.Join(ctlr.Config.Storage.RootDirectory, "zot-mount1-test", "blobs/sha256", dgst.Hex())
+		linkPath = path.Join(ctlr.Config.Storage.RootDirectory, "zot-mount1-test", "blobs/sha256", dgst.Encoded())
 
 		linkFi, err = os.Stat(linkPath)
 		So(err, ShouldBeNil)

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -56,7 +57,7 @@ func TestRoutes(t *testing.T) {
 		Convey("Get manifest", func() {
 			// overwrite controller storage
 			ctlr.StoreController.DefaultStore = &mocks.MockedImageStore{
-				GetImageManifestFn: func(repo string, reference string) ([]byte, string, string, error) {
+				GetImageManifestFn: func(repo string, reference string) ([]byte, godigest.Digest, string, error) {
 					return []byte{}, "", "", zerr.ErrRepoBadVersion
 				},
 			}
@@ -100,7 +101,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte) (string, error) {
+					PutImageManifestFn: func(repo, reference, mediaType string, body []byte) (godigest.Digest, error) {
 						return "", zerr.ErrRepoNotFound
 					},
 				})
@@ -113,7 +114,7 @@ func TestRoutes(t *testing.T) {
 				},
 
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte) (string, error) {
+					PutImageManifestFn: func(repo, reference, mediaType string, body []byte) (godigest.Digest, error) {
 						return "", zerr.ErrManifestNotFound
 					},
 				})
@@ -125,7 +126,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte) (string, error) {
+					PutImageManifestFn: func(repo, reference, mediaType string, body []byte) (godigest.Digest, error) {
 						return "", zerr.ErrBadManifest
 					},
 				})
@@ -137,7 +138,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte) (string, error) {
+					PutImageManifestFn: func(repo, reference, mediaType string, body []byte) (godigest.Digest, error) {
 						return "", zerr.ErrBlobNotFound
 					},
 				})
@@ -150,7 +151,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte) (string, error) {
+					PutImageManifestFn: func(repo, reference, mediaType string, body []byte) (godigest.Digest, error) {
 						return "", zerr.ErrRepoBadVersion
 					},
 				})
@@ -258,7 +259,7 @@ func TestRoutes(t *testing.T) {
 					"digest": test.GetTestBlobDigest("zot-cve-test", "layer").String(),
 				},
 				&mocks.MockedImageStore{
-					DeleteBlobFn: func(repo, digest string) error {
+					DeleteBlobFn: func(repo string, digest godigest.Digest) error {
 						return ErrUnexpectedError
 					},
 				})
@@ -270,7 +271,7 @@ func TestRoutes(t *testing.T) {
 					"digest": "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621",
 				},
 				&mocks.MockedImageStore{
-					DeleteBlobFn: func(repo, digest string) error {
+					DeleteBlobFn: func(repo string, digest godigest.Digest) error {
 						return zerr.ErrBadBlobDigest
 					},
 				})
@@ -283,7 +284,7 @@ func TestRoutes(t *testing.T) {
 					"digest": test.GetTestBlobDigest("zot-cve-test", "layer").String(),
 				},
 				&mocks.MockedImageStore{
-					DeleteBlobFn: func(repo, digest string) error {
+					DeleteBlobFn: func(repo string, digest godigest.Digest) error {
 						return zerr.ErrBlobNotFound
 					},
 				})
@@ -296,7 +297,7 @@ func TestRoutes(t *testing.T) {
 					"digest": test.GetTestBlobDigest("zot-cve-test", "layer").String(),
 				},
 				&mocks.MockedImageStore{
-					DeleteBlobFn: func(repo, digest string) error {
+					DeleteBlobFn: func(repo string, digest godigest.Digest) error {
 						return zerr.ErrRepoNotFound
 					},
 				})
@@ -326,7 +327,7 @@ func TestRoutes(t *testing.T) {
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(repo, digest string) (bool, int64, error) {
+					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrBadBlobDigest
 					},
 				})
@@ -339,7 +340,7 @@ func TestRoutes(t *testing.T) {
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(repo, digest string) (bool, int64, error) {
+					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -352,7 +353,7 @@ func TestRoutes(t *testing.T) {
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(repo, digest string) (bool, int64, error) {
+					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrBlobNotFound
 					},
 				})
@@ -365,7 +366,7 @@ func TestRoutes(t *testing.T) {
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(repo, digest string) (bool, int64, error) {
+					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, ErrUnexpectedError
 					},
 				})
@@ -378,7 +379,7 @@ func TestRoutes(t *testing.T) {
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(repo, digest string) (bool, int64, error) {
+					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 						return false, 0, nil
 					},
 				})
@@ -406,7 +407,7 @@ func TestRoutes(t *testing.T) {
 					"digest": test.GetTestBlobDigest("zot-cve-test", "layer").String(),
 				},
 				&mocks.MockedImageStore{
-					GetBlobFn: func(repo, digest, mediaType string) (io.ReadCloser, int64, error) {
+					GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
 						return io.NopCloser(bytes.NewBuffer([]byte(""))), 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -419,7 +420,7 @@ func TestRoutes(t *testing.T) {
 					"digest": test.GetTestBlobDigest("zot-cve-test", "layer").String(),
 				},
 				&mocks.MockedImageStore{
-					GetBlobFn: func(repo, digest, mediaType string) (io.ReadCloser, int64, error) {
+					GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
 						return io.NopCloser(bytes.NewBuffer([]byte(""))), 0, zerr.ErrBadBlobDigest
 					},
 				})
@@ -470,7 +471,7 @@ func TestRoutes(t *testing.T) {
 					NewBlobUploadFn: func(repo string) (string, error) {
 						return "", zerr.ErrRepoNotFound
 					},
-					CheckBlobFn: func(repo, digest string) (bool, int64, error) {
+					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -487,7 +488,7 @@ func TestRoutes(t *testing.T) {
 					NewBlobUploadFn: func(repo string) (string, error) {
 						return "", zerr.ErrRepoNotFound
 					},
-					CheckBlobFn: func(repo, digest string) (bool, int64, error) {
+					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -505,7 +506,7 @@ func TestRoutes(t *testing.T) {
 					NewBlobUploadFn: func(repo string) (string, error) {
 						return "", zerr.ErrRepoNotFound
 					},
-					CheckBlobFn: func(repo, digest string) (bool, int64, error) {
+					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -521,7 +522,7 @@ func TestRoutes(t *testing.T) {
 					"Content-Length": "100",
 				},
 				&mocks.MockedImageStore{
-					FullBlobUploadFn: func(repo string, body io.Reader, digest string) (string, int64, error) {
+					FullBlobUploadFn: func(repo string, body io.Reader, digest godigest.Digest) (string, int64, error) {
 						return "session", 0, zerr.ErrBadBlobDigest
 					},
 				})
@@ -537,7 +538,7 @@ func TestRoutes(t *testing.T) {
 					"Content-Length": "100",
 				},
 				&mocks.MockedImageStore{
-					FullBlobUploadFn: func(repo string, body io.Reader, digest string) (string, int64, error) {
+					FullBlobUploadFn: func(repo string, body io.Reader, digest godigest.Digest) (string, int64, error) {
 						return "session", 20, nil
 					},
 				})
@@ -965,7 +966,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest string) error {
+					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest godigest.Digest) error {
 						return zerr.ErrBadBlobDigest
 					},
 				},
@@ -985,7 +986,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest string) error {
+					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest godigest.Digest) error {
 						return zerr.ErrBadUploadRange
 					},
 				},
@@ -1005,7 +1006,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest string) error {
+					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest godigest.Digest) error {
 						return zerr.ErrRepoNotFound
 					},
 				},
@@ -1025,7 +1026,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest string) error {
+					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest godigest.Digest) error {
 						return zerr.ErrUploadNotFound
 					},
 				},
@@ -1045,7 +1046,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest string) error {
+					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest godigest.Digest) error {
 						return ErrUnexpectedError
 					},
 					DeleteBlobUploadFn: func(repo, uuid string) error {
@@ -1319,7 +1320,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest string) error {
+					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest godigest.Digest) error {
 						return zerr.ErrUploadNotFound
 					},
 				},
@@ -1339,7 +1340,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest string) error {
+					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest godigest.Digest) error {
 						return zerr.ErrUploadNotFound
 					},
 				},
@@ -1359,7 +1360,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest string) error {
+					FinishBlobUploadFn: func(repo, uuid string, body io.Reader, digest godigest.Digest) error {
 						return zerr.ErrUploadNotFound
 					},
 				},

--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -272,11 +271,8 @@ func (p *requestsPool) doJob(ctx context.Context, job *manifestJob) {
 		p.outputCh <- stringResult{"", err}
 	}
 
-	digest := header.Get("docker-content-digest")
-	digest = strings.TrimPrefix(digest, "sha256:")
-
+	digestStr := header.Get("docker-content-digest")
 	configDigest := job.manifestResp.Config.Digest
-	configDigest = strings.TrimPrefix(configDigest, "sha256:")
 
 	var size uint64
 
@@ -289,7 +285,7 @@ func (p *requestsPool) doJob(ctx context.Context, job *manifestJob) {
 			layers,
 			layer{
 				Size:   entry.Size,
-				Digest: strings.TrimPrefix(entry.Digest, "sha256:"),
+				Digest: entry.Digest,
 			},
 		)
 	}
@@ -298,7 +294,7 @@ func (p *requestsPool) doJob(ctx context.Context, job *manifestJob) {
 	image.verbose = *job.config.verbose
 	image.RepoName = job.imageName
 	image.Tag = job.tagName
-	image.Digest = digest
+	image.Digest = digestStr
 	image.Size = strconv.Itoa(int(size))
 	image.ConfigDigest = configDigest
 	image.Layers = layers

--- a/pkg/cli/cve_cmd_test.go
+++ b/pkg/cli/cve_cmd_test.go
@@ -183,7 +183,7 @@ func TestSearchCVECmd(t *testing.T) {
 		So(err, ShouldBeNil)
 		space := regexp.MustCompile(`\s+`)
 		str := space.ReplaceAllString(buff.String(), " ")
-		So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE dummyImageName tag DigestsA false 123kB")
+		So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE dummyImageName tag 6e2f80bf false 123kB")
 		Convey("using shorthand", func() {
 			args := []string{"cvetest", "-I", "dummyImageName", "--cve-id", "aCVEID", "--url", "someURL"}
 			buff := bytes.NewBufferString("")
@@ -197,7 +197,7 @@ func TestSearchCVECmd(t *testing.T) {
 			So(err, ShouldBeNil)
 			space := regexp.MustCompile(`\s+`)
 			str := space.ReplaceAllString(buff.String(), " ")
-			So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE dummyImageName tag DigestsA false 123kB")
+			So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE dummyImageName tag 6e2f80bf false 123kB")
 		})
 	})
 
@@ -281,7 +281,7 @@ func TestSearchCVECmd(t *testing.T) {
 		err := cveCmd.Execute()
 		space := regexp.MustCompile(`\s+`)
 		str := space.ReplaceAllString(buff.String(), " ")
-		So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE anImage tag DigestsA false 123kB")
+		So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE anImage tag 6e2f80bf false 123kB")
 		So(err, ShouldBeNil)
 
 		Convey("invalid CVE ID", func() {
@@ -326,7 +326,7 @@ func TestSearchCVECmd(t *testing.T) {
 		space := regexp.MustCompile(`\s+`)
 		str := space.ReplaceAllString(buff.String(), " ")
 		So(err, ShouldBeNil)
-		So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE fixedImage tag DigestsA false 123kB")
+		So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE fixedImage tag 6e2f80bf false 123kB")
 
 		Convey("invalid image name", func() {
 			args := []string{"cvetest", "--cve-id", "aCVEID", "--image", "invalidImageName"}

--- a/pkg/extensions/lint/lint.go
+++ b/pkg/extensions/lint/lint.go
@@ -39,7 +39,7 @@ func (linter *Linter) CheckMandatoryAnnotations(repo string, manifestDigest godi
 
 	mandatoryAnnotationsList := linter.config.MandatoryAnnotations
 
-	content, err := imgStore.GetBlobContent(repo, string(manifestDigest))
+	content, err := imgStore.GetBlobContent(repo, manifestDigest)
 	if err != nil {
 		linter.log.Error().Err(err).Msg("linter: unable to get image manifest")
 
@@ -74,16 +74,16 @@ func (linter *Linter) CheckMandatoryAnnotations(repo string, manifestDigest godi
 	// if there are mandatory annotations missing in the manifest, get config and check these annotations too
 	configDigest := manifest.Config.Digest
 
-	content, err = imgStore.GetBlobContent(repo, string(configDigest))
+	content, err = imgStore.GetBlobContent(repo, configDigest)
 	if err != nil {
-		linter.log.Error().Err(err).Msg("linter: couldn't get config JSON " + string(configDigest))
+		linter.log.Error().Err(err).Msg("linter: couldn't get config JSON " + configDigest.String())
 
 		return false, err
 	}
 
 	var imageConfig ispec.Image
 	if err := json.Unmarshal(content, &imageConfig); err != nil {
-		linter.log.Error().Err(err).Msg("linter: couldn't unmarshal config JSON " + string(configDigest))
+		linter.log.Error().Err(err).Msg("linter: couldn't unmarshal config JSON " + configDigest.String())
 
 		return false, err
 	}

--- a/pkg/extensions/lint/lint_test.go
+++ b/pkg/extensions/lint/lint_test.go
@@ -847,7 +847,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		var imageConfig ispec.Image
 		configDigest := manifest.Config.Digest
 		buf, err = os.ReadFile(path.Join(dir, "zot-test", "blobs", "sha256",
-			configDigest.Hex()))
+			configDigest.Encoded()))
 		So(err, ShouldBeNil)
 		err = json.Unmarshal(buf, &imageConfig)
 		So(err, ShouldBeNil)
@@ -863,7 +863,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		So(cfgDigest, ShouldNotBeNil)
 
 		err = os.WriteFile(path.Join(dir, "zot-test", "blobs", "sha256",
-			cfgDigest.Hex()), configContent, 0o600)
+			cfgDigest.Encoded()), configContent, 0o600)
 		So(err, ShouldBeNil)
 
 		// write manifest
@@ -892,7 +892,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		imgStore := local.NewImageStore(dir, false, 0, false, false,
 			log.NewLogger("debug", ""), monitoring.NewMetricsServer(false, log.NewLogger("debug", "")), linter)
 
-		err = os.Chmod(path.Join(dir, "zot-test", "blobs", "sha256", manifest.Config.Digest.Hex()), 0o000)
+		err = os.Chmod(path.Join(dir, "zot-test", "blobs", "sha256", manifest.Config.Digest.Encoded()), 0o000)
 		if err != nil {
 			panic(err)
 		}
@@ -901,7 +901,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(pass, ShouldBeFalse)
 
-		err = os.Chmod(path.Join(dir, "zot-test", "blobs", "sha256", manifest.Config.Digest.Hex()), 0o755)
+		err = os.Chmod(path.Join(dir, "zot-test", "blobs", "sha256", manifest.Config.Digest.Encoded()), 0o755)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/extensions/scrub/scrub_test.go
+++ b/pkg/extensions/scrub/scrub_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/opencontainers/go-digest"
+	godigest "github.com/opencontainers/go-digest"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
 
@@ -124,7 +124,7 @@ func TestScrubExtension(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		var manifestDigest digest.Digest
+		var manifestDigest godigest.Digest
 		manifestDigest, _, _ = test.GetOciLayoutDigests("../../../test/data/zot-test")
 
 		err = os.Remove(path.Join(dir, repoName, "blobs/sha256", manifestDigest.Encoded()))
@@ -276,7 +276,7 @@ func TestRunScrubRepo(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
-		var manifestDigest digest.Digest
+		var manifestDigest godigest.Digest
 		manifestDigest, _, _ = test.GetOciLayoutDigests("../../../test/data/zot-test")
 
 		err = os.Remove(path.Join(dir, repoName, "blobs/sha256", manifestDigest.Encoded()))

--- a/pkg/extensions/search/common/common.go
+++ b/pkg/extensions/search/common/common.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"zotregistry.io/zot/pkg/storage"
@@ -24,7 +25,7 @@ const (
 
 type TagInfo struct {
 	Name      string
-	Digest    string
+	Digest    godigest.Digest
 	Timestamp time.Time
 }
 

--- a/pkg/extensions/search/common/common_test.go
+++ b/pkg/extensions/search/common/common_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
-	"github.com/opencontainers/go-digest"
+	godigest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sigstore/cosign/cmd/cosign/cli/generate"
@@ -491,8 +491,8 @@ func TestRepoListWithNewestImage(t *testing.T) {
 			panic(err)
 		}
 
-		var manifestDigest digest.Digest
-		var configDigest digest.Digest
+		var manifestDigest godigest.Digest
+		var configDigest godigest.Digest
 		manifestDigest, configDigest, _ = GetOciLayoutDigests("../../../../test/data/zot-test")
 
 		// Delete config blob and try.
@@ -840,7 +840,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.ImageSummaries[0].Layers), ShouldNotEqual, 0)
 		found := false
 		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.ImageSummaries {
-			if m.Digest == GetTestBlobDigest("zot-cve-test", "manifest").Encoded() {
+			if m.Digest == GetTestBlobDigest("zot-cve-test", "manifest").String() {
 				found = true
 				So(m.IsSigned, ShouldEqual, false)
 			}
@@ -861,7 +861,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.ImageSummaries[0].Layers), ShouldNotEqual, 0)
 		found = false
 		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.ImageSummaries {
-			if m.Digest == GetTestBlobDigest("zot-cve-test", "manifest").Encoded() {
+			if m.Digest == GetTestBlobDigest("zot-cve-test", "manifest").String() {
 				found = true
 				So(m.IsSigned, ShouldEqual, true)
 			}
@@ -887,7 +887,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.ImageSummaries[0].Layers), ShouldNotEqual, 0)
 		found = false
 		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.ImageSummaries {
-			if m.Digest == GetTestBlobDigest("zot-test", "manifest").Encoded() {
+			if m.Digest == GetTestBlobDigest("zot-test", "manifest").String() {
 				found = true
 				So(m.IsSigned, ShouldEqual, false)
 			}
@@ -908,14 +908,14 @@ func TestExpandedRepoInfo(t *testing.T) {
 		So(len(responseStruct.ExpandedRepoInfo.RepoInfo.ImageSummaries[0].Layers), ShouldNotEqual, 0)
 		found = false
 		for _, m := range responseStruct.ExpandedRepoInfo.RepoInfo.ImageSummaries {
-			if m.Digest == GetTestBlobDigest("zot-test", "manifest").Encoded() {
+			if m.Digest == GetTestBlobDigest("zot-test", "manifest").String() {
 				found = true
 				So(m.IsSigned, ShouldEqual, true)
 			}
 		}
 		So(found, ShouldEqual, true)
 
-		var manifestDigest digest.Digest
+		var manifestDigest godigest.Digest
 		manifestDigest, _, _ = GetOciLayoutDigests("../../../../test/data/zot-test")
 
 		err = os.Remove(path.Join(rootDir, "zot-test/blobs/sha256", manifestDigest.Encoded()))
@@ -1105,7 +1105,7 @@ func TestDerivedImageList(t *testing.T) {
 			OS:           "linux",
 			RootFS: ispec.RootFS{
 				Type:    "layers",
-				DiffIDs: []digest.Digest{},
+				DiffIDs: []godigest.Digest{},
 			},
 			Author: "ZotUser",
 		}
@@ -1113,7 +1113,7 @@ func TestDerivedImageList(t *testing.T) {
 		configBlob, err := json.Marshal(config)
 		So(err, ShouldBeNil)
 
-		configDigest := digest.FromBytes(configBlob)
+		configDigest := godigest.FromBytes(configBlob)
 
 		layers := [][]byte{
 			{10, 11, 10, 11},
@@ -1133,17 +1133,17 @@ func TestDerivedImageList(t *testing.T) {
 			Layers: []ispec.Descriptor{
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[0]),
+					Digest:    godigest.FromBytes(layers[0]),
 					Size:      int64(len(layers[0])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[1]),
+					Digest:    godigest.FromBytes(layers[1]),
 					Size:      int64(len(layers[1])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[2]),
+					Digest:    godigest.FromBytes(layers[2]),
 					Size:      int64(len(layers[2])),
 				},
 			},
@@ -1176,17 +1176,17 @@ func TestDerivedImageList(t *testing.T) {
 			Layers: []ispec.Descriptor{
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[0]),
+					Digest:    godigest.FromBytes(layers[0]),
 					Size:      int64(len(layers[0])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[1]),
+					Digest:    godigest.FromBytes(layers[1]),
 					Size:      int64(len(layers[1])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[2]),
+					Digest:    godigest.FromBytes(layers[2]),
 					Size:      int64(len(layers[2])),
 				},
 			},
@@ -1224,12 +1224,12 @@ func TestDerivedImageList(t *testing.T) {
 			Layers: []ispec.Descriptor{
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[0]),
+					Digest:    godigest.FromBytes(layers[0]),
 					Size:      int64(len(layers[0])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[1]),
+					Digest:    godigest.FromBytes(layers[1]),
 					Size:      int64(len(layers[1])),
 				},
 			},
@@ -1270,27 +1270,27 @@ func TestDerivedImageList(t *testing.T) {
 			Layers: []ispec.Descriptor{
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[0]),
+					Digest:    godigest.FromBytes(layers[0]),
 					Size:      int64(len(layers[0])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[1]),
+					Digest:    godigest.FromBytes(layers[1]),
 					Size:      int64(len(layers[1])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[2]),
+					Digest:    godigest.FromBytes(layers[2]),
 					Size:      int64(len(layers[2])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[3]),
+					Digest:    godigest.FromBytes(layers[3]),
 					Size:      int64(len(layers[3])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[4]),
+					Digest:    godigest.FromBytes(layers[4]),
 					Size:      int64(len(layers[4])),
 				},
 			},
@@ -1450,7 +1450,7 @@ func TestGetImageManifest(t *testing.T) {
 
 	Convey("Test nonexistent image", t, func() {
 		mockImageStore := mocks.MockedImageStore{
-			GetImageManifestFn: func(repo string, reference string) ([]byte, string, string, error) {
+			GetImageManifestFn: func(repo string, reference string) ([]byte, godigest.Digest, string, error) {
 				return []byte{}, "", "", ErrTestError
 			},
 		}
@@ -1520,7 +1520,7 @@ func TestBaseImageList(t *testing.T) {
 			OS:           "linux",
 			RootFS: ispec.RootFS{
 				Type:    "layers",
-				DiffIDs: []digest.Digest{},
+				DiffIDs: []godigest.Digest{},
 			},
 			Author: "ZotUser",
 		}
@@ -1528,7 +1528,7 @@ func TestBaseImageList(t *testing.T) {
 		configBlob, err := json.Marshal(config)
 		So(err, ShouldBeNil)
 
-		configDigest := digest.FromBytes(configBlob)
+		configDigest := godigest.FromBytes(configBlob)
 
 		layers := [][]byte{
 			{10, 11, 10, 11},
@@ -1549,22 +1549,22 @@ func TestBaseImageList(t *testing.T) {
 			Layers: []ispec.Descriptor{
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[0]),
+					Digest:    godigest.FromBytes(layers[0]),
 					Size:      int64(len(layers[0])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[1]),
+					Digest:    godigest.FromBytes(layers[1]),
 					Size:      int64(len(layers[1])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[2]),
+					Digest:    godigest.FromBytes(layers[2]),
 					Size:      int64(len(layers[2])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[3]),
+					Digest:    godigest.FromBytes(layers[3]),
 					Size:      int64(len(layers[3])),
 				},
 			},
@@ -1597,22 +1597,22 @@ func TestBaseImageList(t *testing.T) {
 			Layers: []ispec.Descriptor{
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[0]),
+					Digest:    godigest.FromBytes(layers[0]),
 					Size:      int64(len(layers[0])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[1]),
+					Digest:    godigest.FromBytes(layers[1]),
 					Size:      int64(len(layers[1])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[2]),
+					Digest:    godigest.FromBytes(layers[2]),
 					Size:      int64(len(layers[2])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[3]),
+					Digest:    godigest.FromBytes(layers[3]),
 					Size:      int64(len(layers[3])),
 				},
 			},
@@ -1650,12 +1650,12 @@ func TestBaseImageList(t *testing.T) {
 			Layers: []ispec.Descriptor{
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[0]),
+					Digest:    godigest.FromBytes(layers[0]),
 					Size:      int64(len(layers[0])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[1]),
+					Digest:    godigest.FromBytes(layers[1]),
 					Size:      int64(len(layers[1])),
 				},
 			},
@@ -1693,12 +1693,12 @@ func TestBaseImageList(t *testing.T) {
 			Layers: []ispec.Descriptor{
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[0]),
+					Digest:    godigest.FromBytes(layers[0]),
 					Size:      int64(len(layers[0])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[1]),
+					Digest:    godigest.FromBytes(layers[1]),
 					Size:      int64(len(layers[1])),
 				},
 			},
@@ -1739,27 +1739,27 @@ func TestBaseImageList(t *testing.T) {
 			Layers: []ispec.Descriptor{
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[0]),
+					Digest:    godigest.FromBytes(layers[0]),
 					Size:      int64(len(layers[0])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[1]),
+					Digest:    godigest.FromBytes(layers[1]),
 					Size:      int64(len(layers[1])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[2]),
+					Digest:    godigest.FromBytes(layers[2]),
 					Size:      int64(len(layers[2])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[3]),
+					Digest:    godigest.FromBytes(layers[3]),
 					Size:      int64(len(layers[3])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[4]),
+					Digest:    godigest.FromBytes(layers[4]),
 					Size:      int64(len(layers[4])),
 				},
 			},
@@ -1797,12 +1797,12 @@ func TestBaseImageList(t *testing.T) {
 			Layers: []ispec.Descriptor{
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[0]),
+					Digest:    godigest.FromBytes(layers[0]),
 					Size:      int64(len(layers[0])),
 				},
 				{
 					MediaType: "application/vnd.oci.image.layer.v1.tar",
-					Digest:    digest.FromBytes(layers[1]),
+					Digest:    godigest.FromBytes(layers[1]),
 					Size:      int64(len(layers[1])),
 				},
 			},
@@ -2444,7 +2444,7 @@ func TestImageList(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		var imageConfigInfo ispec.Image
-		imageConfigBuf, err := imageStore.GetBlobContent(repos[0], imageManifest.Config.Digest.String())
+		imageConfigBuf, err := imageStore.GetBlobContent(repos[0], imageManifest.Config.Digest)
 		So(err, ShouldBeNil)
 		err = json.Unmarshal(imageConfigBuf, &imageConfigInfo)
 		So(err, ShouldBeNil)
@@ -2506,7 +2506,7 @@ func TestImageList(t *testing.T) {
 			OS:           "linux",
 			RootFS: ispec.RootFS{
 				Type:    "layers",
-				DiffIDs: []digest.Digest{},
+				DiffIDs: []godigest.Digest{},
 			},
 			Author:  "ZotUser",
 			History: []ispec.History{},
@@ -2515,8 +2515,8 @@ func TestImageList(t *testing.T) {
 		configBlob, err := json.Marshal(config)
 		So(err, ShouldBeNil)
 
-		configDigest := digest.FromBytes(configBlob)
-		layerDigest := digest.FromString(invalid)
+		configDigest := godigest.FromBytes(configBlob)
+		layerDigest := godigest.FromString(invalid)
 		layerblob := []byte(invalid)
 		schemaVersion := 2
 		ispecManifest := ispec.Manifest{
@@ -2623,7 +2623,7 @@ func TestBuildImageInfo(t *testing.T) {
 			OS:           "linux",
 			RootFS: ispec.RootFS{
 				Type:    "layers",
-				DiffIDs: []digest.Digest{},
+				DiffIDs: []godigest.Digest{},
 			},
 			Author: "ZotUser",
 			History: []ispec.History{ // should contain 3 elements, 2 of which corresponding to layers
@@ -2642,8 +2642,8 @@ func TestBuildImageInfo(t *testing.T) {
 		configBlob, err := json.Marshal(config)
 		So(err, ShouldBeNil)
 
-		configDigest := digest.FromBytes(configBlob)
-		layerDigest := digest.FromString(invalid)
+		configDigest := godigest.FromBytes(configBlob)
+		layerDigest := godigest.FromString(invalid)
 		layerblob := []byte(invalid)
 		schemaVersion := 2
 		ispecManifest := ispec.Manifest{
@@ -2666,7 +2666,7 @@ func TestBuildImageInfo(t *testing.T) {
 		manifestLayersSize := ispecManifest.Layers[0].Size
 		manifestBlob, err := json.Marshal(ispecManifest)
 		So(err, ShouldBeNil)
-		manifestDigest := digest.FromBytes(manifestBlob)
+		manifestDigest := godigest.FromBytes(manifestBlob)
 		err = UploadImage(
 			Image{
 				Manifest: ispecManifest,
@@ -2704,7 +2704,7 @@ func TestBaseOciLayoutUtils(t *testing.T) {
 
 	Convey("GetImageManifestSize fail", t, func() {
 		mockStoreController := mocks.MockedImageStore{
-			GetBlobContentFn: func(repo, digest string) ([]byte, error) {
+			GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
 				return []byte{}, ErrTestError
 			},
 		}
@@ -2718,7 +2718,7 @@ func TestBaseOciLayoutUtils(t *testing.T) {
 
 	Convey("GetImageConfigSize: fail GetImageBlobManifest", t, func() {
 		mockStoreController := mocks.MockedImageStore{
-			GetBlobContentFn: func(repo, digest string) ([]byte, error) {
+			GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
 				return []byte{}, ErrTestError
 			},
 		}
@@ -2732,8 +2732,8 @@ func TestBaseOciLayoutUtils(t *testing.T) {
 
 	Convey("GetImageConfigSize: config GetBlobContent fail", t, func() {
 		mockStoreController := mocks.MockedImageStore{
-			GetBlobContentFn: func(_, digest string) ([]byte, error) {
-				if digest == manifestDigest {
+			GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+				if digest.String() == manifestDigest {
 					return []byte{}, ErrTestError
 				}
 
@@ -2929,7 +2929,7 @@ func TestImageSummary(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		configBlob, errConfig := json.Marshal(config)
-		configDigest := digest.FromBytes(configBlob)
+		configDigest := godigest.FromBytes(configBlob)
 		So(errConfig, ShouldBeNil) // marshall success, config is valid JSON
 		go startServer(ctlr)
 		defer stopServer(ctlr)
@@ -2938,7 +2938,7 @@ func TestImageSummary(t *testing.T) {
 		manifestBlob, errMarsal := json.Marshal(manifest)
 		So(errMarsal, ShouldBeNil)
 		So(manifestBlob, ShouldNotBeNil)
-		manifestDigest := digest.FromBytes(manifestBlob)
+		manifestDigest := godigest.FromBytes(manifestBlob)
 		repoName := "test-repo" //nolint:goconst
 
 		tagTarget := "latest"
@@ -2979,11 +2979,11 @@ func TestImageSummary(t *testing.T) {
 
 		imgSummary := imgSummaryResponse.SingleImageSummary.ImageSummary
 		So(imgSummary.RepoName, ShouldContainSubstring, repoName)
-		So(imgSummary.ConfigDigest, ShouldContainSubstring, configDigest.Hex())
-		So(imgSummary.Digest, ShouldContainSubstring, manifestDigest.Hex())
+		So(imgSummary.ConfigDigest, ShouldContainSubstring, configDigest.Encoded())
+		So(imgSummary.Digest, ShouldContainSubstring, manifestDigest.Encoded())
 		So(len(imgSummary.Layers), ShouldEqual, 1)
 		So(imgSummary.Layers[0].Digest, ShouldContainSubstring,
-			digest.FromBytes(layers[0]).Hex())
+			godigest.FromBytes(layers[0]).Encoded())
 
 		t.Log("starting Test retrieve duplicated image same layers based on image identifier")
 		// gqlEndpoint

--- a/pkg/extensions/search/cve/cve.go
+++ b/pkg/extensions/search/cve/cve.go
@@ -3,8 +3,7 @@ package cveinfo
 import (
 	"fmt"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/opencontainers/go-digest"
+	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"zotregistry.io/zot/pkg/extensions/search/common"
@@ -31,8 +30,8 @@ type Scanner interface {
 
 type ImageInfoByCVE struct {
 	Tag      string
-	Digest   digest.Digest
-	Manifest v1.Manifest
+	Digest   godigest.Digest
+	Manifest ispec.Manifest
 }
 
 type ImageCVESummary struct {

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -15,9 +15,8 @@ import (
 	"testing"
 	"time"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	regTypes "github.com/google/go-containerregistry/pkg/v1/types"
-	"github.com/opencontainers/go-digest"
+	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
@@ -394,6 +393,8 @@ func TestDownloadDB(t *testing.T) {
 func TestCVESearch(t *testing.T) {
 	Convey("Test image vulnerability scanning", t, func() {
 		updateDuration, _ = time.ParseDuration("1h")
+		dbDir := "../../../../test/data"
+
 		port := GetFreePort()
 		baseURL := GetBaseURL(port)
 		conf := config.New()
@@ -785,7 +786,7 @@ func TestCVEStruct(t *testing.T) {
 							Annotations: map[string]string{
 								ispec.AnnotationRefName: "0.1.0",
 							},
-							Digest: "abcc",
+							Digest: godigest.FromString("abcc"),
 						},
 						{
 							MediaType: "application/vnd.oci.image.manifest.v1+json",
@@ -793,7 +794,7 @@ func TestCVEStruct(t *testing.T) {
 							Annotations: map[string]string{
 								ispec.AnnotationRefName: "1.0.0",
 							},
-							Digest: "abcd",
+							Digest: godigest.FromString("abcd"),
 						},
 						{
 							MediaType: "application/vnd.oci.image.manifest.v1+json",
@@ -801,7 +802,7 @@ func TestCVEStruct(t *testing.T) {
 							Annotations: map[string]string{
 								ispec.AnnotationRefName: "1.1.0",
 							},
-							Digest: "abce",
+							Digest: godigest.FromString("abce"),
 						},
 						{
 							MediaType: "application/vnd.oci.image.manifest.v1+json",
@@ -809,7 +810,7 @@ func TestCVEStruct(t *testing.T) {
 							Annotations: map[string]string{
 								ispec.AnnotationRefName: "1.0.1",
 							},
-							Digest: "abcf",
+							Digest: godigest.FromString("abcf"),
 						},
 					}, nil
 				}
@@ -823,7 +824,7 @@ func TestCVEStruct(t *testing.T) {
 							Annotations: map[string]string{
 								ispec.AnnotationRefName: "1.0.0",
 							},
-							Digest: "abcd",
+							Digest: godigest.FromString("abcd"),
 						},
 					}, nil
 				}
@@ -837,22 +838,22 @@ func TestCVEStruct(t *testing.T) {
 					return []common.TagInfo{
 						{
 							Name:      "0.1.0",
-							Digest:    "abcc",
+							Digest:    godigest.FromString("abcc"),
 							Timestamp: time.Date(2008, 1, 1, 12, 0, 0, 0, time.UTC),
 						},
 						{
 							Name:      "1.0.0",
-							Digest:    "abcd",
+							Digest:    godigest.FromString("abcd"),
 							Timestamp: time.Date(2009, 1, 1, 12, 0, 0, 0, time.UTC),
 						},
 						{
 							Name:      "1.1.0",
-							Digest:    "abce",
+							Digest:    godigest.FromString("abce"),
 							Timestamp: time.Date(2010, 1, 1, 12, 0, 0, 0, time.UTC),
 						},
 						{
 							Name:      "1.0.1",
-							Digest:    "abcf",
+							Digest:    godigest.FromString("abcf"),
 							Timestamp: time.Date(2011, 1, 1, 12, 0, 0, 0, time.UTC),
 						},
 					}, nil
@@ -863,7 +864,7 @@ func TestCVEStruct(t *testing.T) {
 					return []common.TagInfo{
 						{
 							Name:      "1.0.0",
-							Digest:    "abcd",
+							Digest:    godigest.FromString("abcd"),
 							Timestamp: time.Date(2009, 1, 1, 12, 0, 0, 0, time.UTC),
 						},
 					}, nil
@@ -872,15 +873,15 @@ func TestCVEStruct(t *testing.T) {
 				// By default do not return any tags
 				return []common.TagInfo{}, errors.ErrRepoNotFound
 			},
-			GetImageBlobManifestFn: func(imageDir string, digest digest.Digest) (v1.Manifest, error) {
+			GetImageBlobManifestFn: func(imageDir string, digest godigest.Digest) (ispec.Manifest, error) {
 				// Valid image for scanning
 				if imageDir == "repo1" { //nolint: goconst
-					return v1.Manifest{
-						Layers: []v1.Descriptor{
+					return ispec.Manifest{
+						Layers: []ispec.Descriptor{
 							{
-								MediaType: regTypes.OCILayer,
+								MediaType: ispec.MediaTypeImageLayer,
 								Size:      0,
-								Digest:    v1.Hash{},
+								Digest:    godigest.Digest(""),
 							},
 						},
 					}, nil
@@ -888,18 +889,18 @@ func TestCVEStruct(t *testing.T) {
 
 				// Image with non-scannable blob
 				if imageDir == "repo2" { //nolint: goconst
-					return v1.Manifest{
-						Layers: []v1.Descriptor{
+					return ispec.Manifest{
+						Layers: []ispec.Descriptor{
 							{
-								MediaType: regTypes.OCIRestrictedLayer,
+								MediaType: string(regTypes.OCIRestrictedLayer),
 								Size:      0,
-								Digest:    v1.Hash{},
+								Digest:    godigest.Digest(""),
 							},
 						},
 					}, nil
 				}
 
-				return v1.Manifest{}, errors.ErrBlobNotFound
+				return ispec.Manifest{}, errors.ErrBlobNotFound
 			},
 		}
 
@@ -1010,7 +1011,7 @@ func TestCVEStruct(t *testing.T) {
 
 					for _, imageLayer := range imageLayers {
 						switch imageLayer.MediaType {
-						case regTypes.OCILayer, regTypes.DockerLayer:
+						case ispec.MediaTypeImageLayer, ispec.MediaTypeImageLayerGzip, string(regTypes.DockerLayer):
 							return true, nil
 
 						default:
@@ -1211,9 +1212,9 @@ func TestCVEStruct(t *testing.T) {
 		Convey("Test error while reading blob manifest", func() {
 			localLayoutUtils := layoutUtils
 			localLayoutUtils.GetImageBlobManifestFn = func(imageDir string,
-				digest digest.Digest,
-			) (v1.Manifest, error) {
-				return v1.Manifest{}, errors.ErrBlobNotFound
+				digest godigest.Digest,
+			) (ispec.Manifest, error) {
+				return ispec.Manifest{}, errors.ErrBlobNotFound
 			}
 
 			cveInfo := cveinfo.BaseCveInfo{Log: log, Scanner: scanner, LayoutUtils: localLayoutUtils}

--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -167,7 +167,7 @@ func (scanner Scanner) IsImageFormatScannable(image string) (bool, error) {
 
 		for _, imageLayer := range imageLayers {
 			switch imageLayer.MediaType {
-			case regTypes.OCILayer, regTypes.DockerLayer:
+			case ispec.MediaTypeImageLayer, ispec.MediaTypeImageLayerGzip, string(regTypes.DockerLayer):
 				return true, nil
 
 			default:

--- a/pkg/extensions/search/cve/trivy/scanner_internal_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_internal_test.go
@@ -34,7 +34,7 @@ func generateTestImage(storeController storage.StoreController, image string) {
 	for _, layerBlob := range layers {
 		layerReader := bytes.NewReader(layerBlob)
 		layerDigest := godigest.FromBytes(layerBlob)
-		_, _, err = store.FullBlobUpload(repoName, layerReader, layerDigest.String())
+		_, _, err = store.FullBlobUpload(repoName, layerReader, layerDigest)
 		So(err, ShouldBeNil)
 	}
 
@@ -42,7 +42,7 @@ func generateTestImage(storeController storage.StoreController, image string) {
 	So(err, ShouldBeNil)
 	configReader := bytes.NewReader(configBlob)
 	configDigest := godigest.FromBytes(configBlob)
-	_, _, err = store.FullBlobUpload(repoName, configReader, configDigest.String())
+	_, _, err = store.FullBlobUpload(repoName, configReader, configDigest)
 	So(err, ShouldBeNil)
 
 	manifestBlob, err := json.Marshal(manifest)

--- a/pkg/extensions/search/digest/digest.go
+++ b/pkg/extensions/search/digest/digest.go
@@ -3,8 +3,7 @@ package digestinfo
 import (
 	"strings"
 
-	v1 "github.com/google/go-containerregistry/pkg/v1"
-	"github.com/opencontainers/go-digest"
+	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"zotregistry.io/zot/pkg/extensions/search/common"
@@ -20,8 +19,8 @@ type DigestInfo struct {
 
 type ImageInfoByDigest struct {
 	Tag      string
-	Digest   digest.Digest
-	Manifest v1.Manifest
+	Digest   godigest.Digest
+	Manifest ispec.Manifest
 }
 
 // NewDigestInfo initializes a new DigestInfo object.
@@ -64,14 +63,14 @@ func (digestinfo DigestInfo) GetImageTagsByDigest(repo, digest string) ([]ImageI
 
 			// Check the image config matches the search digest
 			// This is a blob with mediaType application/vnd.oci.image.config.v1+json
-			if strings.Contains(imageBlobManifest.Config.Digest.Algorithm+":"+imageBlobManifest.Config.Digest.Hex, digest) {
+			if strings.Contains(imageBlobManifest.Config.Digest.String(), digest) {
 				tags = append(tags, &val)
 			}
 
 			// Check to see if the individual layers in the oci image manifest match the digest
 			// These are blobs with mediaType application/vnd.oci.image.layer.v1.tar+gzip
 			for _, layer := range imageBlobManifest.Layers {
-				if strings.Contains(layer.Digest.Algorithm+":"+layer.Digest.Hex, digest) {
+				if strings.Contains(layer.Digest.String(), digest) {
 					tags = append(tags, &val)
 				}
 			}

--- a/pkg/extensions/sync/sync.go
+++ b/pkg/extensions/sync/sync.go
@@ -336,7 +336,7 @@ func syncRegistry(ctx context.Context, regCfg RegistryConfig,
 
 			tag := getTagFromRef(upstreamImageRef, log).Tag()
 
-			skipImage, err := canSkipImage(localRepo, tag, upstreamImageDigest.String(), imageStore, log)
+			skipImage, err := canSkipImage(localRepo, tag, upstreamImageDigest, imageStore, log)
 			if err != nil {
 				log.Error().Err(err).Msgf("couldn't check if the upstream image %s can be skipped",
 					upstreamImageRef.DockerReference())

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -374,14 +374,14 @@ func TestSyncInternal(t *testing.T) {
 
 		sig := newSignaturesCopier(resty.New(), *regURL, storage.StoreController{DefaultStore: imageStore}, log)
 
-		canBeSkipped, err = sig.canSkipNotarySignature(testImage, testImageManifestDigest, refs)
+		canBeSkipped, err = sig.canSkipNotarySignature(testImage, testImageManifestDigest.String(), refs)
 		So(err, ShouldBeNil)
 		So(canBeSkipped, ShouldBeFalse)
 
 		err = os.Chmod(path.Join(imageStore.RootDir(), testImage, "index.json"), 0o000)
 		So(err, ShouldBeNil)
 
-		canBeSkipped, err = sig.canSkipNotarySignature(testImage, testImageManifestDigest, refs)
+		canBeSkipped, err = sig.canSkipNotarySignature(testImage, testImageManifestDigest.String(), refs)
 		So(err, ShouldNotBeNil)
 		So(canBeSkipped, ShouldBeFalse)
 
@@ -392,7 +392,7 @@ func TestSyncInternal(t *testing.T) {
 		err = os.Chmod(path.Join(imageStore.RootDir(), testImage, "index.json"), 0o755)
 		So(err, ShouldBeNil)
 
-		canBeSkipped, err = sig.canSkipCosignSignature(testImage, testImageManifestDigest, &cosignManifest)
+		canBeSkipped, err = sig.canSkipCosignSignature(testImage, testImageManifestDigest.String(), &cosignManifest)
 		So(err, ShouldBeNil)
 		So(canBeSkipped, ShouldBeFalse)
 	})
@@ -480,7 +480,7 @@ func TestSyncInternal(t *testing.T) {
 
 				for _, layer := range layers {
 					// upload layer
-					_, _, err := testImageStore.FullBlobUpload(repo, bytes.NewReader(layer), godigest.FromBytes(layer).String())
+					_, _, err := testImageStore.FullBlobUpload(repo, bytes.NewReader(layer), godigest.FromBytes(layer))
 					So(err, ShouldBeNil)
 				}
 
@@ -489,7 +489,7 @@ func TestSyncInternal(t *testing.T) {
 
 				configDigest := godigest.FromBytes(configContent)
 
-				_, _, err = testImageStore.FullBlobUpload(repo, bytes.NewReader(configContent), configDigest.String())
+				_, _, err = testImageStore.FullBlobUpload(repo, bytes.NewReader(configContent), configDigest)
 				So(err, ShouldBeNil)
 
 				manifestContent, err := json.Marshal(manifest)
@@ -612,7 +612,7 @@ func TestSyncInternal(t *testing.T) {
 			}
 
 			if err := os.Chmod(path.Join(testRootDir, testImage, "blobs", "sha256",
-				manifest.Layers[0].Digest.Hex()), 0o000); err != nil {
+				manifest.Layers[0].Digest.Encoded()), 0o000); err != nil {
 				panic(err)
 			}
 
@@ -620,12 +620,12 @@ func TestSyncInternal(t *testing.T) {
 			So(err, ShouldNotBeNil)
 
 			if err := os.Chmod(path.Join(testRootDir, testImage, "blobs", "sha256",
-				manifest.Layers[0].Digest.Hex()), 0o755); err != nil {
+				manifest.Layers[0].Digest.Encoded()), 0o755); err != nil {
 				panic(err)
 			}
 
 			cachedManifestConfigPath := path.Join(imageStore.RootDir(), testImage, SyncBlobUploadDir,
-				testImage, "blobs", "sha256", manifest.Config.Digest.Hex())
+				testImage, "blobs", "sha256", manifest.Config.Digest.Encoded())
 			if err := os.Chmod(cachedManifestConfigPath, 0o000); err != nil {
 				panic(err)
 			}

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -2356,7 +2356,7 @@ func TestPeriodicallySignaturesErr(t *testing.T) {
 		Convey("Trigger error on image manifest", func() {
 			// trigger permission denied on image manifest
 			manifestPath := path.Join(srcDir, repoName, "blobs",
-				string(imageManifestDigest.Algorithm()), imageManifestDigest.Hex())
+				string(imageManifestDigest.Algorithm()), imageManifestDigest.Encoded())
 			err = os.Chmod(manifestPath, 0o000)
 			So(err, ShouldBeNil)
 
@@ -2373,7 +2373,7 @@ func TestPeriodicallySignaturesErr(t *testing.T) {
 
 		Convey("Trigger error on cosign signature", func() {
 			// trigger permission error on cosign signature on upstream
-			cosignTag := string(imageManifestDigest.Algorithm()) + "-" + imageManifestDigest.Hex() +
+			cosignTag := string(imageManifestDigest.Algorithm()) + "-" + imageManifestDigest.Encoded() +
 				"." + remote.SignatureTagSuffix
 
 			getCosignManifestURL := srcBaseURL + path.Join(constants.RoutePrefix, repoName, "manifests", cosignTag)
@@ -2386,7 +2386,7 @@ func TestPeriodicallySignaturesErr(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			for _, blob := range cm.Layers {
-				blobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
+				blobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Encoded())
 				err := os.Chmod(blobPath, 0o000)
 				So(err, ShouldBeNil)
 			}
@@ -2424,7 +2424,7 @@ func TestPeriodicallySignaturesErr(t *testing.T) {
 			// read manifest
 			var artifactManifest artifactspec.Manifest
 			for _, ref := range referrers.References {
-				refPath := path.Join(srcDir, repoName, "blobs", string(ref.Digest.Algorithm()), ref.Digest.Hex())
+				refPath := path.Join(srcDir, repoName, "blobs", string(ref.Digest.Algorithm()), ref.Digest.Encoded())
 				body, err := os.ReadFile(refPath)
 				So(err, ShouldBeNil)
 
@@ -2433,7 +2433,7 @@ func TestPeriodicallySignaturesErr(t *testing.T) {
 
 				// triggers perm denied on sig blobs
 				for _, blob := range artifactManifest.Blobs {
-					blobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
+					blobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Encoded())
 					err := os.Chmod(blobPath, 0o000)
 					So(err, ShouldBeNil)
 				}
@@ -2592,7 +2592,7 @@ func TestSignatures(t *testing.T) {
 
 		var artifactManifest artifactspec.Manifest
 		for _, ref := range referrers.References {
-			refPath := path.Join(srcDir, repoName, "blobs", string(ref.Digest.Algorithm()), ref.Digest.Hex())
+			refPath := path.Join(srcDir, repoName, "blobs", string(ref.Digest.Algorithm()), ref.Digest.Encoded())
 			body, err := os.ReadFile(refPath)
 			So(err, ShouldBeNil)
 
@@ -2601,7 +2601,7 @@ func TestSignatures(t *testing.T) {
 
 			// triggers perm denied on notary sig blobs on downstream
 			for _, blob := range artifactManifest.Blobs {
-				blobPath := path.Join(destDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
+				blobPath := path.Join(destDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Encoded())
 				err := os.MkdirAll(blobPath, 0o755)
 				So(err, ShouldBeNil)
 				err = os.Chmod(blobPath, 0o000)
@@ -2620,7 +2620,7 @@ func TestSignatures(t *testing.T) {
 
 		// triggers perm denied on notary manifest on downstream
 		for _, ref := range referrers.References {
-			refPath := path.Join(destDir, repoName, "blobs", string(ref.Digest.Algorithm()), ref.Digest.Hex())
+			refPath := path.Join(destDir, repoName, "blobs", string(ref.Digest.Algorithm()), ref.Digest.Encoded())
 			err := os.MkdirAll(refPath, 0o755)
 			So(err, ShouldBeNil)
 			err = os.Chmod(refPath, 0o000)
@@ -2634,7 +2634,7 @@ func TestSignatures(t *testing.T) {
 
 		// triggers perm denied on sig blobs
 		for _, blob := range artifactManifest.Blobs {
-			blobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
+			blobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Encoded())
 			err := os.Chmod(blobPath, 0o000)
 			So(err, ShouldBeNil)
 		}
@@ -2679,7 +2679,7 @@ func TestSignatures(t *testing.T) {
 		cosignManifestDigest := godigest.FromBytes(buf)
 
 		for _, blob := range imageManifest.Layers {
-			blobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
+			blobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Encoded())
 			err := os.Chmod(blobPath, 0o000)
 			So(err, ShouldBeNil)
 		}
@@ -2698,11 +2698,11 @@ func TestSignatures(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		for _, blob := range imageManifest.Layers {
-			srcBlobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
+			srcBlobPath := path.Join(srcDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Encoded())
 			err := os.Chmod(srcBlobPath, 0o755)
 			So(err, ShouldBeNil)
 
-			destBlobPath := path.Join(destDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
+			destBlobPath := path.Join(destDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Encoded())
 			err = os.MkdirAll(destBlobPath, 0o755)
 			So(err, ShouldBeNil)
 			err = os.Chmod(destBlobPath, 0o755)
@@ -2715,7 +2715,7 @@ func TestSignatures(t *testing.T) {
 		So(resp.StatusCode(), ShouldEqual, 200)
 
 		for _, blob := range imageManifest.Layers {
-			destBlobPath := path.Join(destDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Hex())
+			destBlobPath := path.Join(destDir, repoName, "blobs", string(blob.Digest.Algorithm()), blob.Digest.Encoded())
 			err = os.Chmod(destBlobPath, 0o755)
 			So(err, ShouldBeNil)
 			err = os.Remove(destBlobPath)
@@ -2724,7 +2724,7 @@ func TestSignatures(t *testing.T) {
 
 		// trigger error on upstream config blob
 		srcConfigBlobPath := path.Join(srcDir, repoName, "blobs", string(imageManifest.Config.Digest.Algorithm()),
-			imageManifest.Config.Digest.Hex())
+			imageManifest.Config.Digest.Encoded())
 		err = os.Chmod(srcConfigBlobPath, 0o000)
 		So(err, ShouldBeNil)
 
@@ -2746,7 +2746,7 @@ func TestSignatures(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		destConfigBlobPath := path.Join(destDir, repoName, "blobs", string(imageManifest.Config.Digest.Algorithm()),
-			imageManifest.Config.Digest.Hex())
+			imageManifest.Config.Digest.Encoded())
 
 		err = os.MkdirAll(destConfigBlobPath, 0o755)
 		So(err, ShouldBeNil)
@@ -2764,7 +2764,7 @@ func TestSignatures(t *testing.T) {
 
 		// trigger error on downstream manifest
 		destManifestPath := path.Join(destDir, repoName, "blobs", string(cosignManifestDigest.Algorithm()),
-			cosignManifestDigest.Hex())
+			cosignManifestDigest.Encoded())
 		err = os.MkdirAll(destManifestPath, 0o755)
 		So(err, ShouldBeNil)
 		err = os.Chmod(destManifestPath, 0o000)
@@ -3277,7 +3277,7 @@ func TestSignaturesOnDemand(t *testing.T) {
 		// trigger errors on cosign blobs
 		// trigger error on cosign config blob
 		srcConfigBlobPath := path.Join(srcDir, repoName, "blobs", string(imageManifest.Config.Digest.Algorithm()),
-			imageManifest.Config.Digest.Hex())
+			imageManifest.Config.Digest.Encoded())
 		err = os.Chmod(srcConfigBlobPath, 0o000)
 		So(err, ShouldBeNil)
 
@@ -3292,7 +3292,7 @@ func TestSignaturesOnDemand(t *testing.T) {
 
 		// trigger error on cosign layer blob
 		srcSignatureBlobPath := path.Join(srcDir, repoName, "blobs", string(imageManifest.Layers[0].Digest.Algorithm()),
-			imageManifest.Layers[0].Digest.Hex())
+			imageManifest.Layers[0].Digest.Encoded())
 
 		err = os.Chmod(srcConfigBlobPath, 0o755)
 		So(err, ShouldBeNil)

--- a/pkg/extensions/sync/utils.go
+++ b/pkg/extensions/sync/utils.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/image/v5/oci/layout"
 	"github.com/containers/image/v5/types"
 	guuid "github.com/gofrs/uuid"
+	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"github.com/sigstore/cosign/pkg/oci/static"
@@ -374,7 +375,7 @@ func pushSyncedLocalImage(localRepo, tag, localCachePath string,
 	}
 
 	for _, manifest := range indexManifest.Manifests {
-		manifestBuf, err := cacheImageStore.GetBlobContent(localRepo, manifest.Digest.String())
+		manifestBuf, err := cacheImageStore.GetBlobContent(localRepo, manifest.Digest)
 		if err != nil {
 			log.Error().Str("errorType", TypeOf(err)).
 				Err(err).Str("dir", path.Join(cacheImageStore.RootDir(), localRepo)).Str("digest", manifest.Digest.String()).
@@ -423,14 +424,14 @@ func copyManifest(localRepo string, manifestContent []byte, reference string,
 	}
 
 	for _, blob := range manifest.Layers {
-		err = copyBlob(localRepo, blob.Digest.String(), blob.MediaType,
+		err = copyBlob(localRepo, blob.Digest, blob.MediaType,
 			cacheImageStore, imageStore, log)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = copyBlob(localRepo, manifest.Config.Digest.String(), manifest.Config.MediaType,
+	err = copyBlob(localRepo, manifest.Config.Digest, manifest.Config.MediaType,
 		cacheImageStore, imageStore, log)
 	if err != nil {
 		return err
@@ -449,7 +450,7 @@ func copyManifest(localRepo string, manifestContent []byte, reference string,
 }
 
 // Copy a blob from one image store to another image store.
-func copyBlob(localRepo, blobDigest, blobMediaType string,
+func copyBlob(localRepo string, blobDigest godigest.Digest, blobMediaType string,
 	souceImageStore, destinationImageStore storage.ImageStore, log log.Logger,
 ) error {
 	if found, _, _ := destinationImageStore.CheckBlob(localRepo, blobDigest); found {
@@ -461,7 +462,7 @@ func copyBlob(localRepo, blobDigest, blobMediaType string,
 	if err != nil {
 		log.Error().Str("errorType", TypeOf(err)).Err(err).
 			Str("dir", path.Join(souceImageStore.RootDir(), localRepo)).
-			Str("blob digest", blobDigest).Str("media type", blobMediaType).
+			Str("blob digest", blobDigest.String()).Str("media type", blobMediaType).
 			Msg("couldn't read blob")
 
 		return err
@@ -471,7 +472,7 @@ func copyBlob(localRepo, blobDigest, blobMediaType string,
 	_, _, err = destinationImageStore.FullBlobUpload(localRepo, blobReadCloser, blobDigest)
 	if err != nil {
 		log.Error().Str("errorType", TypeOf(err)).Err(err).
-			Str("blob digest", blobDigest).Str("media type", blobMediaType).
+			Str("blob digest", blobDigest.String()).Str("media type", blobMediaType).
 			Msg("couldn't upload blob")
 	}
 
@@ -554,7 +555,8 @@ func getLocalCachePath(imageStore storage.ImageStore, repo string) (string, erro
 }
 
 // canSkipImage returns whether or not we already synced this image.
-func canSkipImage(repo, tag, digest string, imageStore storage.ImageStore, log log.Logger) (bool, error) {
+func canSkipImage(repo, tag string, digest godigest.Digest, imageStore storage.ImageStore, log log.Logger,
+) (bool, error) {
 	// check image already synced
 	_, localImageManifestDigest, _, err := imageStore.GetImageManifest(repo, tag)
 	if err != nil {

--- a/pkg/storage/common_test.go
+++ b/pkg/storage/common_test.go
@@ -31,12 +31,12 @@ func TestValidateManifest(t *testing.T) {
 		digest := godigest.FromBytes(content)
 		So(digest, ShouldNotBeNil)
 
-		_, blen, err := imgStore.FullBlobUpload("test", bytes.NewReader(content), digest.String())
+		_, blen, err := imgStore.FullBlobUpload("test", bytes.NewReader(content), digest)
 		So(err, ShouldBeNil)
 		So(blen, ShouldEqual, len(content))
 
 		cblob, cdigest := test.GetRandomImageConfig()
-		_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest.String())
+		_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -390,7 +390,7 @@ func (is *ImageStoreLocal) GetImageTags(repo string) ([]string, error) {
 }
 
 // GetImageManifest returns the image manifest of an image in the specific repository.
-func (is *ImageStoreLocal) GetImageManifest(repo, reference string) ([]byte, string, string, error) {
+func (is *ImageStoreLocal) GetImageManifest(repo, reference string) ([]byte, godigest.Digest, string, error) {
 	dir := path.Join(is.rootDir, repo)
 	if !is.DirExists(dir) {
 		return nil, "", "", zerr.ErrRepoNotFound
@@ -406,7 +406,7 @@ func (is *ImageStoreLocal) GetImageManifest(repo, reference string) ([]byte, str
 		return nil, "", "", zerr.ErrManifestNotFound
 	}
 
-	buf, err := is.GetBlobContent(repo, manifestDesc.Digest.String())
+	buf, err := is.GetBlobContent(repo, manifestDesc.Digest)
 	if err != nil {
 		if errors.Is(err, zerr.ErrBlobNotFound) {
 			return nil, "", "", zerr.ErrManifestNotFound
@@ -424,22 +424,22 @@ func (is *ImageStoreLocal) GetImageManifest(repo, reference string) ([]byte, str
 
 	monitoring.IncDownloadCounter(is.metrics, repo)
 
-	return buf, manifestDesc.Digest.String(), manifestDesc.MediaType, nil
+	return buf, manifestDesc.Digest, manifestDesc.MediaType, nil
 }
 
 // PutImageManifest adds an image manifest to the repository.
 func (is *ImageStoreLocal) PutImageManifest(repo, reference, mediaType string, //nolint: gocyclo
 	body []byte,
-) (string, error) {
+) (godigest.Digest, error) {
 	if err := is.InitRepo(repo); err != nil {
 		is.log.Debug().Err(err).Msg("init repo")
 
 		return "", err
 	}
 
-	dig, err := storage.ValidateManifest(is, repo, reference, mediaType, body, is.log)
+	digest, err := storage.ValidateManifest(is, repo, reference, mediaType, body, is.log)
 	if err != nil {
-		return dig, err
+		return digest, err
 	}
 
 	refIsDigest := true
@@ -447,7 +447,7 @@ func (is *ImageStoreLocal) PutImageManifest(repo, reference, mediaType string, /
 	mDigest, err := storage.GetAndValidateRequestDigest(body, reference, is.log)
 	if err != nil {
 		if errors.Is(err, zerr.ErrBadManifest) {
-			return mDigest.String(), err
+			return mDigest, err
 		}
 
 		refIsDigest = false
@@ -473,7 +473,7 @@ func (is *ImageStoreLocal) PutImageManifest(repo, reference, mediaType string, /
 	}
 
 	if !updateIndex {
-		return desc.Digest.String(), nil
+		return desc.Digest, nil
 	}
 
 	var lockLatency time.Time
@@ -543,7 +543,7 @@ func (is *ImageStoreLocal) PutImageManifest(repo, reference, mediaType string, /
 	monitoring.SetStorageUsage(is.metrics, is.rootDir, repo)
 	monitoring.IncUploadCounter(is.metrics, repo)
 
-	return desc.Digest.String(), nil
+	return desc.Digest, nil
 }
 
 // DeleteImageManifest deletes the image manifest from the repository.
@@ -778,17 +778,14 @@ func (is *ImageStoreLocal) BlobUploadInfo(repo, uuid string) (int64, error) {
 }
 
 // FinishBlobUpload finalizes the blob upload and moves blob the repository.
-func (is *ImageStoreLocal) FinishBlobUpload(repo, uuid string, body io.Reader, digest string) error {
-	dstDigest, err := godigest.Parse(digest)
-	if err != nil {
-		is.log.Error().Err(err).Str("digest", digest).Msg("failed to parse digest")
-
-		return zerr.ErrBadBlobDigest
+func (is *ImageStoreLocal) FinishBlobUpload(repo, uuid string, body io.Reader, dstDigest godigest.Digest) error {
+	if err := dstDigest.Validate(); err != nil {
+		return err
 	}
 
 	src := is.BlobUploadPath(repo, uuid)
 
-	_, err = os.Stat(src)
+	_, err := os.Stat(src)
 	if err != nil {
 		is.log.Error().Err(err).Str("blob", src).Msg("failed to stat blob")
 
@@ -808,7 +805,8 @@ func (is *ImageStoreLocal) FinishBlobUpload(repo, uuid string, body io.Reader, d
 
 	_, err = io.Copy(digester, blobFile)
 	if err != nil {
-		is.log.Error().Err(err).Str("repo", repo).Str("blob", src).Str("digest", digest).Msg("unable to compute hash")
+		is.log.Error().Err(err).Str("repo", repo).Str("blob", src).Str("digest", dstDigest.String()).
+			Msg("unable to compute hash")
 
 		return err
 	}
@@ -859,16 +857,14 @@ func (is *ImageStoreLocal) FinishBlobUpload(repo, uuid string, body io.Reader, d
 }
 
 // FullBlobUpload handles a full blob upload, and no partial session is created.
-func (is *ImageStoreLocal) FullBlobUpload(repo string, body io.Reader, digest string) (string, int64, error) {
-	if err := is.InitRepo(repo); err != nil {
+func (is *ImageStoreLocal) FullBlobUpload(repo string, body io.Reader, dstDigest godigest.Digest,
+) (string, int64, error) {
+	if err := dstDigest.Validate(); err != nil {
 		return "", -1, err
 	}
 
-	dstDigest, err := godigest.Parse(digest)
-	if err != nil {
-		is.log.Error().Err(err).Str("digest", digest).Msg("failed to parse digest")
-
-		return "", -1, zerr.ErrBadBlobDigest
+	if err := is.InitRepo(repo); err != nil {
+		return "", -1, err
 	}
 
 	u, err := guuid.NewV4()
@@ -944,7 +940,7 @@ func (is *ImageStoreLocal) DedupeBlob(src string, dstDigest godigest.Digest, dst
 retry:
 	is.log.Debug().Str("src", src).Str("dstDigest", dstDigest.String()).Str("dst", dst).Msg("dedupe: enter")
 
-	dstRecord, err := is.cache.GetBlob(dstDigest.String())
+	dstRecord, err := is.cache.GetBlob(dstDigest)
 
 	if err != nil && !errors.Is(err, zerr.ErrCacheMiss) {
 		is.log.Error().Err(err).Str("blobPath", dst).Msg("dedupe: unable to lookup blob record")
@@ -954,7 +950,7 @@ retry:
 
 	if dstRecord == "" {
 		// cache record doesn't exist, so first disk and cache entry for this diges
-		if err := is.cache.PutBlob(dstDigest.String(), dst); err != nil {
+		if err := is.cache.PutBlob(dstDigest, dst); err != nil {
 			is.log.Error().Err(err).Str("blobPath", dst).Msg("dedupe: unable to insert blob record")
 
 			return err
@@ -977,7 +973,7 @@ retry:
 		if err != nil {
 			is.log.Error().Err(err).Str("blobPath", dstRecord).Msg("dedupe: unable to stat")
 			// the actual blob on disk may have been removed by GC, so sync the cache
-			if err := is.cache.DeleteBlob(dstDigest.String(), dstRecord); err != nil {
+			if err := is.cache.DeleteBlob(dstDigest, dstRecord); err != nil {
 				//nolint:lll // gofumpt conflicts with lll
 				is.log.Error().Err(err).Str("dstDigest", dstDigest.String()).Str("dst", dst).Msg("dedupe: unable to delete blob record")
 
@@ -1041,17 +1037,14 @@ func (is *ImageStoreLocal) BlobPath(repo string, digest godigest.Digest) string 
 }
 
 // CheckBlob verifies a blob and returns true if the blob is correct.
-func (is *ImageStoreLocal) CheckBlob(repo, digest string) (bool, int64, error) {
+func (is *ImageStoreLocal) CheckBlob(repo string, digest godigest.Digest) (bool, int64, error) {
 	var lockLatency time.Time
 
-	parsedDigest, err := godigest.Parse(digest)
-	if err != nil {
-		is.log.Error().Err(err).Str("digest", digest).Msg("failed to parse digest")
-
-		return false, -1, zerr.ErrBadBlobDigest
+	if err := digest.Validate(); err != nil {
+		return false, -1, err
 	}
 
-	blobPath := is.BlobPath(repo, parsedDigest)
+	blobPath := is.BlobPath(repo, digest)
 
 	if is.dedupe && is.cache != nil {
 		is.Lock(&lockLatency)
@@ -1073,7 +1066,7 @@ func (is *ImageStoreLocal) CheckBlob(repo, digest string) (bool, int64, error) {
 	// Check blobs in cache
 	dstRecord, err := is.checkCacheBlob(digest)
 	if err != nil {
-		is.log.Error().Err(err).Str("digest", digest).Msg("cache: not found")
+		is.log.Error().Err(err).Str("digest", digest.String()).Msg("cache: not found")
 
 		return false, -1, zerr.ErrBlobNotFound
 	}
@@ -1093,7 +1086,11 @@ func (is *ImageStoreLocal) CheckBlob(repo, digest string) (bool, int64, error) {
 	return true, blobSize, nil
 }
 
-func (is *ImageStoreLocal) checkCacheBlob(digest string) (string, error) {
+func (is *ImageStoreLocal) checkCacheBlob(digest godigest.Digest) (string, error) {
+	if err := digest.Validate(); err != nil {
+		return "", err
+	}
+
 	if !is.dedupe || is.cache == nil {
 		return "", zerr.ErrBlobNotFound
 	}
@@ -1110,7 +1107,8 @@ func (is *ImageStoreLocal) checkCacheBlob(digest string) (string, error) {
 
 		// the actual blob on disk may have been removed by GC, so sync the cache
 		if err := is.cache.DeleteBlob(digest, dstRecord); err != nil {
-			is.log.Error().Err(err).Str("digest", digest).Str("blobPath", dstRecord).Msg("unable to remove blob path from cache")
+			is.log.Error().Err(err).Str("digest", digest.String()).Str("blobPath", dstRecord).
+				Msg("unable to remove blob path from cache")
 
 			return "", err
 		}
@@ -1118,7 +1116,7 @@ func (is *ImageStoreLocal) checkCacheBlob(digest string) (string, error) {
 		return "", zerr.ErrBlobNotFound
 	}
 
-	is.log.Debug().Str("digest", digest).Str("dstRecord", dstRecord).Msg("cache: found dedupe record")
+	is.log.Debug().Str("digest", digest.String()).Str("dstRecord", dstRecord).Msg("cache: found dedupe record")
 
 	return dstRecord, nil
 }
@@ -1186,18 +1184,15 @@ func (bs *blobStream) Close() error {
 
 // GetBlobPartial returns a partial stream to read the blob.
 // blob selector instead of directly downloading the blob.
-func (is *ImageStoreLocal) GetBlobPartial(repo, digest, mediaType string, from, to int64,
+func (is *ImageStoreLocal) GetBlobPartial(repo string, digest godigest.Digest, mediaType string, from, to int64,
 ) (io.ReadCloser, int64, int64, error) {
 	var lockLatency time.Time
 
-	parsedDigest, err := godigest.Parse(digest)
-	if err != nil {
-		is.log.Error().Err(err).Str("digest", digest).Msg("failed to parse digest")
-
-		return nil, -1, -1, zerr.ErrBadBlobDigest
+	if err := digest.Validate(); err != nil {
+		return nil, -1, -1, err
 	}
 
-	blobPath := is.BlobPath(repo, parsedDigest)
+	blobPath := is.BlobPath(repo, digest)
 
 	is.RLock(&lockLatency)
 	defer is.RUnlock(&lockLatency)
@@ -1226,17 +1221,15 @@ func (is *ImageStoreLocal) GetBlobPartial(repo, digest, mediaType string, from, 
 
 // GetBlob returns a stream to read the blob.
 // blob selector instead of directly downloading the blob.
-func (is *ImageStoreLocal) GetBlob(repo, digest, mediaType string) (io.ReadCloser, int64, error) {
+func (is *ImageStoreLocal) GetBlob(repo string, digest godigest.Digest, mediaType string,
+) (io.ReadCloser, int64, error) {
 	var lockLatency time.Time
 
-	parsedDigest, err := godigest.Parse(digest)
-	if err != nil {
-		is.log.Error().Err(err).Str("digest", digest).Msg("failed to parse digest")
-
-		return nil, -1, zerr.ErrBadBlobDigest
+	if err := digest.Validate(); err != nil {
+		return nil, -1, err
 	}
 
-	blobPath := is.BlobPath(repo, parsedDigest)
+	blobPath := is.BlobPath(repo, digest)
 
 	is.RLock(&lockLatency)
 	defer is.RUnlock(&lockLatency)
@@ -1259,7 +1252,11 @@ func (is *ImageStoreLocal) GetBlob(repo, digest, mediaType string) (io.ReadClose
 	return blobReadCloser, binfo.Size(), nil
 }
 
-func (is *ImageStoreLocal) GetBlobContent(repo, digest string) ([]byte, error) {
+func (is *ImageStoreLocal) GetBlobContent(repo string, digest godigest.Digest) ([]byte, error) {
+	if err := digest.Validate(); err != nil {
+		return []byte{}, err
+	}
+
 	blob, _, err := is.GetBlob(repo, digest, ispec.MediaTypeImageManifest)
 	if err != nil {
 		return []byte{}, err
@@ -1270,7 +1267,7 @@ func (is *ImageStoreLocal) GetBlobContent(repo, digest string) ([]byte, error) {
 
 	_, err = buf.ReadFrom(blob)
 	if err != nil {
-		is.log.Error().Err(err).Str("digest", digest).Msg("failed to read blob")
+		is.log.Error().Err(err).Str("digest", digest.String()).Msg("failed to read blob")
 
 		return []byte{}, err
 	}
@@ -1303,22 +1300,19 @@ func (is *ImageStoreLocal) GetIndexContent(repo string) ([]byte, error) {
 }
 
 // DeleteBlob removes the blob from the repository.
-func (is *ImageStoreLocal) DeleteBlob(repo, digest string) error {
+func (is *ImageStoreLocal) DeleteBlob(repo string, digest godigest.Digest) error {
 	var lockLatency time.Time
 
-	dgst, err := godigest.Parse(digest)
-	if err != nil {
-		is.log.Error().Err(err).Str("digest", digest).Msg("failed to parse digest")
-
-		return zerr.ErrBlobNotFound
+	if err := digest.Validate(); err != nil {
+		return err
 	}
 
-	blobPath := is.BlobPath(repo, dgst)
+	blobPath := is.BlobPath(repo, digest)
 
 	is.Lock(&lockLatency)
 	defer is.Unlock(&lockLatency)
 
-	_, err = os.Stat(blobPath)
+	_, err := os.Stat(blobPath)
 	if err != nil {
 		is.log.Error().Err(err).Str("blob", blobPath).Msg("failed to stat blob")
 
@@ -1327,7 +1321,8 @@ func (is *ImageStoreLocal) DeleteBlob(repo, digest string) error {
 
 	if is.cache != nil {
 		if err := is.cache.DeleteBlob(digest, blobPath); err != nil {
-			is.log.Error().Err(err).Str("digest", digest).Str("blobPath", blobPath).Msg("unable to remove blob path from cache")
+			is.log.Error().Err(err).Str("digest", digest.String()).Str("blobPath", blobPath).
+				Msg("unable to remove blob path from cache")
 
 			return err
 		}
@@ -1342,19 +1337,17 @@ func (is *ImageStoreLocal) DeleteBlob(repo, digest string) error {
 	return nil
 }
 
-func (is *ImageStoreLocal) GetReferrers(repo, digest, artifactType string) ([]artifactspec.Descriptor, error) {
+func (is *ImageStoreLocal) GetReferrers(repo string, gdigest godigest.Digest, artifactType string,
+) ([]artifactspec.Descriptor, error) {
 	var lockLatency time.Time
+
+	if err := gdigest.Validate(); err != nil {
+		return nil, err
+	}
 
 	dir := path.Join(is.rootDir, repo)
 	if !is.DirExists(dir) {
 		return nil, zerr.ErrRepoNotFound
-	}
-
-	gdigest, err := godigest.Parse(digest)
-	if err != nil {
-		is.log.Error().Err(err).Str("digest", digest).Msg("failed to parse digest")
-
-		return nil, zerr.ErrBadBlobDigest
 	}
 
 	index, err := storage.GetIndex(is, repo, is.log)

--- a/pkg/storage/local/local_elevated_test.go
+++ b/pkg/storage/local/local_elevated_test.go
@@ -45,7 +45,7 @@ func TestElevatedPrivilegesInvalidDedupe(t *testing.T) {
 		blobDigest1 := strings.Split(digest.String(), ":")[1]
 		So(blobDigest1, ShouldNotBeEmpty)
 
-		err = imgStore.FinishBlobUpload("dedupe1", upload, buf, digest.String())
+		err = imgStore.FinishBlobUpload("dedupe1", upload, buf, digest)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -81,7 +81,7 @@ func TestElevatedPrivilegesInvalidDedupe(t *testing.T) {
 			panic(err)
 		}
 
-		err = imgStore.FinishBlobUpload("dedupe2", upload, buf, digest.String())
+		err = imgStore.FinishBlobUpload("dedupe2", upload, buf, digest)
 		So(err, ShouldNotBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -91,7 +91,7 @@ func TestElevatedPrivilegesInvalidDedupe(t *testing.T) {
 			panic(err)
 		}
 
-		err = imgStore.FinishBlobUpload("dedupe2", upload, buf, digest.String())
+		err = imgStore.FinishBlobUpload("dedupe2", upload, buf, digest)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 	})

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -60,17 +60,17 @@ func TestStorageFSAPIs(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			err = imgStore.FinishBlobUpload(repoName, upload, buf, digest.String())
+			err = imgStore.FinishBlobUpload(repoName, upload, buf, digest)
 			So(err, ShouldBeNil)
 
 			annotationsMap := make(map[string]string)
 			annotationsMap[ispec.AnnotationRefName] = tag
 
 			cblob, cdigest := test.GetRandomImageConfig()
-			_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest.String())
+			_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest.String())
+			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -148,7 +148,7 @@ func TestStorageFSAPIs(t *testing.T) {
 			_, err = imgStore.GetReferrers(repoName, "invalid", "invalid")
 			So(err, ShouldNotBeNil)
 
-			_, err = imgStore.GetReferrers(repoName, digest.String(), "invalid")
+			_, err = imgStore.GetReferrers(repoName, digest, "invalid")
 			So(err, ShouldNotBeNil)
 
 			// invalid DeleteImageManifest
@@ -187,7 +187,7 @@ func TestGetReferrers(t *testing.T) {
 			"zot-test", "blobs", digest.Algorithm().String(), digest.Encoded()),
 			buf.Bytes(), 0o644)
 		So(err, ShouldBeNil)
-		_, n, err := imgStore.FullBlobUpload("zot-test", buf, digest.String())
+		_, n, err := imgStore.FullBlobUpload("zot-test", buf, digest)
 		So(err, ShouldBeNil)
 		So(n, ShouldEqual, buflen)
 
@@ -207,7 +207,7 @@ func TestGetReferrers(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		So(err, ShouldBeNil)
-		descriptors, err := imgStore.GetReferrers("zot-test", digest.String(), "signature-example")
+		descriptors, err := imgStore.GetReferrers("zot-test", digest, "signature-example")
 		So(err, ShouldBeNil)
 		So(descriptors, ShouldNotBeEmpty)
 		So(descriptors[0].ArtifactType, ShouldEqual, "signature-example")
@@ -328,11 +328,11 @@ func FuzzTestPutGetImageManifest(f *testing.F) {
 			t.Errorf("error occurred while generating random blob, %v", err)
 		}
 
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest.String())
+		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
 		if err != nil {
 			t.Error(err)
 		}
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(lblob), ldigest.String())
+		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(lblob), ldigest)
 		if err != nil {
 			t.Error(err)
 		}
@@ -374,12 +374,12 @@ func FuzzTestPutDeleteImageManifest(f *testing.F) {
 			t.Errorf("error occurred while generating random blob, %v", err)
 		}
 
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest.String())
+		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
 		if err != nil {
 			t.Error(err)
 		}
 
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(lblob), ldigest.String())
+		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(lblob), ldigest)
 		if err != nil {
 			t.Error(err)
 		}
@@ -594,7 +594,7 @@ func FuzzFinishBlobUpload(f *testing.F) {
 			t.Error(err)
 		}
 
-		err = imgStore.FinishBlobUpload(repoName, upload, buf, digest.String())
+		err = imgStore.FinishBlobUpload(repoName, upload, buf, digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -620,7 +620,7 @@ func FuzzFullBlobUpload(f *testing.F) {
 			t.Errorf("error occurred while generating random blob, %v", err)
 		}
 
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(lblob), ldigest.String())
+		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(lblob), ldigest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -646,7 +646,7 @@ func FuzzDedupeBlob(f *testing.F) {
 		src := path.Join(imgStore.RootDir(), "src")
 		blob := bytes.NewReader([]byte(data))
 
-		_, _, err := imgStore.FullBlobUpload("repoName", blob, blobDigest.String())
+		_, _, err := imgStore.FullBlobUpload("repoName", blob, blobDigest)
 		if err != nil {
 			t.Error(err)
 		}
@@ -719,14 +719,14 @@ func FuzzCheckBlob(f *testing.F) {
 		imgStore := local.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, *log, metrics, nil)
 		digest := godigest.FromString(data)
 
-		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest.String())
+		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
 			}
 			t.Error(err)
 		}
-		_, _, err = imgStore.CheckBlob(repoName, digest.String())
+		_, _, err = imgStore.CheckBlob(repoName, digest)
 		if err != nil {
 			t.Error(err)
 		}
@@ -745,7 +745,7 @@ func FuzzGetBlob(f *testing.F) {
 		imgStore := local.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, *log, metrics, nil)
 		digest := godigest.FromString(data)
 
-		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest.String())
+		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -753,7 +753,7 @@ func FuzzGetBlob(f *testing.F) {
 			t.Error(err)
 		}
 
-		blobReadCloser, _, err := imgStore.GetBlob(repoName, digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		blobReadCloser, _, err := imgStore.GetBlob(repoName, digest, "application/vnd.oci.image.layer.v1.tar+gzip")
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -778,7 +778,7 @@ func FuzzDeleteBlob(f *testing.F) {
 		imgStore := local.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, *log, metrics, nil)
 		digest := godigest.FromString(data)
 
-		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest.String())
+		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -786,7 +786,7 @@ func FuzzDeleteBlob(f *testing.F) {
 			t.Error(err)
 		}
 
-		err = imgStore.DeleteBlob(repoName, digest.String())
+		err = imgStore.DeleteBlob(repoName, digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -808,7 +808,7 @@ func FuzzGetIndexContent(f *testing.F) {
 		imgStore := local.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, *log, metrics, nil)
 		digest := godigest.FromString(data)
 
-		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest.String())
+		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -838,7 +838,7 @@ func FuzzGetBlobContent(f *testing.F) {
 		imgStore := local.NewImageStore(dir, true, storage.DefaultGCDelay, true, true, *log, metrics, nil)
 		digest := godigest.FromString(data)
 
-		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest.String())
+		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -846,7 +846,7 @@ func FuzzGetBlobContent(f *testing.F) {
 			t.Error(err)
 		}
 
-		_, err = imgStore.GetBlobContent(repoName, digest.String())
+		_, err = imgStore.GetBlobContent(repoName, digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -879,7 +879,7 @@ func FuzzGetReferrers(f *testing.F) {
 		if err != nil {
 			t.Error(err)
 		}
-		_, _, err = imgStore.FullBlobUpload("zot-test", buf, digest.String())
+		_, _, err = imgStore.FullBlobUpload("zot-test", buf, digest)
 		if err != nil {
 			t.Error(err)
 		}
@@ -902,7 +902,7 @@ func FuzzGetReferrers(f *testing.F) {
 		if err != nil {
 			t.Error(err)
 		}
-		_, err = imgStore.GetReferrers("zot-test", digest.String(), data)
+		_, err = imgStore.GetReferrers("zot-test", digest, data)
 		if err != nil {
 			if errors.Is(err, zerr.ErrManifestNotFound) || isKnownErr(err) {
 				return
@@ -951,23 +951,23 @@ func TestDedupeLinks(t *testing.T) {
 		blobDigest1 := strings.Split(digest.String(), ":")[1]
 		So(blobDigest1, ShouldNotBeEmpty)
 
-		err = imgStore.FinishBlobUpload("dedupe1", upload, buf, digest.String())
+		err = imgStore.FinishBlobUpload("dedupe1", upload, buf, digest)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		_, _, err = imgStore.CheckBlob("dedupe1", digest.String())
+		_, _, err = imgStore.CheckBlob("dedupe1", digest)
 		So(err, ShouldBeNil)
 
-		blobrc, _, err := imgStore.GetBlob("dedupe1", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		blobrc, _, err := imgStore.GetBlob("dedupe1", digest, "application/vnd.oci.image.layer.v1.tar+gzip")
 		So(err, ShouldBeNil)
 		err = blobrc.Close()
 		So(err, ShouldBeNil)
 
 		cblob, cdigest := test.GetRandomImageConfig()
-		_, clen, err := imgStore.FullBlobUpload("dedupe1", bytes.NewReader(cblob), cdigest.String())
+		_, clen, err := imgStore.FullBlobUpload("dedupe1", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
-		hasBlob, _, err := imgStore.CheckBlob("dedupe1", cdigest.String())
+		hasBlob, _, err := imgStore.CheckBlob("dedupe1", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -1011,23 +1011,23 @@ func TestDedupeLinks(t *testing.T) {
 		blobDigest2 := strings.Split(digest.String(), ":")[1]
 		So(blobDigest2, ShouldNotBeEmpty)
 
-		err = imgStore.FinishBlobUpload("dedupe2", upload, buf, digest.String())
+		err = imgStore.FinishBlobUpload("dedupe2", upload, buf, digest)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		_, _, err = imgStore.CheckBlob("dedupe2", digest.String())
+		_, _, err = imgStore.CheckBlob("dedupe2", digest)
 		So(err, ShouldBeNil)
 
-		blobrc, _, err = imgStore.GetBlob("dedupe2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		blobrc, _, err = imgStore.GetBlob("dedupe2", digest, "application/vnd.oci.image.layer.v1.tar+gzip")
 		So(err, ShouldBeNil)
 		err = blobrc.Close()
 		So(err, ShouldBeNil)
 
 		cblob, cdigest = test.GetRandomImageConfig()
-		_, clen, err = imgStore.FullBlobUpload("dedupe2", bytes.NewReader(cblob), cdigest.String())
+		_, clen, err = imgStore.FullBlobUpload("dedupe2", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
-		hasBlob, _, err = imgStore.CheckBlob("dedupe2", cdigest.String())
+		hasBlob, _, err = imgStore.CheckBlob("dedupe2", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -1085,7 +1085,7 @@ func TestDedupeLinks(t *testing.T) {
 			blobDigest2 := strings.Split(digest.String(), ":")[1]
 			So(blobDigest2, ShouldNotBeEmpty)
 
-			err = imgStore.FinishBlobUpload("dedupe3", upload, buf, digest.String())
+			err = imgStore.FinishBlobUpload("dedupe3", upload, buf, digest)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 		})
@@ -1585,17 +1585,17 @@ func TestGarbageCollect(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			err = imgStore.FinishBlobUpload(repoName, upload, buf, bdigest.String())
+			err = imgStore.FinishBlobUpload(repoName, upload, buf, bdigest)
 			So(err, ShouldBeNil)
 
 			annotationsMap := make(map[string]string)
 			annotationsMap[ispec.AnnotationRefName] = tag
 
 			cblob, cdigest := test.GetRandomImageConfig()
-			_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest.String())
+			_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest.String())
+			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1623,14 +1623,14 @@ func TestGarbageCollect(t *testing.T) {
 			_, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest, manifestBuf)
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
 			err = imgStore.DeleteImageManifest(repoName, digest.String())
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 		})
@@ -1653,7 +1653,7 @@ func TestGarbageCollect(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			err = imgStore.FinishBlobUpload(repoName, upload, buf, odigest.String())
+			err = imgStore.FinishBlobUpload(repoName, upload, buf, odigest)
 			So(err, ShouldBeNil)
 
 			// sleep so orphan blob can be GC'ed
@@ -1673,17 +1673,17 @@ func TestGarbageCollect(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			err = imgStore.FinishBlobUpload(repoName, upload, buf, bdigest.String())
+			err = imgStore.FinishBlobUpload(repoName, upload, buf, bdigest)
 			So(err, ShouldBeNil)
 
 			annotationsMap := make(map[string]string)
 			annotationsMap[ispec.AnnotationRefName] = tag
 
 			cblob, cdigest := test.GetRandomImageConfig()
-			_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest.String())
+			_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest.String())
+			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1711,11 +1711,11 @@ func TestGarbageCollect(t *testing.T) {
 			_, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest, manifestBuf)
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, odigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repoName, odigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1725,7 +1725,7 @@ func TestGarbageCollect(t *testing.T) {
 			err = imgStore.DeleteImageManifest(repoName, digest.String())
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 		})
@@ -1753,17 +1753,17 @@ func TestGarbageCollect(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			err = imgStore.FinishBlobUpload(repo1Name, upload, buf, bdigest.String())
+			err = imgStore.FinishBlobUpload(repo1Name, upload, buf, bdigest)
 			So(err, ShouldBeNil)
 
 			annotationsMap := make(map[string]string)
 			annotationsMap[ispec.AnnotationRefName] = tag
 
 			cblob, cdigest := test.GetRandomImageConfig()
-			_, clen, err := imgStore.FullBlobUpload(repo1Name, bytes.NewReader(cblob), cdigest.String())
+			_, clen, err := imgStore.FullBlobUpload(repo1Name, bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err := imgStore.CheckBlob(repo1Name, cdigest.String())
+			hasBlob, _, err := imgStore.CheckBlob(repo1Name, cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1790,14 +1790,14 @@ func TestGarbageCollect(t *testing.T) {
 			_, err = imgStore.PutImageManifest(repo1Name, tag, ispec.MediaTypeImageManifest, manifestBuf)
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repo1Name, tdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo1Name, tdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
 			// sleep so past GC timeout
 			time.Sleep(10 * time.Second)
 
-			hasBlob, _, err = imgStore.CheckBlob(repo1Name, tdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo1Name, tdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1816,17 +1816,17 @@ func TestGarbageCollect(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			err = imgStore.FinishBlobUpload(repo2Name, upload, buf, bdigest.String())
+			err = imgStore.FinishBlobUpload(repo2Name, upload, buf, bdigest)
 			So(err, ShouldBeNil)
 
 			annotationsMap = make(map[string]string)
 			annotationsMap[ispec.AnnotationRefName] = tag
 
 			cblob, cdigest = test.GetRandomImageConfig()
-			_, clen, err = imgStore.FullBlobUpload(repo2Name, bytes.NewReader(cblob), cdigest.String())
+			_, clen, err = imgStore.FullBlobUpload(repo2Name, bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err = imgStore.CheckBlob(repo2Name, cdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo2Name, cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1853,7 +1853,7 @@ func TestGarbageCollect(t *testing.T) {
 			_, err = imgStore.PutImageManifest(repo2Name, tag, ispec.MediaTypeImageManifest, manifestBuf)
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repo2Name, bdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo2Name, bdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1872,17 +1872,17 @@ func TestGarbageCollect(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			err = imgStore.FinishBlobUpload(repo2Name, upload, buf, bdigest.String())
+			err = imgStore.FinishBlobUpload(repo2Name, upload, buf, bdigest)
 			So(err, ShouldBeNil)
 
 			annotationsMap = make(map[string]string)
 			annotationsMap[ispec.AnnotationRefName] = tag
 
 			cblob, cdigest = test.GetRandomImageConfig()
-			_, clen, err = imgStore.FullBlobUpload(repo2Name, bytes.NewReader(cblob), cdigest.String())
+			_, clen, err = imgStore.FullBlobUpload(repo2Name, bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err = imgStore.CheckBlob(repo2Name, cdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo2Name, cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1912,7 +1912,7 @@ func TestGarbageCollect(t *testing.T) {
 
 			// original blob should exist
 
-			hasBlob, _, err = imgStore.CheckBlob(repo2Name, tdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob(repo2Name, tdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -2144,22 +2144,22 @@ func TestPullRange(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			err = imgStore.FinishBlobUpload(repoName, upload, buf, bdigest.String())
+			err = imgStore.FinishBlobUpload(repoName, upload, buf, bdigest)
 			So(err, ShouldBeNil)
 
 			_, _, _, err = imgStore.GetBlobPartial(repoName, "", "application/octet-stream", 0, 1)
 			So(err, ShouldNotBeNil)
 
-			_, _, _, err = imgStore.GetBlobPartial(repoName, bdigest.String(), "application/octet-stream", 1, 0)
+			_, _, _, err = imgStore.GetBlobPartial(repoName, bdigest, "application/octet-stream", 1, 0)
 			So(err, ShouldNotBeNil)
 
-			_, _, _, err = imgStore.GetBlobPartial(repoName, bdigest.String(), "application/octet-stream", 1, 0)
+			_, _, _, err = imgStore.GetBlobPartial(repoName, bdigest, "application/octet-stream", 1, 0)
 			So(err, ShouldNotBeNil)
 
 			blobPath := path.Join(imgStore.RootDir(), repoName, "blobs", bdigest.Algorithm().String(), bdigest.Encoded())
 			err = os.Chmod(blobPath, 0o000)
 			So(err, ShouldBeNil)
-			_, _, _, err = imgStore.GetBlobPartial(repoName, bdigest.String(), "application/octet-stream", -1, 1)
+			_, _, _, err = imgStore.GetBlobPartial(repoName, bdigest, "application/octet-stream", -1, 1)
 			So(err, ShouldNotBeNil)
 		})
 	})

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -462,7 +462,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			err = stwr.Close()
 			So(err, ShouldBeNil)
 
-			err = imgStore.FinishBlobUpload(testImage, upload, buf, digest.String())
+			err = imgStore.FinishBlobUpload(testImage, upload, buf, digest)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -513,10 +513,10 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			_, err = imgStore.PutBlobChunk(testImage, upload, 0, int64(buflen), buf)
 			So(err, ShouldNotBeNil)
 
-			err = imgStore.FinishBlobUpload(testImage, upload, buf, digest.String())
+			err = imgStore.FinishBlobUpload(testImage, upload, buf, digest)
 			So(err, ShouldNotBeNil)
 
-			err = imgStore.DeleteBlob(testImage, digest.String())
+			err = imgStore.DeleteBlob(testImage, digest)
 			So(err, ShouldNotBeNil)
 
 			err = imgStore.DeleteBlobUpload(testImage, upload)
@@ -534,7 +534,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			_, _, err = imgStore.FullBlobUpload(testImage, bytes.NewBuffer([]byte{}), "inexistent")
 			So(err, ShouldNotBeNil)
 
-			_, _, err = imgStore.CheckBlob(testImage, digest.String())
+			_, _, err = imgStore.CheckBlob(testImage, digest)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -750,7 +750,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			d := godigest.FromBytes([]byte("test"))
-			err := imgStore.FinishBlobUpload(testImage, "uuid", io.NopCloser(strings.NewReader("")), d.String())
+			err := imgStore.FinishBlobUpload(testImage, "uuid", io.NopCloser(strings.NewReader("")), d)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -765,7 +765,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			d := godigest.FromBytes([]byte("test"))
-			err := imgStore.FinishBlobUpload(testImage, "uuid", io.NopCloser(strings.NewReader("")), d.String())
+			err := imgStore.FinishBlobUpload(testImage, "uuid", io.NopCloser(strings.NewReader("")), d)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -776,7 +776,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			d := godigest.FromBytes([]byte("test"))
-			err := imgStore.FinishBlobUpload(testImage, "uuid", io.NopCloser(strings.NewReader("")), d.String())
+			err := imgStore.FinishBlobUpload(testImage, "uuid", io.NopCloser(strings.NewReader("")), d)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -787,7 +787,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			d := godigest.FromBytes([]byte(""))
-			err := imgStore.FinishBlobUpload(testImage, "uuid", io.NopCloser(strings.NewReader("")), d.String())
+			err := imgStore.FinishBlobUpload(testImage, "uuid", io.NopCloser(strings.NewReader("")), d)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -798,14 +798,14 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			d := godigest.FromBytes([]byte(""))
-			_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d.String())
+			_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d)
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Test FullBlobUpload2", func(c C) {
 			imgStore = createMockStorage(testDir, tdir, false, &StorageDriverMock{})
 			d := godigest.FromBytes([]byte(" "))
-			_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d.String())
+			_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -816,7 +816,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			d := godigest.FromBytes([]byte(""))
-			_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d.String())
+			_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -827,7 +827,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			d := godigest.FromBytes([]byte(""))
-			_, _, err := imgStore.GetBlob(testImage, d.String(), "")
+			_, _, err := imgStore.GetBlob(testImage, d, "")
 			So(err, ShouldNotBeNil)
 		})
 
@@ -838,7 +838,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			d := godigest.FromBytes([]byte(""))
-			err := imgStore.DeleteBlob(testImage, d.String())
+			err := imgStore.DeleteBlob(testImage, d)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -849,7 +849,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			d := godigest.FromBytes([]byte(""))
-			_, err := imgStore.GetReferrers(testImage, d.String(), "application/image")
+			_, err := imgStore.GetReferrers(testImage, d, "application/image")
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, zerr.ErrMethodNotSupported)
 		})
@@ -883,18 +883,18 @@ func TestS3Dedupe(t *testing.T) {
 		blob, err := imgStore.PutBlobChunkStreamed("dedupe1", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
-		blobDigest1 := strings.Split(digest.String(), ":")[1]
+		blobDigest1 := digest
 		So(blobDigest1, ShouldNotBeEmpty)
 
-		err = imgStore.FinishBlobUpload("dedupe1", upload, buf, digest.String())
+		err = imgStore.FinishBlobUpload("dedupe1", upload, buf, digest)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		_, checkBlobSize1, err := imgStore.CheckBlob("dedupe1", digest.String())
+		_, checkBlobSize1, err := imgStore.CheckBlob("dedupe1", digest)
 		So(checkBlobSize1, ShouldBeGreaterThan, 0)
 		So(err, ShouldBeNil)
 
-		blobReadCloser, getBlobSize1, err := imgStore.GetBlob("dedupe1", digest.String(),
+		blobReadCloser, getBlobSize1, err := imgStore.GetBlob("dedupe1", digest,
 			"application/vnd.oci.image.layer.v1.tar+gzip")
 		So(getBlobSize1, ShouldBeGreaterThan, 0)
 		So(err, ShouldBeNil)
@@ -902,10 +902,10 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cblob, cdigest := test.GetRandomImageConfig()
-		_, clen, err := imgStore.FullBlobUpload("dedupe1", bytes.NewReader(cblob), cdigest.String())
+		_, clen, err := imgStore.FullBlobUpload("dedupe1", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
-		hasBlob, _, err := imgStore.CheckBlob("dedupe1", cdigest.String())
+		hasBlob, _, err := imgStore.CheckBlob("dedupe1", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -948,18 +948,18 @@ func TestS3Dedupe(t *testing.T) {
 		blob, err = imgStore.PutBlobChunkStreamed("dedupe2", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
-		blobDigest2 := strings.Split(digest.String(), ":")[1]
+		blobDigest2 := digest
 		So(blobDigest2, ShouldNotBeEmpty)
 
-		err = imgStore.FinishBlobUpload("dedupe2", upload, buf, digest.String())
+		err = imgStore.FinishBlobUpload("dedupe2", upload, buf, digest)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		_, checkBlobSize2, err := imgStore.CheckBlob("dedupe2", digest.String())
+		_, checkBlobSize2, err := imgStore.CheckBlob("dedupe2", digest)
 		So(err, ShouldBeNil)
 		So(checkBlobSize2, ShouldBeGreaterThan, 0)
 
-		blobReadCloser, getBlobSize2, err := imgStore.GetBlob("dedupe2", digest.String(),
+		blobReadCloser, getBlobSize2, err := imgStore.GetBlob("dedupe2", digest,
 			"application/vnd.oci.image.layer.v1.tar+gzip")
 		So(err, ShouldBeNil)
 		So(getBlobSize2, ShouldBeGreaterThan, 0)
@@ -969,10 +969,10 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cblob, cdigest = test.GetRandomImageConfig()
-		_, clen, err = imgStore.FullBlobUpload("dedupe2", bytes.NewReader(cblob), cdigest.String())
+		_, clen, err = imgStore.FullBlobUpload("dedupe2", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
-		hasBlob, _, err = imgStore.CheckBlob("dedupe2", cdigest.String())
+		hasBlob, _, err = imgStore.CheckBlob("dedupe2", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -1001,10 +1001,12 @@ func TestS3Dedupe(t *testing.T) {
 		_, _, _, err = imgStore.GetImageManifest("dedupe2", digest.String())
 		So(err, ShouldBeNil)
 
-		fi1, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe1", "blobs", "sha256", blobDigest1))
+		fi1, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe1", "blobs", "sha256",
+			blobDigest1.Encoded()))
 		So(err, ShouldBeNil)
 
-		fi2, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe2", "blobs", "sha256", blobDigest2))
+		fi2, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe2", "blobs", "sha256",
+			blobDigest2.Encoded()))
 		So(err, ShouldBeNil)
 
 		// original blob should have the real content of blob
@@ -1015,23 +1017,26 @@ func TestS3Dedupe(t *testing.T) {
 
 		Convey("Check that delete blobs moves the real content to the next contenders", func() {
 			// if we delete blob1, the content should be moved to blob2
-			err = imgStore.DeleteBlob("dedupe1", "sha256:"+blobDigest1)
+			err = imgStore.DeleteBlob("dedupe1", blobDigest1)
 			So(err, ShouldBeNil)
 
-			_, err = storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe1", "blobs", "sha256", blobDigest1))
+			_, err = storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe1", "blobs", "sha256",
+				blobDigest1.Encoded()))
 			So(err, ShouldNotBeNil)
 
-			fi2, err = storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe2", "blobs", "sha256", blobDigest2))
+			fi2, err = storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe2", "blobs", "sha256",
+				blobDigest2.Encoded()))
 			So(err, ShouldBeNil)
 
 			So(fi2.Size(), ShouldBeGreaterThan, 0)
 			// the second blob should now be equal to the deleted blob.
 			So(fi2.Size(), ShouldEqual, fi1.Size())
 
-			err = imgStore.DeleteBlob("dedupe2", "sha256:"+blobDigest2)
+			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
 			So(err, ShouldBeNil)
 
-			_, err = storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe2", "blobs", "sha256", blobDigest2))
+			_, err = storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe2", "blobs", "sha256",
+				blobDigest2.Encoded()))
 			So(err, ShouldNotBeNil)
 		})
 
@@ -1062,43 +1067,43 @@ func TestS3Dedupe(t *testing.T) {
 			blob, err = imgStore.PutBlobChunkStreamed("dedupe3", upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
-			blobDigest2 := strings.Split(digest.String(), ":")[1]
+			blobDigest2 := digest
 			So(blobDigest2, ShouldNotBeEmpty)
 
-			err = imgStore.FinishBlobUpload("dedupe3", upload, buf, digest.String())
+			err = imgStore.FinishBlobUpload("dedupe3", upload, buf, digest)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			_, _, err = imgStore.CheckBlob("dedupe3", digest.String())
+			_, _, err = imgStore.CheckBlob("dedupe3", digest)
 			So(err, ShouldBeNil)
 
 			// check that we retrieve the real dedupe2/blob (which is deduped earlier - 0 size) when switching to dedupe false
-			blobReadCloser, getBlobSize2, err = imgStore.GetBlob("dedupe2", digest.String(),
+			blobReadCloser, getBlobSize2, err = imgStore.GetBlob("dedupe2", digest,
 				"application/vnd.oci.image.layer.v1.tar+gzip")
 			So(err, ShouldBeNil)
 			So(getBlobSize1, ShouldEqual, getBlobSize2)
 			err = blobReadCloser.Close()
 			So(err, ShouldBeNil)
 
-			_, checkBlobSize2, err := imgStore.CheckBlob("dedupe2", digest.String())
+			_, checkBlobSize2, err := imgStore.CheckBlob("dedupe2", digest)
 			So(err, ShouldBeNil)
 			So(checkBlobSize2, ShouldBeGreaterThan, 0)
 			So(checkBlobSize2, ShouldEqual, getBlobSize2)
 
-			_, getBlobSize3, err := imgStore.GetBlob("dedupe3", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+			_, getBlobSize3, err := imgStore.GetBlob("dedupe3", digest, "application/vnd.oci.image.layer.v1.tar+gzip")
 			So(err, ShouldBeNil)
 			So(getBlobSize1, ShouldEqual, getBlobSize3)
 
-			_, checkBlobSize3, err := imgStore.CheckBlob("dedupe3", digest.String())
+			_, checkBlobSize3, err := imgStore.CheckBlob("dedupe3", digest)
 			So(err, ShouldBeNil)
 			So(checkBlobSize3, ShouldBeGreaterThan, 0)
 			So(checkBlobSize3, ShouldEqual, getBlobSize3)
 
 			cblob, cdigest = test.GetRandomImageConfig()
-			_, clen, err = imgStore.FullBlobUpload("dedupe3", bytes.NewReader(cblob), cdigest.String())
+			_, clen, err = imgStore.FullBlobUpload("dedupe3", bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
-			hasBlob, _, err = imgStore.CheckBlob("dedupe3", cdigest.String())
+			hasBlob, _, err = imgStore.CheckBlob("dedupe3", cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1127,14 +1132,17 @@ func TestS3Dedupe(t *testing.T) {
 			_, _, _, err = imgStore.GetImageManifest("dedupe3", digest.String())
 			So(err, ShouldBeNil)
 
-			fi1, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe1", "blobs", "sha256", blobDigest1))
+			fi1, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe1", "blobs", "sha256",
+				blobDigest1.Encoded()))
 			So(err, ShouldBeNil)
 
-			fi2, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe2", "blobs", "sha256", blobDigest1))
+			fi2, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe2", "blobs", "sha256",
+				blobDigest1.Encoded()))
 			So(err, ShouldBeNil)
 			So(fi2.Size(), ShouldEqual, 0)
 
-			fi3, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe3", "blobs", "sha256", blobDigest2))
+			fi3, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe3", "blobs", "sha256",
+				blobDigest2.Encoded()))
 			So(err, ShouldBeNil)
 
 			// the new blob with dedupe false should be equal with the origin blob from dedupe1
@@ -1171,54 +1179,54 @@ func TestS3PullRange(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		err = imgStore.FinishBlobUpload("index", upload, buf, digest.String())
+		err = imgStore.FinishBlobUpload("index", upload, buf, digest)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
 		Convey("Without Dedupe", func() {
-			reader, _, _, err := imgStore.GetBlobPartial("index", digest.String(), "*/*", 0, -1)
+			reader, _, _, err := imgStore.GetBlobPartial("index", digest, "*/*", 0, -1)
 			So(err, ShouldBeNil)
 			rdbuf, err := io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content)
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("index", digest.String(), "application/octet-stream", 0, -1)
+			reader, _, _, err = imgStore.GetBlobPartial("index", digest, "application/octet-stream", 0, -1)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content)
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("index", digest.String(), "*/*", 0, 100)
+			reader, _, _, err = imgStore.GetBlobPartial("index", digest, "*/*", 0, 100)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content)
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("index", digest.String(), "*/*", 0, 10)
+			reader, _, _, err = imgStore.GetBlobPartial("index", digest, "*/*", 0, 10)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content)
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("index", digest.String(), "*/*", 0, 0)
+			reader, _, _, err = imgStore.GetBlobPartial("index", digest, "*/*", 0, 0)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content[0:1])
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("index", digest.String(), "*/*", 0, 1)
+			reader, _, _, err = imgStore.GetBlobPartial("index", digest, "*/*", 0, 1)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content[0:2])
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("index", digest.String(), "*/*", 2, 3)
+			reader, _, _, err = imgStore.GetBlobPartial("index", digest, "*/*", 2, 3)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
@@ -1241,53 +1249,53 @@ func TestS3PullRange(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			err = imgStore.FinishBlobUpload("dupindex", upload, buf, digest.String())
+			err = imgStore.FinishBlobUpload("dupindex", upload, buf, digest)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			reader, _, _, err := imgStore.GetBlobPartial("dupindex", digest.String(), "*/*", 0, -1)
+			reader, _, _, err := imgStore.GetBlobPartial("dupindex", digest, "*/*", 0, -1)
 			So(err, ShouldBeNil)
 			rdbuf, err := io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content)
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest.String(), "application/octet-stream", 0, -1)
+			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest, "application/octet-stream", 0, -1)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content)
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest.String(), "*/*", 0, 100)
+			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest, "*/*", 0, 100)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content)
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest.String(), "*/*", 0, 10)
+			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest, "*/*", 0, 10)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content)
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest.String(), "*/*", 0, 0)
+			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest, "*/*", 0, 0)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content[0:1])
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest.String(), "*/*", 0, 1)
+			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest, "*/*", 0, 1)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
 			So(rdbuf, ShouldResemble, content[0:2])
 			reader.Close()
 
-			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest.String(), "*/*", 2, 3)
+			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest, "*/*", 2, 3)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
@@ -1295,10 +1303,10 @@ func TestS3PullRange(t *testing.T) {
 			reader.Close()
 
 			// delete original blob
-			err = imgStore.DeleteBlob("index", digest.String())
+			err = imgStore.DeleteBlob("index", digest)
 			So(err, ShouldBeNil)
 
-			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest.String(), "*/*", 2, 3)
+			reader, _, _, err = imgStore.GetBlobPartial("dupindex", digest, "*/*", 2, 3)
 			So(err, ShouldBeNil)
 			rdbuf, err = io.ReadAll(reader)
 			So(err, ShouldBeNil)
@@ -1313,7 +1321,7 @@ func TestS3PullRange(t *testing.T) {
 			content := []byte("invalid content")
 			digest := godigest.FromBytes(content)
 
-			_, _, _, err = imgStore.GetBlobPartial("index", digest.String(), "*/*", 0, -1)
+			_, _, _, err = imgStore.GetBlobPartial("index", digest, "*/*", 0, -1)
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -1349,7 +1357,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		bdgst1 := digest
 		bsize1 := len(content)
 
-		err = imgStore.FinishBlobUpload("index", upload, buf, digest.String())
+		err = imgStore.FinishBlobUpload("index", upload, buf, digest)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -1365,7 +1373,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		err = imgStore.FinishBlobUpload("index", upload, buf, cdigest.String())
+		err = imgStore.FinishBlobUpload("index", upload, buf, cdigest)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -1407,7 +1415,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		err = imgStore.FinishBlobUpload("index", upload, buf, cdigest.String())
+		err = imgStore.FinishBlobUpload("index", upload, buf, cdigest)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -1449,7 +1457,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			err = imgStore.FinishBlobUpload("index", upload, buf, cdigest.String())
+			err = imgStore.FinishBlobUpload("index", upload, buf, cdigest)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -1513,7 +1521,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			err = imgStore.FinishBlobUpload("index", upload, buf, cdigest.String())
+			err = imgStore.FinishBlobUpload("index", upload, buf, cdigest)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -1663,7 +1671,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(blob, ShouldEqual, buflen)
 
-				err = imgStore.FinishBlobUpload("index", upload, buf, digest.String())
+				err = imgStore.FinishBlobUpload("index", upload, buf, digest)
 				So(err, ShouldBeNil)
 				So(blob, ShouldEqual, buflen)
 
@@ -1909,7 +1917,7 @@ func TestS3DedupeErr(t *testing.T) {
 		err := imgStore.DedupeBlob("repo", digest, "dst")
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.CheckBlob("repo", digest.String())
+		_, _, err = imgStore.CheckBlob("repo", digest)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -1930,7 +1938,7 @@ func TestS3DedupeErr(t *testing.T) {
 		err := imgStore.DedupeBlob("repo", digest, "dst")
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.CheckBlob("repo", digest.String())
+		_, _, err = imgStore.CheckBlob("repo", digest)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -1948,7 +1956,7 @@ func TestS3DedupeErr(t *testing.T) {
 		err := imgStore.DedupeBlob("repo", digest, "dst")
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.CheckBlob("repo", digest.String())
+		_, _, err = imgStore.CheckBlob("repo", digest)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -1985,10 +1993,10 @@ func TestS3DedupeErr(t *testing.T) {
 			},
 		})
 
-		_, _, err = imgStore.GetBlob("repo2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		_, _, err = imgStore.GetBlob("repo2", digest, "application/vnd.oci.image.layer.v1.tar+gzip")
 		So(err, ShouldNotBeNil)
 
-		_, _, _, err = imgStore.GetBlobPartial("repo2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip", 0, 1)
+		_, _, _, err = imgStore.GetBlobPartial("repo2", digest, "application/vnd.oci.image.layer.v1.tar+gzip", 0, 1)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -2032,10 +2040,10 @@ func TestS3DedupeErr(t *testing.T) {
 			},
 		})
 
-		_, _, err = imgStore.GetBlob("repo2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		_, _, err = imgStore.GetBlob("repo2", digest, "application/vnd.oci.image.layer.v1.tar+gzip")
 		So(err, ShouldNotBeNil)
 
-		_, _, _, err = imgStore.GetBlobPartial("repo2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip", 0, 1)
+		_, _, _, err = imgStore.GetBlobPartial("repo2", digest, "application/vnd.oci.image.layer.v1.tar+gzip", 0, 1)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -2055,10 +2063,10 @@ func TestS3DedupeErr(t *testing.T) {
 			},
 		})
 
-		_, _, err = imgStore.GetBlob("repo2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+		_, _, err = imgStore.GetBlob("repo2", digest, "application/vnd.oci.image.layer.v1.tar+gzip")
 		So(err, ShouldNotBeNil)
 
-		_, _, _, err = imgStore.GetBlobPartial("repo2", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip", 0, 1)
+		_, _, _, err = imgStore.GetBlobPartial("repo2", digest, "application/vnd.oci.image.layer.v1.tar+gzip", 0, 1)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -2090,10 +2098,10 @@ func TestS3DedupeErr(t *testing.T) {
 		err := imgStore.DedupeBlob("repo", digest, blobPath)
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.CheckBlob("repo2", digest.String())
+		_, _, err = imgStore.CheckBlob("repo2", digest)
 		So(err, ShouldBeNil)
 
-		err = imgStore.DeleteBlob("repo", digest.String())
+		err = imgStore.DeleteBlob("repo", digest)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -2105,7 +2113,7 @@ func TestS3DedupeErr(t *testing.T) {
 			},
 		})
 		d := godigest.FromBytes([]byte(""))
-		_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d.String())
+		_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -2117,7 +2125,7 @@ func TestS3DedupeErr(t *testing.T) {
 			},
 		})
 		d := godigest.FromBytes([]byte(""))
-		err := imgStore.FinishBlobUpload(testImage, "uuid", io.NopCloser(strings.NewReader("")), d.String())
+		err := imgStore.FinishBlobUpload(testImage, "uuid", io.NopCloser(strings.NewReader("")), d)
 		So(err, ShouldNotBeNil)
 	})
 }

--- a/pkg/storage/scrub.go
+++ b/pkg/storage/scrub.go
@@ -143,7 +143,7 @@ func checkIntegrity(ctx context.Context, imageName, tagName string, oci casext.E
 			}
 
 			// check layer
-			layerPath := path.Join(dir, "blobs", layer.Digest.Algorithm().String(), layer.Digest.Hex())
+			layerPath := path.Join(dir, "blobs", layer.Digest.Algorithm().String(), layer.Digest.Encoded())
 
 			_, err = os.Stat(layerPath)
 			if err != nil {

--- a/pkg/storage/scrub_test.go
+++ b/pkg/storage/scrub_test.go
@@ -50,6 +50,9 @@ func TestCheckAllBlobsIntegrity(t *testing.T) {
 
 		const tag = "1.0"
 
+		var manifestDigest godigest.Digest
+		var configDigest godigest.Digest
+		var layerDigest godigest.Digest
 		var manifest string
 		var config string
 		var layer string
@@ -59,10 +62,11 @@ func TestCheckAllBlobsIntegrity(t *testing.T) {
 		buf := bytes.NewBuffer(body)
 		buflen := buf.Len()
 		digest := godigest.FromBytes(body)
-		upload, n, err := imgStore.FullBlobUpload(repoName, buf, digest.String())
+		upload, n, err := imgStore.FullBlobUpload(repoName, buf, digest)
 		So(err, ShouldBeNil)
 		So(n, ShouldEqual, len(body))
 		So(upload, ShouldNotBeEmpty)
+		layerDigest = digest
 		layer = digest.String()
 
 		// create config digest
@@ -92,8 +96,8 @@ func TestCheckAllBlobsIntegrity(t *testing.T) {
 			}`, created, created, created))
 		configBuf := bytes.NewBuffer(configBody)
 		configLen := configBuf.Len()
-		configDigest := godigest.FromBytes(configBody)
-		uConfig, nConfig, err := imgStore.FullBlobUpload(repoName, configBuf, configDigest.String())
+		configDigest = godigest.FromBytes(configBody)
+		uConfig, nConfig, err := imgStore.FullBlobUpload(repoName, configBuf, configDigest)
 		So(err, ShouldBeNil)
 		So(nConfig, ShouldEqual, len(configBody))
 		So(uConfig, ShouldNotBeEmpty)
@@ -122,9 +126,11 @@ func TestCheckAllBlobsIntegrity(t *testing.T) {
 		mbytes, err := json.Marshal(mnfst)
 		So(err, ShouldBeNil)
 
-		manifest, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest,
+		manifestDigest, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest,
 			mbytes)
 		So(err, ShouldBeNil)
+
+		manifest = manifestDigest.String()
 
 		Convey("Blobs integrity not affected", func() {
 			buff := bytes.NewBufferString("")
@@ -171,7 +177,7 @@ func TestCheckAllBlobsIntegrity(t *testing.T) {
 
 		Convey("Config integrity affected", func() {
 			// get content of config file
-			content, err := imgStore.GetBlobContent(repoName, config)
+			content, err := imgStore.GetBlobContent(repoName, configDigest)
 			So(err, ShouldBeNil)
 
 			// delete content of config file
@@ -199,7 +205,7 @@ func TestCheckAllBlobsIntegrity(t *testing.T) {
 
 		Convey("Layers integrity affected", func() {
 			// get content of layer
-			content, err := imgStore.GetBlobContent(repoName, layer)
+			content, err := imgStore.GetBlobContent(repoName, layerDigest)
 			So(err, ShouldBeNil)
 
 			// delete content of layer file

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -4,7 +4,7 @@ import (
 	"io"
 	"time"
 
-	"github.com/opencontainers/go-digest"
+	godigest "github.com/opencontainers/go-digest"
 	artifactspec "github.com/oras-project/artifacts-spec/specs-go/v1"
 
 	"zotregistry.io/zot/pkg/scheduler"
@@ -27,8 +27,8 @@ type ImageStore interface { //nolint:interfacebloat
 	GetRepositories() ([]string, error)
 	GetNextRepository(repo string) (string, error)
 	GetImageTags(repo string) ([]string, error)
-	GetImageManifest(repo, reference string) ([]byte, string, string, error)
-	PutImageManifest(repo, reference, mediaType string, body []byte) (string, error)
+	GetImageManifest(repo, reference string) ([]byte, godigest.Digest, string, error)
+	PutImageManifest(repo, reference, mediaType string, body []byte) (godigest.Digest, error)
 	DeleteImageManifest(repo, reference string) error
 	BlobUploadPath(repo, uuid string) string
 	NewBlobUpload(repo string) (string, error)
@@ -36,18 +36,19 @@ type ImageStore interface { //nolint:interfacebloat
 	PutBlobChunkStreamed(repo, uuid string, body io.Reader) (int64, error)
 	PutBlobChunk(repo, uuid string, from, to int64, body io.Reader) (int64, error)
 	BlobUploadInfo(repo, uuid string) (int64, error)
-	FinishBlobUpload(repo, uuid string, body io.Reader, digest string) error
-	FullBlobUpload(repo string, body io.Reader, digest string) (string, int64, error)
-	DedupeBlob(src string, dstDigest digest.Digest, dst string) error
+	FinishBlobUpload(repo, uuid string, body io.Reader, digest godigest.Digest) error
+	FullBlobUpload(repo string, body io.Reader, digest godigest.Digest) (string, int64, error)
+	DedupeBlob(src string, dstDigest godigest.Digest, dst string) error
 	DeleteBlobUpload(repo, uuid string) error
-	BlobPath(repo string, digest digest.Digest) string
-	CheckBlob(repo, digest string) (bool, int64, error)
-	GetBlob(repo, digest, mediaType string) (io.ReadCloser, int64, error)
-	GetBlobPartial(repo, digest, mediaType string, from, to int64) (io.ReadCloser, int64, int64, error)
-	DeleteBlob(repo, digest string) error
+	BlobPath(repo string, digest godigest.Digest) string
+	CheckBlob(repo string, digest godigest.Digest) (bool, int64, error)
+	GetBlob(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error)
+	GetBlobPartial(repo string, digest godigest.Digest, mediaType string, from, to int64,
+	) (io.ReadCloser, int64, int64, error)
+	DeleteBlob(repo string, digest godigest.Digest) error
 	GetIndexContent(repo string) ([]byte, error)
-	GetBlobContent(repo, digest string) ([]byte, error)
-	GetReferrers(repo, digest string, mediaType string) ([]artifactspec.Descriptor, error)
+	GetBlobContent(repo string, digest godigest.Digest) ([]byte, error)
+	GetReferrers(repo string, digest godigest.Digest, mediaType string) ([]artifactspec.Descriptor, error)
 	RunGCRepo(repo string) error
 	RunGCPeriodically(interval time.Duration, sch *scheduler.Scheduler)
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -170,7 +170,7 @@ func TestStorageAPIs(t *testing.T) {
 					body := []byte("this is a blob")
 					buf := bytes.NewBuffer(body)
 					digest := godigest.FromBytes(body)
-					upload, n, err := imgStore.FullBlobUpload("test", buf, digest.String())
+					upload, n, err := imgStore.FullBlobUpload("test", buf, digest)
 					So(err, ShouldBeNil)
 					So(n, ShouldEqual, len(body))
 					So(upload, ShouldNotBeEmpty)
@@ -238,13 +238,13 @@ func TestStorageAPIs(t *testing.T) {
 						So(err, ShouldBeNil)
 						So(bupload, ShouldEqual, secondChunkLen)
 
-						err = imgStore.FinishBlobUpload("test", upload, buf, digest.String())
+						err = imgStore.FinishBlobUpload("test", upload, buf, digest)
 						So(err, ShouldBeNil)
 
-						_, _, err = imgStore.CheckBlob("test", digest.String())
+						_, _, err = imgStore.CheckBlob("test", digest)
 						So(err, ShouldBeNil)
 
-						blob, _, err := imgStore.GetBlob("test", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+						blob, _, err := imgStore.GetBlob("test", digest, "application/vnd.oci.image.layer.v1.tar+gzip")
 						So(err, ShouldBeNil)
 						err = blob.Close()
 						So(err, ShouldBeNil)
@@ -280,10 +280,10 @@ func TestStorageAPIs(t *testing.T) {
 
 						Convey("Good image manifest", func() {
 							cblob, cdigest := test.GetRandomImageConfig()
-							_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest.String())
+							_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest)
 							So(err, ShouldBeNil)
 							So(clen, ShouldEqual, len(cblob))
-							hasBlob, _, err := imgStore.CheckBlob("test", cdigest.String())
+							hasBlob, _, err := imgStore.CheckBlob("test", cdigest)
 							So(err, ShouldBeNil)
 							So(hasBlob, ShouldEqual, true)
 
@@ -353,7 +353,7 @@ func TestStorageAPIs(t *testing.T) {
 							So(len(tags), ShouldEqual, 2)
 
 							// We deleted only one tag, make sure blob should not be removed.
-							hasBlob, _, err = imgStore.CheckBlob("test", digest.String())
+							hasBlob, _, err = imgStore.CheckBlob("test", digest)
 							So(err, ShouldBeNil)
 							So(hasBlob, ShouldEqual, true)
 
@@ -366,17 +366,17 @@ func TestStorageAPIs(t *testing.T) {
 							So(len(tags), ShouldEqual, 0)
 
 							// All tags/references are deleted, blob should not be present in disk.
-							hasBlob, _, err = imgStore.CheckBlob("test", digest.String())
+							hasBlob, _, err = imgStore.CheckBlob("test", digest)
 							So(err, ShouldNotBeNil)
 							So(hasBlob, ShouldEqual, false)
 
 							err = imgStore.DeleteBlob("test", "inexistent")
 							So(err, ShouldNotBeNil)
 
-							err = imgStore.DeleteBlob("test", godigest.FromBytes([]byte("inexistent")).String())
+							err = imgStore.DeleteBlob("test", godigest.FromBytes([]byte("inexistent")))
 							So(err, ShouldNotBeNil)
 
-							err = imgStore.DeleteBlob("test", blobDigest.String())
+							err = imgStore.DeleteBlob("test", blobDigest)
 							So(err, ShouldBeNil)
 
 							_, _, _, err = imgStore.GetImageManifest("test", digest.String())
@@ -394,9 +394,6 @@ func TestStorageAPIs(t *testing.T) {
 					So(bupload, ShouldNotBeEmpty)
 
 					Convey("Get blob upload", func() {
-						err = imgStore.FinishBlobUpload("test", bupload, bytes.NewBuffer([]byte{}), "inexistent")
-						So(err, ShouldNotBeNil)
-
 						upload, err := imgStore.GetBlobUpload("test", "invalid")
 						So(err, ShouldNotBeNil)
 						So(upload, ShouldEqual, -1)
@@ -423,28 +420,28 @@ func TestStorageAPIs(t *testing.T) {
 						_, err = imgStore.PutBlobChunkStreamed("test", "inexistent", buf)
 						So(err, ShouldNotBeNil)
 
-						err = imgStore.FinishBlobUpload("test", "inexistent", buf, digest.String())
+						err = imgStore.FinishBlobUpload("test", "inexistent", buf, digest)
 						So(err, ShouldNotBeNil)
 
-						err = imgStore.FinishBlobUpload("test", bupload, buf, digest.String())
+						err = imgStore.FinishBlobUpload("test", bupload, buf, digest)
 						So(err, ShouldBeNil)
 
-						_, _, err = imgStore.CheckBlob("test", digest.String())
+						_, _, err = imgStore.CheckBlob("test", digest)
 						So(err, ShouldBeNil)
 
 						_, _, err = imgStore.GetBlob("test", "inexistent", "application/vnd.oci.image.layer.v1.tar+gzip")
 						So(err, ShouldNotBeNil)
 
-						blob, _, err := imgStore.GetBlob("test", digest.String(), "application/vnd.oci.image.layer.v1.tar+gzip")
+						blob, _, err := imgStore.GetBlob("test", digest, "application/vnd.oci.image.layer.v1.tar+gzip")
 						So(err, ShouldBeNil)
 						err = blob.Close()
 						So(err, ShouldBeNil)
 
-						blobContent, err := imgStore.GetBlobContent("test", digest.String())
+						blobContent, err := imgStore.GetBlobContent("test", digest)
 						So(err, ShouldBeNil)
 						So(content, ShouldResemble, blobContent)
 
-						_, err = imgStore.GetBlobContent("inexistent", digest.String())
+						_, err = imgStore.GetBlobContent("inexistent", digest)
 						So(err, ShouldNotBeNil)
 
 						manifest := ispec.Manifest{}
@@ -475,10 +472,10 @@ func TestStorageAPIs(t *testing.T) {
 
 						Convey("Good image manifest", func() {
 							cblob, cdigest := test.GetRandomImageConfig()
-							_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest.String())
+							_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest)
 							So(err, ShouldBeNil)
 							So(clen, ShouldEqual, len(cblob))
-							hasBlob, _, err := imgStore.CheckBlob("test", cdigest.String())
+							hasBlob, _, err := imgStore.CheckBlob("test", cdigest)
 							So(err, ShouldBeNil)
 							So(hasBlob, ShouldEqual, true)
 
@@ -567,15 +564,15 @@ func TestStorageAPIs(t *testing.T) {
 					blobDigest1 := strings.Split(digest.String(), ":")[1]
 					So(blobDigest1, ShouldNotBeEmpty)
 
-					err = imgStore.FinishBlobUpload("replace", upload, buf, digest.String())
+					err = imgStore.FinishBlobUpload("replace", upload, buf, digest)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
 					cblob, cdigest := test.GetRandomImageConfig()
-					_, clen, err := imgStore.FullBlobUpload("replace", bytes.NewReader(cblob), cdigest.String())
+					_, clen, err := imgStore.FullBlobUpload("replace", bytes.NewReader(cblob), cdigest)
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
-					hasBlob, _, err := imgStore.CheckBlob("replace", cdigest.String())
+					hasBlob, _, err := imgStore.CheckBlob("replace", cdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -619,15 +616,15 @@ func TestStorageAPIs(t *testing.T) {
 					blobDigest2 := strings.Split(digest.String(), ":")[1]
 					So(blobDigest2, ShouldNotBeEmpty)
 
-					err = imgStore.FinishBlobUpload("replace", upload, buf, digest.String())
+					err = imgStore.FinishBlobUpload("replace", upload, buf, digest)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
 					cblob, cdigest = test.GetRandomImageConfig()
-					_, clen, err = imgStore.FullBlobUpload("replace", bytes.NewReader(cblob), cdigest.String())
+					_, clen, err = imgStore.FullBlobUpload("replace", bytes.NewReader(cblob), cdigest)
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
-					hasBlob, _, err = imgStore.CheckBlob("replace", cdigest.String())
+					hasBlob, _, err = imgStore.CheckBlob("replace", cdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -728,11 +725,11 @@ func TestMandatoryAnnotations(t *testing.T) {
 				buflen := buf.Len()
 				digest := godigest.FromBytes(content)
 
-				_, _, err := imgStore.FullBlobUpload("test", bytes.NewReader(buf.Bytes()), digest.String())
+				_, _, err := imgStore.FullBlobUpload("test", bytes.NewReader(buf.Bytes()), digest)
 				So(err, ShouldBeNil)
 
 				cblob, cdigest := test.GetRandomImageConfig()
-				_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest.String())
+				_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest)
 				So(err, ShouldBeNil)
 				So(clen, ShouldEqual, len(cblob))
 

--- a/pkg/test/common_test.go
+++ b/pkg/test/common_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/opencontainers/go-digest"
+	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -267,7 +267,7 @@ func TestUploadImage(t *testing.T) {
 		test.WaitTillServerReady(baseURL)
 
 		layerBlob := []byte("test")
-		layerBlobDigest := digest.FromBytes(layerBlob)
+		layerBlobDigest := godigest.FromBytes(layerBlob)
 		layerPath := path.Join(tempDir, "test", "blobs", "sha256")
 
 		if _, err := os.Stat(layerPath); os.IsNotExist(err) {

--- a/pkg/test/mocks/oci_mock.go
+++ b/pkg/test/mocks/oci_mock.go
@@ -1,7 +1,6 @@
 package mocks
 
 import (
-	v1 "github.com/google/go-containerregistry/pkg/v1"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
@@ -9,10 +8,10 @@ import (
 )
 
 type OciLayoutUtilsMock struct {
-	GetImageManifestFn          func(repo string, reference string) (ispec.Manifest, string, error)
-	GetImageManifestsFn         func(image string) ([]ispec.Descriptor, error)
-	GetImageBlobManifestFn      func(imageDir string, digest godigest.Digest) (v1.Manifest, error)
-	GetImageInfoFn              func(imageDir string, hash v1.Hash) (ispec.Image, error)
+	GetImageManifestFn          func(repo string, reference string) (ispec.Manifest, godigest.Digest, error)
+	GetImageManifestsFn         func(repo string) ([]ispec.Descriptor, error)
+	GetImageBlobManifestFn      func(repo string, digest godigest.Digest) (ispec.Manifest, error)
+	GetImageInfoFn              func(repo string, digest godigest.Digest) (ispec.Image, error)
 	GetImageTagsWithTimestampFn func(repo string) ([]common.TagInfo, error)
 	GetImagePlatformFn          func(imageInfo ispec.Image) (string, string)
 	GetImageVendorFn            func(imageInfo ispec.Image) string
@@ -25,7 +24,8 @@ type OciLayoutUtilsMock struct {
 	GetRepositoriesFn           func() ([]string, error)
 }
 
-func (olum OciLayoutUtilsMock) GetImageManifest(repo string, reference string) (ispec.Manifest, string, error) {
+func (olum OciLayoutUtilsMock) GetImageManifest(repo string, reference string,
+) (ispec.Manifest, godigest.Digest, error) {
 	if olum.GetImageManifestFn != nil {
 		return olum.GetImageManifestFn(repo, reference)
 	}
@@ -41,25 +41,25 @@ func (olum OciLayoutUtilsMock) GetRepositories() ([]string, error) {
 	return []string{}, nil
 }
 
-func (olum OciLayoutUtilsMock) GetImageManifests(image string) ([]ispec.Descriptor, error) {
+func (olum OciLayoutUtilsMock) GetImageManifests(repo string) ([]ispec.Descriptor, error) {
 	if olum.GetImageManifestsFn != nil {
-		return olum.GetImageManifestsFn(image)
+		return olum.GetImageManifestsFn(repo)
 	}
 
 	return []ispec.Descriptor{}, nil
 }
 
-func (olum OciLayoutUtilsMock) GetImageBlobManifest(imageDir string, digest godigest.Digest) (v1.Manifest, error) {
+func (olum OciLayoutUtilsMock) GetImageBlobManifest(repo string, digest godigest.Digest) (ispec.Manifest, error) {
 	if olum.GetImageBlobManifestFn != nil {
-		return olum.GetImageBlobManifestFn(imageDir, digest)
+		return olum.GetImageBlobManifestFn(repo, digest)
 	}
 
-	return v1.Manifest{}, nil
+	return ispec.Manifest{}, nil
 }
 
-func (olum OciLayoutUtilsMock) GetImageInfo(imageDir string, hash v1.Hash) (ispec.Image, error) {
+func (olum OciLayoutUtilsMock) GetImageInfo(repo string, digest godigest.Digest) (ispec.Image, error) {
 	if olum.GetImageInfoFn != nil {
-		return olum.GetImageInfoFn(imageDir, hash)
+		return olum.GetImageInfoFn(repo, digest)
 	}
 
 	return ispec.Image{}, nil


### PR DESCRIPTION
  - Digests were represented by different ways
  - We needed a uniform way to represent the digests and enforce a format
  - also replace usage of github.com/google/go-containerregistry/pkg/v1 with github.com/opencontainers/image-spec/specs-go/v1

Signed-off-by: Laurentiu Niculae <niculae.laurentiu1@gmail.com>
(cherry picked from commit 96b2f29d6d57070a913ce419149cd481c0723815) 
(cherry picked from commit 3d41b583daea654c98378ce3dcb78937d71538e8)

**What type of PR is this?**
refactoring

**Which issue does this PR fix**:
https://github.com/project-zot/zot/issues/869

**What does this PR do / Why do we need it**:
In some cases it's unclear if the digest strings are supposed to contain just the hex or also the algorithm.
API now returns full digests with the algorithm name, and the cli now removes it for easy of view purpose (in any case if we don't remove it the algorithm name uses half the characters allowed by the digest column width).
Using the go-digest.Digest struct has some additional benefits such as having validation as methods.
Also we were using 2 different structs for manifest used in some places, resulting in incompatibility between these types when we wanted to compare objects, and duplicating methods returning basically the same information in different struct types. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
