### PR TITLE
fix(cli): do not show signatures and fix tls verification client side

### DIFF
--- a/pkg/cli/discover.go
+++ b/pkg/cli/discover.go
@@ -1,0 +1,100 @@
+//go:build search
+// +build search
+
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	distext "github.com/opencontainers/distribution-spec/specs-go/v1/extensions"
+
+	"zotregistry.io/zot/pkg/api/constants"
+)
+
+type field struct {
+	Name string `json:"name"`
+}
+
+type schemaList struct {
+	Data struct {
+		Schema struct {
+			QueryType struct {
+				Fields []field `json:"fields"`
+			} `json:"queryType"` //nolint:tagliatelle // graphQL schema
+		} `json:"__schema"` //nolint:tagliatelle // graphQL schema
+	} `json:"data"`
+	Errors []errorGraphQL `json:"errors"`
+}
+
+func containsGQLQuery(queryList []field, query string) bool {
+	for _, q := range queryList {
+		if q.Name == query {
+			return true
+		}
+	}
+
+	return false
+}
+
+func checkExtEndPoint(config searchConfig) bool {
+	username, password := getUsernameAndPassword(*config.user)
+	ctx := context.Background()
+
+	discoverEndPoint, err := combineServerAndEndpointURL(*config.servURL, fmt.Sprintf("%s%s",
+		constants.RoutePrefix, constants.ExtOciDiscoverPrefix))
+	if err != nil {
+		return false
+	}
+
+	discoverResponse := &distext.ExtensionList{}
+
+	_, err = makeGETRequest(ctx, discoverEndPoint, username, password, *config.verifyTLS,
+		*config.debug, &discoverResponse, config.resultWriter)
+	if err != nil {
+		return false
+	}
+
+	searchEnabled := false
+
+	for _, extension := range discoverResponse.Extensions {
+		if extension.Name == "_zot" {
+			for _, endpoint := range extension.Endpoints {
+				if endpoint == constants.FullSearchPrefix {
+					searchEnabled = true
+				}
+			}
+		}
+	}
+
+	if !searchEnabled {
+		return false
+	}
+
+	searchEndPoint, _ := combineServerAndEndpointURL(*config.servURL, constants.FullSearchPrefix)
+
+	query := `
+        {
+            __schema() {
+                queryType {
+                    fields {
+                        name
+                    }
+                }
+            }
+        }`
+
+	queryResponse := &schemaList{}
+
+	err = makeGraphQLRequest(ctx, searchEndPoint, query, username, password, *config.verifyTLS,
+		*config.debug, queryResponse, config.resultWriter)
+	if err != nil {
+		return false
+	}
+
+	if err = checkResultGraphQLQuery(ctx, err, queryResponse.Errors); err != nil {
+		return false
+	}
+
+	return containsGQLQuery(queryResponse.Data.Schema.QueryType.Fields, "ImageList")
+}

--- a/pkg/cli/image_cmd.go
+++ b/pkg/cli/image_cmd.go
@@ -138,7 +138,7 @@ func setupImageFlags(imageCmd *cobra.Command, searchImageParams map[string]*stri
 func searchImage(searchConfig searchConfig) error {
 	var searchers []searcher
 
-	if checkExtEndPoint(*searchConfig.servURL) {
+	if checkExtEndPoint(searchConfig) {
 		searchers = getImageSearchersGQL()
 	} else {
 		searchers = getImageSearchers()

--- a/pkg/cli/service.go
+++ b/pkg/cli/service.go
@@ -324,6 +324,15 @@ func getImage(ctx context.Context, config searchConfig, username, password, imag
 	}
 
 	for _, tag := range tagList.Tags {
+		hasTagPrefix := strings.HasPrefix(tag, "sha256-")
+		hasTagSuffix := strings.HasSuffix(tag, ".sig")
+
+		// check if it's an image or a signature
+		// we don't want to show signatures in cli responses
+		if hasTagPrefix && hasTagSuffix {
+			continue
+		}
+
 		wtgrp.Add(1)
 
 		go addManifestCallToPool(ctx, config, pool, username, password, imageName, tag, rch, wtgrp)


### PR DESCRIPTION
Issues fixed:
- the cli calls reaching out to the catalog endpoint used to request signature manifests
- resty was used instead of the cli http client to check if the discovery api was available but it did not take into account TLS verification configuration (testing locally with self-signed certificates did not work)

Signed-off-by: Andrei Aaron <andaaron@cisco.com>
(cherry picked from commit ca42031ae9b1ceb459f5cd4f86cb82b3c9f78157)

**What type of PR is this?**
bug/refactoring

**Testing done on this change**:
Tested

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
