### PR TITLE
fix(sync): PreserveDigests flag prevents docker mediatype manifests t…

### DIFF
--- a/pkg/extensions/sync/on_demand.go
+++ b/pkg/extensions/sync/on_demand.go
@@ -257,6 +257,11 @@ func syncOneImage(imageChannel chan error, cfg Config, storeController storage.S
 							Err(err).Msgf("sync routine: error while copying image %s", demandedImageRef)
 					}
 				}()
+			} else {
+				// if successfully synced then return
+				imageChannel <- nil
+
+				return
 			}
 		}
 	}

--- a/pkg/extensions/sync/sync.go
+++ b/pkg/extensions/sync/sync.go
@@ -182,7 +182,6 @@ func getCopyOptions(upstreamCtx, localCtx *types.SystemContext) copy.Options {
 		SourceCtx:             upstreamCtx,
 		ReportWriter:          io.Discard,
 		ForceManifestMIMEType: ispec.MediaTypeImageManifest, // force only oci manifest MIME type
-		PreserveDigests:       true,
 		ImageListSelection:    copy.CopyAllImages,
 	}
 


### PR DESCRIPTION
…o be converted to oci mediatype

Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Because of preserveDigests flag, sync on demand doesn't work with docker.io (dockerhub) images
because it can not converts them from docker mediatype to oci mediatype

**What does this PR do / Why do we need it**:
Fix sync on demand with dockerhub


**Will this break upgrades or downgrades?**
no

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
no

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
