### PR TITLE
refactor(tests): removed globals from digest test, more hardcoded digests

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3215,7 +3215,7 @@ func TestCrossRepoMount(t *testing.T) {
 			baseURL, constants.RoutePrefix, constants.Blobs, constants.Uploads))
 
 		incorrectParams := make(map[string]string)
-		incorrectParams["mount"] = "sha256:63a795ca90aa6e7dda60941e826810a4cd0a2e73ea02bf458241df2a5c973e29"
+		incorrectParams["mount"] = test.GetTestBlobDigest("zot-cve-test", "manifest").String()
 		incorrectParams["from"] = "zot-x-test"
 
 		postResponse, err = client.R().

--- a/pkg/cli/cve_cmd_test.go
+++ b/pkg/cli/cve_cmd_test.go
@@ -481,7 +481,8 @@ func TestServerCVEResponseGQL(t *testing.T) {
 		str := space.ReplaceAllString(buff.String(), " ")
 		str = strings.TrimSpace(str)
 		So(err, ShouldBeNil)
-		So(str, ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE zot-cve-test 0.0.1 63a795ca false 75MB")
+		So(str, ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE zot-cve-test 0.0.1 "+
+			test.GetTestBlobDigest("zot-cve-test", "manifest").Encoded()[:8]+" false 75MB")
 
 		Convey("invalid CVE ID", func() {
 			args := []string{"cvetest", "--cve-id", "invalid"}
@@ -596,7 +597,8 @@ func TestServerCVEResponseGQL(t *testing.T) {
 		space := regexp.MustCompile(`\s+`)
 		str := space.ReplaceAllString(buff.String(), " ")
 		So(err, ShouldBeNil)
-		So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE zot-cve-test 0.0.1 63a795ca false 75MB")
+		So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE zot-cve-test 0.0.1 "+
+			test.GetTestBlobDigest("zot-cve-test", "manifest").Encoded()[:8]+" false 75MB")
 
 		Convey("invalid name and CVE ID", func() {
 			args := []string{"cvetest", "--image", "test", "--cve-id", "CVE-20807"}
@@ -905,7 +907,8 @@ func TestServerCVEResponse(t *testing.T) {
 		str := space.ReplaceAllString(buff.String(), " ")
 		str = strings.TrimSpace(str)
 		So(err, ShouldBeNil)
-		So(str, ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE zot-cve-test 0.0.1 63a795ca false 75MB")
+		So(str, ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE zot-cve-test 0.0.1 "+
+			test.GetTestBlobDigest("zot-cve-test", "manifest").Encoded()[:8]+" false 75MB")
 		Convey("invalid CVE ID", func() {
 			args := []string{"cvetest", "--cve-id", "invalid"}
 			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, url))
@@ -987,7 +990,8 @@ func TestServerCVEResponse(t *testing.T) {
 		space := regexp.MustCompile(`\s+`)
 		str := space.ReplaceAllString(buff.String(), " ")
 		So(err, ShouldBeNil)
-		So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE zot-cve-test 0.0.1 63a795ca false 75MB")
+		So(strings.TrimSpace(str), ShouldEqual, "IMAGE NAME TAG DIGEST SIGNED SIZE zot-cve-test 0.0.1 "+
+			test.GetTestBlobDigest("zot-cve-test", "manifest").Encoded()[:8]+" false 75MB")
 		Convey("invalid name and CVE ID", func() {
 			args := []string{"cvetest", "--image", "test", "--cve-id", "CVE-20807"}
 			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, url))

--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -1377,7 +1377,7 @@ func TestServerResponseGQLWithoutPermissions(t *testing.T) {
 	})
 
 	Convey("Test image by digest", t, func() {
-		args := []string{"imagetest", "--digest", "2bacca16"}
+		args := []string{"imagetest", "--digest", test.GetTestBlobDigest("zot-test", "manifest").Encoded()}
 		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 		defer os.Remove(configPath)
 		cmd := NewImageCommand(new(searchService))

--- a/pkg/extensions/search/common/common_test.go
+++ b/pkg/extensions/search/common/common_test.go
@@ -2750,7 +2750,7 @@ func TestBaseOciLayoutUtils(t *testing.T) {
 					"layers": [
 						{
 							"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
-							"digest": "sha256:2d473b07cdd5f0912cd6f1a703352c82b512407db6b05b43f2553732b55df3bc",
+							"digest": "` + GetTestBlobDigest("zot-test", "layer").String() + `",
 							"size": 76097157
 						}
 					]


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**What does this PR do / Why do we need it**:
Sometimes unpredictable issues when running digest tests individually due to global vars, this PR removes the global vars and updates the test setup helper function
Also removes a bunch of hardcoded digests I missed in my last PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
