### PR TITLE
fix(storage): deleting manifests with identical digests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,6 +314,18 @@ test-bats-metrics-verbose: EXTENSIONS=metrics
 test-bats-metrics-verbose: binary check-skopeo $(BATS)
 	$(BATS) --trace -p --verbose-run --print-output-on-failure --show-output-of-passing-tests test/blackbox/metrics.bats
 
+.PHONY: test-anonymous-push-pull
+test-anonymous-push-pull: binary check-skopeo $(BATS)
+	$(BATS) --trace --print-output-on-failure test/blackbox/anonymous_policy.bats
+
+.PHONY: test-annotations
+test-annotations: binary check-skopeo $(BATS) $(STACKER) $(NOTATION) $(COSIGN)
+	$(BATS) --trace --print-output-on-failure test/blackbox/annotations.bats
+
+.PHONY: test-detect-manifest-collision
+test-detect-manifest-collision: binary check-skopeo $(BATS)
+	$(BATS) --trace --print-output-on-failure test/blackbox/detect_manifest_collision.bats
+
 .PHONY: fuzz-all
 fuzz-all: fuzztime=${1}
 fuzz-all:
@@ -325,10 +337,6 @@ fuzz-all:
 	bash test/scripts/fuzzAll.sh ${fuzztime}; \
 	rm -rf pkg/storage/testdata; \
 
-.PHONY: test-anonymous-push-pull
-test-anonymous-push-pull: binary check-skopeo $(BATS)
-	$(BATS) --trace --print-output-on-failure test/blackbox/anonymous_policiy.bats
-
 $(STACKER):
 	mkdir -p $(TOOLSDIR)/bin; \
 	curl -fsSL https://github.com/project-stacker/stacker/releases/latest/download/stacker -o $@; \
@@ -338,7 +346,3 @@ $(COSIGN):
 	mkdir -p $(TOOLSDIR)/bin
 	curl -fsSL https://github.com/sigstore/cosign/releases/download/v1.13.0/cosign-linux-amd64 -o $@; \
 	chmod +x $@
-
-.PHONY: test-annotations
-test-annotations: binary check-skopeo $(BATS) $(STACKER) $(NOTATION) $(COSIGN)
-	$(BATS) --trace --print-output-on-failure test/blackbox/annotations.bats

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -59,4 +59,5 @@ var (
 	ErrParsingHTTPHeader       = errors.New("routes: invalid HTTP header")
 	ErrBadRange                = errors.New("storage: bad range")
 	ErrBadLayerCount           = errors.New("manifest: layers count doesn't correspond to config history")
+	ErrManifestConflict        = errors.New("manifest: multiple manifests found")
 )

--- a/examples/README.md
+++ b/examples/README.md
@@ -175,8 +175,11 @@ Should authentication fail, to prevent automated attacks, a delayed response can
 ## Identity-based Authorization
 
 Allowing actions on one or more repository paths can be tied to user
-identities. An additional per-repository default policy can be specified for
-identities not in the whitelist. Furthermore, a global admin policy can also be
+identities. Two additional per-repository policies can be specified for identities not in the whitelist:
+- anonymousPolicy - applied for unathenticated users.
+- defaultPolicy - applied for authenticated users.
+
+Furthermore, a global admin policy can also be
 specified which can override per-repository policies.
 
 Glob patterns can also be used as repository paths.
@@ -191,7 +194,15 @@ because it will be longer. So that's why we have the option to specify an adminP
 
 Basically '**' means repositories not matched by any other per-repository policy.
 
-create/update/delete can not be used without 'read' action, make sure read is always included in policies!
+Method-based action list:
+- "read" - list/pull images
+- "create" - push images (needs "read")
+- "update" - overwrite tags (needs "read" and "create")
+- "delete" - delete images (needs "read")
+
+Behaviour-based action list
+- "detectManifestCollision" - delete manifest by digest will throw an error if multiple manifests have the same digest (needs "read" and "delete")
+
 
 ```
 "accessControl": {
@@ -202,8 +213,8 @@ create/update/delete can not be used without 'read' action, make sure read is al
           "actions": ["read", "create", "update"]
         }
       ],
-      "defaultPolicy": ["read", "create"],                     # default policy which is applied for authenticated users, other than "charlie"=> so these users can read/create repositories
-      "anonymousPolicy": ["read]                               # anonymous policy which is applied for unauthenticated users => so they can read repositories
+      "defaultPolicy": ["read", "create", "delete", "detectManifestCollision"], # default policy which is applied for authenticated users, other than "charlie"=> so these users can read/create/delete repositories and also can detect manifests collision.
+      "anonymousPolicy": ["read"]                               # anonymous policy which is applied for unauthenticated users => so they can read repositories
     },
     "tmp/**": {                                                # matches all repos under tmp/ recursively
       "defaultPolicy": ["read", "create", "update"]            # so all users have read/create/update on all repos under tmp/ eg: tmp/infra/repo

--- a/examples/config-policy.json
+++ b/examples/config-policy.json
@@ -30,7 +30,9 @@
         ],
         "defaultPolicy": [
           "read",
-          "create"
+          "create",
+          "delete",
+          "detectManifestCollision"
         ]
       },
       "tmp/**": {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -5789,6 +5789,140 @@ func TestManifestImageIndex(t *testing.T) {
 	})
 }
 
+func TestManifestCollision(t *testing.T) {
+	Convey("Make a new controller", t, func() {
+		port := test.GetFreePort()
+		baseURL := test.GetBaseURL(port)
+		conf := config.New()
+		conf.HTTP.Port = port
+
+		ctlr := api.NewController(conf)
+		dir := t.TempDir()
+		ctlr.Config.Storage.RootDirectory = dir
+
+		conf.AccessControl = &config.AccessControlConfig{
+			Repositories: config.Repositories{
+				AuthorizationAllRepos: config.PolicyGroup{
+					AnonymousPolicy: []string{api.Read, api.Create, api.Delete, api.DetectManifestCollision},
+				},
+			},
+		}
+
+		go startServer(ctlr)
+		defer stopServer(ctlr)
+		test.WaitTillServerReady(baseURL)
+
+		// create a blob/layer
+		resp, err := resty.R().Post(baseURL + "/v2/index/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+		loc := test.Location(baseURL, resp)
+		So(loc, ShouldNotBeEmpty)
+
+		// since we are not specifying any prefix i.e provided in config while starting server,
+		// so it should store index1 to global root dir
+		_, err = os.Stat(path.Join(dir, "index"))
+		So(err, ShouldBeNil)
+
+		resp, err = resty.R().Get(loc)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNoContent)
+		content := []byte("this is a blob1")
+		digest := godigest.FromBytes(content)
+		So(digest, ShouldNotBeNil)
+		// monolithic blob upload: success
+		resp, err = resty.R().SetQueryParam("digest", digest.String()).
+			SetHeader("Content-Type", "application/octet-stream").SetBody(content).Put(loc)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+		blobLoc := resp.Header().Get("Location")
+		So(blobLoc, ShouldNotBeEmpty)
+		So(resp.Header().Get("Content-Length"), ShouldEqual, "0")
+		So(resp.Header().Get(constants.DistContentDigestKey), ShouldNotBeEmpty)
+
+		// check a non-existent manifest
+		resp, err = resty.R().SetHeader("Content-Type", ispec.MediaTypeImageManifest).
+			SetBody(content).Head(baseURL + "/v2/unknown/manifests/test:1.0")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+		// upload image config blob
+		resp, err = resty.R().Post(baseURL + "/v2/index/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+		loc = test.Location(baseURL, resp)
+		cblob, cdigest := test.GetRandomImageConfig()
+
+		resp, err = resty.R().
+			SetContentLength(true).
+			SetHeader("Content-Length", fmt.Sprintf("%d", len(cblob))).
+			SetHeader("Content-Type", "application/octet-stream").
+			SetQueryParam("digest", cdigest.String()).
+			SetBody(cblob).
+			Put(loc)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		// create a manifest
+		manifest := ispec.Manifest{
+			Config: ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageConfig,
+				Digest:    cdigest,
+				Size:      int64(len(cblob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: ispec.MediaTypeImageLayer,
+					Digest:    digest,
+					Size:      int64(len(content)),
+				},
+			},
+		}
+		manifest.SchemaVersion = 2
+		content, err = json.Marshal(manifest)
+		So(err, ShouldBeNil)
+		digest = godigest.FromBytes(content)
+		So(digest, ShouldNotBeNil)
+		resp, err = resty.R().SetHeader("Content-Type", ispec.MediaTypeImageManifest).
+			SetBody(content).Put(baseURL + "/v2/index/manifests/test:1.0")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+		digestHdr := resp.Header().Get(constants.DistContentDigestKey)
+		So(digestHdr, ShouldNotBeEmpty)
+		So(digestHdr, ShouldEqual, digest.String())
+
+		resp, err = resty.R().SetHeader("Content-Type", ispec.MediaTypeImageManifest).
+			SetBody(content).Put(baseURL + "/v2/index/manifests/test:2.0")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+		digestHdr = resp.Header().Get(constants.DistContentDigestKey)
+		So(digestHdr, ShouldNotBeEmpty)
+		So(digestHdr, ShouldEqual, digest.String())
+
+		// Deletion should fail if using digest
+		resp, err = resty.R().Delete(baseURL + "/v2/index/manifests/" + digest.String())
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusConflict)
+
+		// remove detectManifestCollision action from ** (all repos)
+		repoPolicy := conf.AccessControl.Repositories[AuthorizationAllRepos]
+		repoPolicy.AnonymousPolicy = []string{"read", "delete"}
+		conf.AccessControl.Repositories[AuthorizationAllRepos] = repoPolicy
+
+		resp, err = resty.R().Delete(baseURL + "/v2/index/manifests/" + digest.String())
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+		resp, err = resty.R().Get(baseURL + "/v2/index/manifests/test:1.0")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+		resp, err = resty.R().Get(baseURL + "/v2/index/manifests/test:2.0")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+	})
+}
+
 func TestPullRange(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		port := test.GetFreePort()

--- a/pkg/extensions/search/resolver_test.go
+++ b/pkg/extensions/search/resolver_test.go
@@ -337,8 +337,8 @@ func TestExtractImageDetails(t *testing.T) {
 		authzCtxKey := localCtx.GetContextKey()
 		ctx = context.WithValue(ctx, authzCtxKey,
 			localCtx.AccessControlContext{
-				GlobPatterns: map[string]bool{"*": true, "**": true},
-				Username:     "jane_doe",
+				ReadGlobPatterns: map[string]bool{"*": true, "**": true},
+				Username:         "jane_doe",
 			})
 		configBlobContent, _ := json.MarshalIndent(&config, "", "\t")
 		configDigest := godigest.FromBytes(configBlobContent)
@@ -429,8 +429,8 @@ func TestExtractImageDetails(t *testing.T) {
 		Convey("extractImageDetails without proper authz", func() {
 			ctx = context.WithValue(ctx, authzCtxKey,
 				localCtx.AccessControlContext{
-					GlobPatterns: map[string]bool{},
-					Username:     "jane_doe",
+					ReadGlobPatterns: map[string]bool{},
+					Username:         "jane_doe",
 				})
 			mockOlum := mocks.OciLayoutUtilsMock{
 				GetImageConfigInfoFn: func(repo string, digest godigest.Digest) (

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -1408,7 +1408,7 @@ func TestBasicAuth(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(resp.StatusCode(), ShouldEqual, 200)
 
-			err = dctlr.StoreController.DefaultStore.DeleteImageManifest(testImage, testImageTag)
+			err = dctlr.StoreController.DefaultStore.DeleteImageManifest(testImage, testImageTag, false)
 			So(err, ShouldBeNil)
 
 			resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + "1.1.1")

--- a/pkg/requestcontext/context.go
+++ b/pkg/requestcontext/context.go
@@ -1,5 +1,12 @@
 package requestcontext
 
+import (
+	"context"
+
+	glob "github.com/bmatcuk/doublestar/v4" //nolint:gci
+	"zotregistry.io/zot/errors"
+)
+
 type Key int
 
 // request-local context key.
@@ -12,7 +19,53 @@ func GetContextKey() *Key {
 
 // AccessControlContext context passed down to http.Handlers.
 type AccessControlContext struct {
-	GlobPatterns map[string]bool
-	IsAdmin      bool
-	Username     string
+	// read method action
+	ReadGlobPatterns map[string]bool
+	// detectManifestCollision behaviour action
+	DmcGlobPatterns map[string]bool
+	IsAdmin         bool
+	Username        string
+}
+
+func GetAccessControlContext(ctx context.Context) (*AccessControlContext, error) {
+	authzCtxKey := GetContextKey()
+	if authCtx := ctx.Value(authzCtxKey); authCtx != nil {
+		acCtx, ok := authCtx.(AccessControlContext)
+		if !ok {
+			return nil, errors.ErrBadType
+		}
+
+		return &acCtx, nil
+	}
+
+	return nil, nil //nolint: nilnil
+}
+
+// returns either a user has or not rights on 'repository'.
+func (acCtx *AccessControlContext) matchesRepo(globPatterns map[string]bool, repository string) bool {
+	var longestMatchedPattern string
+
+	// because of the longest path matching rule, we need to check all patterns from config
+	for pattern := range globPatterns {
+		matched, err := glob.Match(pattern, repository)
+		if err == nil {
+			if matched && len(pattern) > len(longestMatchedPattern) {
+				longestMatchedPattern = pattern
+			}
+		}
+	}
+
+	allowed := globPatterns[longestMatchedPattern]
+
+	return allowed
+}
+
+// returns either a user has or not read rights on 'repository'.
+func (acCtx *AccessControlContext) CanReadRepo(repository string) bool {
+	return acCtx.matchesRepo(acCtx.ReadGlobPatterns, repository)
+}
+
+// returns either a user has or not detectManifestCollision rights on 'repository'.
+func (acCtx *AccessControlContext) CanDetectManifestCollision(repository string) bool {
+	return acCtx.matchesRepo(acCtx.DmcGlobPatterns, repository)
 }

--- a/pkg/storage/common.go
+++ b/pkg/storage/common.go
@@ -178,7 +178,7 @@ func GetAndValidateRequestDigest(body []byte, digestStr string, log zerolog.Logg
 }
 
 /*
-	CheckIfIndexNeedsUpdate verifies if an index needs to be updated given a new manifest descriptor.
+CheckIfIndexNeedsUpdate verifies if an index needs to be updated given a new manifest descriptor.
 
 Returns whether or not index needs update, in the latter case it will also return the previous digest.
 */
@@ -272,10 +272,13 @@ func GetIndex(imgStore ImageStore, repo string, log zerolog.Logger) (ispec.Index
 	return index, nil
 }
 
-func RemoveManifestDescByReference(index *ispec.Index, reference string) (ispec.Descriptor, bool) {
+func RemoveManifestDescByReference(index *ispec.Index, reference string, detectCollisions bool,
+) (ispec.Descriptor, bool, error) {
 	var removedManifest ispec.Descriptor
 
 	var found bool
+
+	foundCount := 0
 
 	var outIndex ispec.Index
 
@@ -284,11 +287,13 @@ func RemoveManifestDescByReference(index *ispec.Index, reference string) (ispec.
 		if ok && tag == reference {
 			removedManifest = manifest
 			found = true
+			foundCount++
 
 			continue
 		} else if reference == manifest.Digest.String() {
 			removedManifest = manifest
 			found = true
+			foundCount++
 
 			continue
 		}
@@ -296,14 +301,17 @@ func RemoveManifestDescByReference(index *ispec.Index, reference string) (ispec.
 		outIndex.Manifests = append(outIndex.Manifests, manifest)
 	}
 
+	if foundCount > 1 && detectCollisions {
+		return ispec.Descriptor{}, false, zerr.ErrManifestConflict
+	}
+
 	index.Manifests = outIndex.Manifests
 
-	return removedManifest, found
+	return removedManifest, found, nil
 }
 
 /*
-	additionally, unmarshal an image index and for all manifests in that
-
+Unmarshal an image index and for all manifests in that
 index, ensure that they do not have a name or they are not in other
 manifest indexes else GC can never clean them.
 */
@@ -333,13 +341,12 @@ func UpdateIndexWithPrunedImageManifests(imgStore ImageStore, index *ispec.Index
 }
 
 /*
-*
-before an image index manifest is pushed to a repo, its constituent manifests
+Before an image index manifest is pushed to a repo, its constituent manifests
 are pushed first, so when updating/removing this image index manifest, we also
 need to determine if there are other image index manifests which refer to the
 same constitutent manifests so that they can be garbage-collected correctly
 
-pruneImageManifestsFromIndex is a helper routine to achieve this.
+PruneImageManifestsFromIndex is a helper routine to achieve this.
 */
 func PruneImageManifestsFromIndex(imgStore ImageStore, repo string, digest godigest.Digest, //nolint:gocyclo
 	outIndex ispec.Index, otherImgIndexes []ispec.Descriptor, log zerolog.Logger,

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -549,7 +549,7 @@ func (is *ImageStoreLocal) PutImageManifest(repo, reference, mediaType string, /
 }
 
 // DeleteImageManifest deletes the image manifest from the repository.
-func (is *ImageStoreLocal) DeleteImageManifest(repo, reference string) error {
+func (is *ImageStoreLocal) DeleteImageManifest(repo, reference string, detectCollision bool) error {
 	var lockLatency time.Time
 
 	dir := path.Join(is.rootDir, repo)
@@ -562,7 +562,11 @@ func (is *ImageStoreLocal) DeleteImageManifest(repo, reference string) error {
 		return err
 	}
 
-	manifestDesc, found := storage.RemoveManifestDescByReference(&index, reference)
+	manifestDesc, found, err := storage.RemoveManifestDescByReference(&index, reference, detectCollision)
+	if err != nil {
+		return err
+	}
+
 	if !found {
 		return zerr.ErrManifestNotFound
 	}

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -164,7 +164,7 @@ func TestStorageFSAPIs(t *testing.T) {
 				panic(err)
 			}
 
-			err = imgStore.DeleteImageManifest(repoName, digest.String())
+			err = imgStore.DeleteImageManifest(repoName, digest.String(), false)
 			So(err, ShouldNotBeNil)
 
 			err = os.RemoveAll(path.Join(imgStore.RootDir(), repoName))
@@ -440,7 +440,7 @@ func FuzzTestPutDeleteImageManifest(f *testing.F) {
 			t.Errorf("the error that occurred is %v \n", err)
 		}
 
-		err = imgStore.DeleteImageManifest(repoName, mdigest.String())
+		err = imgStore.DeleteImageManifest(repoName, mdigest.String(), false)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -470,7 +470,7 @@ func FuzzTestDeleteImageManifest(f *testing.F) {
 		if err != nil {
 			return
 		}
-		err = imgStore.DeleteImageManifest(string(data), digest.String())
+		err = imgStore.DeleteImageManifest(string(data), digest.String(), false)
 		if err != nil {
 			if errors.Is(err, zerr.ErrRepoNotFound) || isKnownErr(err) {
 				return
@@ -1822,7 +1822,7 @@ func TestGarbageCollect(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
-			err = imgStore.DeleteImageManifest(repoName, digest.String())
+			err = imgStore.DeleteImageManifest(repoName, digest.String(), false)
 			So(err, ShouldBeNil)
 
 			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
@@ -1922,7 +1922,7 @@ func TestGarbageCollect(t *testing.T) {
 			// sleep so orphan blob can be GC'ed
 			time.Sleep(5 * time.Second)
 
-			err = imgStore.DeleteImageManifest(repoName, digest.String())
+			err = imgStore.DeleteImageManifest(repoName, digest.String(), false)
 			So(err, ShouldBeNil)
 
 			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -442,7 +442,7 @@ func (is *ObjectStorage) PutImageManifest(repo, reference, mediaType string, //n
 }
 
 // DeleteImageManifest deletes the image manifest from the repository.
-func (is *ObjectStorage) DeleteImageManifest(repo, reference string) error {
+func (is *ObjectStorage) DeleteImageManifest(repo, reference string, detectCollisions bool) error {
 	var lockLatency time.Time
 
 	dir := path.Join(is.rootDir, repo)
@@ -455,7 +455,11 @@ func (is *ObjectStorage) DeleteImageManifest(repo, reference string) error {
 		return err
 	}
 
-	manifestDesc, found := storage.RemoveManifestDescByReference(&index, reference)
+	manifestDesc, found, err := storage.RemoveManifestDescByReference(&index, reference, detectCollisions)
+	if err != nil {
+		return err
+	}
+
 	if !found {
 		return zerr.ErrManifestNotFound
 	}

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -783,7 +783,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			err = imgStore.DeleteBlobUpload(testImage, upload)
 			So(err, ShouldNotBeNil)
 
-			err = imgStore.DeleteImageManifest(testImage, "1.0")
+			err = imgStore.DeleteImageManifest(testImage, "1.0", false)
 			So(err, ShouldNotBeNil)
 
 			_, err = imgStore.PutImageManifest(testImage, "1.0", "application/json", []byte{})
@@ -887,13 +887,13 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 					return []byte{}, errS3
 				},
 			})
-			err := imgStore.DeleteImageManifest(testImage, "1.0")
+			err := imgStore.DeleteImageManifest(testImage, "1.0", false)
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Test DeleteImageManifest2", func(c C) {
 			imgStore = createMockStorage(testDir, tdir, false, &StorageDriverMock{})
-			err := imgStore.DeleteImageManifest(testImage, "1.0")
+			err := imgStore.DeleteImageManifest(testImage, "1.0", false)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -1891,12 +1891,12 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 			Convey("Deleting an image index", func() {
 				// delete manifest by tag should pass
-				err := imgStore.DeleteImageManifest("index", "test:index3")
+				err := imgStore.DeleteImageManifest("index", "test:index3", false)
 				So(err, ShouldNotBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index3")
 				So(err, ShouldNotBeNil)
 
-				err = imgStore.DeleteImageManifest("index", "test:index1")
+				err = imgStore.DeleteImageManifest("index", "test:index1", false)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 				So(err, ShouldNotBeNil)
@@ -1907,12 +1907,12 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 			Convey("Deleting an image index by digest", func() {
 				// delete manifest by tag should pass
-				err := imgStore.DeleteImageManifest("index", "test:index3")
+				err := imgStore.DeleteImageManifest("index", "test:index3", false)
 				So(err, ShouldNotBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index3")
 				So(err, ShouldNotBeNil)
 
-				err = imgStore.DeleteImageManifest("index", index1dgst.String())
+				err = imgStore.DeleteImageManifest("index", index1dgst.String(), false)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 				So(err, ShouldNotBeNil)
@@ -1983,7 +1983,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 				So(err, ShouldBeNil)
 
-				err = imgStore.DeleteImageManifest("index", "test:index1")
+				err = imgStore.DeleteImageManifest("index", "test:index1", false)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 				So(err, ShouldNotBeNil)
@@ -1994,7 +1994,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 					cleanupStorage(storeDriver, path.Join(testDir, "index", "blobs",
 						index1dgst.Algorithm().String(), index1dgst.Encoded()))
 
-					err = imgStore.DeleteImageManifest("index", index1dgst.String())
+					err = imgStore.DeleteImageManifest("index", index1dgst.String(), false)
 					So(err, ShouldNotBeNil)
 					_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 					So(err, ShouldNotBeNil)
@@ -2009,7 +2009,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 					_, err = wrtr.Write([]byte("deadbeef"))
 					So(err, ShouldBeNil)
 					wrtr.Close()
-					err = imgStore.DeleteImageManifest("index", index1dgst.String())
+					err = imgStore.DeleteImageManifest("index", index1dgst.String(), false)
 					So(err, ShouldBeNil)
 					_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 					So(err, ShouldNotBeNil)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -30,7 +30,7 @@ type ImageStore interface { //nolint:interfacebloat
 	GetImageTags(repo string) ([]string, error)
 	GetImageManifest(repo, reference string) ([]byte, godigest.Digest, string, error)
 	PutImageManifest(repo, reference, mediaType string, body []byte) (godigest.Digest, error)
-	DeleteImageManifest(repo, reference string) error
+	DeleteImageManifest(repo, reference string, detectCollision bool) error
 	BlobUploadPath(repo, uuid string) string
 	NewBlobUpload(repo string) (string, error)
 	GetBlobUpload(repo, uuid string) (int64, error)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -356,7 +356,7 @@ func TestStorageAPIs(t *testing.T) {
 							_, _, _, err = imgStore.GetImageManifest("test", "3.0")
 							So(err, ShouldBeNil)
 
-							err = imgStore.DeleteImageManifest("test", "1.0")
+							err = imgStore.DeleteImageManifest("test", "1.0", false)
 							So(err, ShouldBeNil)
 
 							tags, err = imgStore.GetImageTags("test")
@@ -368,8 +368,12 @@ func TestStorageAPIs(t *testing.T) {
 							So(err, ShouldBeNil)
 							So(hasBlob, ShouldEqual, true)
 
+							// with detectManifestCollision should get error
+							err = imgStore.DeleteImageManifest("test", digest.String(), true)
+							So(err, ShouldNotBeNil)
+
 							// If we pass reference all manifest with input reference should be deleted.
-							err = imgStore.DeleteImageManifest("test", digest.String())
+							err = imgStore.DeleteImageManifest("test", digest.String(), false)
 							So(err, ShouldBeNil)
 
 							tags, err = imgStore.GetImageTags("test")
@@ -541,13 +545,13 @@ func TestStorageAPIs(t *testing.T) {
 							So(err, ShouldBeNil)
 
 							So(len(index.Manifests), ShouldEqual, 1)
-							err = imgStore.DeleteImageManifest("test", "1.0")
+							err = imgStore.DeleteImageManifest("test", "1.0", false)
 							So(err, ShouldNotBeNil)
 
-							err = imgStore.DeleteImageManifest("inexistent", "1.0")
+							err = imgStore.DeleteImageManifest("inexistent", "1.0", false)
 							So(err, ShouldNotBeNil)
 
-							err = imgStore.DeleteImageManifest("test", digest.String())
+							err = imgStore.DeleteImageManifest("test", digest.String(), false)
 							So(err, ShouldBeNil)
 
 							_, _, _, err = imgStore.GetImageManifest("test", digest.String())

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -21,7 +21,7 @@ type MockedImageStore struct {
 	GetImageTagsFn         func(repo string) ([]string, error)
 	GetImageManifestFn     func(repo string, reference string) ([]byte, godigest.Digest, string, error)
 	PutImageManifestFn     func(repo string, reference string, mediaType string, body []byte) (godigest.Digest, error)
-	DeleteImageManifestFn  func(repo string, reference string) error
+	DeleteImageManifestFn  func(repo string, reference string, detectCollision bool) error
 	BlobUploadPathFn       func(repo string, uuid string) string
 	NewBlobUploadFn        func(repo string) (string, error)
 	GetBlobUploadFn        func(repo string, uuid string) (int64, error)
@@ -136,9 +136,9 @@ func (is MockedImageStore) GetImageTags(name string) ([]string, error) {
 	return []string{}, nil
 }
 
-func (is MockedImageStore) DeleteImageManifest(name string, reference string) error {
+func (is MockedImageStore) DeleteImageManifest(name string, reference string, detectCollision bool) error {
 	if is.DeleteImageManifestFn != nil {
-		return is.DeleteImageManifestFn(name, reference)
+		return is.DeleteImageManifestFn(name, reference, detectCollision)
 	}
 
 	return nil

--- a/test/blackbox/anonymous_policy.bats
+++ b/test/blackbox/anonymous_policy.bats
@@ -1,0 +1,88 @@
+load helpers_pushpull
+
+function setup_file() {
+    # Verify prerequisites are available
+    if ! verify_prerequisites; then
+        exit 1
+    fi
+
+    # Download test data to folder common for the entire suite, not just this file
+    skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.18 oci:${TEST_DATA_DIR}/golang:1.18
+    # Setup zot server
+    local zot_root_dir=${BATS_FILE_TMPDIR}/zot
+    local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
+    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
+    local htpasswordFile=${BATS_FILE_TMPDIR}/htpasswd
+    mkdir -p ${zot_root_dir}
+    mkdir -p ${oci_data_dir}
+    echo 'test:$2a$10$EIIoeCnvsIDAJeDL4T1sEOnL2fWOvsq7ACZbs3RT40BBBXg.Ih7V.' >> ${htpasswordFile}
+    cat > ${zot_config_file}<<EOF
+{
+    "distSpecVersion": "1.0.1",
+    "storage": {
+        "rootDirectory": "${zot_root_dir}"
+    },
+    "http": {
+        "address": "127.0.0.1",
+        "port": "8080",
+        "auth": {
+            "htpasswd": {
+                "path": "${htpasswordFile}"
+            }
+        },
+        "accessControl": {
+            "**": {
+                "anonymousPolicy": ["read"],
+                "policies": [
+                    {
+                        "users": [
+                            "test"
+                        ],
+                        "actions": [
+                            "read",
+                            "create",
+                            "update"
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    "log": {
+        "level": "debug"
+    }
+}
+EOF
+    setup_zot_file_level ${zot_config_file}
+    wait_zot_reachable "http://127.0.0.1:8080/v2/_catalog"   
+}
+
+function teardown_file() {
+    local zot_root_dir=${BATS_FILE_TMPDIR}/zot
+    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
+    teardown_zot_file_level
+    rm -rf ${zot_root_dir}
+    rm -rf ${oci_data_dir}
+}
+
+@test "push image user policy" {
+    run skopeo --insecure-policy copy --dest-creds test:test --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/golang:1.18 \
+        docker://127.0.0.1:8080/golang:1.18
+    [ "$status" -eq 0 ]
+}
+
+@test "pull image anonymous policy" {
+    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
+    run skopeo --insecure-policy copy --src-tls-verify=false \
+        docker://127.0.0.1:8080/golang:1.18 \
+        oci:${oci_data_dir}/golang:1.18
+    [ "$status" -eq 0 ]
+}
+
+@test "push image anonymous policy" {
+    run skopeo --insecure-policy copy --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/golang:1.18 \
+        docker://127.0.0.1:8080/golang:1.18
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Suppose we push two identical manifests (sharing same digest) but with different tags, then deleting by digest should throw an error otherwise we end up deleting all image tags (with gc) or dangling references (without gc)

This behaviour is controlled via Authorization, added a new policy action named detectManifestsCollision which enables this behaviour

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>
Signed-off-by: Petu Eusebiu <peusebiu@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
