### PR TITLE
feat(graphql): add an api to return referrers

### DIFF
--- a/pkg/extensions/search/common/model.go
+++ b/pkg/extensions/search/common/model.go
@@ -71,3 +71,16 @@ type HistoryDescription struct {
 	Comment    string    `json:"comment"`
 	EmptyLayer bool      `json:"emptyLayer"`
 }
+
+type Referrer struct {
+	MediaType    string       `json:"mediatype"`
+	ArtifactType string       `json:"artifacttype"`
+	Size         int          `json:"size"`
+	Digest       string       `json:"digest"`
+	Annotations  []Annotation `json:"annotations"`
+}
+
+type Annotation struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}

--- a/pkg/extensions/search/gql_generated/models_gen.go
+++ b/pkg/extensions/search/gql_generated/models_gen.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+type Annotation struct {
+	Key   *string `json:"Key"`
+	Value *string `json:"Value"`
+}
+
 // Contains various details about the CVE and a list of PackageInfo about the affected packages
 type Cve struct {
 	ID          *string        `json:"Id"`
@@ -93,6 +98,14 @@ type PackageInfo struct {
 	Name             *string `json:"Name"`
 	InstalledVersion *string `json:"InstalledVersion"`
 	FixedVersion     *string `json:"FixedVersion"`
+}
+
+type Referrer struct {
+	MediaType    *string       `json:"MediaType"`
+	ArtifactType *string       `json:"ArtifactType"`
+	Size         *int          `json:"Size"`
+	Digest       *string       `json:"Digest"`
+	Annotations  []*Annotation `json:"Annotations"`
 }
 
 // Contains details about the repo: a list of image summaries and a summary of the repo

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -134,6 +134,19 @@ type LayerHistory {
     HistoryDescription: HistoryDescription
 }
 
+type Annotation {
+    Key: String
+    Value: String
+}
+
+type Referrer {
+        MediaType:    String
+        ArtifactType: String
+        Size:         Int
+        Digest:       String
+        Annotations:  [Annotation]!
+}
+
 """
 Contains details about the supported OS and architecture of the image
 """
@@ -197,4 +210,10 @@ type Query {
     Search for a specific image using its name
     """
     Image(image: String!): ImageSummary
+
+    """
+    Returns a list of descriptors of an image or artifact manifest that are found in a <repo> and have a subject field of <digest>
+    Can be filtered based on a specific artifact type <type>
+    """
+    Referrers(repo: String!, digest: String!, type: String!): [Referrer]!
 }

--- a/pkg/extensions/search/schema.resolvers.go
+++ b/pkg/extensions/search/schema.resolvers.go
@@ -564,6 +564,20 @@ func (r *queryResolver) Image(ctx context.Context, image string) (*gql_generated
 	return result, nil
 }
 
+// Referrers is the resolver for the Referrers field.
+func (r *queryResolver) Referrers(ctx context.Context, repo string, digest string, typeArg string) ([]*gql_generated.Referrer, error) {
+	store := r.storeController.GetImageStore(repo)
+
+	referrers, err := getReferrers(store, repo, digest, typeArg, r.log)
+	if err != nil {
+		r.log.Error().Err(err).Msg("unable to get referrers from default store")
+
+		return []*gql_generated.Referrer{}, err
+	}
+
+	return referrers, nil
+}
+
 // Query returns gql_generated.QueryResolver implementation.
 func (r *Resolver) Query() gql_generated.QueryResolver { return &queryResolver{r} }
 


### PR DESCRIPTION
UI can now make use of OCI artifacts and references using `Referrers` gQL query. It returns a list of descriptors that refer on their `subject` field to another digest.

Closes https://github.com/project-zot/zot/issues/1006

Signed-off-by: Alex Stan <alexandrustan96@yahoo.ro>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
UI can now use gQL queries to get list of referrer artifacts

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
