### PR TITLE
fix(oras): relax artifactType check to allow other types

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -4145,12 +4145,12 @@ func TestImageSignatures(t *testing.T) {
 			resp, err = resty.R().Get(
 				fmt.Sprintf("%s/oras/artifacts/v1/%s/manifests/%s/referrers", baseURL, repoName, digest.String()))
 			So(err, ShouldBeNil)
-			So(resp.StatusCode(), ShouldEqual, http.StatusBadRequest)
+			So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
 
 			resp, err = resty.R().SetQueryParam("artifactType", "badArtifact").Get(
 				fmt.Sprintf("%s/oras/artifacts/v1/%s/manifests/%s/referrers", baseURL, repoName, digest.String()))
 			So(err, ShouldBeNil)
-			So(resp.StatusCode(), ShouldEqual, http.StatusBadRequest)
+			So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
 
 			resp, err = resty.R().SetQueryParam("artifactType", notreg.ArtifactTypeNotation).Get(
 				fmt.Sprintf("%s/oras/artifacts/v1/%s/manifests/%s/referrers", baseURL, "badRepo", digest.String()))

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/gorilla/mux"
 	jsoniter "github.com/json-iterator/go"
-	notreg "github.com/notaryproject/notation-go/registry"
 	"github.com/opencontainers/distribution-spec/specs-go/v1/extensions"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -1685,13 +1684,6 @@ func (rh *RouteHandler) GetOrasReferrers(response http.ResponseWriter, request *
 		}
 
 		artifactType = artifactTypes[0]
-	}
-
-	if artifactType != notreg.ArtifactTypeNotation {
-		rh.c.Log.Error().Str("artifactType", artifactType).Msg("invalid artifact type")
-		response.WriteHeader(http.StatusBadRequest)
-
-		return
 	}
 
 	imgStore := rh.getImageStore(name)


### PR DESCRIPTION
Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:

oras cli now allows for different artifactTypes. Originally, zot was interested in the notation use case only. No reason to constrain.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
