### PR TITLE
fix(config): warn if cve is used with remote storage driver

### DIFF
--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -66,7 +66,6 @@ jobs:
           echo "Startup complete"          
       - name: Run cloud-only tests
         run: |
-            sudo mkdir /zot
             make test-cloud-only
         env:
           AWS_ACCESS_KEY_ID: fake

--- a/examples/config-search.json
+++ b/examples/config-search.json
@@ -12,10 +12,7 @@
     },
     "extensions": {
         "search": {
-          "enable": true,
-          "cve": {
-            "updateInterval": "24h"
-          }
+          "enable": true
         }
     }
 }

--- a/pkg/cli/extensions_test.go
+++ b/pkg/cli/extensions_test.go
@@ -637,15 +637,10 @@ func TestServeSearchEnabled(t *testing.T) {
 		logPath, err := runCLIWithConfig(tempDir, content)
 		So(err, ShouldBeNil)
 		// to avoid data race when multiple go routines write to trivy DB instance.
-		WaitTillTrivyDBDownloadStarted(tempDir)
 		defer os.Remove(logPath) // clean up
 
-		substring := "\"Extensions\":{\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":86400000000000}},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
+		substring := "\"Extensions\":{\"Search\":{\"Enable\":true,\"CVE\":null},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
 		found, err := readLogFileAndSearchString(logPath, substring, readLogFileTimeout)
-		So(found, ShouldBeTrue)
-		So(err, ShouldBeNil)
-
-		found, err = readLogFileAndSearchString(logPath, "updating the CVE database", readLogFileTimeout)
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
 	})
@@ -730,15 +725,9 @@ func TestServeSearchEnabledNoCVE(t *testing.T) {
 		logPath, err := runCLIWithConfig(tempDir, content)
 		So(err, ShouldBeNil)
 		defer os.Remove(logPath) // clean up
-		// to avoid data race when multiple go routines write to trivy DB instance.
-		WaitTillTrivyDBDownloadStarted(tempDir)
 
-		substring := "\"Extensions\":{\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":86400000000000}},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
+		substring := "\"Extensions\":{\"Search\":{\"Enable\":true,\"CVE\":null},\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null}" //nolint:lll // gofumpt conflicts with lll
 		found, err := readLogFileAndSearchString(logPath, substring, readLogFileTimeout)
-		So(found, ShouldBeTrue)
-		So(err, ShouldBeNil)
-
-		found, err = readLogFileAndSearchString(logPath, "updating the CVE database", readLogFileTimeout)
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
 	})

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -306,6 +306,26 @@ func validateCacheConfig(cfg *config.Config) error {
 	return nil
 }
 
+func validateExtensionsConfig(cfg *config.Config) error {
+	//nolint:lll
+	if cfg.Storage.StorageDriver != nil && cfg.Extensions != nil && cfg.Extensions.Search != nil && cfg.Extensions.Search.CVE != nil {
+		log.Warn().Err(errors.ErrBadConfig).Msg("CVE functionality can't be used with remote storage. Please disable CVE")
+
+		return errors.ErrBadConfig
+	}
+
+	for _, subPath := range cfg.Storage.SubPaths {
+		//nolint:lll
+		if subPath.StorageDriver != nil && cfg.Extensions != nil && cfg.Extensions.Search != nil && cfg.Extensions.Search.CVE != nil {
+			log.Warn().Err(errors.ErrBadConfig).Msg("CVE functionality can't be used with remote storage. Please disable CVE")
+
+			return errors.ErrBadConfig
+		}
+	}
+
+	return nil
+}
+
 func validateConfiguration(config *config.Config) error {
 	if err := validateHTTP(config); err != nil {
 		return err
@@ -328,6 +348,10 @@ func validateConfiguration(config *config.Config) error {
 	}
 
 	if err := validateCacheConfig(config); err != nil {
+		return err
+	}
+
+	if err := validateExtensionsConfig(config); err != nil {
 		return err
 	}
 
@@ -448,10 +472,6 @@ func applyDefaultValues(config *config.Config, viperInstance *viper.Viper) {
 		if config.Extensions.Search != nil {
 			if config.Extensions.Search.Enable == nil {
 				config.Extensions.Search.Enable = &defaultVal
-			}
-
-			if config.Extensions.Search.CVE == nil {
-				config.Extensions.Search.CVE = &extconf.CVEConfig{UpdateInterval: 24 * time.Hour} //nolint: gomnd
 			}
 		}
 

--- a/test/blackbox/cloud-only.bats
+++ b/test/blackbox/cloud-only.bats
@@ -52,9 +52,7 @@ function setup() {
             }
         },
 		"search": {
-			"cve": {
-				"updateInterval": "2h"
-			}
+            "enable": true
 		},
 		"scrub": {
 			"enable": true,
@@ -64,7 +62,7 @@ function setup() {
 }
 EOF
     awslocal s3 --region "us-east-2" mb s3://zot-storage
-    awslocal dynamodb --endpoint-url "http://localhost:4566" --region "us-east-2" create-table --table-name "BlobTable" --attribute-definitions AttributeName=Digest,AttributeType=S --key-schema AttributeName=Digest,KeyType=HASH --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=5
+    awslocal dynamodb --region "us-east-2" create-table --table-name "BlobTable" --attribute-definitions AttributeName=Digest,AttributeType=S --key-schema AttributeName=Digest,KeyType=HASH --provisioned-throughput ReadCapacityUnits=10,WriteCapacityUnits=5
     zot_serve_strace ${zot_config_file}
     wait_zot_reachable "http://127.0.0.1:8080/v2/_catalog"
 }
@@ -73,8 +71,8 @@ function teardown() {
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     zot_stop
     rm -rf ${zot_root_dir}
-    aws s3 --endpoint-url "http://localhost:4566" rb s3://"zot-storage" --force
-    aws dynamodb --endpoint-url "http://localhost:4566" --region "us-east-2" delete-table --table-name "BlobTable"
+    awslocal s3 rb s3://"zot-storage" --force
+    awslocal dynamodb --region "us-east-2" delete-table --table-name "BlobTable"
 }
 
 @test "check for local disk writes" {


### PR DESCRIPTION
**What type of PR is this?**

config hardening

**What does this PR do / Why do we need it**:

Checks if remote storage driver is used while CVE is enabled at config verification time, warns that they are incompatible and exits with BadConfig. Also adjusts tests to reflect this.

**If an issue # is not available please add repro steps and logs showing the issue**:

If running zot with cve enabled and an s3 storage driver, the cve extension will treat the s3 root directory as a local directory leading to unexpected behavior


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
