### PR TITLE
feat(artifacts): add check logic for logo artifacts

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -10,6 +10,7 @@ var (
 	ErrRepoBadVersion          = errors.New("repository: unsupported layout version")
 	ErrManifestNotFound        = errors.New("manifest: not found")
 	ErrBadManifest             = errors.New("manifest: invalid contents")
+	ErrBadLogo                 = errors.New("logo: invalid blob contents")
 	ErrBadIndex                = errors.New("index: invalid contents")
 	ErrUploadNotFound          = errors.New("uploads: not found")
 	ErrBadUploadRange          = errors.New("uploads: bad range")

--- a/go.mod
+++ b/go.mod
@@ -149,6 +149,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/chai2010/webp v1.1.1
 	github.com/cheggaaa/pb/v3 v3.0.3 // indirect
 	github.com/chrismellard/docker-credential-acr-env v0.0.0-20220119192733-fe33c00cee21 // indirect
 	github.com/clbanning/mxj/v2 v2.5.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -553,6 +553,8 @@ github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghf
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
+github.com/chai2010/webp v1.1.1 h1:jTRmEccAJ4MGrhFOrPMpNGIJ/eybIgwKpcACsrTEapk=
+github.com/chai2010/webp v1.1.1/go.mod h1:0XVwvZWdjjdxpUEIf7b9g9VkHFnInUSYujwqTLEuldU=
 github.com/chartmuseum/auth v0.5.0 h1:ENNmoxvjxcR/JR0HrghAEtGQe7hToMNj16+UoS5CK9Y=
 github.com/chartmuseum/auth v0.5.0/go.mod h1:BvoSXHyvbsq+/bbhNgVTDQsModM+HERBTNY5o9Vyrig=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=

--- a/pkg/extensions/lint/lint-disabled.go
+++ b/pkg/extensions/lint/lint-disabled.go
@@ -4,14 +4,14 @@
 package lint
 
 import (
-	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"zotregistry.io/zot/pkg/storage"
 )
 
 type Linter struct{}
 
-func (linter *Linter) Lint(repo string, manifestDigest godigest.Digest,
+func (linter *Linter) Lint(repo string, manifestDescriptor ispec.Descriptor,
 	imageStore storage.ImageStore,
 ) (bool, error) {
 	return true, nil

--- a/pkg/extensions/lint/lint.go
+++ b/pkg/extensions/lint/lint.go
@@ -4,14 +4,22 @@
 package lint
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
+	"image"
+	_ "image/gif"  // imported for the registration of it's decoder func
+	_ "image/jpeg" // imported for the registration of it's decoder func
+	_ "image/png"  // imported for the registration of it's decoder func
 
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
+	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/extensions/config"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/storage"
+	storageConstants "zotregistry.io/zot/pkg/storage/constants"
 )
 
 type Linter struct {
@@ -26,7 +34,61 @@ func NewLinter(config *config.LintConfig, log log.Logger) *Linter {
 	}
 }
 
-func (linter *Linter) CheckMandatoryAnnotations(repo string, manifestDigest godigest.Digest,
+func (linter *Linter) CheckMandatoryConditions(repo string, manifestDescriptor ispec.Descriptor,
+	imgStore storage.ImageStore,
+) (bool, error) {
+	passing := false
+
+	passing, err := linter.CheckMandatoryAnnotations(repo, manifestDescriptor, imgStore)
+	if err != nil || !passing {
+		return passing, err
+	}
+
+	if manifestDescriptor.MediaType == ispec.MediaTypeArtifactManifest {
+		return linter.CheckArtifactIfLogo(repo, manifestDescriptor.Digest, imgStore)
+	}
+
+	return passing, nil
+}
+
+func (linter *Linter) CheckArtifactIfLogo(repo string, manifestDigest godigest.Digest,
+	imgStore storage.ImageStore,
+) (bool, error) {
+	artifactManifestBlob, err := imgStore.GetBlobContent(repo, manifestDigest)
+	if err != nil {
+		linter.log.Error().Err(err).Msg("linter: unable to get artifact manifest")
+
+		return false, err
+	}
+
+	var artifact ispec.Artifact
+	if err := json.Unmarshal(artifactManifestBlob, &artifact); err != nil {
+		linter.log.Error().Err(err).Msg("unable to unmarshal JSON")
+
+		return false, zerr.ErrBadManifest
+	}
+
+	if artifact.ArtifactType == storageConstants.LogoKey {
+		artifactBlobDigest := artifact.Blobs[0].Digest
+
+		artifactBlob, err := imgStore.GetBlobContent(repo, artifactBlobDigest)
+		if err != nil {
+			linter.log.Error().Err(err).Msg("linter: unable to get artifact blob")
+
+			return false, zerr.ErrBadManifest
+		}
+
+		if !isLogoDataValid(string(artifactBlob), linter.log) {
+			linter.log.Error().Err(err).Msg("invalid logo data")
+
+			return false, zerr.ErrImageLintAnnotations
+		}
+	}
+
+	return true, nil
+}
+
+func (linter *Linter) CheckMandatoryAnnotations(repo string, manifestDescriptor ispec.Descriptor,
 	imgStore storage.ImageStore,
 ) (bool, error) {
 	if linter.config == nil {
@@ -39,17 +101,9 @@ func (linter *Linter) CheckMandatoryAnnotations(repo string, manifestDigest godi
 
 	mandatoryAnnotationsList := linter.config.MandatoryAnnotations
 
-	content, err := imgStore.GetBlobContent(repo, manifestDigest)
+	content, err := imgStore.GetBlobContent(repo, manifestDescriptor.Digest)
 	if err != nil {
 		linter.log.Error().Err(err).Msg("linter: unable to get image manifest")
-
-		return false, err
-	}
-
-	var manifest ispec.Manifest
-
-	if err := json.Unmarshal(content, &manifest); err != nil {
-		linter.log.Error().Err(err).Msg("linter: couldn't unmarshal manifest JSON")
 
 		return false, err
 	}
@@ -59,58 +113,106 @@ func (linter *Linter) CheckMandatoryAnnotations(repo string, manifestDigest godi
 		mandatoryAnnotationsMap[annotation] = false
 	}
 
-	manifestAnnotations := manifest.Annotations
-	for annotation := range manifestAnnotations {
-		if _, ok := mandatoryAnnotationsMap[annotation]; ok {
-			mandatoryAnnotationsMap[annotation] = true
+	if manifestDescriptor.MediaType == ispec.MediaTypeImageManifest {
+		var manifest ispec.Manifest
+
+		if err := json.Unmarshal(content, &manifest); err != nil {
+			linter.log.Error().Err(err).Msg("linter: couldn't unmarshal manifest JSON")
+
+			return false, err
+		}
+
+		manifestAnnotations := manifest.Annotations
+		for annotation := range manifestAnnotations {
+			if _, ok := mandatoryAnnotationsMap[annotation]; ok {
+				mandatoryAnnotationsMap[annotation] = true
+			}
+		}
+
+		missingAnnotations := getMissingAnnotations(mandatoryAnnotationsMap)
+		if len(missingAnnotations) == 0 {
+			return true, nil
+		}
+
+		// if there are mandatory annotations missing in the manifest, get config and check these annotations too
+		configDigest := manifest.Config.Digest
+
+		content, err = imgStore.GetBlobContent(repo, configDigest)
+		if err != nil {
+			linter.log.Error().Err(err).Msg("linter: couldn't get config JSON " + configDigest.String())
+
+			return false, err
+		}
+
+		var imageConfig ispec.Image
+		if err := json.Unmarshal(content, &imageConfig); err != nil {
+			linter.log.Error().Err(err).Msg("linter: couldn't unmarshal config JSON " + configDigest.String())
+
+			return false, err
+		}
+
+		configAnnotations := imageConfig.Config.Labels
+
+		for annotation := range configAnnotations {
+			if _, ok := mandatoryAnnotationsMap[annotation]; ok {
+				mandatoryAnnotationsMap[annotation] = true
+			}
+		}
+
+		missingAnnotations = getMissingAnnotations(mandatoryAnnotationsMap)
+		if len(missingAnnotations) > 0 {
+			linter.log.Error().Msgf("linter: manifest %s / config %s are missing annotations: %s",
+				string(manifestDescriptor.Digest), string(configDigest), missingAnnotations)
+
+			return false, nil
 		}
 	}
 
-	missingAnnotations := getMissingAnnotations(mandatoryAnnotationsMap)
-	if len(missingAnnotations) == 0 {
-		return true, nil
-	}
+	if manifestDescriptor.MediaType == ispec.MediaTypeArtifactManifest {
+		var artifactManifest ispec.Artifact
+		if err := json.Unmarshal(content, &artifactManifest); err != nil {
+			linter.log.Error().Err(err).Msg("linter: couldn't unmarshal artifact manifest JSON")
 
-	// if there are mandatory annotations missing in the manifest, get config and check these annotations too
-	configDigest := manifest.Config.Digest
-
-	content, err = imgStore.GetBlobContent(repo, configDigest)
-	if err != nil {
-		linter.log.Error().Err(err).Msg("linter: couldn't get config JSON " + configDigest.String())
-
-		return false, err
-	}
-
-	var imageConfig ispec.Image
-	if err := json.Unmarshal(content, &imageConfig); err != nil {
-		linter.log.Error().Err(err).Msg("linter: couldn't unmarshal config JSON " + configDigest.String())
-
-		return false, err
-	}
-
-	configAnnotations := imageConfig.Config.Labels
-
-	for annotation := range configAnnotations {
-		if _, ok := mandatoryAnnotationsMap[annotation]; ok {
-			mandatoryAnnotationsMap[annotation] = true
+			return false, err
 		}
-	}
 
-	missingAnnotations = getMissingAnnotations(mandatoryAnnotationsMap)
-	if len(missingAnnotations) > 0 {
-		linter.log.Error().Msgf("linter: manifest %s / config %s are missing annotations: %s",
-			string(manifestDigest), string(configDigest), missingAnnotations)
+		artifactAnnotations := artifactManifest.Annotations
+		for annotation := range artifactAnnotations {
+			if _, ok := mandatoryAnnotationsMap[annotation]; ok {
+				mandatoryAnnotationsMap[annotation] = true
+			}
+		}
 
-		return false, nil
+		missingAnnotations := getMissingAnnotations(mandatoryAnnotationsMap)
+		if len(missingAnnotations) == 0 {
+			return true, nil
+		}
+
+		// if there are mandatory annotations missing in the artifact, get blobs and check these annotations too
+		for _, blobDescriptor := range artifactManifest.Blobs {
+			for annotation := range blobDescriptor.Annotations {
+				if _, ok := mandatoryAnnotationsMap[annotation]; ok {
+					mandatoryAnnotationsMap[annotation] = true
+				}
+			}
+		}
+
+		missingAnnotations = getMissingAnnotations(mandatoryAnnotationsMap)
+		if len(missingAnnotations) > 0 {
+			linter.log.Error().Msgf("linter: artifact manifest %s and its blobs  are missing annotations: %s",
+				string(manifestDescriptor.Digest), missingAnnotations)
+
+			return false, nil
+		}
 	}
 
 	return true, nil
 }
 
-func (linter *Linter) Lint(repo string, manifestDigest godigest.Digest,
+func (linter *Linter) Lint(repo string, manifestDescriptor ispec.Descriptor,
 	imageStore storage.ImageStore,
 ) (bool, error) {
-	return linter.CheckMandatoryAnnotations(repo, manifestDigest, imageStore)
+	return linter.CheckMandatoryConditions(repo, manifestDescriptor, imageStore)
 }
 
 func getMissingAnnotations(mandatoryAnnotationsMap map[string]bool) []string {
@@ -123,4 +225,35 @@ func getMissingAnnotations(mandatoryAnnotationsMap map[string]bool) []string {
 	}
 
 	return missingAnnotations
+}
+
+func isLogoDataValid(logoVal string, log log.Logger) bool {
+	decodedVal, err := base64.StdEncoding.DecodeString(logoVal)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to decode value")
+
+		return false
+	}
+	imageVal := bytes.NewBuffer(decodedVal)
+
+	logoConf, format, err := image.DecodeConfig(imageVal)
+	if err != nil {
+		log.Error().Err(err).Msg("unable to decode image")
+
+		return false
+	}
+
+	if format != "jpeg" && format != "gif" && format != "png" {
+		log.Error().Msg("encoded logo is of incorrect format, allowed formats are jpeg/png/gif")
+
+		return false
+	}
+
+	if logoConf.Height > 200 || logoConf.Width > 200 {
+		log.Error().Msg("encoded logo is of incorrect size")
+
+		return false
+	}
+
+	return true
 }

--- a/pkg/extensions/lint/lint_test.go
+++ b/pkg/extensions/lint/lint_test.go
@@ -4,25 +4,37 @@
 package lint_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"image"
+	"image/color"
+	"image/gif"
+	"image/jpeg"
+	"image/png"
 	"net/http"
 	"os"
 	"path"
 	"testing"
 
+	"github.com/chai2010/webp"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/rs/zerolog"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
 
+	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	extconf "zotregistry.io/zot/pkg/extensions/config"
 	"zotregistry.io/zot/pkg/extensions/lint"
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"
+	"zotregistry.io/zot/pkg/storage"
+	storageConstants "zotregistry.io/zot/pkg/storage/constants"
 	"zotregistry.io/zot/pkg/storage/local"
 	"zotregistry.io/zot/pkg/test"
 )
@@ -38,6 +50,10 @@ const (
 	ALICE                  = "alice"
 	AuthorizationNamespace = "authz/image"
 	AuthorizationAllRepos  = "**"
+	tag                    = "1.0"
+	logoKey                = "com.zot.logo"
+	repoName               = "test"
+	artifactContentType    = "application/octet-stream"
 )
 
 func TestVerifyMandatoryAnnotations(t *testing.T) {
@@ -420,6 +436,125 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 		So(resp.StatusCode(), ShouldEqual, http.StatusBadRequest)
 	})
 
+	Convey("Mandatory annotations incomplete in artifact", t, func() {
+		enable := true
+		lintConfig := &extconf.LintConfig{
+			BaseConfig: extconf.BaseConfig{
+				Enable: &enable,
+			},
+			MandatoryAnnotations: []string{"annotation1", "annotation2", "annotation3"},
+		}
+
+		dir := t.TempDir()
+		linter := lint.NewLinter(lintConfig, log.NewLogger("debug", ""))
+
+		log := log.Logger{Logger: zerolog.New(os.Stdout)}
+		metrics := monitoring.NewMetricsServer(false, log)
+
+		imgStore := local.NewImageStore(dir, true, storage.DefaultGCDelay, true,
+			true, log, metrics, linter, nil)
+
+		content := []byte("this is a blob")
+		digest := godigest.FromBytes(content)
+		So(digest, ShouldNotBeNil)
+
+		_, blen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(content), digest)
+		So(err, ShouldBeNil)
+		So(blen, ShouldEqual, len(content))
+
+		annotationsMap := make(map[string]string)
+		annotationsMap[ispec.AnnotationRefName] = tag
+
+		cblob, cdigest := test.GetRandomImageConfig()
+		_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
+		So(err, ShouldBeNil)
+		So(clen, ShouldEqual, len(cblob))
+		hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest)
+		So(err, ShouldBeNil)
+		So(hasBlob, ShouldEqual, true)
+
+		manifest := ispec.Manifest{
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    cdigest,
+				Size:      int64(len(cblob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    digest,
+					Size:      int64(len(content)),
+				},
+			},
+			Annotations: map[string]string{
+				"annotation1": "test",
+				"annotation2": "test",
+				"annotation3": "test",
+			},
+		}
+
+		manifest.SchemaVersion = 2
+		manifestBuf, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+		manifestSize := int64(len(manifestBuf))
+
+		manifestDigest, err := imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, manifestBuf)
+		So(err, ShouldBeNil)
+
+		width := 190
+		height := 190
+
+		upLeft := image.Point{0, 0}
+		lowRight := image.Point{width, height}
+		logo := image.NewRGBA(image.Rectangle{upLeft, lowRight})
+
+		buff := new(bytes.Buffer)
+		err = png.Encode(buff, logo)
+		So(err, ShouldBeNil)
+
+		artifactContentBlob := []byte(base64.StdEncoding.EncodeToString(buff.Bytes()))
+
+		artifactContentBlobSize := int64(len(artifactContentBlob))
+		artifactContentBlobDigest := godigest.FromBytes(artifactContentBlob)
+		artifactTypeLogo := logoKey
+
+		_, artifactLen, err := imgStore.FullBlobUpload(repoName,
+			bytes.NewReader(artifactContentBlob), artifactContentBlobDigest)
+		So(err, ShouldBeNil)
+		So(artifactLen, ShouldEqual, len(artifactContentBlob))
+
+		subjectDescriptor := &ispec.Descriptor{
+			MediaType: "application/vnd.oci.image.manifest.v1+json",
+			Size:      manifestSize,
+			Digest:    manifestDigest,
+		}
+
+		artifact := &ispec.Artifact{
+			Blobs: []ispec.Descriptor{
+				{
+					MediaType: artifactContentType,
+					Digest:    artifactContentBlobDigest,
+					Size:      artifactContentBlobSize,
+				},
+			},
+			Subject:      subjectDescriptor,
+			MediaType:    ispec.MediaTypeArtifactManifest,
+			ArtifactType: artifactTypeLogo,
+			Annotations: map[string]string{
+				"annotation1": "test",
+			},
+		}
+
+		artifactManifestBlob, err := json.Marshal(artifact)
+		So(err, ShouldBeNil)
+		artifactManifestDigest := godigest.FromBytes(artifactManifestBlob)
+
+		_, err = imgStore.PutImageManifest(repoName, artifactManifestDigest.String(),
+			ispec.MediaTypeArtifactManifest, artifactManifestBlob)
+		So(err, ShouldNotBeNil)
+		So(err, ShouldEqual, zerr.ErrImageLintAnnotations)
+	})
+
 	Convey("Mandatory annotations verification passing - more annotations than the mandatory list", t, func() {
 		port := test.GetFreePort()
 		baseURL := test.GetBaseURL(port)
@@ -476,6 +611,17 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 }
 
 func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
+	Convey("linter config does not exist", t, func() {
+		dir := t.TempDir()
+		linter := lint.NewLinter(nil, log.NewLogger("debug", ""))
+		imgStore := local.NewImageStore(dir, false, 0, false, false,
+			log.NewLogger("debug", ""), monitoring.NewMetricsServer(false, log.NewLogger("debug", "")), linter, nil)
+
+		pass, err := linter.CheckMandatoryAnnotations("zot-test", ispec.Descriptor{}, imgStore)
+		So(err, ShouldBeNil)
+		So(pass, ShouldBeTrue)
+	})
+
 	Convey("Mandatory annotations disabled", t, func() {
 		enable := false
 
@@ -502,9 +648,9 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		err = json.Unmarshal(indexContent, &index)
 		So(err, ShouldBeNil)
 
-		manifestDigest := index.Manifests[0].Digest
+		manifestDescriptor := index.Manifests[0]
 
-		pass, err := linter.CheckMandatoryAnnotations("zot-test", manifestDigest, imgStore)
+		pass, err := linter.CheckMandatoryAnnotations("zot-test", manifestDescriptor, imgStore)
 		So(err, ShouldBeNil)
 		So(pass, ShouldBeTrue)
 	})
@@ -535,11 +681,179 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		err = json.Unmarshal(indexContent, &index)
 		So(err, ShouldBeNil)
 
-		manifestDigest := index.Manifests[0].Digest
+		manifestDescriptor := index.Manifests[0]
 
-		pass, err := linter.CheckMandatoryAnnotations("zot-test", manifestDigest, imgStore)
+		pass, err := linter.CheckMandatoryAnnotations("zot-test", manifestDescriptor, imgStore)
 		So(err, ShouldBeNil)
 		So(pass, ShouldBeTrue)
+	})
+
+	Convey("Mandatory annotations invalid manifest", t, func() {
+		enable := true
+
+		lintConfig := &extconf.LintConfig{
+			BaseConfig:           extconf.BaseConfig{Enable: &enable},
+			MandatoryAnnotations: []string{"annotation1", "annotation2", "annotation3"},
+		}
+
+		dir := t.TempDir()
+
+		invalidData := []byte("invalid")
+		manifestDigest := godigest.FromBytes(invalidData)
+
+		manifestDesc := ispec.Descriptor{
+			MediaType: ispec.MediaTypeImageManifest,
+			Digest:    manifestDigest,
+		}
+
+		err := os.MkdirAll(path.Join(dir, "test", "blobs", "sha256"), 0o755)
+		So(err, ShouldBeNil)
+		err = os.WriteFile(path.Join(dir, "test", "blobs", "sha256", manifestDigest.Encoded()),
+			invalidData, 0o600)
+		So(err, ShouldBeNil)
+
+		linter := lint.NewLinter(lintConfig, log.NewLogger("debug", ""))
+		imgStore := local.NewImageStore(dir, false, 0, false, false,
+			log.NewLogger("debug", ""), monitoring.NewMetricsServer(false, log.NewLogger("debug", "")), linter, nil)
+
+		pass, err := linter.CheckMandatoryAnnotations("test", manifestDesc, imgStore)
+		So(pass, ShouldBeFalse)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Mandatory annotations invalid artifact", t, func() {
+		enable := true
+
+		lintConfig := &extconf.LintConfig{
+			BaseConfig:           extconf.BaseConfig{Enable: &enable},
+			MandatoryAnnotations: []string{"annotation1", "annotation2", "annotation3"},
+		}
+
+		dir := t.TempDir()
+
+		invalidData := []byte("invalid")
+		artifactDigest := godigest.FromBytes(invalidData)
+
+		artifactDesc := ispec.Descriptor{
+			MediaType: ispec.MediaTypeArtifactManifest,
+			Digest:    artifactDigest,
+		}
+
+		err := os.MkdirAll(path.Join(dir, "test", "blobs", "sha256"), 0o755)
+		So(err, ShouldBeNil)
+		err = os.WriteFile(path.Join(dir, "test", "blobs", "sha256", artifactDigest.Encoded()),
+			invalidData, 0o600)
+		So(err, ShouldBeNil)
+
+		linter := lint.NewLinter(lintConfig, log.NewLogger("debug", ""))
+		imgStore := local.NewImageStore(dir, false, 0, false, false,
+			log.NewLogger("debug", ""), monitoring.NewMetricsServer(false, log.NewLogger("debug", "")), linter, nil)
+
+		pass, err := linter.CheckMandatoryAnnotations("test", artifactDesc, imgStore)
+		So(pass, ShouldBeFalse)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Mandatory annotations invalid manifest config", t, func() {
+		enable := true
+
+		lintConfig := &extconf.LintConfig{
+			BaseConfig:           extconf.BaseConfig{Enable: &enable},
+			MandatoryAnnotations: []string{"annotation1", "annotation2", "annotation3"},
+		}
+
+		dir := t.TempDir()
+
+		config := []byte("invalid config")
+		cdigest := godigest.FromBytes(config)
+
+		imageManifest := ispec.Manifest{
+			MediaType: ispec.MediaTypeImageManifest,
+			Config: ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageConfig,
+				Digest:    cdigest,
+			},
+		}
+
+		content, err := json.Marshal(imageManifest)
+		So(err, ShouldBeNil)
+		manifestDigest := godigest.FromBytes(content)
+
+		manifestDesc := ispec.Descriptor{
+			MediaType: ispec.MediaTypeImageManifest,
+			Digest:    manifestDigest,
+		}
+
+		err = os.MkdirAll(path.Join(dir, "test", "blobs", "sha256"), 0o755)
+		So(err, ShouldBeNil)
+		err = os.WriteFile(path.Join(dir, "test", "blobs", "sha256", cdigest.Encoded()),
+			config, 0o600)
+		So(err, ShouldBeNil)
+		err = os.WriteFile(path.Join(dir, "test", "blobs", "sha256", manifestDigest.Encoded()),
+			content, 0o600)
+		So(err, ShouldBeNil)
+
+		linter := lint.NewLinter(lintConfig, log.NewLogger("debug", ""))
+		imgStore := local.NewImageStore(dir, false, 0, false, false,
+			log.NewLogger("debug", ""), monitoring.NewMetricsServer(false, log.NewLogger("debug", "")), linter, nil)
+
+		pass, err := linter.CheckMandatoryAnnotations("test", manifestDesc, imgStore)
+		So(pass, ShouldBeFalse)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Mandatory annotations in artifact blobs, passing", t, func() {
+		enable := true
+		lintConfig := &extconf.LintConfig{
+			BaseConfig: extconf.BaseConfig{
+				Enable: &enable,
+			},
+			MandatoryAnnotations: []string{"annotation1", "annotation2", "annotation3"},
+		}
+
+		dir := t.TempDir()
+
+		artifact := &ispec.Artifact{
+			Blobs: []ispec.Descriptor{
+				{
+					MediaType: artifactContentType,
+					// Digest:    artifactContentBlobDigest,
+					// Size:      artifactContentBlobSize,
+					Annotations: map[string]string{
+						"annotation2": "test",
+						"annotation3": "test",
+					},
+				},
+			},
+			MediaType:    ispec.MediaTypeArtifactManifest,
+			ArtifactType: "test.type",
+			Annotations: map[string]string{
+				"annotation1": "test",
+			},
+		}
+
+		artifactManifestBlob, err := json.Marshal(artifact)
+		So(err, ShouldBeNil)
+		artifactManifestDigest := godigest.FromBytes(artifactManifestBlob)
+
+		err = os.MkdirAll(path.Join(dir, "test", "blobs", "sha256"), 0o755)
+		So(err, ShouldBeNil)
+		err = os.WriteFile(path.Join(dir, "test", "blobs", "sha256", artifactManifestDigest.Encoded()),
+			artifactManifestBlob, 0o600)
+		So(err, ShouldBeNil)
+
+		artifactDesc := ispec.Descriptor{
+			MediaType: ispec.MediaTypeArtifactManifest,
+			Digest:    artifactManifestDigest,
+		}
+
+		linter := lint.NewLinter(lintConfig, log.NewLogger("debug", ""))
+		imgStore := local.NewImageStore(dir, false, 0, false, false,
+			log.NewLogger("debug", ""), monitoring.NewMetricsServer(false, log.NewLogger("debug", "")), linter, nil)
+
+		pass, err := linter.CheckMandatoryAnnotations("test", artifactDesc, imgStore)
+		So(pass, ShouldBeTrue)
+		So(err, ShouldBeNil)
 	})
 
 	Convey("Mandatory annotations verification passing", t, func() {
@@ -591,8 +905,9 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDesc := ispec.Descriptor{
-			Size:   int64(len(content)),
-			Digest: digest,
+			MediaType: ispec.MediaTypeImageManifest,
+			Size:      int64(len(content)),
+			Digest:    digest,
 		}
 
 		index.Manifests = append(index.Manifests, manifestDesc)
@@ -601,7 +916,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		imgStore := local.NewImageStore(dir, false, 0, false, false,
 			log.NewLogger("debug", ""), monitoring.NewMetricsServer(false, log.NewLogger("debug", "")), linter, nil)
 
-		pass, err := linter.CheckMandatoryAnnotations("zot-test", digest, imgStore)
+		pass, err := linter.CheckMandatoryAnnotations("zot-test", manifestDesc, imgStore)
 		So(err, ShouldBeNil)
 		So(pass, ShouldBeTrue)
 	})
@@ -654,8 +969,9 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDesc := ispec.Descriptor{
-			Size:   int64(len(content)),
-			Digest: digest,
+			MediaType: ispec.MediaTypeImageManifest,
+			Size:      int64(len(content)),
+			Digest:    digest,
 		}
 
 		index.Manifests = append(index.Manifests, manifestDesc)
@@ -664,7 +980,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		imgStore := local.NewImageStore(dir, false, 0, false, false,
 			log.NewLogger("debug", ""), monitoring.NewMetricsServer(false, log.NewLogger("debug", "")), linter, nil)
 
-		pass, err := linter.CheckMandatoryAnnotations("zot-test", digest, imgStore)
+		pass, err := linter.CheckMandatoryAnnotations("zot-test", manifestDesc, imgStore)
 		So(err, ShouldBeNil)
 		So(pass, ShouldBeFalse)
 	})
@@ -719,8 +1035,9 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDesc := ispec.Descriptor{
-			Size:   int64(len(content)),
-			Digest: digest,
+			MediaType: ispec.MediaTypeImageManifest,
+			Size:      int64(len(content)),
+			Digest:    digest,
 		}
 
 		index.Manifests = append(index.Manifests, manifestDesc)
@@ -729,7 +1046,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		imgStore := local.NewImageStore(dir, false, 0, false, false,
 			log.NewLogger("debug", ""), monitoring.NewMetricsServer(false, log.NewLogger("debug", "")), linter, nil)
 
-		pass, err := linter.CheckMandatoryAnnotations("zot-test", digest, imgStore)
+		pass, err := linter.CheckMandatoryAnnotations("zot-test", manifestDesc, imgStore)
 		So(err, ShouldBeNil)
 		So(pass, ShouldBeTrue)
 	})
@@ -783,8 +1100,9 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDesc := ispec.Descriptor{
-			Size:   int64(len(content)),
-			Digest: digest,
+			MediaType: ispec.MediaTypeImageManifest,
+			Size:      int64(len(content)),
+			Digest:    digest,
 		}
 
 		index.Manifests = append(index.Manifests, manifestDesc)
@@ -798,7 +1116,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 			panic(err)
 		}
 
-		pass, err := linter.CheckMandatoryAnnotations("zot-test", digest, imgStore)
+		pass, err := linter.CheckMandatoryAnnotations("zot-test", manifestDesc, imgStore)
 		So(err, ShouldNotBeNil)
 		So(pass, ShouldBeFalse)
 
@@ -882,8 +1200,9 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDesc := ispec.Descriptor{
-			Size:   int64(len(manifestContent)),
-			Digest: digest,
+			MediaType: ispec.MediaTypeImageManifest,
+			Size:      int64(len(manifestContent)),
+			Digest:    digest,
 		}
 
 		index.Manifests = append(index.Manifests, manifestDesc)
@@ -897,7 +1216,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 			panic(err)
 		}
 
-		pass, err := linter.CheckMandatoryAnnotations("zot-test", digest, imgStore)
+		pass, err := linter.CheckMandatoryAnnotations("zot-test", manifestDesc, imgStore)
 		So(err, ShouldNotBeNil)
 		So(pass, ShouldBeFalse)
 
@@ -905,6 +1224,513 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 		if err != nil {
 			panic(err)
 		}
+	})
+}
+
+func TestCheckArtifactIfLogoFunction(t *testing.T) {
+	Convey("invalid artifact manifest", t, func() {
+		enable := true
+
+		lintConfig := &extconf.LintConfig{
+			BaseConfig:           extconf.BaseConfig{Enable: &enable},
+			MandatoryAnnotations: []string{},
+		}
+
+		dir := t.TempDir()
+
+		err := test.CopyFiles("../../../test/data", dir)
+		if err != nil {
+			panic(err)
+		}
+
+		// var index ispec.Index
+
+		linter := lint.NewLinter(lintConfig, log.NewLogger("debug", ""))
+		imgStore := local.NewImageStore(dir, false, 0, false, false,
+			log.NewLogger("debug", ""), monitoring.NewMetricsServer(false, log.NewLogger("debug", "")), linter, nil)
+
+		Convey("artifact blob does not exist", func() {
+			manifestDigest := godigest.FromString("invalid")
+
+			pass, err := linter.CheckArtifactIfLogo("zot-test", manifestDigest, imgStore)
+			So(err, ShouldNotBeNil)
+			So(pass, ShouldBeFalse)
+		})
+
+		Convey("artifact blob exists, invalid format", func() {
+			content := []byte("invalid format")
+			digest := godigest.FromBytes(content)
+			err = os.WriteFile(path.Join(dir, "zot-test", "blobs",
+				digest.Algorithm().String(), digest.Encoded()), content, 0o600)
+			So(err, ShouldBeNil)
+
+			pass, err := linter.CheckArtifactIfLogo("zot-test", digest, imgStore)
+			So(err, ShouldNotBeNil)
+			So(pass, ShouldBeFalse)
+		})
+
+		Convey("artifact content blob does not exist", func() {
+			artifactContentBlob := []byte("invalid data")
+			artifactContentBlobDigest := godigest.FromBytes(artifactContentBlob)
+			artifact := ispec.Artifact{
+				MediaType:    ispec.MediaTypeArtifactManifest,
+				ArtifactType: storageConstants.LogoKey,
+				Blobs: []ispec.Descriptor{
+					{
+						Digest: artifactContentBlobDigest,
+					},
+				},
+			}
+
+			artifactBlob, err := json.Marshal(artifact)
+			So(err, ShouldBeNil)
+
+			artifactDigest := godigest.FromBytes(artifactBlob)
+			err = os.WriteFile(path.Join(dir, "zot-test", "blobs",
+				artifactDigest.Algorithm().String(), artifactDigest.Encoded()), artifactBlob, 0o600)
+			So(err, ShouldBeNil)
+
+			pass, err := linter.CheckArtifactIfLogo("zot-test",
+				artifactDigest, imgStore)
+			So(err, ShouldNotBeNil)
+			So(pass, ShouldBeFalse)
+		})
+	})
+}
+
+func TestValidateLogo(t *testing.T) {
+	Convey("Make manifest", t, func(c C) {
+		dir := t.TempDir()
+
+		enabled := true
+
+		lintConfig := &extconf.LintConfig{
+			BaseConfig: extconf.BaseConfig{
+				Enable: &enabled,
+			},
+			MandatoryAnnotations: []string{
+				"com.artifact.format",
+			},
+		}
+
+		linter := lint.NewLinter(lintConfig, log.NewLogger("debug", ""))
+
+		log := log.Logger{Logger: zerolog.New(os.Stdout)}
+		metrics := monitoring.NewMetricsServer(false, log)
+		imgStore := local.NewImageStore(dir, true, storage.DefaultGCDelay, true,
+			true, log, metrics, linter, nil)
+
+		content := []byte("this is a blob")
+		digest := godigest.FromBytes(content)
+		So(digest, ShouldNotBeNil)
+
+		_, blen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(content), digest)
+		So(err, ShouldBeNil)
+		So(blen, ShouldEqual, len(content))
+
+		Convey("Check artifact if valid logo", func() {
+			annotationsMap := make(map[string]string)
+			annotationsMap[ispec.AnnotationRefName] = tag
+
+			cblob, cdigest := test.GetRandomImageConfig()
+			_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
+			So(err, ShouldBeNil)
+			So(clen, ShouldEqual, len(cblob))
+			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest)
+			So(err, ShouldBeNil)
+			So(hasBlob, ShouldEqual, true)
+
+			manifest := ispec.Manifest{
+				Config: ispec.Descriptor{
+					MediaType: "application/vnd.oci.image.config.v1+json",
+					Digest:    cdigest,
+					Size:      int64(len(cblob)),
+				},
+				Layers: []ispec.Descriptor{
+					{
+						MediaType: "application/vnd.oci.image.layer.v1.tar",
+						Digest:    digest,
+						Size:      int64(len(content)),
+					},
+				},
+				Annotations: map[string]string{
+					"com.artifact.format": "test",
+				},
+			}
+
+			manifest.SchemaVersion = 2
+			manifestBuf, err := json.Marshal(manifest)
+			So(err, ShouldBeNil)
+			digest = godigest.FromBytes(manifestBuf)
+			manifestSize := int64(len(manifestBuf))
+
+			manifestDigest, err := imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, manifestBuf)
+			So(err, ShouldBeNil)
+
+			Convey("logo string not in base64 encoding", func() {
+				artifactContentBlob := []byte("test artifact")
+				artifactContentBlobSize := int64(len(artifactContentBlob))
+
+				artifactContentBlobDigest := godigest.FromBytes(artifactContentBlob)
+				artifactTypeLogo := logoKey
+
+				_, artifactLen, err := imgStore.FullBlobUpload(repoName,
+					bytes.NewReader(artifactContentBlob), artifactContentBlobDigest)
+				So(err, ShouldBeNil)
+				So(artifactLen, ShouldEqual, len(artifactContentBlob))
+
+				subjectDescriptor := &ispec.Descriptor{
+					MediaType: "application/vnd.oci.image.manifest.v1+json",
+					Size:      manifestSize,
+					Digest:    manifestDigest,
+				}
+
+				artifact := &ispec.Artifact{
+					Blobs: []ispec.Descriptor{
+						{
+							MediaType: artifactContentType,
+							Digest:    artifactContentBlobDigest,
+							Size:      artifactContentBlobSize,
+						},
+					},
+					Subject:      subjectDescriptor,
+					MediaType:    ispec.MediaTypeArtifactManifest,
+					ArtifactType: artifactTypeLogo,
+					Annotations: map[string]string{
+						"com.artifact.format": "test",
+					},
+				}
+
+				artifactManifestBlob, err := json.Marshal(artifact)
+				So(err, ShouldBeNil)
+				artifactManifestDigest := godigest.FromBytes(artifactManifestBlob)
+
+				_, err = imgStore.PutImageManifest(repoName, artifactManifestDigest.String(),
+					ispec.MediaTypeArtifactManifest, artifactManifestBlob)
+				So(err, ShouldEqual, zerr.ErrImageLintAnnotations)
+			})
+
+			Convey("base64 encoded, but not an image format", func() {
+				artifactContentBlob := []byte(base64.StdEncoding.EncodeToString([]byte("invalid")))
+				artifactContentBlobSize := int64(len(artifactContentBlob))
+				artifactContentBlobDigest := godigest.FromBytes(artifactContentBlob)
+				artifactTypeLogo := logoKey
+
+				_, artifactLen, err := imgStore.FullBlobUpload(repoName,
+					bytes.NewReader(artifactContentBlob), artifactContentBlobDigest)
+				So(err, ShouldBeNil)
+				So(artifactLen, ShouldEqual, len(artifactContentBlob))
+
+				subjectDescriptor := &ispec.Descriptor{
+					MediaType: "application/vnd.oci.image.manifest.v1+json",
+					Size:      manifestSize,
+					Digest:    manifestDigest,
+				}
+
+				artifact := &ispec.Artifact{
+					Blobs: []ispec.Descriptor{
+						{
+							MediaType: artifactContentType,
+							Digest:    artifactContentBlobDigest,
+							Size:      artifactContentBlobSize,
+						},
+					},
+					Subject:      subjectDescriptor,
+					MediaType:    ispec.MediaTypeArtifactManifest,
+					ArtifactType: artifactTypeLogo,
+					Annotations: map[string]string{
+						"com.artifact.format": "test",
+					},
+				}
+
+				artifactManifestBlob, err := json.Marshal(artifact)
+				So(err, ShouldBeNil)
+				artifactManifestDigest := godigest.FromBytes(artifactManifestBlob)
+
+				_, err = imgStore.PutImageManifest(repoName, artifactManifestDigest.String(),
+					ispec.MediaTypeArtifactManifest, artifactManifestBlob)
+				So(err, ShouldEqual, zerr.ErrImageLintAnnotations)
+			})
+
+			Convey("base64 encoded, but invalid image format", func() {
+				width := 190
+				height := 190
+
+				upLeft := image.Point{0, 0}
+				lowRight := image.Point{width, height}
+				logoImage := image.NewRGBA(image.Rectangle{upLeft, lowRight})
+
+				buff := new(bytes.Buffer)
+				err := webp.Encode(buff, logoImage, nil)
+				So(err, ShouldBeNil)
+				artifactContentBlob := []byte(base64.StdEncoding.EncodeToString(buff.Bytes()))
+				artifactContentBlobSize := int64(len(artifactContentBlob))
+				artifactContentBlobDigest := godigest.FromBytes(artifactContentBlob)
+				artifactTypeLogo := logoKey
+
+				_, artifactLen, err := imgStore.FullBlobUpload(repoName,
+					bytes.NewReader(artifactContentBlob), artifactContentBlobDigest)
+				So(err, ShouldBeNil)
+				So(artifactLen, ShouldEqual, len(artifactContentBlob))
+
+				subjectDescriptor := &ispec.Descriptor{
+					MediaType: "application/vnd.oci.image.manifest.v1+json",
+					Size:      manifestSize,
+					Digest:    manifestDigest,
+				}
+
+				artifact := &ispec.Artifact{
+					Blobs: []ispec.Descriptor{
+						{
+							MediaType: artifactContentType,
+							Digest:    artifactContentBlobDigest,
+							Size:      artifactContentBlobSize,
+						},
+					},
+					Subject:      subjectDescriptor,
+					MediaType:    ispec.MediaTypeArtifactManifest,
+					ArtifactType: artifactTypeLogo,
+					Annotations: map[string]string{
+						"com.artifact.format": "test",
+					},
+				}
+
+				artifactManifestBlob, err := json.Marshal(artifact)
+				So(err, ShouldBeNil)
+				artifactManifestDigest := godigest.FromBytes(artifactManifestBlob)
+
+				_, err = imgStore.PutImageManifest(repoName, artifactManifestDigest.String(),
+					ispec.MediaTypeArtifactManifest, artifactManifestBlob)
+				So(err, ShouldEqual, zerr.ErrImageLintAnnotations)
+			})
+
+			Convey("bad logo size", func() {
+				width := 250
+				height := 190
+
+				upLeft := image.Point{0, 0}
+				lowRight := image.Point{width, height}
+				logo := image.NewRGBA(image.Rectangle{upLeft, lowRight})
+
+				buff := new(bytes.Buffer)
+				err := png.Encode(buff, logo)
+				So(err, ShouldBeNil)
+
+				artifactContentBlob := []byte(base64.StdEncoding.EncodeToString(buff.Bytes()))
+
+				artifactContentBlobSize := int64(len(artifactContentBlob))
+				artifactContentBlobDigest := godigest.FromBytes(artifactContentBlob)
+				artifactTypeLogo := logoKey
+
+				_, artifactLen, err := imgStore.FullBlobUpload(repoName,
+					bytes.NewReader(artifactContentBlob), artifactContentBlobDigest)
+				So(err, ShouldBeNil)
+				So(artifactLen, ShouldEqual, len(artifactContentBlob))
+
+				subjectDescriptor := &ispec.Descriptor{
+					MediaType: "application/vnd.oci.image.manifest.v1+json",
+					Size:      manifestSize,
+					Digest:    manifestDigest,
+				}
+
+				artifact := &ispec.Artifact{
+					Blobs: []ispec.Descriptor{
+						{
+							MediaType: artifactContentType,
+							Digest:    artifactContentBlobDigest,
+							Size:      artifactContentBlobSize,
+						},
+					},
+					Subject:      subjectDescriptor,
+					MediaType:    ispec.MediaTypeArtifactManifest,
+					ArtifactType: artifactTypeLogo,
+					Annotations: map[string]string{
+						"com.artifact.format": "test",
+					},
+				}
+
+				artifactManifestBlob, err := json.Marshal(artifact)
+				So(err, ShouldBeNil)
+				artifactManifestDigest := godigest.FromBytes(artifactManifestBlob)
+
+				_, err = imgStore.PutImageManifest(repoName, artifactManifestDigest.String(),
+					ispec.MediaTypeArtifactManifest, artifactManifestBlob)
+				So(err, ShouldEqual, zerr.ErrImageLintAnnotations)
+			})
+
+			Convey("logo with good png format", func() {
+				width := 190
+				height := 190
+
+				upLeft := image.Point{0, 0}
+				lowRight := image.Point{width, height}
+				logo := image.NewRGBA(image.Rectangle{upLeft, lowRight})
+
+				buff := new(bytes.Buffer)
+				err := png.Encode(buff, logo)
+				So(err, ShouldBeNil)
+
+				artifactContentBlob := []byte(base64.StdEncoding.EncodeToString(buff.Bytes()))
+
+				artifactContentBlobSize := int64(len(artifactContentBlob))
+				artifactContentBlobDigest := godigest.FromBytes(artifactContentBlob)
+				artifactTypeLogo := logoKey
+
+				_, artifactLen, err := imgStore.FullBlobUpload(repoName,
+					bytes.NewReader(artifactContentBlob), artifactContentBlobDigest)
+				So(err, ShouldBeNil)
+				So(artifactLen, ShouldEqual, len(artifactContentBlob))
+
+				subjectDescriptor := &ispec.Descriptor{
+					MediaType: "application/vnd.oci.image.manifest.v1+json",
+					Size:      manifestSize,
+					Digest:    manifestDigest,
+				}
+
+				artifact := &ispec.Artifact{
+					Blobs: []ispec.Descriptor{
+						{
+							MediaType: artifactContentType,
+							Digest:    artifactContentBlobDigest,
+							Size:      artifactContentBlobSize,
+						},
+					},
+					Subject:      subjectDescriptor,
+					MediaType:    ispec.MediaTypeArtifactManifest,
+					ArtifactType: artifactTypeLogo,
+					Annotations: map[string]string{
+						"com.artifact.format": "test",
+					},
+				}
+
+				artifactManifestBlob, err := json.Marshal(artifact)
+				So(err, ShouldBeNil)
+				artifactManifestDigest := godigest.FromBytes(artifactManifestBlob)
+
+				returnedDigest, err := imgStore.PutImageManifest(repoName, artifactManifestDigest.String(),
+					ispec.MediaTypeArtifactManifest, artifactManifestBlob)
+				So(err, ShouldBeNil)
+				So(returnedDigest, ShouldEqual, artifactManifestDigest)
+			})
+
+			Convey("logo with good jpeg format", func() {
+				width := 190
+				height := 190
+
+				upLeft := image.Point{0, 0}
+				lowRight := image.Point{width, height}
+				logo := image.NewRGBA(image.Rectangle{upLeft, lowRight})
+
+				buff := new(bytes.Buffer)
+				err := jpeg.Encode(buff, logo, nil)
+				So(err, ShouldBeNil)
+
+				artifactContentBlob := []byte(base64.StdEncoding.EncodeToString(buff.Bytes()))
+
+				artifactContentBlobSize := int64(len(artifactContentBlob))
+				artifactContentBlobDigest := godigest.FromBytes(artifactContentBlob)
+				artifactTypeLogo := logoKey
+
+				_, artifactLen, err := imgStore.FullBlobUpload(repoName,
+					bytes.NewReader(artifactContentBlob), artifactContentBlobDigest)
+				So(err, ShouldBeNil)
+				So(artifactLen, ShouldEqual, len(artifactContentBlob))
+
+				subjectDescriptor := &ispec.Descriptor{
+					MediaType: "application/vnd.oci.image.manifest.v1+json",
+					Size:      manifestSize,
+					Digest:    manifestDigest,
+				}
+
+				artifact := &ispec.Artifact{
+					Blobs: []ispec.Descriptor{
+						{
+							MediaType: artifactContentType,
+							Digest:    artifactContentBlobDigest,
+							Size:      artifactContentBlobSize,
+						},
+					},
+					Subject:      subjectDescriptor,
+					MediaType:    ispec.MediaTypeArtifactManifest,
+					ArtifactType: artifactTypeLogo,
+					Annotations: map[string]string{
+						"com.artifact.format": "test",
+					},
+				}
+
+				artifactManifestBlob, err := json.Marshal(artifact)
+				So(err, ShouldBeNil)
+				artifactManifestDigest := godigest.FromBytes(artifactManifestBlob)
+
+				returnedDigest, err := imgStore.PutImageManifest(repoName, artifactManifestDigest.String(),
+					ispec.MediaTypeArtifactManifest, artifactManifestBlob)
+				So(err, ShouldBeNil)
+				So(returnedDigest, ShouldEqual, artifactManifestDigest)
+			})
+
+			Convey("logo with good gif format", func() {
+				width := 190
+				height := 190
+
+				upLeft := image.Point{0, 0}
+				lowRight := image.Point{width, height}
+				palette := []color.Color{color.White, color.Black}
+				rect := image.Rectangle{upLeft, lowRight}
+				logo := image.NewPaletted(rect, palette)
+
+				logo.SetColorIndex(width/2, height/2, 1)
+
+				anim := gif.GIF{Delay: []int{0}, Image: []*image.Paletted{logo}}
+
+				buff := new(bytes.Buffer)
+				err := gif.EncodeAll(buff, &anim)
+
+				// err := png.Encode(buff, logo)
+				So(err, ShouldBeNil)
+
+				artifactContentBlob := []byte(base64.StdEncoding.EncodeToString(buff.Bytes()))
+
+				artifactContentBlobSize := int64(len(artifactContentBlob))
+				artifactContentBlobDigest := godigest.FromBytes(artifactContentBlob)
+				artifactTypeLogo := logoKey
+
+				_, artifactLen, err := imgStore.FullBlobUpload(repoName,
+					bytes.NewReader(artifactContentBlob), artifactContentBlobDigest)
+				So(err, ShouldBeNil)
+				So(artifactLen, ShouldEqual, len(artifactContentBlob))
+
+				subjectDescriptor := &ispec.Descriptor{
+					MediaType: "application/vnd.oci.image.manifest.v1+json",
+					Size:      manifestSize,
+					Digest:    manifestDigest,
+				}
+
+				artifact := &ispec.Artifact{
+					Blobs: []ispec.Descriptor{
+						{
+							MediaType: artifactContentType,
+							Digest:    artifactContentBlobDigest,
+							Size:      artifactContentBlobSize,
+						},
+					},
+					Subject:      subjectDescriptor,
+					MediaType:    ispec.MediaTypeArtifactManifest,
+					ArtifactType: artifactTypeLogo,
+					Annotations: map[string]string{
+						"com.artifact.format": "test",
+					},
+				}
+
+				artifactManifestBlob, err := json.Marshal(artifact)
+				So(err, ShouldBeNil)
+				artifactManifestDigest := godigest.FromBytes(artifactManifestBlob)
+
+				returnedDigest, err := imgStore.PutImageManifest(repoName, artifactManifestDigest.String(),
+					ispec.MediaTypeArtifactManifest, artifactManifestBlob)
+				So(err, ShouldBeNil)
+				So(returnedDigest, ShouldEqual, artifactManifestDigest)
+			})
+		})
 	})
 }
 

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -551,7 +551,7 @@ func TestSyncInternal(t *testing.T) {
 			// trigger linter error on manifest push
 			imageStoreWithLinter := local.NewImageStore(t.TempDir(), false, storage.DefaultGCDelay,
 				false, false, log, metrics, &mocks.MockedLint{
-					LintFn: func(repo string, manifestDigest godigest.Digest, imageStore storage.ImageStore) (bool, error) {
+					LintFn: func(repo string, manifestDescriptor ispec.Descriptor, imageStore storage.ImageStore) (bool, error) {
 						return false, nil
 					},
 				}, nil,

--- a/pkg/storage/common.go
+++ b/pkg/storage/common.go
@@ -457,7 +457,19 @@ func ApplyLinter(imgStore ImageStore, linter Lint, repo string, manifestDesc isp
 			!strings.HasPrefix(tag, "sha256-") &&
 			!strings.HasSuffix(tag, remote.SignatureTagSuffix) {
 			// lint new index with new manifest before writing to disk
-			pass, err := linter.Lint(repo, manifestDesc.Digest, imgStore)
+			pass, err := linter.Lint(repo, manifestDesc, imgStore)
+			if err != nil {
+				return false, err
+			}
+
+			if !pass {
+				return false, zerr.ErrImageLintAnnotations
+			}
+		}
+
+		if manifestDesc.MediaType == ispec.MediaTypeArtifactManifest {
+			// lint new index with new manifest before writing to disk
+			pass, err := linter.Lint(repo, manifestDesc, imgStore)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/storage/constants/constants.go
+++ b/pkg/storage/constants/constants.go
@@ -20,4 +20,5 @@ const (
 	BoltdbName               = "cache"
 	ReferrerFilterAnnotation = "org.opencontainers.references.filtersApplied"
 	DynamoDBDriverName       = "dynamodb"
+	LogoKey                  = "com.zot.logo"
 )

--- a/pkg/storage/lint-interface.go
+++ b/pkg/storage/lint-interface.go
@@ -1,9 +1,9 @@
 package storage
 
 import (
-	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type Lint interface {
-	Lint(repo string, manifestDigest godigest.Digest, imageStore ImageStore) (bool, error)
+	Lint(repo string, manifestDescriptor ispec.Descriptor, imageStore ImageStore) (bool, error)
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -730,7 +730,7 @@ func TestMandatoryAnnotations(t *testing.T) {
 				store, _, _ = createObjectsStore(testDir, tdir)
 				imgStore = s3.NewImageStore(testDir, tdir, false, 1, false, false, log, metrics,
 					&mocks.MockedLint{
-						LintFn: func(repo string, manifestDigest godigest.Digest, imageStore storage.ImageStore) (bool, error) {
+						LintFn: func(repo string, manifestDescriptor ispec.Descriptor, imageStore storage.ImageStore) (bool, error) {
 							return false, nil
 						},
 					}, store, nil)
@@ -745,7 +745,7 @@ func TestMandatoryAnnotations(t *testing.T) {
 				}, log)
 				imgStore = local.NewImageStore(tdir, true, storage.DefaultGCDelay, true,
 					true, log, metrics, &mocks.MockedLint{
-						LintFn: func(repo string, manifestDigest godigest.Digest, imageStore storage.ImageStore) (bool, error) {
+						LintFn: func(repo string, manifestDescriptor ispec.Descriptor, imageStore storage.ImageStore) (bool, error) {
 							return false, nil
 						},
 					}, cacheDriver)
@@ -797,7 +797,7 @@ func TestMandatoryAnnotations(t *testing.T) {
 					if testcase.storageType == "s3" {
 						imgStore = s3.NewImageStore(testDir, tdir, false, 1, false, false, log, metrics,
 							&mocks.MockedLint{
-								LintFn: func(repo string, manifestDigest godigest.Digest, imageStore storage.ImageStore) (bool, error) {
+								LintFn: func(repo string, manifestDescriptor ispec.Descriptor, imageStore storage.ImageStore) (bool, error) {
 									//nolint: goerr113
 									return false, errors.New("linter error")
 								},
@@ -810,7 +810,7 @@ func TestMandatoryAnnotations(t *testing.T) {
 						}, log)
 						imgStore = local.NewImageStore(tdir, true, storage.DefaultGCDelay, true,
 							true, log, metrics, &mocks.MockedLint{
-								LintFn: func(repo string, manifestDigest godigest.Digest, imageStore storage.ImageStore) (bool, error) {
+								LintFn: func(repo string, manifestDescriptor ispec.Descriptor, imageStore storage.ImageStore) (bool, error) {
 									//nolint: goerr113
 									return false, errors.New("linter error")
 								},

--- a/pkg/test/mocks/lint_mock.go
+++ b/pkg/test/mocks/lint_mock.go
@@ -1,18 +1,20 @@
 package mocks
 
 import (
-	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"zotregistry.io/zot/pkg/storage"
 )
 
 type MockedLint struct {
-	LintFn func(repo string, manifestDigest godigest.Digest, imageStore storage.ImageStore) (bool, error)
+	LintFn func(repo string, manifestDescriptor ispec.Descriptor, imageStore storage.ImageStore) (bool, error)
 }
 
-func (lint MockedLint) Lint(repo string, manifestDigest godigest.Digest, imageStore storage.ImageStore) (bool, error) {
+func (lint MockedLint) Lint(repo string, manifestDescriptor ispec.Descriptor,
+	imageStore storage.ImageStore,
+) (bool, error) {
 	if lint.LintFn != nil {
-		return lint.LintFn(repo, manifestDigest, imageStore)
+		return lint.LintFn(repo, manifestDescriptor, imageStore)
 	}
 
 	return false, nil


### PR DESCRIPTION
Linter functionality was added to check whether the logo artifact data is correct when a new artifact manifest is uploaded, with the artifactType 'com.zot.logo' .

Signed-off-by: Alex Stan <alexandrustan96@yahoo.ro>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes https://github.com/project-zot/zot/issues/971

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
