### PR TITLE
fix: queries with images without a reference should return an error

### DIFF
--- a/pkg/extensions/search/schema.resolvers.go
+++ b/pkg/extensions/search/schema.resolvers.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/vektah/gqlparser/v2/gqlerror"
 	"zotregistry.io/zot/pkg/extensions/search/common"
 	"zotregistry.io/zot/pkg/extensions/search/gql_generated"
 )
@@ -20,6 +21,10 @@ func (r *queryResolver) CVEListForImage(ctx context.Context, image string) (*gql
 	}
 
 	_, copyImgTag := common.GetImageDirAndTag(image)
+
+	if copyImgTag == "" {
+		return &gql_generated.CVEResultForImage{}, gqlerror.Errorf("no reference provided")
+	}
 
 	cveids := []*gql_generated.Cve{}
 
@@ -421,6 +426,10 @@ func (r *queryResolver) DerivedImageList(ctx context.Context, image string) ([]*
 
 	imageDir, imageTag := common.GetImageDirAndTag(image)
 
+	if imageTag == "" {
+		return []*gql_generated.ImageSummary{}, gqlerror.Errorf("no reference provided")
+	}
+
 	imageManifest, _, err := layoutUtils.GetImageManifest(imageDir, imageTag)
 	if err != nil {
 		r.log.Info().Str("image", image).Msg("image not found")
@@ -489,6 +498,10 @@ func (r *queryResolver) BaseImageList(ctx context.Context, image string) ([]*gql
 
 	imageDir, imageTag := common.GetImageDirAndTag(image)
 
+	if imageTag == "" {
+		return []*gql_generated.ImageSummary{}, gqlerror.Errorf("no reference provided")
+	}
+
 	imageManifest, _, err := layoutUtils.GetImageManifest(imageDir, imageTag)
 	if err != nil {
 		r.log.Info().Str("image", image).Msg("image not found")
@@ -551,6 +564,10 @@ func (r *queryResolver) BaseImageList(ctx context.Context, image string) ([]*gql
 func (r *queryResolver) Image(ctx context.Context, image string) (*gql_generated.ImageSummary, error) {
 	repo, tag := common.GetImageDirAndTag(image)
 	layoutUtils := common.NewBaseOciLayoutUtils(r.storeController, r.log)
+
+	if tag == "" {
+		return &gql_generated.ImageSummary{}, gqlerror.Errorf("no reference provided")
+	}
 
 	digest, manifest, imageConfig, err := extractImageDetails(ctx, layoutUtils, repo, tag, r.log)
 	if err != nil {


### PR DESCRIPTION


Currently there is no push-back on queries that should contain image names but have only the repo name. This commit adds a check that will return an error for images w/o a reference(tag or digest).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
closes https://github.com/project-zot/zot/issues/908

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
