### PR TITLE
feat(cve): cache trivy results for an image:tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -243,7 +243,7 @@ require (
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/hashicorp/golang-lru v0.5.4
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.10.1 // indirect
 	github.com/huandu/xstrings v1.3.2 // indirect

--- a/pkg/extensions/search/cve/trivy/cache.go
+++ b/pkg/extensions/search/cve/trivy/cache.go
@@ -1,0 +1,41 @@
+package trivy
+
+import (
+	lru "github.com/hashicorp/golang-lru"
+
+	cvemodel "zotregistry.io/zot/pkg/extensions/search/cve/model"
+	"zotregistry.io/zot/pkg/log"
+)
+
+type CveCache struct {
+	cache *lru.Cache
+	log   log.Logger
+}
+
+func NewCveCache(size int, log log.Logger) *CveCache {
+	cache, _ := lru.New(size)
+
+	return &CveCache{cache: cache, log: log}
+}
+
+func (cveCache *CveCache) Add(image string, cveMap map[string]cvemodel.CVE) {
+	cveCache.cache.Add(image, cveMap)
+}
+
+func (cveCache *CveCache) Get(image string) map[string]cvemodel.CVE {
+	value, ok := cveCache.cache.Get(image)
+	if !ok {
+		return nil
+	}
+
+	cveMap, ok := value.(map[string]cvemodel.CVE)
+	if !ok {
+		return nil
+	}
+
+	return cveMap
+}
+
+func (cveCache *CveCache) Purge() {
+	cveCache.cache.Purge()
+}


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Right now the trivy scanner logic is triggered every time a call is made to scan an image.

**What does this PR do / Why do we need it**:
By caching the results, we can avoid some of the repetitive calls made for the same image (specifically in the UI use case).
We can also add pagination on the results if we already have them cached (which is a separate commit which will be ported to main branch after this one is merged).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
