### PR TITLE
feat(repodb): add pagination for ImageListForDigest and implement FilterTags

### DIFF
--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -1046,8 +1046,8 @@ func TestServerResponseGQL(t *testing.T) {
 			// repo7         test:2.0  a0ca253b  15B
 			// repo7         test:1.0  a0ca253b  15B
 			So(actual, ShouldContainSubstring, "IMAGE NAME TAG DIGEST SIGNED SIZE")
-			So(actual, ShouldContainSubstring, "repo7 test:2.0 883fc0c5 false 15B")
-			So(actual, ShouldContainSubstring, "repo7 test:1.0 883fc0c5 false 15B")
+			So(actual, ShouldContainSubstring, "repo7 test:2.0 883fc0c5 false 492B")
+			So(actual, ShouldContainSubstring, "repo7 test:1.0 883fc0c5 false 492B")
 
 			Convey("with shorthand", func() {
 				args := []string{"imagetest", "-d", "883fc0c5"}
@@ -1064,8 +1064,8 @@ func TestServerResponseGQL(t *testing.T) {
 				str := space.ReplaceAllString(buff.String(), " ")
 				actual := strings.TrimSpace(str)
 				So(actual, ShouldContainSubstring, "IMAGE NAME TAG DIGEST SIGNED SIZE")
-				So(actual, ShouldContainSubstring, "repo7 test:2.0 883fc0c5 false 15B")
-				So(actual, ShouldContainSubstring, "repo7 test:1.0 883fc0c5 false 15B")
+				So(actual, ShouldContainSubstring, "repo7 test:2.0 883fc0c5 false 492B")
+				So(actual, ShouldContainSubstring, "repo7 test:1.0 883fc0c5 false 492B")
 			})
 
 			Convey("nonexistent digest", func() {

--- a/pkg/extensions/search/gql_generated/generated.go
+++ b/pkg/extensions/search/gql_generated/generated.go
@@ -143,7 +143,7 @@ type ComplexityRoot struct {
 		Image                   func(childComplexity int, image string) int
 		ImageList               func(childComplexity int, repo string) int
 		ImageListForCve         func(childComplexity int, id string) int
-		ImageListForDigest      func(childComplexity int, id string) int
+		ImageListForDigest      func(childComplexity int, id string, requestedPage *PageInput) int
 		ImageListWithCVEFixed   func(childComplexity int, id string, image string) int
 		Referrers               func(childComplexity int, repo string, digest string, typeArg string) int
 		RepoListWithNewestImage func(childComplexity int, requestedPage *PageInput) int
@@ -181,7 +181,7 @@ type QueryResolver interface {
 	CVEListForImage(ctx context.Context, image string) (*CVEResultForImage, error)
 	ImageListForCve(ctx context.Context, id string) ([]*ImageSummary, error)
 	ImageListWithCVEFixed(ctx context.Context, id string, image string) ([]*ImageSummary, error)
-	ImageListForDigest(ctx context.Context, id string) ([]*ImageSummary, error)
+	ImageListForDigest(ctx context.Context, id string, requestedPage *PageInput) ([]*ImageSummary, error)
 	RepoListWithNewestImage(ctx context.Context, requestedPage *PageInput) ([]*RepoSummary, error)
 	ImageList(ctx context.Context, repo string) ([]*ImageSummary, error)
 	ExpandedRepoInfo(ctx context.Context, repo string) (*RepoInfo, error)
@@ -698,7 +698,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.ImageListForDigest(childComplexity, args["id"].(string)), true
+		return e.complexity.Query.ImageListForDigest(childComplexity, args["id"].(string), args["requestedPage"].(*PageInput)), true
 
 	case "Query.ImageListWithCVEFixed":
 		if e.complexity.Query.ImageListWithCVEFixed == nil {
@@ -1124,7 +1124,7 @@ type Query {
     """
     Returns a list of images which contain the specified digest 
     """
-    ImageListForDigest(id: String!): [ImageSummary!]
+    ImageListForDigest(id: String!, requestedPage: PageInput): [ImageSummary!]
 
     """
     Returns a list of repos with the newest tag within
@@ -1295,6 +1295,15 @@ func (ec *executionContext) field_Query_ImageListForDigest_args(ctx context.Cont
 		}
 	}
 	args["id"] = arg0
+	var arg1 *PageInput
+	if tmp, ok := rawArgs["requestedPage"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requestedPage"))
+		arg1, err = ec.unmarshalOPageInput2ᚖzotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐPageInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["requestedPage"] = arg1
 	return args, nil
 }
 
@@ -4130,7 +4139,7 @@ func (ec *executionContext) _Query_ImageListForDigest(ctx context.Context, field
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().ImageListForDigest(rctx, fc.Args["id"].(string))
+		return ec.resolvers.Query().ImageListForDigest(rctx, fc.Args["id"].(string), fc.Args["requestedPage"].(*PageInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)

--- a/pkg/extensions/search/resolver_test.go
+++ b/pkg/extensions/search/resolver_test.go
@@ -555,7 +555,7 @@ func TestRepoListWithNewestImage(t *testing.T) {
 
 func TestImageListForDigest(t *testing.T) {
 	Convey("getImageList", t, func() {
-		Convey("no page requested, SearchRepoFn returns error", func() {
+		Convey("no page requested, FilterTagsFn returns error", func() {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
@@ -615,7 +615,7 @@ func TestImageListForDigest(t *testing.T) {
 			So(imageList, ShouldBeEmpty)
 		})
 
-		Convey("valid repoListForDigest returned for matching manifest digest", func() {
+		Convey("valid imageListForDigest returned for matching manifest digest", func() {
 			manifestBlob, err := json.Marshal(ispec.Manifest{})
 			So(err, ShouldBeNil)
 
@@ -685,7 +685,7 @@ func TestImageListForDigest(t *testing.T) {
 			So(len(imageSummaries), ShouldEqual, 0)
 		})
 
-		Convey("valid repoListForDigest returned for matching config digest", func() {
+		Convey("valid imageListForDigest returned for matching config digest", func() {
 			manifestBlob, err := json.Marshal(ispec.Manifest{})
 			So(err, ShouldBeNil)
 
@@ -759,7 +759,7 @@ func TestImageListForDigest(t *testing.T) {
 			So(len(imageSummaries), ShouldEqual, 1)
 		})
 
-		Convey("valid repoListForDigest returned for matching layer digest", func() {
+		Convey("valid imageListForDigest returned for matching layer digest", func() {
 			manifestBlob, err := json.Marshal(ispec.Manifest{})
 			So(err, ShouldBeNil)
 
@@ -835,7 +835,7 @@ func TestImageListForDigest(t *testing.T) {
 			So(len(imageSummaries), ShouldEqual, 1)
 		})
 
-		Convey("valid repoListForDigest, multiple matching tags", func() {
+		Convey("valid imageListForDigest, multiple matching tags", func() {
 			manifestBlob, err := json.Marshal(ispec.Manifest{})
 			So(err, ShouldBeNil)
 
@@ -904,7 +904,7 @@ func TestImageListForDigest(t *testing.T) {
 			So(len(imageSummaries), ShouldEqual, 2)
 		})
 
-		Convey("valid repoListForDigest, multiple matching tags limited by pageInput", func() {
+		Convey("valid imageListForDigest, multiple matching tags limited by pageInput", func() {
 			manifestBlob, err := json.Marshal(ispec.Manifest{})
 			So(err, ShouldBeNil)
 

--- a/pkg/extensions/search/resolver_test.go
+++ b/pkg/extensions/search/resolver_test.go
@@ -107,11 +107,11 @@ func TestGlobalSearch(t *testing.T) {
 
 			const query = "repo1"
 			limit := 1
-			ofset := 0
+			offset := 0
 			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
 			pageInput := gql_generated.PageInput{
 				Limit:  &limit,
-				Offset: &ofset,
+				Offset: &offset,
 				SortBy: &sortCriteria,
 			}
 
@@ -160,11 +160,11 @@ func TestGlobalSearch(t *testing.T) {
 
 			query := "repo1"
 			limit := 1
-			ofset := 0
+			offset := 0
 			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
 			pageInput := gql_generated.PageInput{
 				Limit:  &limit,
-				Offset: &ofset,
+				Offset: &offset,
 				SortBy: &sortCriteria,
 			}
 
@@ -224,11 +224,11 @@ func TestGlobalSearch(t *testing.T) {
 
 			query := "repo1"
 			limit := 1
-			ofset := 0
+			offset := 0
 			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
 			pageInput := gql_generated.PageInput{
 				Limit:  &limit,
-				Offset: &ofset,
+				Offset: &offset,
 				SortBy: &sortCriteria,
 			}
 
@@ -329,11 +329,11 @@ func TestGlobalSearch(t *testing.T) {
 
 			const query = "repo1:1.0.1"
 			limit := 1
-			ofset := 0
+			offset := 0
 			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
 			pageInput := gql_generated.PageInput{
 				Limit:  &limit,
-				Offset: &ofset,
+				Offset: &offset,
 				SortBy: &sortCriteria,
 			}
 
@@ -365,11 +365,11 @@ func TestRepoListWithNewestImage(t *testing.T) {
 			mockCve := mocks.CveInfoMock{}
 
 			limit := 1
-			ofset := 0
+			offset := 0
 			sortCriteria := gql_generated.SortCriteriaUpdateTime
 			pageInput := gql_generated.PageInput{
 				Limit:  &limit,
-				Offset: &ofset,
+				Offset: &offset,
 				SortBy: &sortCriteria,
 			}
 			repos, err := repoListWithNewestImage(responseContext, mockCve, log.NewLogger("debug", ""), &pageInput, mockRepoDB)
@@ -431,11 +431,11 @@ func TestRepoListWithNewestImage(t *testing.T) {
 			mockCve := mocks.CveInfoMock{}
 
 			limit := 1
-			ofset := 0
+			offset := 0
 			sortCriteria := gql_generated.SortCriteriaUpdateTime
 			pageInput := gql_generated.PageInput{
 				Limit:  &limit,
-				Offset: &ofset,
+				Offset: &offset,
 				SortBy: &sortCriteria,
 			}
 			repos, err := repoListWithNewestImage(responseContext, mockCve, log.NewLogger("debug", ""), &pageInput, mockRepoDB)
@@ -529,11 +529,11 @@ func TestRepoListWithNewestImage(t *testing.T) {
 
 			Convey("RepoDB SearchRepo is successful", func() {
 				limit := 2
-				ofset := 0
+				offset := 0
 				sortCriteria := gql_generated.SortCriteriaUpdateTime
 				pageInput := gql_generated.PageInput{
 					Limit:  &limit,
-					Offset: &ofset,
+					Offset: &offset,
 					SortBy: &sortCriteria,
 				}
 
@@ -549,6 +549,439 @@ func TestRepoListWithNewestImage(t *testing.T) {
 				So(*repos[0].Name, ShouldEqual, "repo2")
 				So(*repos[0].LastUpdated, ShouldEqual, createTime2)
 			})
+		})
+	})
+}
+
+func TestImageListForDigest(t *testing.T) {
+	Convey("getImageList", t, func() {
+		Convey("no page requested, SearchRepoFn returns error", func() {
+			mockSearchDB := mocks.RepoDBMock{
+				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+					requestedPage repodb.PageInput,
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+					return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, ErrTestError
+				},
+			}
+
+			responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+				graphql.DefaultRecover)
+
+			_, err := getImageListForDigest(responseContext, "invalid", mockSearchDB, mocks.CveInfoMock{}, nil)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("invalid manifest blob", func() {
+			mockSearchDB := mocks.RepoDBMock{
+				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+					requestedPage repodb.PageInput,
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+					repos := []repodb.RepoMetadata{
+						{
+							Name: "test",
+							Tags: map[string]repodb.Descriptor{
+								"1.0.1": {Digest: "digestTag1.0.1", MediaType: ispec.MediaTypeImageManifest},
+							},
+							Stars: 100,
+						},
+					}
+
+					configBlob, err := json.Marshal(ispec.Image{
+						Config: ispec.ImageConfig{
+							Labels: map[string]string{},
+						},
+					})
+					So(err, ShouldBeNil)
+
+					manifestBlob := []byte("invalid")
+
+					manifestMetaDatas := map[string]repodb.ManifestMetadata{
+						"digestTag1.0.1": {
+							ManifestBlob:  manifestBlob,
+							ConfigBlob:    configBlob,
+							DownloadCount: 0,
+						},
+					}
+
+					return repos, manifestMetaDatas, nil
+				},
+			}
+
+			responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+				graphql.DefaultRecover)
+
+			imageList, err := getImageListForDigest(responseContext, "test", mockSearchDB, mocks.CveInfoMock{}, nil)
+			So(err, ShouldBeNil)
+			So(imageList, ShouldBeEmpty)
+		})
+
+		Convey("valid repoListForDigest returned for matching manifest digest", func() {
+			manifestBlob, err := json.Marshal(ispec.Manifest{})
+			So(err, ShouldBeNil)
+
+			manifestDigest := godigest.FromBytes(manifestBlob).String()
+
+			mockSearchDB := mocks.RepoDBMock{
+				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+					requestedPage repodb.PageInput,
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+					repos := []repodb.RepoMetadata{
+						{
+							Name: "test",
+							Tags: map[string]repodb.Descriptor{
+								"1.0.1": {Digest: manifestDigest, MediaType: ispec.MediaTypeImageManifest},
+							},
+							Stars: 100,
+						},
+					}
+
+					configBlob, err := json.Marshal(ispec.ImageConfig{})
+					So(err, ShouldBeNil)
+
+					manifestMetaDatas := map[string]repodb.ManifestMetadata{
+						manifestDigest: {
+							ManifestBlob:  manifestBlob,
+							ConfigBlob:    configBlob,
+							DownloadCount: 0,
+						},
+					}
+
+					matchedTags := repos[0].Tags
+					for tag, descriptor := range repos[0].Tags {
+						if !filter(repos[0], manifestMetaDatas[descriptor.Digest]) {
+							delete(matchedTags, tag)
+							delete(manifestMetaDatas, descriptor.Digest)
+
+							continue
+						}
+					}
+
+					repos[0].Tags = matchedTags
+
+					return repos, manifestMetaDatas, nil
+				},
+			}
+
+			limit := 1
+			offset := 0
+			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
+			pageInput := gql_generated.PageInput{
+				Limit:  &limit,
+				Offset: &offset,
+				SortBy: &sortCriteria,
+			}
+
+			responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+				graphql.DefaultRecover)
+
+			imageSummaries, err := getImageListForDigest(responseContext, manifestDigest,
+				mockSearchDB, mocks.CveInfoMock{}, &pageInput)
+			So(err, ShouldBeNil)
+			So(len(imageSummaries), ShouldEqual, 1)
+
+			imageSummaries, err = getImageListForDigest(responseContext, "invalid",
+				mockSearchDB, mocks.CveInfoMock{}, &pageInput)
+			So(err, ShouldBeNil)
+			So(len(imageSummaries), ShouldEqual, 0)
+		})
+
+		Convey("valid repoListForDigest returned for matching config digest", func() {
+			manifestBlob, err := json.Marshal(ispec.Manifest{})
+			So(err, ShouldBeNil)
+
+			manifestDigest := godigest.FromBytes(manifestBlob).String()
+
+			configBlob, err := json.Marshal(ispec.Image{})
+			So(err, ShouldBeNil)
+
+			configDigest := godigest.FromBytes(configBlob)
+
+			mockSearchDB := mocks.RepoDBMock{
+				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+					requestedPage repodb.PageInput,
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+					repos := []repodb.RepoMetadata{
+						{
+							Name: "test",
+							Tags: map[string]repodb.Descriptor{
+								"1.0.1": {Digest: manifestDigest, MediaType: ispec.MediaTypeImageManifest},
+							},
+							Stars: 100,
+						},
+					}
+
+					manifestBlob, err := json.Marshal(ispec.Manifest{
+						Config: ispec.Descriptor{
+							Digest: configDigest,
+						},
+					})
+					So(err, ShouldBeNil)
+
+					manifestMetaDatas := map[string]repodb.ManifestMetadata{
+						manifestDigest: {
+							ManifestBlob:  manifestBlob,
+							ConfigBlob:    configBlob,
+							DownloadCount: 0,
+						},
+					}
+
+					matchedTags := repos[0].Tags
+					for tag, descriptor := range repos[0].Tags {
+						if !filter(repos[0], manifestMetaDatas[descriptor.Digest]) {
+							delete(matchedTags, tag)
+							delete(manifestMetaDatas, descriptor.Digest)
+
+							continue
+						}
+					}
+
+					repos[0].Tags = matchedTags
+
+					return repos, manifestMetaDatas, nil
+				},
+			}
+
+			limit := 1
+			offset := 0
+			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
+			pageInput := gql_generated.PageInput{
+				Limit:  &limit,
+				Offset: &offset,
+				SortBy: &sortCriteria,
+			}
+
+			responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+				graphql.DefaultRecover)
+
+			imageSummaries, err := getImageListForDigest(responseContext, configDigest.String(),
+				mockSearchDB, mocks.CveInfoMock{}, &pageInput)
+			So(err, ShouldBeNil)
+			So(len(imageSummaries), ShouldEqual, 1)
+		})
+
+		Convey("valid repoListForDigest returned for matching layer digest", func() {
+			manifestBlob, err := json.Marshal(ispec.Manifest{})
+			So(err, ShouldBeNil)
+
+			manifestDigest := godigest.FromBytes(manifestBlob).String()
+
+			configBlob, err := json.Marshal(ispec.Image{})
+			So(err, ShouldBeNil)
+
+			layerDigest := godigest.Digest("validDigest")
+
+			mockSearchDB := mocks.RepoDBMock{
+				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+					requestedPage repodb.PageInput,
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+					repos := []repodb.RepoMetadata{
+						{
+							Name: "test",
+							Tags: map[string]repodb.Descriptor{
+								"1.0.1": {Digest: manifestDigest, MediaType: ispec.MediaTypeImageManifest},
+							},
+							Stars: 100,
+						},
+					}
+
+					manifestBlob, err := json.Marshal(ispec.Manifest{
+						Layers: []ispec.Descriptor{
+							{
+								Digest: layerDigest,
+							},
+						},
+					})
+					So(err, ShouldBeNil)
+
+					manifestMetaDatas := map[string]repodb.ManifestMetadata{
+						manifestDigest: {
+							ManifestBlob:  manifestBlob,
+							ConfigBlob:    configBlob,
+							DownloadCount: 0,
+						},
+					}
+
+					matchedTags := repos[0].Tags
+					for tag, descriptor := range repos[0].Tags {
+						if !filter(repos[0], manifestMetaDatas[descriptor.Digest]) {
+							delete(matchedTags, tag)
+							delete(manifestMetaDatas, descriptor.Digest)
+
+							continue
+						}
+					}
+
+					repos[0].Tags = matchedTags
+
+					return repos, manifestMetaDatas, nil
+				},
+			}
+
+			limit := 1
+			offset := 0
+			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
+			pageInput := gql_generated.PageInput{
+				Limit:  &limit,
+				Offset: &offset,
+				SortBy: &sortCriteria,
+			}
+
+			responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+				graphql.DefaultRecover)
+
+			imageSummaries, err := getImageListForDigest(responseContext, layerDigest.String(),
+				mockSearchDB, mocks.CveInfoMock{}, &pageInput)
+			So(err, ShouldBeNil)
+			So(len(imageSummaries), ShouldEqual, 1)
+		})
+
+		Convey("valid repoListForDigest, multiple matching tags", func() {
+			manifestBlob, err := json.Marshal(ispec.Manifest{})
+			So(err, ShouldBeNil)
+
+			manifestDigest := godigest.FromBytes(manifestBlob).String()
+
+			configBlob, err := json.Marshal(ispec.Image{})
+			So(err, ShouldBeNil)
+
+			mockSearchDB := mocks.RepoDBMock{
+				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+					requestedPage repodb.PageInput,
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+					repos := []repodb.RepoMetadata{
+						{
+							Name: "test",
+							Tags: map[string]repodb.Descriptor{
+								"1.0.1": {Digest: manifestDigest, MediaType: ispec.MediaTypeImageManifest},
+								"1.0.2": {Digest: manifestDigest, MediaType: ispec.MediaTypeImageManifest},
+							},
+							Stars: 100,
+						},
+					}
+
+					manifestMetaDatas := map[string]repodb.ManifestMetadata{
+						manifestDigest: {
+							ManifestBlob:  manifestBlob,
+							ConfigBlob:    configBlob,
+							DownloadCount: 0,
+						},
+					}
+
+					for i, repo := range repos {
+						matchedTags := repo.Tags
+
+						for tag, descriptor := range repo.Tags {
+							if !filter(repo, manifestMetaDatas[descriptor.Digest]) {
+								delete(matchedTags, tag)
+								delete(manifestMetaDatas, descriptor.Digest)
+
+								continue
+							}
+						}
+
+						repos[i].Tags = matchedTags
+					}
+
+					return repos, manifestMetaDatas, nil
+				},
+			}
+
+			limit := 1
+			offset := 0
+			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
+			pageInput := gql_generated.PageInput{
+				Limit:  &limit,
+				Offset: &offset,
+				SortBy: &sortCriteria,
+			}
+
+			responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+				graphql.DefaultRecover)
+
+			imageSummaries, err := getImageListForDigest(responseContext, manifestDigest,
+				mockSearchDB, mocks.CveInfoMock{}, &pageInput)
+			So(err, ShouldBeNil)
+			So(len(imageSummaries), ShouldEqual, 2)
+		})
+
+		Convey("valid repoListForDigest, multiple matching tags limited by pageInput", func() {
+			manifestBlob, err := json.Marshal(ispec.Manifest{})
+			So(err, ShouldBeNil)
+
+			manifestDigest := godigest.FromBytes(manifestBlob).String()
+
+			configBlob, err := json.Marshal(ispec.Image{})
+			So(err, ShouldBeNil)
+
+			mockSearchDB := mocks.RepoDBMock{
+				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+					requestedPage repodb.PageInput,
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+					pageFinder, err := repodb.NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
+					if err != nil {
+						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, err
+					}
+
+					repos := []repodb.RepoMetadata{
+						{
+							Name: "test",
+							Tags: map[string]repodb.Descriptor{
+								"1.0.1": {Digest: manifestDigest, MediaType: ispec.MediaTypeImageManifest},
+								"1.0.2": {Digest: manifestDigest, MediaType: ispec.MediaTypeImageManifest},
+							},
+							Stars: 100,
+						},
+					}
+
+					manifestMetaDatas := map[string]repodb.ManifestMetadata{
+						manifestDigest: {
+							ManifestBlob:  manifestBlob,
+							ConfigBlob:    configBlob,
+							DownloadCount: 0,
+						},
+					}
+
+					for i, repo := range repos {
+						matchedTags := repo.Tags
+
+						for tag, descriptor := range repo.Tags {
+							if !filter(repo, manifestMetaDatas[descriptor.Digest]) {
+								delete(matchedTags, tag)
+								delete(manifestMetaDatas, descriptor.Digest)
+
+								continue
+							}
+						}
+
+						repos[i].Tags = matchedTags
+
+						pageFinder.Add(repodb.DetailedRepoMeta{
+							RepoMeta: repo,
+						})
+					}
+
+					repos = pageFinder.Page()
+
+					return repos, manifestMetaDatas, nil
+				},
+			}
+
+			limit := 1
+			offset := 0
+			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
+			pageInput := gql_generated.PageInput{
+				Limit:  &limit,
+				Offset: &offset,
+				SortBy: &sortCriteria,
+			}
+
+			responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+				graphql.DefaultRecover)
+
+			imageSummaries, err := getImageListForDigest(responseContext, manifestDigest,
+				mockSearchDB, mocks.CveInfoMock{}, &pageInput)
+			So(err, ShouldBeNil)
+			So(len(imageSummaries), ShouldEqual, 1)
 		})
 	})
 }
@@ -904,120 +1337,6 @@ func TestQueryResolverErrors(t *testing.T) {
 			}
 
 			_, err := qr.ImageListWithCVEFixed(ctx, "a", "d")
-			So(err, ShouldNotBeNil)
-		})
-
-		Convey("ImageListForDigest defaultStore.GetRepositories() errors", func() {
-			resolverConfig := NewResolver(
-				log,
-				storage.StoreController{
-					DefaultStore: mocks.MockedImageStore{
-						GetRepositoriesFn: func() ([]string, error) {
-							return nil, ErrTestError
-						},
-					},
-				},
-				mocks.RepoDBMock{},
-				mocks.CveInfoMock{},
-			)
-
-			qr := queryResolver{
-				resolverConfig,
-			}
-
-			_, err := qr.ImageListForDigest(ctx, "")
-			So(err, ShouldNotBeNil)
-		})
-
-		Convey("ImageListForDigest getImageListForDigest() errors", func() {
-			resolverConfig := NewResolver(
-				log,
-				storage.StoreController{
-					DefaultStore: mocks.MockedImageStore{
-						GetRepositoriesFn: func() ([]string, error) {
-							return []string{"repo"}, nil
-						},
-						GetIndexContentFn: func(repo string) ([]byte, error) {
-							return nil, ErrTestError
-						},
-					},
-				},
-				mocks.RepoDBMock{},
-				mocks.CveInfoMock{},
-			)
-
-			qr := queryResolver{
-				resolverConfig,
-			}
-
-			_, err := qr.ImageListForDigest(ctx, "")
-			So(err, ShouldNotBeNil)
-		})
-
-		Convey("ImageListForDigest substores store.GetRepositories() errors", func() {
-			resolverConfig := NewResolver(
-				log,
-				storage.StoreController{
-					DefaultStore: mocks.MockedImageStore{
-						GetIndexContentFn: func(repo string) ([]byte, error) {
-							return []byte("{}"), nil
-						},
-						GetRepositoriesFn: func() ([]string, error) {
-							return []string{"repo"}, nil
-						},
-					},
-					SubStore: map[string]storage.ImageStore{
-						"sub1": mocks.MockedImageStore{
-							GetRepositoriesFn: func() ([]string, error) {
-								return []string{"repo"}, ErrTestError
-							},
-						},
-					},
-				},
-				mocks.RepoDBMock{},
-				mocks.CveInfoMock{},
-			)
-
-			qr := queryResolver{
-				resolverConfig,
-			}
-
-			_, err := qr.ImageListForDigest(ctx, "")
-			So(err, ShouldNotBeNil)
-		})
-
-		Convey("ImageListForDigest substores getImageListForDigest() errors", func() {
-			resolverConfig := NewResolver(
-				log,
-				storage.StoreController{
-					DefaultStore: mocks.MockedImageStore{
-						GetIndexContentFn: func(repo string) ([]byte, error) {
-							return []byte("{}"), nil
-						},
-						GetRepositoriesFn: func() ([]string, error) {
-							return []string{"repo"}, nil
-						},
-					},
-					SubStore: map[string]storage.ImageStore{
-						"/sub1": mocks.MockedImageStore{
-							GetRepositoriesFn: func() ([]string, error) {
-								return []string{"sub1/repo"}, nil
-							},
-							GetIndexContentFn: func(repo string) ([]byte, error) {
-								return nil, ErrTestError
-							},
-						},
-					},
-				},
-				mocks.RepoDBMock{},
-				mocks.CveInfoMock{},
-			)
-
-			qr := queryResolver{
-				resolverConfig,
-			}
-
-			_, err := qr.ImageListForDigest(ctx, "")
 			So(err, ShouldNotBeNil)
 		})
 

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -205,7 +205,7 @@ type Query {
     """
     Returns a list of images which contain the specified digest 
     """
-    ImageListForDigest(id: String!): [ImageSummary!]
+    ImageListForDigest(id: String!, requestedPage: PageInput): [ImageSummary!]
 
     """
     Returns a list of repos with the newest tag within

--- a/pkg/extensions/search/schema.resolvers.go
+++ b/pkg/extensions/search/schema.resolvers.go
@@ -163,51 +163,12 @@ func (r *queryResolver) ImageListWithCVEFixed(ctx context.Context, id string, im
 }
 
 // ImageListForDigest is the resolver for the ImageListForDigest field.
-func (r *queryResolver) ImageListForDigest(ctx context.Context, id string) ([]*gql_generated.ImageSummary, error) {
-	imgResultForDigest := []*gql_generated.ImageSummary{}
-
+func (r *queryResolver) ImageListForDigest(ctx context.Context, id string, requestedPage *gql_generated.PageInput) ([]*gql_generated.ImageSummary, error) {
 	r.log.Info().Msg("extracting repositories")
 
-	defaultStore := r.storeController.DefaultStore
+	imgResultForDigest, err := getImageListForDigest(ctx, id, r.repoDB, r.cveInfo, requestedPage)
 
-	repoList, err := defaultStore.GetRepositories()
-	if err != nil {
-		r.log.Error().Err(err).Msg("unable to search repositories")
-
-		return imgResultForDigest, err
-	}
-
-	r.log.Info().Msg("scanning each global repository")
-
-	partialImgResultForDigest, err := r.getImageListForDigest(repoList, id)
-	if err != nil {
-		r.log.Error().Err(err).Msg("unable to get image and tag list for global repositories")
-
-		return imgResultForDigest, err
-	}
-
-	imgResultForDigest = append(imgResultForDigest, partialImgResultForDigest...)
-
-	subStore := r.storeController.SubStore
-	for _, store := range subStore {
-		subRepoList, err := store.GetRepositories()
-		if err != nil {
-			r.log.Error().Err(err).Msg("unable to search sub-repositories")
-
-			return imgResultForDigest, err
-		}
-
-		partialImgResultForDigest, err = r.getImageListForDigest(subRepoList, id)
-		if err != nil {
-			r.log.Error().Err(err).Msg("unable to get image and tag list for sub-repositories")
-
-			return imgResultForDigest, err
-		}
-
-		imgResultForDigest = append(imgResultForDigest, partialImgResultForDigest...)
-	}
-
-	return imgResultForDigest, nil
+	return imgResultForDigest, err
 }
 
 // RepoListWithNewestImage is the resolver for the RepoListWithNewestImage field.

--- a/pkg/meta/repodb/dynamodb-wrapper/dynamo_wrapper.go
+++ b/pkg/meta/repodb/dynamodb-wrapper/dynamo_wrapper.go
@@ -650,6 +650,104 @@ func (dwr DBWrapper) SearchRepos(ctx context.Context, searchText string, filter 
 	return foundRepos, foundManifestMetadataMap, err
 }
 
+func (dwr DBWrapper) FilterTags(ctx context.Context, filter repodb.FilterFunc,
+	requestedPage repodb.PageInput,
+) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+	var (
+		foundManifestMetadataMap  = make(map[string]repodb.ManifestMetadata)
+		manifestMetadataMap       = make(map[string]repodb.ManifestMetadata)
+		pageFinder                repodb.PageFinder
+		repoMetaAttributeIterator iterator.AttributesIterator
+	)
+
+	repoMetaAttributeIterator = iterator.NewBaseDynamoAttributesIterator(
+		dwr.Client, dwr.RepoMetaTablename, "RepoMetadata", 0, dwr.Log,
+	)
+
+	pageFinder, err := repodb.NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
+	if err != nil {
+		return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, err
+	}
+
+	repoMetaAttribute, err := repoMetaAttributeIterator.First(ctx)
+
+	for ; repoMetaAttribute != nil; repoMetaAttribute, err = repoMetaAttributeIterator.Next(ctx) {
+		if err != nil {
+			// log
+			return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, err
+		}
+
+		var repoMeta repodb.RepoMetadata
+
+		err := attributevalue.Unmarshal(repoMetaAttribute, &repoMeta)
+		if err != nil {
+			return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, err
+		}
+
+		if ok, err := localCtx.RepoIsUserAvailable(ctx, repoMeta.Name); !ok || err != nil {
+			continue
+		}
+		matchedTags := make(map[string]repodb.Descriptor)
+		// take all manifestMetas
+		for tag, descriptor := range repoMeta.Tags {
+			manifestDigest := descriptor.Digest
+
+			matchedTags[tag] = descriptor
+
+			// in case tags reference the same manifest we don't download from DB multiple times
+			if manifestMeta, manifestExists := manifestMetadataMap[manifestDigest]; manifestExists {
+				manifestMetadataMap[manifestDigest] = manifestMeta
+
+				continue
+			}
+
+			manifestMeta, err := dwr.GetManifestMeta(repoMeta.Name, godigest.Digest(manifestDigest)) //nolint:contextcheck
+			if err != nil {
+				return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{},
+					errors.Wrapf(err, "repodb: error while unmashaling manifest metadata for digest %s", manifestDigest)
+			}
+
+			var configContent ispec.Image
+
+			err = json.Unmarshal(manifestMeta.ConfigBlob, &configContent)
+			if err != nil {
+				return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{},
+					errors.Wrapf(err, "repodb: error while unmashaling manifest metadata for digest %s", manifestDigest)
+			}
+
+			if !filter(repoMeta, manifestMeta) {
+				delete(matchedTags, tag)
+				delete(manifestMetadataMap, manifestDigest)
+
+				continue
+			}
+
+			manifestMetadataMap[manifestDigest] = manifestMeta
+		}
+
+		if len(matchedTags) == 0 {
+			continue
+		}
+
+		repoMeta.Tags = matchedTags
+
+		pageFinder.Add(repodb.DetailedRepoMeta{
+			RepoMeta: repoMeta,
+		})
+	}
+
+	foundRepos := pageFinder.Page()
+
+	// keep just the manifestMeta we need
+	for _, repoMeta := range foundRepos {
+		for _, descriptor := range repoMeta.Tags {
+			foundManifestMetadataMap[descriptor.Digest] = manifestMetadataMap[descriptor.Digest]
+		}
+	}
+
+	return foundRepos, foundManifestMetadataMap, err
+}
+
 func (dwr DBWrapper) SearchTags(ctx context.Context, searchText string, filter repodb.Filter,
 	requestedPage repodb.PageInput,
 ) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
@@ -738,6 +836,10 @@ func (dwr DBWrapper) SearchTags(ctx context.Context, searchText string, filter r
 				}
 
 				manifestMetadataMap[descriptor.Digest] = manifestMeta
+			}
+
+			if len(matchedTags) == 0 {
+				continue
 			}
 
 			repoMeta.Tags = matchedTags

--- a/pkg/meta/repodb/pagination.go
+++ b/pkg/meta/repodb/pagination.go
@@ -149,6 +149,17 @@ func (bpt *ImagePageFinder) Page() []RepoMetadata {
 	remainingOffset := bpt.offset
 	remainingLimit := bpt.limit
 
+	repos := make([]RepoMetadata, 0)
+
+	if remainingOffset == 0 && remainingLimit == 0 {
+		for _, drm := range bpt.pageBuffer {
+			repo := drm.RepoMeta
+			repos = append(repos, repo)
+		}
+
+		return repos
+	}
+
 	// bring cursor to position in RepoMeta array
 	for _, drm := range bpt.pageBuffer {
 		if remainingOffset < len(drm.RepoMeta.Tags) {
@@ -165,8 +176,6 @@ func (bpt *ImagePageFinder) Page() []RepoMetadata {
 	if repoStartIndex >= len(bpt.pageBuffer) {
 		return []RepoMetadata{}
 	}
-
-	repos := make([]RepoMetadata, 0)
 
 	// finish counting remaining tags inside the first repo meta
 	partialTags := map[string]Descriptor{}

--- a/pkg/meta/repodb/repodb.go
+++ b/pkg/meta/repodb/repodb.go
@@ -21,6 +21,8 @@ const (
 	CosignType        = "cosign"
 )
 
+type FilterFunc func(repoMeta RepoMetadata, manifestMeta ManifestMetadata) bool
+
 type RepoDB interface { //nolint:interfacebloat
 	// IncrementRepoStars adds 1 to the star count of an image
 	IncrementRepoStars(repo string) error
@@ -73,6 +75,10 @@ type RepoDB interface { //nolint:interfacebloat
 	// SearchTags searches for images(repo:tag) given a search string
 	SearchTags(ctx context.Context, searchText string, filter Filter, requestedPage PageInput) (
 		[]RepoMetadata, map[string]ManifestMetadata, error)
+
+	// FilterTags filters for images given a filter function
+	FilterTags(ctx context.Context, filter FilterFunc,
+		requestedPage PageInput) ([]RepoMetadata, map[string]ManifestMetadata, error)
 
 	PatchDB() error
 }

--- a/pkg/test/mocks/repo_db_mock.go
+++ b/pkg/test/mocks/repo_db_mock.go
@@ -48,6 +48,10 @@ type RepoDBMock struct {
 	SearchTagsFn func(ctx context.Context, searchText string, filter repodb.Filter, requestedPage repodb.PageInput) (
 		[]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error)
 
+	FilterTagsFn func(ctx context.Context, filter repodb.FilterFunc,
+		requestedPage repodb.PageInput,
+	) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error)
+
 	SearchDigestsFn func(ctx context.Context, searchText string, requestedPage repodb.PageInput) (
 		[]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error)
 
@@ -212,6 +216,16 @@ func (sdm RepoDBMock) SearchTags(ctx context.Context, searchText string, filter 
 ) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
 	if sdm.SearchTagsFn != nil {
 		return sdm.SearchTagsFn(ctx, searchText, filter, requestedPage)
+	}
+
+	return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, nil
+}
+
+func (sdm RepoDBMock) FilterTags(ctx context.Context, filter repodb.FilterFunc,
+	requestedPage repodb.PageInput,
+) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+	if sdm.FilterTagsFn != nil {
+		return sdm.FilterTagsFn(ctx, filter, requestedPage)
 	}
 
 	return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, nil


### PR DESCRIPTION
ImageListForDigest can now return paginated results, directly from DB. It uses FilterTags, a new method to filter tags (obviously) based on the criteria provided in the filter function.
Pagination of tags is now slightly different, it shows all results if no limit and offset are provided.

Signed-off-by: Alex Stan <alexandrustan96@yahoo.ro>

bug(tests): cli tests for digests expecting wrong size

Signed-off-by: Andrei Aaron <aaaron@luxoft.com>
(cherry picked from commit 369216df931a4053c18278a8d89f86d2e1e6a436)

Signed-off-by: Andrei Aaron <aaaron@luxoft.com>

**What type of PR is this?**
feature

**Which issue does this PR fix**:
The call ImageListForDigest  was not returning paginated results, actually it was not returning data from RepoDB, it was using the layout.

**What does this PR do / Why do we need it**:
FilterTags is a new RepoDB API used to return the images from RepoDB matching an arbitrary function sent as parameter to FilterTags.
This will also be used in other calls from subsequent PRs.

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
The ImageListForDigest GraphQL API changes to return only the entries for a specific page of images.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
