### PR TITLE
feat(repodb): DerivedImageList and BaseImageList make use of RepoDB

### DIFF
--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -483,7 +483,7 @@ func TestDerivedImageList(t *testing.T) {
 	cm.StartAndWait(conf.HTTP.Port)
 	defer cm.StopServer()
 
-	err := uploadManifest(url)
+	err := uploadManifestDerivedBase(url)
 	if err != nil {
 		panic(err)
 	}
@@ -493,7 +493,7 @@ func TestDerivedImageList(t *testing.T) {
 	Convey("Test from real server", t, func() {
 		Convey("Test derived images list working", func() {
 			t.Logf("%s", ctlr.Config.Storage.RootDirectory)
-			args := []string{"imagetest", "--derived-images", "repo7:test:1.0"}
+			args := []string{"imagetest", "--derived-images", "repo7:test:2.0"}
 			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 			defer os.Remove(configPath)
 			cmd := NewImageCommand(new(searchService))
@@ -507,19 +507,11 @@ func TestDerivedImageList(t *testing.T) {
 			str := space.ReplaceAllString(buff.String(), " ")
 			actual := strings.TrimSpace(str)
 			So(actual, ShouldContainSubstring, "IMAGE NAME TAG DIGEST SIGNED SIZE")
-			So(actual, ShouldContainSubstring, "repo7 test:2.0 883fc0c5 false 492B")
+			So(actual, ShouldContainSubstring, "repo7 test:1.0 2694fdb0 false 824B")
 		})
 
-		Convey("Test derived images fail", func() {
-			t.Logf("%s", ctlr.Config.Storage.RootDirectory)
-			err = os.Chmod(ctlr.Config.Storage.RootDirectory, 0o000)
-			So(err, ShouldBeNil)
-
-			defer func() {
-				err := os.Chmod(ctlr.Config.Storage.RootDirectory, 0o755)
-				So(err, ShouldBeNil)
-			}()
-			args := []string{"imagetest", "--derived-images", "repo7:test:1.0"}
+		Convey("Test derived images list fails", func() {
+			args := []string{"imagetest", "--derived-images", "repo7:test:missing"}
 			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 			defer os.Remove(configPath)
 			cmd := NewImageCommand(new(searchService))
@@ -533,7 +525,7 @@ func TestDerivedImageList(t *testing.T) {
 
 		Convey("Test derived images list cannot print", func() {
 			t.Logf("%s", ctlr.Config.Storage.RootDirectory)
-			args := []string{"imagetest", "--derived-images", "repo7:test:1.0", "-o", "random"}
+			args := []string{"imagetest", "--derived-images", "repo7:test:2.0", "-o", "random"}
 			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 			defer os.Remove(configPath)
 			cmd := NewImageCommand(new(searchService))
@@ -564,7 +556,7 @@ func TestBaseImageList(t *testing.T) {
 	cm.StartAndWait(conf.HTTP.Port)
 	defer cm.StopServer()
 
-	err := uploadManifest(url)
+	err := uploadManifestDerivedBase(url)
 	if err != nil {
 		panic(err)
 	}
@@ -588,19 +580,11 @@ func TestBaseImageList(t *testing.T) {
 			str := space.ReplaceAllString(buff.String(), " ")
 			actual := strings.TrimSpace(str)
 			So(actual, ShouldContainSubstring, "IMAGE NAME TAG DIGEST SIGNED SIZE")
-			So(actual, ShouldContainSubstring, "repo7 test:2.0 883fc0c5 false 492B")
+			So(actual, ShouldContainSubstring, "repo7 test:2.0 3fc80493 false 494B")
 		})
 
-		Convey("Test base images fail", func() {
-			t.Logf("%s", ctlr.Config.Storage.RootDirectory)
-			err = os.Chmod(ctlr.Config.Storage.RootDirectory, 0o000)
-			So(err, ShouldBeNil)
-
-			defer func() {
-				err := os.Chmod(ctlr.Config.Storage.RootDirectory, 0o755)
-				So(err, ShouldBeNil)
-			}()
-			args := []string{"imagetest", "--base-images", "repo7:test:1.0"}
+		Convey("Test base images list fail", func() {
+			args := []string{"imagetest", "--base-images", "repo7:test:missing"}
 			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 			defer os.Remove(configPath)
 			cmd := NewImageCommand(new(searchService))
@@ -1481,6 +1465,98 @@ func uploadManifest(url string) error {
 	return nil
 }
 
+func uploadManifestDerivedBase(url string) error {
+	// create a blob/layer
+	_, _ = resty.R().Post(url + "/v2/repo7/blobs/uploads/")
+
+	content1 := []byte("this is a blob5.0")
+	content2 := []byte("this is a blob5.1")
+	content3 := []byte("this is a blob5.2")
+	digest1 := godigest.FromBytes(content1)
+	digest2 := godigest.FromBytes(content2)
+	digest3 := godigest.FromBytes(content3)
+	_, _ = resty.R().SetQueryParam("digest", digest1.String()).
+		SetHeader("Content-Type", "application/octet-stream").SetBody(content1).Post(url + "/v2/repo7/blobs/uploads/")
+	_, _ = resty.R().SetQueryParam("digest", digest2.String()).
+		SetHeader("Content-Type", "application/octet-stream").SetBody(content2).Post(url + "/v2/repo7/blobs/uploads/")
+	_, _ = resty.R().SetQueryParam("digest", digest3.String()).
+		SetHeader("Content-Type", "application/octet-stream").SetBody(content3).Post(url + "/v2/repo7/blobs/uploads/")
+
+	// upload image config blob
+	resp, _ := resty.R().Post(url + "/v2/repo7/blobs/uploads/")
+	loc := test.Location(url, resp)
+	cblob, cdigest := test.GetImageConfig()
+
+	_, _ = resty.R().
+		SetContentLength(true).
+		SetHeader("Content-Length", fmt.Sprintf("%d", len(cblob))).
+		SetHeader("Content-Type", "application/octet-stream").
+		SetQueryParam("digest", cdigest.String()).
+		SetBody(cblob).
+		Put(loc)
+
+	// create a manifest
+	manifest := ispec.Manifest{
+		Config: ispec.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    cdigest,
+			Size:      int64(len(cblob)),
+		},
+		Layers: []ispec.Descriptor{
+			{
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    digest1,
+				Size:      int64(len(content1)),
+			}, {
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    digest2,
+				Size:      int64(len(content2)),
+			}, {
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    digest3,
+				Size:      int64(len(content3)),
+			},
+		},
+	}
+	manifest.SchemaVersion = 2
+
+	content, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+
+	_, _ = resty.R().SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+		SetBody(content).Put(url + "/v2/repo7/manifests/test:1.0")
+
+	content1 = []byte("this is a blob5.0")
+	digest1 = godigest.FromBytes(content1)
+	// create a manifest with one common layer blob
+	manifest = ispec.Manifest{
+		Config: ispec.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    cdigest,
+			Size:      int64(len(cblob)),
+		},
+		Layers: []ispec.Descriptor{
+			{
+				MediaType: "application/vnd.oci.image.layer.v1.tar",
+				Digest:    digest1,
+				Size:      int64(len(content1)),
+			},
+		},
+	}
+	manifest.SchemaVersion = 2
+
+	content, err = json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+	_, _ = resty.R().SetHeader("Content-Type", "application/vnd.oci.image.manifest.v1+json").
+		SetBody(content).Put(url + "/v2/repo7/manifests/test:2.0")
+
+	return nil
+}
+
 type mockService struct{}
 
 func (service mockService) getRepos(ctx context.Context, config searchConfig, username,
@@ -1501,7 +1577,7 @@ func (service mockService) getDerivedImageListGQL(ctx context.Context, config se
 	derivedImage string,
 ) (*imageListStructForDerivedImagesGQL, error) {
 	imageListGQLResponse := &imageListStructForDerivedImagesGQL{}
-	imageListGQLResponse.Data.ImageList = []imageStruct{
+	imageListGQLResponse.Data.ImageList.Results = []imageStruct{
 		{
 			RepoName:     "dummyImageName",
 			Tag:          "tag",
@@ -1519,7 +1595,7 @@ func (service mockService) getBaseImageListGQL(ctx context.Context, config searc
 	derivedImage string,
 ) (*imageListStructForBaseImagesGQL, error) {
 	imageListGQLResponse := &imageListStructForBaseImagesGQL{}
-	imageListGQLResponse.Data.ImageList = []imageStruct{
+	imageListGQLResponse.Data.ImageList.Results = []imageStruct{
 		{
 			RepoName:     "dummyImageName",
 			Tag:          "tag",

--- a/pkg/cli/searcher.go
+++ b/pkg/cli/searcher.go
@@ -241,7 +241,7 @@ func (search derivedImageListSearcherGQL) search(config searchConfig) (bool, err
 		return true, err
 	}
 
-	if err := printResult(config, imageList.Data.ImageList); err != nil {
+	if err := printResult(config, imageList.Data.ImageList.Results); err != nil {
 		return true, err
 	}
 
@@ -266,7 +266,7 @@ func (search baseImageListSearcherGQL) search(config searchConfig) (bool, error)
 		return true, err
 	}
 
-	if err := printResult(config, imageList.Data.ImageList); err != nil {
+	if err := printResult(config, imageList.Data.ImageList.Results); err != nil {
 		return true, err
 	}
 

--- a/pkg/cli/service.go
+++ b/pkg/cli/service.go
@@ -71,14 +71,16 @@ func (service searchService) getDerivedImageListGQL(ctx context.Context, config 
 	query := fmt.Sprintf(`
 		{
 			DerivedImageList(image:"%s"){
-				RepoName,
-				Tag,
-				Digest,
-				ConfigDigest,
-				Layers {Size Digest},
-				LastUpdated,
-				IsSigned,
-				Size
+				Results{
+					RepoName,
+					Tag,
+					Digest,
+					ConfigDigest,
+					Layers {Size Digest},
+					LastUpdated,
+					IsSigned,
+					Size
+				}
 			}
 		}`, derivedImage)
 
@@ -98,14 +100,16 @@ func (service searchService) getBaseImageListGQL(ctx context.Context, config sea
 	query := fmt.Sprintf(`
 		{
 			BaseImageList(image:"%s"){
-				RepoName,
-				Tag,
-				Digest,
-				ConfigDigest,
-				Layers {Size Digest},
-				LastUpdated,
-				IsSigned,
-				Size
+				Results{
+					RepoName,
+					Tag,
+					Digest,
+					ConfigDigest,
+					Layers {Size Digest},
+					LastUpdated,
+					IsSigned,
+					Size
+				}
 			}
 		}`, baseImage)
 
@@ -862,6 +866,13 @@ type imageStruct struct {
 	IsSigned     bool `json:"isSigned"`
 }
 
+type DerivedImageList struct {
+	Results []imageStruct `json:"results"`
+}
+type BaseImageList struct {
+	Results []imageStruct `json:"results"`
+}
+
 type imageListStructGQL struct {
 	Errors []errorGraphQL `json:"errors"`
 	Data   struct {
@@ -879,14 +890,14 @@ type imageListStructForDigestGQL struct {
 type imageListStructForDerivedImagesGQL struct {
 	Errors []errorGraphQL `json:"errors"`
 	Data   struct {
-		ImageList []imageStruct `json:"DerivedImageList"` //nolint:tagliatelle
+		ImageList DerivedImageList `json:"DerivedImageList"` //nolint:tagliatelle
 	} `json:"data"`
 }
 
 type imageListStructForBaseImagesGQL struct {
 	Errors []errorGraphQL `json:"errors"`
 	Data   struct {
-		ImageList []imageStruct `json:"BaseImageList"` //nolint:tagliatelle
+		ImageList BaseImageList `json:"BaseImageList"` //nolint:tagliatelle
 	} `json:"data"`
 }
 

--- a/pkg/extensions/search/gql_generated/generated.go
+++ b/pkg/extensions/search/gql_generated/generated.go
@@ -144,9 +144,9 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		BaseImageList           func(childComplexity int, image string) int
+		BaseImageList           func(childComplexity int, image string, requestedPage *PageInput) int
 		CVEListForImage         func(childComplexity int, image string, requestedPage *PageInput) int
-		DerivedImageList        func(childComplexity int, image string) int
+		DerivedImageList        func(childComplexity int, image string, requestedPage *PageInput) int
 		ExpandedRepoInfo        func(childComplexity int, repo string) int
 		GlobalSearch            func(childComplexity int, query string, filter *Filter, requestedPage *PageInput) int
 		Image                   func(childComplexity int, image string) int
@@ -195,8 +195,8 @@ type QueryResolver interface {
 	ImageList(ctx context.Context, repo string, requestedPage *PageInput) ([]*ImageSummary, error)
 	ExpandedRepoInfo(ctx context.Context, repo string) (*RepoInfo, error)
 	GlobalSearch(ctx context.Context, query string, filter *Filter, requestedPage *PageInput) (*GlobalSearchResult, error)
-	DerivedImageList(ctx context.Context, image string) ([]*ImageSummary, error)
-	BaseImageList(ctx context.Context, image string) ([]*ImageSummary, error)
+	DerivedImageList(ctx context.Context, image string, requestedPage *PageInput) (*PaginatedImagesResult, error)
+	BaseImageList(ctx context.Context, image string, requestedPage *PageInput) (*PaginatedImagesResult, error)
 	Image(ctx context.Context, image string) (*ImageSummary, error)
 	Referrers(ctx context.Context, repo string, digest string, typeArg string) ([]*Referrer, error)
 }
@@ -632,7 +632,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.BaseImageList(childComplexity, args["image"].(string)), true
+		return e.complexity.Query.BaseImageList(childComplexity, args["image"].(string), args["requestedPage"].(*PageInput)), true
 
 	case "Query.CVEListForImage":
 		if e.complexity.Query.CVEListForImage == nil {
@@ -656,7 +656,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			return 0, false
 		}
 
-		return e.complexity.Query.DerivedImageList(childComplexity, args["image"].(string)), true
+		return e.complexity.Query.DerivedImageList(childComplexity, args["image"].(string), args["requestedPage"].(*PageInput)), true
 
 	case "Query.ExpandedRepoInfo":
 		if e.complexity.Query.ExpandedRepoInfo == nil {
@@ -1193,12 +1193,12 @@ type Query {
     """
     List of images which use the argument image
     """
-    DerivedImageList(image: String!): [ImageSummary!]
+    DerivedImageList(image: String!, requestedPage: PageInput): PaginatedImagesResult!
 
     """
     List of images on which the argument image depends on
     """
-    BaseImageList(image: String!): [ImageSummary!]
+    BaseImageList(image: String!, requestedPage: PageInput): PaginatedImagesResult!
 
     """
     Search for a specific image using its name
@@ -1231,6 +1231,15 @@ func (ec *executionContext) field_Query_BaseImageList_args(ctx context.Context, 
 		}
 	}
 	args["image"] = arg0
+	var arg1 *PageInput
+	if tmp, ok := rawArgs["requestedPage"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requestedPage"))
+		arg1, err = ec.unmarshalOPageInput2ᚖzotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐPageInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["requestedPage"] = arg1
 	return args, nil
 }
 
@@ -1270,6 +1279,15 @@ func (ec *executionContext) field_Query_DerivedImageList_args(ctx context.Contex
 		}
 	}
 	args["image"] = arg0
+	var arg1 *PageInput
+	if tmp, ok := rawArgs["requestedPage"]; ok {
+		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("requestedPage"))
+		arg1, err = ec.unmarshalOPageInput2ᚖzotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐPageInput(ctx, tmp)
+		if err != nil {
+			return nil, err
+		}
+	}
+	args["requestedPage"] = arg1
 	return args, nil
 }
 
@@ -4814,18 +4832,21 @@ func (ec *executionContext) _Query_DerivedImageList(ctx context.Context, field g
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().DerivedImageList(rctx, fc.Args["image"].(string))
+		return ec.resolvers.Query().DerivedImageList(rctx, fc.Args["image"].(string), fc.Args["requestedPage"].(*PageInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.([]*ImageSummary)
+	res := resTmp.(*PaginatedImagesResult)
 	fc.Result = res
-	return ec.marshalOImageSummary2ᚕᚖzotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐImageSummaryᚄ(ctx, field.Selections, res)
+	return ec.marshalNPaginatedImagesResult2ᚖzotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐPaginatedImagesResult(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_DerivedImageList(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -4836,50 +4857,12 @@ func (ec *executionContext) fieldContext_Query_DerivedImageList(ctx context.Cont
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "RepoName":
-				return ec.fieldContext_ImageSummary_RepoName(ctx, field)
-			case "Tag":
-				return ec.fieldContext_ImageSummary_Tag(ctx, field)
-			case "Digest":
-				return ec.fieldContext_ImageSummary_Digest(ctx, field)
-			case "ConfigDigest":
-				return ec.fieldContext_ImageSummary_ConfigDigest(ctx, field)
-			case "LastUpdated":
-				return ec.fieldContext_ImageSummary_LastUpdated(ctx, field)
-			case "IsSigned":
-				return ec.fieldContext_ImageSummary_IsSigned(ctx, field)
-			case "Size":
-				return ec.fieldContext_ImageSummary_Size(ctx, field)
-			case "Platform":
-				return ec.fieldContext_ImageSummary_Platform(ctx, field)
-			case "Vendor":
-				return ec.fieldContext_ImageSummary_Vendor(ctx, field)
-			case "Score":
-				return ec.fieldContext_ImageSummary_Score(ctx, field)
-			case "DownloadCount":
-				return ec.fieldContext_ImageSummary_DownloadCount(ctx, field)
-			case "Layers":
-				return ec.fieldContext_ImageSummary_Layers(ctx, field)
-			case "Description":
-				return ec.fieldContext_ImageSummary_Description(ctx, field)
-			case "Licenses":
-				return ec.fieldContext_ImageSummary_Licenses(ctx, field)
-			case "Labels":
-				return ec.fieldContext_ImageSummary_Labels(ctx, field)
-			case "Title":
-				return ec.fieldContext_ImageSummary_Title(ctx, field)
-			case "Source":
-				return ec.fieldContext_ImageSummary_Source(ctx, field)
-			case "Documentation":
-				return ec.fieldContext_ImageSummary_Documentation(ctx, field)
-			case "History":
-				return ec.fieldContext_ImageSummary_History(ctx, field)
-			case "Vulnerabilities":
-				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
-			case "Authors":
-				return ec.fieldContext_ImageSummary_Authors(ctx, field)
+			case "Page":
+				return ec.fieldContext_PaginatedImagesResult_Page(ctx, field)
+			case "Results":
+				return ec.fieldContext_PaginatedImagesResult_Results(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type PaginatedImagesResult", field.Name)
 		},
 	}
 	defer func() {
@@ -4910,18 +4893,21 @@ func (ec *executionContext) _Query_BaseImageList(ctx context.Context, field grap
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Query().BaseImageList(rctx, fc.Args["image"].(string))
+		return ec.resolvers.Query().BaseImageList(rctx, fc.Args["image"].(string), fc.Args["requestedPage"].(*PageInput))
 	})
 	if err != nil {
 		ec.Error(ctx, err)
 		return graphql.Null
 	}
 	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
 		return graphql.Null
 	}
-	res := resTmp.([]*ImageSummary)
+	res := resTmp.(*PaginatedImagesResult)
 	fc.Result = res
-	return ec.marshalOImageSummary2ᚕᚖzotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐImageSummaryᚄ(ctx, field.Selections, res)
+	return ec.marshalNPaginatedImagesResult2ᚖzotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐPaginatedImagesResult(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Query_BaseImageList(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -4932,50 +4918,12 @@ func (ec *executionContext) fieldContext_Query_BaseImageList(ctx context.Context
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
-			case "RepoName":
-				return ec.fieldContext_ImageSummary_RepoName(ctx, field)
-			case "Tag":
-				return ec.fieldContext_ImageSummary_Tag(ctx, field)
-			case "Digest":
-				return ec.fieldContext_ImageSummary_Digest(ctx, field)
-			case "ConfigDigest":
-				return ec.fieldContext_ImageSummary_ConfigDigest(ctx, field)
-			case "LastUpdated":
-				return ec.fieldContext_ImageSummary_LastUpdated(ctx, field)
-			case "IsSigned":
-				return ec.fieldContext_ImageSummary_IsSigned(ctx, field)
-			case "Size":
-				return ec.fieldContext_ImageSummary_Size(ctx, field)
-			case "Platform":
-				return ec.fieldContext_ImageSummary_Platform(ctx, field)
-			case "Vendor":
-				return ec.fieldContext_ImageSummary_Vendor(ctx, field)
-			case "Score":
-				return ec.fieldContext_ImageSummary_Score(ctx, field)
-			case "DownloadCount":
-				return ec.fieldContext_ImageSummary_DownloadCount(ctx, field)
-			case "Layers":
-				return ec.fieldContext_ImageSummary_Layers(ctx, field)
-			case "Description":
-				return ec.fieldContext_ImageSummary_Description(ctx, field)
-			case "Licenses":
-				return ec.fieldContext_ImageSummary_Licenses(ctx, field)
-			case "Labels":
-				return ec.fieldContext_ImageSummary_Labels(ctx, field)
-			case "Title":
-				return ec.fieldContext_ImageSummary_Title(ctx, field)
-			case "Source":
-				return ec.fieldContext_ImageSummary_Source(ctx, field)
-			case "Documentation":
-				return ec.fieldContext_ImageSummary_Documentation(ctx, field)
-			case "History":
-				return ec.fieldContext_ImageSummary_History(ctx, field)
-			case "Vulnerabilities":
-				return ec.fieldContext_ImageSummary_Vulnerabilities(ctx, field)
-			case "Authors":
-				return ec.fieldContext_ImageSummary_Authors(ctx, field)
+			case "Page":
+				return ec.fieldContext_PaginatedImagesResult_Page(ctx, field)
+			case "Results":
+				return ec.fieldContext_PaginatedImagesResult_Results(ctx, field)
 			}
-			return nil, fmt.Errorf("no field named %q was found under type ImageSummary", field.Name)
+			return nil, fmt.Errorf("no field named %q was found under type PaginatedImagesResult", field.Name)
 		},
 	}
 	defer func() {
@@ -8757,6 +8705,9 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_DerivedImageList(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -8777,6 +8728,9 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_BaseImageList(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&invalids, 1)
+				}
 				return res
 			}
 
@@ -9457,6 +9411,20 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 		}
 	}
 	return res
+}
+
+func (ec *executionContext) marshalNPaginatedImagesResult2zotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐPaginatedImagesResult(ctx context.Context, sel ast.SelectionSet, v PaginatedImagesResult) graphql.Marshaler {
+	return ec._PaginatedImagesResult(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNPaginatedImagesResult2ᚖzotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐPaginatedImagesResult(ctx context.Context, sel ast.SelectionSet, v *PaginatedImagesResult) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._PaginatedImagesResult(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalNPaginatedReposResult2zotregistryᚗioᚋzotᚋpkgᚋextensionsᚋsearchᚋgql_generatedᚐPaginatedReposResult(ctx context.Context, sel ast.SelectionSet, v PaginatedReposResult) graphql.Marshaler {

--- a/pkg/extensions/search/resolver_test.go
+++ b/pkg/extensions/search/resolver_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/99designs/gqlgen/graphql"
 	godigest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -562,8 +563,8 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
-					return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, ErrTestError
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+					return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, ErrTestError
 				},
 			}
 
@@ -577,7 +578,7 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -604,7 +605,7 @@ func TestImageListForDigest(t *testing.T) {
 						},
 					}
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -625,7 +626,7 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -658,7 +659,7 @@ func TestImageListForDigest(t *testing.T) {
 
 					repos[0].Tags = matchedTags
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -698,7 +699,7 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -736,7 +737,7 @@ func TestImageListForDigest(t *testing.T) {
 
 					repos[0].Tags = matchedTags
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -772,7 +773,7 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -812,7 +813,7 @@ func TestImageListForDigest(t *testing.T) {
 
 					repos[0].Tags = matchedTags
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -846,7 +847,7 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -881,7 +882,7 @@ func TestImageListForDigest(t *testing.T) {
 						repos[i].Tags = matchedTags
 					}
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -915,10 +916,10 @@ func TestImageListForDigest(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					pageFinder, err := repodb.NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
 					if err != nil {
-						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, err
+						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, err
 					}
 
 					repos := []repodb.RepoMetadata{
@@ -961,7 +962,7 @@ func TestImageListForDigest(t *testing.T) {
 
 					repos, _ = pageFinder.Page()
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -992,8 +993,8 @@ func TestImageList(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
-					return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, ErrTestError
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+					return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, ErrTestError
 				},
 			}
 
@@ -1008,7 +1009,7 @@ func TestImageList(t *testing.T) {
 			mockSearchDB := mocks.RepoDBMock{
 				FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 					requestedPage repodb.PageInput,
-				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+				) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 					repos := []repodb.RepoMetadata{
 						{
 							Name: "test",
@@ -1052,7 +1053,7 @@ func TestImageList(t *testing.T) {
 						},
 					}
 
-					return repos, manifestMetaDatas, nil
+					return repos, manifestMetaDatas, repodb.PageInfo{}, nil
 				},
 			}
 
@@ -1273,6 +1274,42 @@ func TestQueryResolverErrors(t *testing.T) {
 		log := log.NewLogger("debug", "")
 		ctx := context.Background()
 
+		Convey("GlobalSearch error bad requested page", func() {
+			resolverConfig := NewResolver(
+				log,
+				storage.StoreController{},
+				mocks.RepoDBMock{},
+				mocks.CveInfoMock{},
+			)
+
+			resolver := queryResolver{
+				resolverConfig,
+			}
+
+			limit := -1
+			offset := 0
+			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
+			pageInput := gql_generated.PageInput{
+				Limit:  &limit,
+				Offset: &offset,
+				SortBy: &sortCriteria,
+			}
+
+			_, err := resolver.GlobalSearch(ctx, "some_string", &gql_generated.Filter{}, &pageInput)
+			So(err, ShouldNotBeNil)
+
+			limit = 0
+			offset = -1
+			pageInput = gql_generated.PageInput{
+				Limit:  &limit,
+				Offset: &offset,
+				SortBy: &sortCriteria,
+			}
+
+			_, err = resolver.GlobalSearch(ctx, "some_string", &gql_generated.Filter{}, &pageInput)
+			So(err, ShouldNotBeNil)
+		})
+
 		Convey("ImageListForCve error in GetMultipleRepoMeta", func() {
 			resolverConfig := NewResolver(
 				log,
@@ -1306,8 +1343,8 @@ func TestQueryResolverErrors(t *testing.T) {
 				mocks.RepoDBMock{
 					FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 						requestedPage repodb.PageInput,
-					) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
-						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, ErrTestError
+					) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, ErrTestError
 					},
 				},
 				mocks.CveInfoMock{},
@@ -1330,8 +1367,8 @@ func TestQueryResolverErrors(t *testing.T) {
 				mocks.RepoDBMock{
 					FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 						requestedPage repodb.PageInput,
-					) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
-						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, ErrTestError
+					) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, ErrTestError
 					},
 				},
 				mocks.CveInfoMock{},
@@ -1398,8 +1435,8 @@ func TestQueryResolverErrors(t *testing.T) {
 				mocks.RepoDBMock{
 					FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
 						requestedPage repodb.PageInput,
-					) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
-						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, ErrTestError
+					) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, ErrTestError
 					},
 				},
 				mocks.CveInfoMock{},
@@ -1438,7 +1475,7 @@ func TestQueryResolverErrors(t *testing.T) {
 				resolverConfig,
 			}
 
-			_, err := qr.DerivedImageList(ctx, "repo:tag")
+			_, err := qr.DerivedImageList(ctx, "repo:tag", &gql_generated.PageInput{})
 			So(err, ShouldNotBeNil)
 		})
 
@@ -1467,7 +1504,60 @@ func TestQueryResolverErrors(t *testing.T) {
 				resolverConfig,
 			}
 
-			_, err := qr.BaseImageList(ctx, "repo:tag")
+			_, err := qr.BaseImageList(ctx, "repo:tag", &gql_generated.PageInput{})
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("DerivedImageList and BaseImage List FilterTags() errors", func() {
+			configBlob, err := json.Marshal(ispec.Image{
+				Config: ispec.ImageConfig{
+					Labels: map[string]string{},
+				},
+			})
+			So(err, ShouldBeNil)
+
+			manifest := ispec.Manifest{}
+
+			manifestBlob, err := json.Marshal(manifest)
+			So(err, ShouldBeNil)
+
+			manifestDigest := godigest.FromBytes(manifestBlob)
+
+			resolverConfig := NewResolver(
+				log,
+				storage.StoreController{},
+				mocks.RepoDBMock{
+					FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+						requestedPage repodb.PageInput,
+					) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+						return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, ErrTestError
+					},
+					GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+						return repodb.RepoMetadata{
+							Name: "repo",
+							Tags: map[string]repodb.Descriptor{
+								"tag": {Digest: manifestDigest.String(), MediaType: ispec.MediaTypeImageManifest},
+							},
+						}, nil
+					},
+					GetManifestMetaFn: func(repo string, manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+						return repodb.ManifestMetadata{
+							ManifestBlob: manifestBlob,
+							ConfigBlob:   configBlob,
+						}, nil
+					},
+				},
+				mocks.CveInfoMock{},
+			)
+
+			resolver := queryResolver{
+				resolverConfig,
+			}
+
+			_, err = resolver.DerivedImageList(ctx, "repo:tag", &gql_generated.PageInput{})
+			So(err, ShouldNotBeNil)
+
+			_, err = resolver.BaseImageList(ctx, "repo:tag", &gql_generated.PageInput{})
 			So(err, ShouldNotBeNil)
 		})
 
@@ -2181,4 +2271,676 @@ func getPageInput(limit int, offset int) *gql_generated.PageInput {
 		Offset: &offset,
 		SortBy: &sortCriteria,
 	}
+}
+
+func TestDerivedImageList(t *testing.T) {
+	Convey("RepoDB FilterTags error", t, func() {
+		mockSearchDB := mocks.RepoDBMock{
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				return make([]repodb.RepoMetadata, 0), make(map[string]repodb.ManifestMetadata), repodb.PageInfo{}, ErrTestError
+			},
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{}, ErrTestError
+			},
+			GetManifestMetaFn: func(repo string, manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{}, ErrTestError
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+		images, err := derivedImageList(responseContext, "repo1:1.0.1", mockSearchDB, &gql_generated.PageInput{},
+			mockCve, log.NewLogger("debug", ""))
+		So(err, ShouldNotBeNil)
+		So(images.Results, ShouldBeEmpty)
+	})
+
+	//nolint: dupl
+	Convey("RepoDB FilterTags no repo available", t, func() {
+		configBlob, err := json.Marshal(ispec.Image{
+			Config: ispec.ImageConfig{
+				Labels: map[string]string{},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		manifest := ispec.Manifest{}
+
+		manifestBlob, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+
+		manifestDigest := godigest.FromBytes(manifestBlob)
+
+		mockSearchDB := mocks.RepoDBMock{
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				return make([]repodb.RepoMetadata, 0), make(map[string]repodb.ManifestMetadata), repodb.PageInfo{}, nil
+			},
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{
+					Name: "repo1",
+					Tags: map[string]repodb.Descriptor{
+						"1.0.1": {Digest: manifestDigest.String(), MediaType: ispec.MediaTypeImageManifest},
+					},
+				}, nil
+			},
+			GetManifestMetaFn: func(repo string, manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{
+					ManifestBlob: manifestBlob,
+					ConfigBlob:   configBlob,
+				}, nil
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+		images, err := derivedImageList(responseContext, "repo1:1.0.1", mockSearchDB, &gql_generated.PageInput{},
+			mockCve, log.NewLogger("debug", ""))
+		So(err, ShouldBeNil)
+		So(images.Results, ShouldBeEmpty)
+	})
+
+	//nolint: dupl
+	Convey("derived image list working", t, func() {
+		configBlob, err := json.Marshal(ispec.Image{
+			Config: ispec.ImageConfig{
+				Labels: map[string]string{},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		configDigest := godigest.FromBytes(configBlob)
+
+		layers := [][]byte{
+			{10, 11, 10, 11},
+			{11, 11, 11, 11},
+			{10, 10, 10, 11},
+			{13, 14, 15, 11},
+		}
+
+		manifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		derivedManifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[3]),
+					Size:      int64(len(layers[3])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		manifestMetas := map[string]repodb.ManifestMetadata{
+			"digestTag1.0.1": {
+				ManifestBlob:  manifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(repodb.ManifestSignatures),
+			},
+			"digestTag1.0.2": {
+				ManifestBlob:  derivedManifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(repodb.ManifestSignatures),
+			},
+			"digestTag1.0.3": {
+				ManifestBlob:  derivedManifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(repodb.ManifestSignatures),
+			},
+		}
+		manifestDigest := godigest.FromBytes(manifestBlob)
+
+		mockSearchDB := mocks.RepoDBMock{
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{
+					Name: "repo1",
+					Tags: map[string]repodb.Descriptor{
+						"1.0.1": {Digest: manifestDigest.String(), MediaType: ispec.MediaTypeImageManifest},
+					},
+				}, nil
+			},
+			GetManifestMetaFn: func(repo string, manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{
+					ManifestBlob: manifestBlob,
+					ConfigBlob:   configBlob,
+				}, nil
+			},
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				pageFinder, err := repodb.NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
+				So(err, ShouldBeNil)
+
+				repos := []repodb.RepoMetadata{
+					{
+						Name: "repo1",
+						Tags: map[string]repodb.Descriptor{
+							"1.0.1": {Digest: "digestTag1.0.1", MediaType: ispec.MediaTypeImageManifest},
+							"1.0.2": {Digest: "digestTag1.0.2", MediaType: ispec.MediaTypeImageManifest},
+							"1.0.3": {Digest: "digestTag1.0.3", MediaType: ispec.MediaTypeImageManifest},
+						},
+						Stars: 100,
+					},
+				}
+
+				for i, repo := range repos {
+					matchedTags := repo.Tags
+
+					for tag, descriptor := range repo.Tags {
+						if !filter(repo, manifestMetas[descriptor.Digest]) {
+							delete(matchedTags, tag)
+							delete(manifestMetas, descriptor.Digest)
+
+							continue
+						}
+					}
+
+					repos[i].Tags = matchedTags
+
+					pageFinder.Add(repodb.DetailedRepoMeta{
+						RepoMeta: repo,
+					})
+				}
+				repos, pageInfo := pageFinder.Page()
+
+				return repos, manifestMetas, pageInfo, nil
+			},
+		}
+
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+
+		Convey("valid derivedImageList, results not affected by pageInput", func() {
+			images, err := derivedImageList(responseContext, "repo1:1.0.1", mockSearchDB, &gql_generated.PageInput{},
+				mockCve, log.NewLogger("debug", ""))
+			So(err, ShouldBeNil)
+			So(images.Results, ShouldNotBeEmpty)
+			So(len(images.Results), ShouldEqual, 2)
+		})
+
+		Convey("valid derivedImageList, results affected by pageInput", func() {
+			limit := 1
+			offset := 0
+			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
+			pageInput := gql_generated.PageInput{
+				Limit:  &limit,
+				Offset: &offset,
+				SortBy: &sortCriteria,
+			}
+
+			images, err := derivedImageList(responseContext, "repo1:1.0.1", mockSearchDB, &pageInput,
+				mockCve, log.NewLogger("debug", ""))
+			So(err, ShouldBeNil)
+			So(images.Results, ShouldNotBeEmpty)
+			So(len(images.Results), ShouldEqual, limit)
+		})
+	})
+}
+
+func TestBaseImageList(t *testing.T) {
+	Convey("RepoDB FilterTags error", t, func() {
+		mockSearchDB := mocks.RepoDBMock{
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				return make([]repodb.RepoMetadata, 0), make(map[string]repodb.ManifestMetadata), repodb.PageInfo{}, ErrTestError
+			},
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{}, ErrTestError
+			},
+			GetManifestMetaFn: func(repo string, manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{}, ErrTestError
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+		images, err := baseImageList(responseContext, "repo1:1.0.2", mockSearchDB, &gql_generated.PageInput{},
+			mockCve, log.NewLogger("debug", ""))
+		So(err, ShouldNotBeNil)
+		So(images.Results, ShouldBeEmpty)
+	})
+
+	//nolint: dupl
+	Convey("RepoDB FilterTags no repo available", t, func() {
+		configBlob, err := json.Marshal(ispec.Image{
+			Config: ispec.ImageConfig{
+				Labels: map[string]string{},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		manifest := ispec.Manifest{}
+
+		manifestBlob, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+
+		manifestDigest := godigest.FromBytes(manifestBlob)
+
+		mockSearchDB := mocks.RepoDBMock{
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				return make([]repodb.RepoMetadata, 0), make(map[string]repodb.ManifestMetadata), repodb.PageInfo{}, nil
+			},
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{
+					Name: "repo1",
+					Tags: map[string]repodb.Descriptor{
+						"1.0.2": {Digest: manifestDigest.String(), MediaType: ispec.MediaTypeImageManifest},
+					},
+				}, nil
+			},
+			GetManifestMetaFn: func(repo string, manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{
+					ManifestBlob: manifestBlob,
+					ConfigBlob:   configBlob,
+				}, nil
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+		images, err := baseImageList(responseContext, "repo1:1.0.2", mockSearchDB, &gql_generated.PageInput{},
+			mockCve, log.NewLogger("debug", ""))
+		So(err, ShouldBeNil)
+		So(images.Results, ShouldBeEmpty)
+	})
+
+	//nolint: dupl
+	Convey("base image list working", t, func() {
+		configBlob, err := json.Marshal(ispec.Image{
+			Config: ispec.ImageConfig{
+				Labels: map[string]string{},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		configDigest := godigest.FromBytes(configBlob)
+
+		layers := [][]byte{
+			{10, 11, 10, 11},
+			{11, 11, 11, 11},
+			{10, 10, 10, 11},
+			{13, 14, 15, 11},
+		}
+
+		manifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		derivedManifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[3]),
+					Size:      int64(len(layers[3])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		manifestMetas := map[string]repodb.ManifestMetadata{
+			"digestTag1.0.1": {
+				ManifestBlob:  manifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(repodb.ManifestSignatures),
+			},
+			"digestTag1.0.2": {
+				ManifestBlob:  derivedManifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(repodb.ManifestSignatures),
+			},
+		}
+		derivedManifestDigest := godigest.FromBytes(derivedManifestBlob)
+
+		mockSearchDB := mocks.RepoDBMock{
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{
+					Name: "repo1",
+					Tags: map[string]repodb.Descriptor{
+						"1.0.2": {Digest: derivedManifestDigest.String(), MediaType: ispec.MediaTypeImageManifest},
+					},
+				}, nil
+			},
+			GetManifestMetaFn: func(repo string, manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{
+					ManifestBlob: derivedManifestBlob,
+					ConfigBlob:   configBlob,
+				}, nil
+			},
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				pageFinder, err := repodb.NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
+				So(err, ShouldBeNil)
+
+				repos := []repodb.RepoMetadata{
+					{
+						Name: "repo1",
+						Tags: map[string]repodb.Descriptor{
+							"1.0.1": {Digest: "digestTag1.0.1", MediaType: ispec.MediaTypeImageManifest},
+							"1.0.3": {Digest: "digestTag1.0.1", MediaType: ispec.MediaTypeImageManifest},
+							"1.0.2": {Digest: "digestTag1.0.2", MediaType: ispec.MediaTypeImageManifest},
+						},
+						Stars: 100,
+					},
+				}
+
+				for i, repo := range repos {
+					matchedTags := repo.Tags
+
+					for tag, descriptor := range repo.Tags {
+						if !filter(repo, manifestMetas[descriptor.Digest]) {
+							delete(matchedTags, tag)
+							delete(manifestMetas, descriptor.Digest)
+
+							continue
+						}
+					}
+
+					repos[i].Tags = matchedTags
+
+					pageFinder.Add(repodb.DetailedRepoMeta{
+						RepoMeta: repo,
+					})
+				}
+
+				repos, pageInfo := pageFinder.Page()
+
+				return repos, manifestMetas, pageInfo, nil
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+
+		Convey("valid baseImageList, results not affected by pageInput", func() {
+			images, err := baseImageList(responseContext, "repo1:1.0.2", mockSearchDB,
+				&gql_generated.PageInput{}, mockCve, log.NewLogger("debug", ""))
+			So(err, ShouldBeNil)
+			So(images.Results, ShouldNotBeEmpty)
+			So(len(images.Results), ShouldEqual, 2)
+			expectedTags := []string{"1.0.1", "1.0.3"}
+			So(expectedTags, ShouldContain, *images.Results[0].Tag)
+			So(expectedTags, ShouldContain, *images.Results[1].Tag)
+		})
+
+		Convey("valid baseImageList, results affected by pageInput", func() {
+			limit := 1
+			offset := 0
+			sortCriteria := gql_generated.SortCriteriaAlphabeticAsc
+			pageInput := gql_generated.PageInput{
+				Limit:  &limit,
+				Offset: &offset,
+				SortBy: &sortCriteria,
+			}
+
+			images, err := baseImageList(responseContext, "repo1:1.0.2", mockSearchDB,
+				&pageInput, mockCve, log.NewLogger("debug", ""))
+			So(err, ShouldBeNil)
+			So(images.Results, ShouldNotBeEmpty)
+			So(len(images.Results), ShouldEqual, limit)
+			So(*images.Results[0].Tag, ShouldEqual, "1.0.1")
+		})
+	})
+
+	//nolint: dupl
+	Convey("filterTags working, no base image list found", t, func() {
+		configBlob, err := json.Marshal(ispec.Image{
+			Config: ispec.ImageConfig{
+				Labels: map[string]string{},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		configDigest := godigest.FromBytes(configBlob)
+
+		layers := [][]byte{
+			{10, 11, 10, 11},
+			{11, 11, 11, 11},
+			{10, 10, 10, 11},
+			{13, 14, 15, 11},
+		}
+
+		manifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		derivedManifestBlob, err := json.Marshal(ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[3]),
+					Size:      int64(len(layers[3])),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		manifestMetas := map[string]repodb.ManifestMetadata{
+			"digestTag1.0.1": {
+				ManifestBlob:  manifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(repodb.ManifestSignatures),
+			},
+			"digestTag1.0.2": {
+				ManifestBlob:  derivedManifestBlob,
+				ConfigBlob:    configBlob,
+				DownloadCount: 100,
+				Signatures:    make(repodb.ManifestSignatures),
+			},
+		}
+		derivedManifestDigest := godigest.FromBytes(derivedManifestBlob)
+
+		mockSearchDB := mocks.RepoDBMock{
+			GetRepoMetaFn: func(repo string) (repodb.RepoMetadata, error) {
+				return repodb.RepoMetadata{
+					Name: "repo1",
+					Tags: map[string]repodb.Descriptor{
+						"1.0.2": {Digest: derivedManifestDigest.String(), MediaType: ispec.MediaTypeImageManifest},
+					},
+				}, nil
+			},
+			GetManifestMetaFn: func(repo string, manifestDigest godigest.Digest) (repodb.ManifestMetadata, error) {
+				return repodb.ManifestMetadata{
+					ManifestBlob: derivedManifestBlob,
+					ConfigBlob:   configBlob,
+				}, nil
+			},
+			FilterTagsFn: func(ctx context.Context, filter repodb.FilterFunc,
+				requestedPage repodb.PageInput,
+			) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
+				pageFinder, err := repodb.NewBaseImagePageFinder(requestedPage.Limit, requestedPage.Offset, requestedPage.SortBy)
+				So(err, ShouldBeNil)
+
+				repos := []repodb.RepoMetadata{
+					{
+						Name: "repo1",
+						Tags: map[string]repodb.Descriptor{
+							"1.0.1": {Digest: "digestTag1.0.1", MediaType: ispec.MediaTypeImageManifest},
+							"1.0.2": {Digest: "digestTag1.0.2", MediaType: ispec.MediaTypeImageManifest},
+						},
+						Stars: 100,
+					},
+				}
+
+				for i, repo := range repos {
+					matchedTags := repo.Tags
+
+					for tag, descriptor := range repo.Tags {
+						if !filter(repo, manifestMetas[descriptor.Digest]) {
+							delete(matchedTags, tag)
+							delete(manifestMetas, descriptor.Digest)
+
+							continue
+						}
+					}
+
+					repos[i].Tags = matchedTags
+
+					pageFinder.Add(repodb.DetailedRepoMeta{
+						RepoMeta: repo,
+					})
+				}
+
+				return repos, manifestMetas, repodb.PageInfo{}, nil
+			},
+		}
+		responseContext := graphql.WithResponseContext(context.Background(), graphql.DefaultErrorPresenter,
+			graphql.DefaultRecover)
+
+		mockCve := mocks.CveInfoMock{}
+		images, err := baseImageList(responseContext, "repo1:1.0.2", mockSearchDB, &gql_generated.PageInput{},
+			mockCve, log.NewLogger("debug", ""))
+		So(err, ShouldBeNil)
+		So(images.Results, ShouldBeEmpty)
+	})
 }

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -244,12 +244,12 @@ type Query {
     """
     List of images which use the argument image
     """
-    DerivedImageList(image: String!): [ImageSummary!]
+    DerivedImageList(image: String!, requestedPage: PageInput): PaginatedImagesResult!
 
     """
     List of images on which the argument image depends on
     """
-    BaseImageList(image: String!): [ImageSummary!]
+    BaseImageList(image: String!, requestedPage: PageInput): PaginatedImagesResult!
 
     """
     Search for a specific image using its name

--- a/pkg/meta/repodb/dynamodb-wrapper/dynamo_test.go
+++ b/pkg/meta/repodb/dynamodb-wrapper/dynamo_test.go
@@ -398,7 +398,7 @@ func TestWrapperErrors(t *testing.T) {
 			err = setBadRepoMeta(dynamoWrapper.Client, repoMetaTablename, "repo") //nolint:contextcheck
 			So(err, ShouldBeNil)
 
-			_, _, err = dynamoWrapper.FilterTags(
+			_, _, _, err = dynamoWrapper.FilterTags(
 				ctx,
 				func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
 					return true
@@ -413,7 +413,7 @@ func TestWrapperErrors(t *testing.T) {
 			err := dynamoWrapper.SetRepoTag("repo", "tag1", "manifestNotFound", "") //nolint:contextcheck
 			So(err, ShouldBeNil)
 
-			_, _, err = dynamoWrapper.FilterTags(
+			_, _, _, err = dynamoWrapper.FilterTags(
 				ctx,
 				func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
 					return true
@@ -431,7 +431,7 @@ func TestWrapperErrors(t *testing.T) {
 			err = setBadManifestData(dynamoWrapper.Client, manifestDataTablename, "dig") //nolint:contextcheck
 			So(err, ShouldBeNil)
 
-			_, _, err = dynamoWrapper.FilterTags(
+			_, _, _, err = dynamoWrapper.FilterTags(
 				ctx,
 				func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
 					return true
@@ -452,7 +452,7 @@ func TestWrapperErrors(t *testing.T) {
 			})
 			So(err, ShouldBeNil)
 
-			_, _, err = dynamoWrapper.FilterTags(
+			_, _, _, err = dynamoWrapper.FilterTags(
 				ctx,
 				func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
 					return true

--- a/pkg/meta/repodb/repodb.go
+++ b/pkg/meta/repodb/repodb.go
@@ -78,7 +78,7 @@ type RepoDB interface { //nolint:interfacebloat
 
 	// FilterTags filters for images given a filter function
 	FilterTags(ctx context.Context, filter FilterFunc,
-		requestedPage PageInput) ([]RepoMetadata, map[string]ManifestMetadata, error)
+		requestedPage PageInput) ([]RepoMetadata, map[string]ManifestMetadata, PageInfo, error)
 
 	PatchDB() error
 }

--- a/pkg/meta/repodb/repodb_test.go
+++ b/pkg/meta/repodb/repodb_test.go
@@ -1335,7 +1335,7 @@ func RunRepoDBTests(repoDB repodb.RepoDB, preparationFuncs ...func() error) {
 			So(err, ShouldBeNil)
 
 			Convey("Return all tags", func() {
-				repos, manifesMetaMap, err := repoDB.FilterTags(
+				repos, manifesMetaMap, pageInfo, err := repoDB.FilterTags(
 					ctx,
 					func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
 						return true
@@ -1358,10 +1358,12 @@ func RunRepoDBTests(repoDB repodb.RepoDB, preparationFuncs ...func() error) {
 				So(manifesMetaMap, ShouldContainKey, manifestDigest1.String())
 				So(manifesMetaMap, ShouldContainKey, manifestDigest2.String())
 				So(manifesMetaMap, ShouldContainKey, manifestDigest3.String())
+				So(pageInfo.ItemCount, ShouldEqual, 6)
+				So(pageInfo.TotalCount, ShouldEqual, 6)
 			})
 
 			Convey("Return all tags in a specific repo", func() {
-				repos, manifesMetaMap, err := repoDB.FilterTags(
+				repos, manifesMetaMap, pageInfo, err := repoDB.FilterTags(
 					ctx,
 					func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
 						return repoMeta.Name == repo1
@@ -1381,10 +1383,12 @@ func RunRepoDBTests(repoDB repodb.RepoDB, preparationFuncs ...func() error) {
 				So(manifesMetaMap, ShouldContainKey, manifestDigest1.String())
 				So(manifesMetaMap, ShouldContainKey, manifestDigest2.String())
 				So(manifesMetaMap, ShouldContainKey, manifestDigest3.String())
+				So(pageInfo.ItemCount, ShouldEqual, 5)
+				So(pageInfo.TotalCount, ShouldEqual, 5)
 			})
 
 			Convey("Filter everything out", func() {
-				repos, manifesMetaMap, err := repoDB.FilterTags(
+				repos, manifesMetaMap, pageInfo, err := repoDB.FilterTags(
 					ctx,
 					func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
 						return false
@@ -1395,6 +1399,8 @@ func RunRepoDBTests(repoDB repodb.RepoDB, preparationFuncs ...func() error) {
 				So(err, ShouldBeNil)
 				So(len(repos), ShouldEqual, 0)
 				So(len(manifesMetaMap), ShouldEqual, 0)
+				So(pageInfo.ItemCount, ShouldEqual, 0)
+				So(pageInfo.TotalCount, ShouldEqual, 0)
 			})
 
 			Convey("Search with access control", func() {
@@ -1409,7 +1415,7 @@ func RunRepoDBTests(repoDB repodb.RepoDB, preparationFuncs ...func() error) {
 				authzCtxKey := localCtx.GetContextKey()
 				ctx := context.WithValue(context.Background(), authzCtxKey, acCtx)
 
-				repos, manifesMetaMap, err := repoDB.FilterTags(
+				repos, manifesMetaMap, pageInfo, err := repoDB.FilterTags(
 					ctx,
 					func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
 						return true
@@ -1423,10 +1429,12 @@ func RunRepoDBTests(repoDB repodb.RepoDB, preparationFuncs ...func() error) {
 				So(len(repos[0].Tags), ShouldEqual, 1)
 				So(repos[0].Tags, ShouldContainKey, "0.0.1")
 				So(manifesMetaMap, ShouldContainKey, manifestDigest3.String())
+				So(pageInfo.ItemCount, ShouldEqual, 1)
+				So(pageInfo.TotalCount, ShouldEqual, 1)
 			})
 
 			Convey("With wrong pagination input", func() {
-				repos, _, err := repoDB.FilterTags(
+				repos, _, _, err := repoDB.FilterTags(
 					ctx,
 					func(repoMeta repodb.RepoMetadata, manifestMeta repodb.ManifestMetadata) bool {
 						return true

--- a/pkg/test/mocks/repo_db_mock.go
+++ b/pkg/test/mocks/repo_db_mock.go
@@ -50,7 +50,7 @@ type RepoDBMock struct {
 
 	FilterTagsFn func(ctx context.Context, filter repodb.FilterFunc,
 		requestedPage repodb.PageInput,
-	) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error)
+	) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error)
 
 	SearchDigestsFn func(ctx context.Context, searchText string, requestedPage repodb.PageInput) (
 		[]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error)
@@ -223,12 +223,12 @@ func (sdm RepoDBMock) SearchTags(ctx context.Context, searchText string, filter 
 
 func (sdm RepoDBMock) FilterTags(ctx context.Context, filter repodb.FilterFunc,
 	requestedPage repodb.PageInput,
-) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, error) {
+) ([]repodb.RepoMetadata, map[string]repodb.ManifestMetadata, repodb.PageInfo, error) {
 	if sdm.FilterTagsFn != nil {
 		return sdm.FilterTagsFn(ctx, filter, requestedPage)
 	}
 
-	return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, nil
+	return []repodb.RepoMetadata{}, map[string]repodb.ManifestMetadata{}, repodb.PageInfo{}, nil
 }
 
 func (sdm RepoDBMock) SearchDigests(ctx context.Context, searchText string, requestedPage repodb.PageInput,


### PR DESCRIPTION
- derivedImageList and baseImageList now use FilterTags to obtain results, each with its own filter function
- images that have the exact same manifest as the one provided as a parameter are no longer considered base images or derived images
- both calls can be made with specific pagination parameters, and the response will include PageInfo

Signed-off-by: Alex Stan <alexandrustan96@yahoo.ro>

fix(tests): fix one of the pagination tests

The results were not reliable as the 2 returned tags were sorted by created date/time which was not set, resulting in an unpredictable order

Signed-off-by: Andrei Aaron <andaaron@cisco.com>
(cherry picked from commit be504200a1127371422aeb0e5c0219e2a1ead20a) (cherry picked from commit ed8d797e639f262a63840120afe92da7db9a7600)
Signed-off-by: Andrei Aaron <aaaron@luxoft.com>

Resolves #861 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
