### PR TITLE
fix(referrers): annotation key is incorrect

### DIFF
--- a/pkg/storage/constants/constants.go
+++ b/pkg/storage/constants/constants.go
@@ -18,6 +18,6 @@ const (
 	DBExtensionName          = ".db"
 	DBCacheLockCheckTimeout  = 10 * time.Second
 	BoltdbName               = "cache"
-	ReferrerFilterAnnotation = "org.opencontainers.references.filtersApplied"
+	ReferrerFilterAnnotation = "org.opencontainers.referrers.filtersApplied"
 	DynamoDBDriverName       = "dynamodb"
 )


### PR DESCRIPTION
"If filtering is requested and applied, the response MUST include an annotation (org.opencontainers.referrers.filtersApplied) denoting that an artifactType filter was applied.""

Signed-off-by: Ramkumar Chinchani <rchincha@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
