### PR TITLE
chore: update the version of go-lru we use to the latest available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/json-iterator/go v1.1.12
 	github.com/minio/sha256-simd v1.0.0
 	github.com/mitchellh/mapstructure v1.5.0
@@ -99,7 +100,6 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7 // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.1 // indirect
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect
@@ -331,7 +331,7 @@ require (
 	github.com/hashicorp/go-safetemp v1.0.0 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.14.1 // indirect
 	github.com/huandu/xstrings v1.3.3 // indirect

--- a/pkg/extensions/search/cve/trivy/cache.go
+++ b/pkg/extensions/search/cve/trivy/cache.go
@@ -1,19 +1,19 @@
 package trivy
 
 import (
-	lru "github.com/hashicorp/golang-lru"
+	lru "github.com/hashicorp/golang-lru/v2"
 
 	cvemodel "zotregistry.io/zot/pkg/extensions/search/cve/model"
 	"zotregistry.io/zot/pkg/log"
 )
 
 type CveCache struct {
-	cache *lru.Cache
+	cache *lru.Cache[string, map[string]cvemodel.CVE]
 	log   log.Logger
 }
 
 func NewCveCache(size int, log log.Logger) *CveCache {
-	cache, _ := lru.New(size)
+	cache, _ := lru.New[string, map[string]cvemodel.CVE](size)
 
 	return &CveCache{cache: cache, log: log}
 }
@@ -23,12 +23,7 @@ func (cveCache *CveCache) Add(image string, cveMap map[string]cvemodel.CVE) {
 }
 
 func (cveCache *CveCache) Get(image string) map[string]cvemodel.CVE {
-	value, ok := cveCache.cache.Get(image)
-	if !ok {
-		return nil
-	}
-
-	cveMap, ok := value.(map[string]cvemodel.CVE)
+	cveMap, ok := cveCache.cache.Get(image)
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
We are now using v2.0.1 in the cve cache logic.
Unfortunately we are also using v0.5.4 indirectly, as it is required for gqlgen, see: https://github.com/99designs/gqlgen/blob/e6114a2c6af22bcdc92180660a58e6125e7946ad/go.mod#L7

Signed-off-by: Andrei Aaron <aaaron@luxoft.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
