### PR TITLE
fix(test): update the zot tests not to use test/data as rootDir (use …

### DIFF
--- a/pkg/common/common_test.go
+++ b/pkg/common/common_test.go
@@ -42,8 +42,9 @@ func TestCommon(t *testing.T) {
 	Convey("test dirExists()", t, func() {
 		exists := common.DirExists("testdir")
 		So(exists, ShouldBeFalse)
+		tempDir := t.TempDir()
 
-		file, err := os.Create("file.txt")
+		file, err := os.Create(path.Join(tempDir, "file.txt"))
 		So(err, ShouldBeNil)
 		isDir := common.DirExists(file.Name())
 		So(isDir, ShouldBeFalse)

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -42,7 +42,6 @@ import (
 const (
 	username   = "test"
 	passphrase = "test"
-	testDir    = "../../../../test/data"
 )
 
 type CveResult struct {
@@ -373,8 +372,6 @@ func TestImageFormat(t *testing.T) {
 
 func TestCVESearchDisabled(t *testing.T) {
 	Convey("Test with CVE search disabled", t, func() {
-		dbDir := testDir
-
 		port := GetFreePort()
 		baseURL := GetBaseURL(port)
 		conf := config.New()
@@ -388,6 +385,8 @@ func TestCVESearchDisabled(t *testing.T) {
 			},
 		}
 
+		dbDir, err := testSetup(t)
+		So(err, ShouldBeNil)
 		conf.Storage.RootDirectory = dbDir
 		defaultVal := true
 		searchConfig := &extconf.SearchConfig{
@@ -748,15 +747,9 @@ func TestHTTPOptionsResponse(t *testing.T) {
 
 		ctlr := api.NewController(conf)
 
-		firstDir, err := os.MkdirTemp("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
+		firstDir := t.TempDir()
 
-		secondDir, err := os.MkdirTemp("", "oci-repo-test")
-		if err != nil {
-			panic(err)
-		}
+		secondDir := t.TempDir()
 		defer os.RemoveAll(firstDir)
 		defer os.RemoveAll(secondDir)
 

--- a/pkg/extensions/search/digest/digest_test.go
+++ b/pkg/extensions/search/digest/digest_test.go
@@ -273,10 +273,7 @@ func TestDigestSearchHTTPSubPaths(t *testing.T) {
 
 		ctlr := api.NewController(conf)
 
-		globalDir, err := os.MkdirTemp("", "digest_test")
-		if err != nil {
-			panic(err)
-		}
+		globalDir := t.TempDir()
 		defer os.RemoveAll(globalDir)
 
 		ctlr.Config.Storage.RootDirectory = globalDir

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -742,10 +742,8 @@ func TestConfigReloader(t *testing.T) {
 
 		destConfig.HTTP.Port = destPort
 
-		destDir, err := os.MkdirTemp("", "oci-dest-repo-test")
-		if err != nil {
-			panic(err)
-		}
+		// change
+		destDir := t.TempDir()
 
 		defer os.RemoveAll(destDir)
 
@@ -3928,8 +3926,7 @@ func TestSyncSignaturesDiff(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		defer func() { _ = os.Chdir(cwd) }()
-		tdir, err := os.MkdirTemp("", "sigs")
-		So(err, ShouldBeNil)
+		tdir := t.TempDir()
 
 		_ = os.Chdir(tdir)
 		generateKeyPairs(tdir)
@@ -4021,8 +4018,7 @@ func TestSyncSignaturesDiff(t *testing.T) {
 
 		// now add new signatures to upstream and let sync detect that upstream signatures changed and pull them
 		So(os.RemoveAll(tdir), ShouldBeNil)
-		tdir, err = os.MkdirTemp("", "sigs")
-		So(err, ShouldBeNil)
+		tdir = t.TempDir()
 		defer os.RemoveAll(tdir)
 		_ = os.Chdir(tdir)
 		generateKeyPairs(tdir)


### PR DESCRIPTION
…a temporary folder instead)
- Use testing's TempDir() to create temporary directories intead of os.MkdirTemp()

Signed-off-by: Nicol Draghici <idraghic@cisco.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Closes #1160 

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
