### PR TITLE
test: avoid running trivy tests if search build label is missing

### DIFF
--- a/pkg/extensions/search/cve/pagination_test.go
+++ b/pkg/extensions/search/cve/pagination_test.go
@@ -1,3 +1,6 @@
+//go:build search
+// +build search
+
 package cveinfo_test
 
 import (

--- a/pkg/extensions/search/cve/trivy/scanner_internal_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_internal_test.go
@@ -1,3 +1,6 @@
+//go:build search
+// +build search
+
 package trivy
 
 import (


### PR DESCRIPTION
The 'test' makefile target runs the tests for both 'minimal' and equivalent of the former 'extended' build. The trivy package tests were run twice, even if the trivy logic is unreachable if search is disabled. With this update we should see a cut of about 150s of test time.

Signed-off-by: Andrei Aaron <aaaron@luxoft.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
