### PR TITLE
refactor(cve): improve CVE test time by mocking trivy

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -50,6 +50,7 @@ type Controller struct {
 	Audit           *log.Logger
 	Server          *http.Server
 	Metrics         monitoring.MetricServer
+	CveInfo         ext.CveInfo
 	wgShutDown      *goSync.WaitGroup // use it to gracefully shutdown goroutines
 	// runtime params
 	chosenPort int // kernel-chosen port
@@ -120,11 +121,7 @@ func (c *Controller) GetPort() int {
 }
 
 func (c *Controller) Run(reloadCtx context.Context) error {
-	// print the current configuration, but strip secrets
-	c.Log.Info().Interface("params", c.Config.Sanitize()).Msg("configuration settings")
-
-	// print the current runtime environment
-	DumpRuntimeParams(c.Log)
+	c.StartBackgroundTasks(reloadCtx)
 
 	// setup HTTP API router
 	engine := mux.NewRouter()
@@ -152,26 +149,6 @@ func (c *Controller) Run(reloadCtx context.Context) error {
 
 	c.Router = engine
 	c.Router.UseEncodedPath()
-
-	var enabled bool
-	if c.Config != nil &&
-		c.Config.Extensions != nil &&
-		c.Config.Extensions.Metrics != nil &&
-		*c.Config.Extensions.Metrics.Enable {
-		enabled = true
-	}
-
-	c.Metrics = monitoring.NewMetricsServer(enabled, c.Log)
-
-	if err := c.InitImageStore(reloadCtx); err != nil {
-		return err
-	}
-
-	if err := c.InitRepoDB(reloadCtx); err != nil {
-		return err
-	}
-
-	c.StartBackgroundTasks(reloadCtx)
 
 	monitoring.SetServerInfo(c.Metrics, c.Config.Commit, c.Config.BinaryType, c.Config.GoVersion,
 		c.Config.DistSpecVersion)
@@ -257,6 +234,43 @@ func (c *Controller) Run(reloadCtx context.Context) error {
 	}
 
 	return server.Serve(listener)
+}
+
+func (c *Controller) Init(reloadCtx context.Context) error {
+	// print the current configuration, but strip secrets
+	c.Log.Info().Interface("params", c.Config.Sanitize()).Msg("configuration settings")
+
+	// print the current runtime environment
+	DumpRuntimeParams(c.Log)
+
+	var enabled bool
+	if c.Config != nil &&
+		c.Config.Extensions != nil &&
+		c.Config.Extensions.Metrics != nil &&
+		*c.Config.Extensions.Metrics.Enable {
+		enabled = true
+	}
+
+	c.Metrics = monitoring.NewMetricsServer(enabled, c.Log)
+
+	if err := c.InitImageStore(reloadCtx); err != nil {
+		return err
+	}
+
+	if err := c.InitRepoDB(reloadCtx); err != nil {
+		return err
+	}
+
+	c.InitCVEInfo()
+
+	return nil
+}
+
+func (c *Controller) InitCVEInfo() {
+	// Enable CVE extension if extension config is provided
+	if c.Config != nil && c.Config.Extensions != nil {
+		c.CveInfo = ext.GetCVEInfo(c.Config, c.StoreController, c.RepoDB, c.Log)
+	}
 }
 
 func (c *Controller) InitImageStore(ctx context.Context) error {
@@ -616,7 +630,7 @@ func (c *Controller) StartBackgroundTasks(reloadCtx context.Context) {
 	// Enable extensions if extension config is provided for DefaultStore
 	if c.Config != nil && c.Config.Extensions != nil {
 		ext.EnableMetricsExtension(c.Config, c.Log, c.Config.Storage.RootDirectory)
-		ext.EnableSearchExtension(c.Config, c.StoreController, c.RepoDB, c.Log)
+		ext.EnableSearchExtension(c.Config, c.StoreController, c.RepoDB, c.CveInfo, c.Log)
 	}
 
 	if c.Config.Storage.SubPaths != nil {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -260,7 +260,10 @@ func TestRunAlreadyRunningServer(t *testing.T) {
 		cm.StartAndWait(port)
 		defer cm.StopServer()
 
-		err := ctlr.Run(context.Background())
+		err := ctlr.Init(context.Background())
+		So(err, ShouldBeNil)
+
+		err = ctlr.Run(context.Background())
 		So(err, ShouldNotBeNil)
 	})
 }
@@ -328,7 +331,7 @@ func TestObjectStorageController(t *testing.T) {
 		ctlr := makeController(conf, "zot", "")
 		So(ctlr, ShouldNotBeNil)
 
-		err := ctlr.Run(context.Background())
+		err := ctlr.Init(context.Background())
 		So(err, ShouldNotBeNil)
 	})
 
@@ -928,7 +931,7 @@ func TestMultipleInstance(t *testing.T) {
 			},
 		}
 		ctlr := api.NewController(conf)
-		err := ctlr.Run(context.Background())
+		err := ctlr.Init(context.Background())
 		So(err, ShouldEqual, errors.ErrImgStoreNotFound)
 
 		globalDir := t.TempDir()
@@ -1016,7 +1019,7 @@ func TestMultipleInstance(t *testing.T) {
 
 		ctlr.Config.Storage.SubPaths = subPathMap
 
-		err := ctlr.Run(context.Background())
+		err := ctlr.Init(context.Background())
 		So(err, ShouldNotBeNil)
 
 		// subpath root directory does not exist.
@@ -1025,7 +1028,7 @@ func TestMultipleInstance(t *testing.T) {
 
 		ctlr.Config.Storage.SubPaths = subPathMap
 
-		err = ctlr.Run(context.Background())
+		err = ctlr.Init(context.Background())
 		So(err, ShouldNotBeNil)
 
 		subPathMap["/a"] = config.StorageConfig{RootDirectory: subDir, Dedupe: true, GC: true}

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -126,7 +126,7 @@ func (rh *RouteHandler) SetupRoutes() {
 		} else {
 			// extended build
 			ext.SetupMetricsRoutes(rh.c.Config, rh.c.Router, rh.c.StoreController, rh.c.Log)
-			ext.SetupSearchRoutes(rh.c.Config, rh.c.Router, rh.c.StoreController, rh.c.RepoDB, rh.c.Log)
+			ext.SetupSearchRoutes(rh.c.Config, rh.c.Router, rh.c.StoreController, rh.c.RepoDB, rh.c.CveInfo, rh.c.Log)
 			gqlPlayground.SetupGQLPlaygroundRoutes(rh.c.Config, rh.c.Router, rh.c.StoreController, rh.c.Log)
 		}
 	}

--- a/pkg/cli/cve_cmd_test.go
+++ b/pkg/cli/cve_cmd_test.go
@@ -5,8 +5,12 @@ package cli //nolint:testpackage
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"regexp"
@@ -14,6 +18,9 @@ import (
 	"testing"
 	"time"
 
+	regTypes "github.com/google/go-containerregistry/pkg/v1/types"
+	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/spf13/cobra"
 
@@ -21,7 +28,12 @@ import (
 	"zotregistry.io/zot/pkg/api"
 	"zotregistry.io/zot/pkg/api/config"
 	extconf "zotregistry.io/zot/pkg/extensions/config"
+	cveinfo "zotregistry.io/zot/pkg/extensions/search/cve"
+	cvemodel "zotregistry.io/zot/pkg/extensions/search/cve/model"
+	"zotregistry.io/zot/pkg/log"
+	"zotregistry.io/zot/pkg/meta/repodb"
 	"zotregistry.io/zot/pkg/test"
+	"zotregistry.io/zot/pkg/test/mocks"
 )
 
 func TestSearchCVECmd(t *testing.T) {
@@ -441,9 +453,23 @@ func TestNegativeServerResponse(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlr.Log.Logger = ctlr.Log.Output(writers)
 
-		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
-		defer cm.StopServer()
+		ctx := context.Background()
+
+		if err := ctlr.Init(ctx); err != nil {
+			panic(err)
+		}
+
+		ctlr.CveInfo = getMockCveInfo(ctlr.RepoDB, ctlr.Log)
+
+		go func() {
+			if err := ctlr.Run(ctx); !errors.Is(err, http.ErrServerClosed) {
+				panic(err)
+			}
+		}()
+
+		defer ctlr.Shutdown()
+
+		test.WaitTillServerReady(url)
 
 		_, err = test.ReadLogFileAndSearchString(logPath, "DB update completed, next update scheduled", 90*time.Second)
 		if err != nil {
@@ -504,10 +530,23 @@ func TestServerCVEResponse(t *testing.T) {
 	ctlr := api.NewController(conf)
 	ctlr.Log.Logger = ctlr.Log.Output(writers)
 
-	cm := test.NewControllerManager(ctlr)
+	ctx := context.Background()
 
-	cm.StartAndWait(conf.HTTP.Port)
-	defer cm.StopServer()
+	if err := ctlr.Init(ctx); err != nil {
+		panic(err)
+	}
+
+	ctlr.CveInfo = getMockCveInfo(ctlr.RepoDB, ctlr.Log)
+
+	go func() {
+		if err := ctlr.Run(ctx); !errors.Is(err, http.ErrServerClosed) {
+			panic(err)
+		}
+	}()
+
+	defer ctlr.Shutdown()
+
+	test.WaitTillServerReady(url)
 
 	_, err = test.ReadLogFileAndSearchString(logPath, "DB update completed, next update scheduled", 90*time.Second)
 	if err != nil {
@@ -987,4 +1026,119 @@ func MockSearchCve(searchConfig searchConfig) error {
 	}
 
 	return zotErrors.ErrInvalidFlagsCombination
+}
+
+func getMockCveInfo(repoDB repodb.RepoDB, log log.Logger) cveinfo.CveInfo {
+	// RepoDB loaded with initial data, mock the scanner
+	severities := map[string]int{
+		"UNKNOWN":  0,
+		"LOW":      1,
+		"MEDIUM":   2,
+		"HIGH":     3,
+		"CRITICAL": 4,
+	}
+
+	// Setup test CVE data in mock scanner
+	scanner := mocks.CveScannerMock{
+		ScanImageFn: func(image string) (map[string]cvemodel.CVE, error) {
+			if image == "zot-cve-test:0.0.1" {
+				return map[string]cvemodel.CVE{
+					"CVE-1": {
+						ID:          "CVE-1",
+						Severity:    "CRITICAL",
+						Title:       "Title for CVE-C1",
+						Description: "Description of CVE-1",
+					},
+					"CVE-2019-9923": {
+						ID:          "CVE-2019-9923",
+						Severity:    "HIGH",
+						Title:       "Title for CVE-2",
+						Description: "Description of CVE-2",
+					},
+					"CVE-3": {
+						ID:          "CVE-3",
+						Severity:    "MEDIUM",
+						Title:       "Title for CVE-3",
+						Description: "Description of CVE-3",
+					},
+					"CVE-4": {
+						ID:          "CVE-4",
+						Severity:    "LOW",
+						Title:       "Title for CVE-4",
+						Description: "Description of CVE-4",
+					},
+					"CVE-5": {
+						ID:          "CVE-5",
+						Severity:    "UNKNOWN",
+						Title:       "Title for CVE-5",
+						Description: "Description of CVE-5",
+					},
+				}, nil
+			}
+
+			// By default the image has no vulnerabilities
+			return map[string]cvemodel.CVE{}, nil
+		},
+		CompareSeveritiesFn: func(severity1, severity2 string) int {
+			return severities[severity2] - severities[severity1]
+		},
+		IsImageFormatScannableFn: func(image string) (bool, error) {
+			// Almost same logic compared to actual Trivy specific implementation
+			var imageDir string
+
+			var inputTag string
+
+			if strings.Contains(image, ":") {
+				imageDir, inputTag, _ = strings.Cut(image, ":")
+			} else {
+				imageDir = image
+			}
+
+			repoMeta, err := repoDB.GetRepoMeta(imageDir)
+			if err != nil {
+				return false, err
+			}
+
+			manifestDigestStr, ok := repoMeta.Tags[inputTag]
+			if !ok {
+				return false, zotErrors.ErrTagMetaNotFound
+			}
+
+			manifestDigest, err := godigest.Parse(manifestDigestStr.Digest)
+			if err != nil {
+				return false, err
+			}
+
+			manifestData, err := repoDB.GetManifestData(manifestDigest)
+			if err != nil {
+				return false, err
+			}
+
+			var manifestContent ispec.Manifest
+
+			err = json.Unmarshal(manifestData.ManifestBlob, &manifestContent)
+			if err != nil {
+				return false, zotErrors.ErrScanNotSupported
+			}
+
+			for _, imageLayer := range manifestContent.Layers {
+				switch imageLayer.MediaType {
+				case ispec.MediaTypeImageLayerGzip, ispec.MediaTypeImageLayer, string(regTypes.DockerLayer):
+
+					return true, nil
+				default:
+
+					return false, zotErrors.ErrScanNotSupported
+				}
+			}
+
+			return false, nil
+		},
+	}
+
+	return &cveinfo.BaseCveInfo{
+		Log:     log,
+		Scanner: scanner,
+		RepoDB:  repoDB,
+	}
 }

--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -1292,7 +1292,7 @@ func TestServerResponseGQLWithoutPermissions(t *testing.T) {
 		}
 
 		ctlr := api.NewController(conf)
-		if err := ctlr.Run(context.Background()); err != nil {
+		if err := ctlr.Init(context.Background()); err != nil {
 			So(err, ShouldNotBeNil)
 		}
 	})

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -63,6 +63,10 @@ func newServeCmd(conf *config.Config) *cobra.Command {
 			we can change their config on the fly (restart routines with different config) */
 			reloaderCtx := hotReloader.Start()
 
+			if err := ctlr.Init(reloaderCtx); err != nil {
+				panic(err)
+			}
+
 			if err := ctlr.Run(reloaderCtx); err != nil {
 				panic(err)
 			}

--- a/pkg/compliance/v1_0_0/check_test.go
+++ b/pkg/compliance/v1_0_0/check_test.go
@@ -81,6 +81,10 @@ func startServer(t *testing.T) (*api.Controller, string) {
 	ctrl.Config.Storage.SubPaths = subPaths
 
 	go func() {
+		if err := ctrl.Init(context.Background()); err != nil {
+			return
+		}
+
 		// this blocks
 		if err := ctrl.Run(context.Background()); err != nil {
 			return

--- a/pkg/exporter/api/controller_test.go
+++ b/pkg/exporter/api/controller_test.go
@@ -126,14 +126,18 @@ func TestNewExporter(t *testing.T) {
 
 				dir := t.TempDir()
 				serverController.Config.Storage.RootDirectory = dir
-				go func(c *zotapi.Controller) {
+				go func(ctrl *zotapi.Controller) {
+					if err := ctrl.Init(context.Background()); err != nil {
+						panic(err)
+					}
+
 					// this blocks
-					if err := c.Run(context.Background()); !errors.Is(err, http.ErrServerClosed) {
+					if err := ctrl.Run(context.Background()); !errors.Is(err, http.ErrServerClosed) {
 						panic(err)
 					}
 				}(serverController)
-				defer func(c *zotapi.Controller) {
-					_ = c.Server.Shutdown(context.TODO())
+				defer func(ctrl *zotapi.Controller) {
+					_ = ctrl.Server.Shutdown(context.TODO())
 				}(serverController)
 				// wait till ready
 				for {

--- a/pkg/extensions/extension_search_disabled.go
+++ b/pkg/extensions/extension_search_disabled.go
@@ -13,9 +13,17 @@ import (
 	"zotregistry.io/zot/pkg/storage"
 )
 
+type CveInfo interface{}
+
+func GetCVEInfo(config *config.Config, storeController storage.StoreController,
+	repoDB repodb.RepoDB, log log.Logger,
+) CveInfo {
+	return nil
+}
+
 // EnableSearchExtension ...
 func EnableSearchExtension(config *config.Config, storeController storage.StoreController,
-	repoDB repodb.RepoDB, log log.Logger,
+	repoDB repodb.RepoDB, cveInfo CveInfo, log log.Logger,
 ) {
 	log.Warn().Msg("skipping enabling search extension because given zot binary doesn't include this feature," +
 		"please build a binary that does so")
@@ -23,7 +31,7 @@ func EnableSearchExtension(config *config.Config, storeController storage.StoreC
 
 // SetupSearchRoutes ...
 func SetupSearchRoutes(config *config.Config, router *mux.Router, storeController storage.StoreController,
-	repoDB repodb.RepoDB, log log.Logger,
+	repoDB repodb.RepoDB, cveInfo CveInfo, log log.Logger,
 ) {
 	log.Warn().Msg("skipping setting up search routes because given zot binary doesn't include this feature," +
 		"please build a binary that does so")

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -784,6 +784,10 @@ func TestConfigReloader(t *testing.T) {
 
 		go func() {
 			// this blocks
+			if err := dctlr.Init(reloadCtx); err != nil {
+				return
+			}
+
 			if err := dctlr.Run(reloadCtx); err != nil {
 				return
 			}


### PR DESCRIPTION
- refactor(cve): remove the global of type cveinfo.CveInfo from the extensions package Replace it with an attribute on controller level
- refactor(controller): extract initialization logic from controller.Run()
- test(cve): mock cve scanner in cli tests

Signed-off-by: Andrei Aaron <aaaron@luxoft.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
