### PR TITLE
refactor(cve): improve CVE test time by mocking trivy

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -50,6 +50,7 @@ type Controller struct {
 	Audit           *log.Logger
 	Server          *http.Server
 	Metrics         monitoring.MetricServer
+	CveInfo         ext.CveInfo
 	wgShutDown      *goSync.WaitGroup // use it to gracefully shutdown goroutines
 	// runtime params
 	chosenPort int // kernel-chosen port
@@ -120,11 +121,7 @@ func (c *Controller) GetPort() int {
 }
 
 func (c *Controller) Run(reloadCtx context.Context) error {
-	// print the current configuration, but strip secrets
-	c.Log.Info().Interface("params", c.Config.Sanitize()).Msg("configuration settings")
-
-	// print the current runtime environment
-	DumpRuntimeParams(c.Log)
+	c.StartBackgroundTasks(reloadCtx)
 
 	// setup HTTP API router
 	engine := mux.NewRouter()
@@ -152,26 +149,6 @@ func (c *Controller) Run(reloadCtx context.Context) error {
 
 	c.Router = engine
 	c.Router.UseEncodedPath()
-
-	var enabled bool
-	if c.Config != nil &&
-		c.Config.Extensions != nil &&
-		c.Config.Extensions.Metrics != nil &&
-		*c.Config.Extensions.Metrics.Enable {
-		enabled = true
-	}
-
-	c.Metrics = monitoring.NewMetricsServer(enabled, c.Log)
-
-	if err := c.InitImageStore(reloadCtx); err != nil {
-		return err
-	}
-
-	if err := c.InitRepoDB(reloadCtx); err != nil {
-		return err
-	}
-
-	c.StartBackgroundTasks(reloadCtx)
 
 	monitoring.SetServerInfo(c.Metrics, c.Config.Commit, c.Config.BinaryType, c.Config.GoVersion,
 		c.Config.DistSpecVersion)
@@ -257,6 +234,43 @@ func (c *Controller) Run(reloadCtx context.Context) error {
 	}
 
 	return server.Serve(listener)
+}
+
+func (c *Controller) Init(reloadCtx context.Context) error {
+	// print the current configuration, but strip secrets
+	c.Log.Info().Interface("params", c.Config.Sanitize()).Msg("configuration settings")
+
+	// print the current runtime environment
+	DumpRuntimeParams(c.Log)
+
+	var enabled bool
+	if c.Config != nil &&
+		c.Config.Extensions != nil &&
+		c.Config.Extensions.Metrics != nil &&
+		*c.Config.Extensions.Metrics.Enable {
+		enabled = true
+	}
+
+	c.Metrics = monitoring.NewMetricsServer(enabled, c.Log)
+
+	if err := c.InitImageStore(reloadCtx); err != nil {
+		return err
+	}
+
+	if err := c.InitRepoDB(reloadCtx); err != nil {
+		return err
+	}
+
+	c.InitCVEInfo()
+
+	return nil
+}
+
+func (c *Controller) InitCVEInfo() {
+	// Enable CVE extension if extension config is provided
+	if c.Config != nil && c.Config.Extensions != nil {
+		c.CveInfo = ext.GetCVEInfo(c.Config, c.StoreController, c.RepoDB, c.Log)
+	}
 }
 
 func (c *Controller) InitImageStore(ctx context.Context) error {
@@ -616,7 +630,7 @@ func (c *Controller) StartBackgroundTasks(reloadCtx context.Context) {
 	// Enable extensions if extension config is provided for DefaultStore
 	if c.Config != nil && c.Config.Extensions != nil {
 		ext.EnableMetricsExtension(c.Config, c.Log, c.Config.Storage.RootDirectory)
-		ext.EnableSearchExtension(c.Config, c.StoreController, c.RepoDB, c.Log)
+		ext.EnableSearchExtension(c.Config, c.StoreController, c.RepoDB, c.CveInfo, c.Log)
 	}
 
 	if c.Config.Storage.SubPaths != nil {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -260,7 +260,10 @@ func TestRunAlreadyRunningServer(t *testing.T) {
 		cm.StartAndWait(port)
 		defer cm.StopServer()
 
-		err := ctlr.Run(context.Background())
+		err := ctlr.Init(context.Background())
+		So(err, ShouldBeNil)
+
+		err = ctlr.Run(context.Background())
 		So(err, ShouldNotBeNil)
 	})
 }
@@ -328,7 +331,7 @@ func TestObjectStorageController(t *testing.T) {
 		ctlr := makeController(conf, "zot", "")
 		So(ctlr, ShouldNotBeNil)
 
-		err := ctlr.Run(context.Background())
+		err := ctlr.Init(context.Background())
 		So(err, ShouldNotBeNil)
 	})
 
@@ -928,7 +931,7 @@ func TestMultipleInstance(t *testing.T) {
 			},
 		}
 		ctlr := api.NewController(conf)
-		err := ctlr.Run(context.Background())
+		err := ctlr.Init(context.Background())
 		So(err, ShouldEqual, errors.ErrImgStoreNotFound)
 
 		globalDir := t.TempDir()
@@ -1016,7 +1019,7 @@ func TestMultipleInstance(t *testing.T) {
 
 		ctlr.Config.Storage.SubPaths = subPathMap
 
-		err := ctlr.Run(context.Background())
+		err := ctlr.Init(context.Background())
 		So(err, ShouldNotBeNil)
 
 		// subpath root directory does not exist.
@@ -1025,7 +1028,7 @@ func TestMultipleInstance(t *testing.T) {
 
 		ctlr.Config.Storage.SubPaths = subPathMap
 
-		err = ctlr.Run(context.Background())
+		err = ctlr.Init(context.Background())
 		So(err, ShouldNotBeNil)
 
 		subPathMap["/a"] = config.StorageConfig{RootDirectory: subDir, Dedupe: true, GC: true}

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -126,7 +126,7 @@ func (rh *RouteHandler) SetupRoutes() {
 		} else {
 			// extended build
 			ext.SetupMetricsRoutes(rh.c.Config, rh.c.Router, rh.c.StoreController, rh.c.Log)
-			ext.SetupSearchRoutes(rh.c.Config, rh.c.Router, rh.c.StoreController, rh.c.RepoDB, rh.c.Log)
+			ext.SetupSearchRoutes(rh.c.Config, rh.c.Router, rh.c.StoreController, rh.c.RepoDB, rh.c.CveInfo, rh.c.Log)
 			gqlPlayground.SetupGQLPlaygroundRoutes(rh.c.Config, rh.c.Router, rh.c.StoreController, rh.c.Log)
 		}
 	}

--- a/pkg/cli/image_cmd_test.go
+++ b/pkg/cli/image_cmd_test.go
@@ -1292,7 +1292,7 @@ func TestServerResponseGQLWithoutPermissions(t *testing.T) {
 		}
 
 		ctlr := api.NewController(conf)
-		if err := ctlr.Run(context.Background()); err != nil {
+		if err := ctlr.Init(context.Background()); err != nil {
 			So(err, ShouldNotBeNil)
 		}
 	})

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -63,6 +63,10 @@ func newServeCmd(conf *config.Config) *cobra.Command {
 			we can change their config on the fly (restart routines with different config) */
 			reloaderCtx := hotReloader.Start()
 
+			if err := ctlr.Init(reloaderCtx); err != nil {
+				panic(err)
+			}
+
 			if err := ctlr.Run(reloaderCtx); err != nil {
 				panic(err)
 			}

--- a/pkg/compliance/v1_0_0/check_test.go
+++ b/pkg/compliance/v1_0_0/check_test.go
@@ -81,6 +81,10 @@ func startServer(t *testing.T) (*api.Controller, string) {
 	ctrl.Config.Storage.SubPaths = subPaths
 
 	go func() {
+		if err := ctrl.Init(context.Background()); err != nil {
+			return
+		}
+
 		// this blocks
 		if err := ctrl.Run(context.Background()); err != nil {
 			return

--- a/pkg/exporter/api/controller_test.go
+++ b/pkg/exporter/api/controller_test.go
@@ -126,14 +126,18 @@ func TestNewExporter(t *testing.T) {
 
 				dir := t.TempDir()
 				serverController.Config.Storage.RootDirectory = dir
-				go func(c *zotapi.Controller) {
+				go func(ctrl *zotapi.Controller) {
+					if err := ctrl.Init(context.Background()); err != nil {
+						panic(err)
+					}
+
 					// this blocks
-					if err := c.Run(context.Background()); !errors.Is(err, http.ErrServerClosed) {
+					if err := ctrl.Run(context.Background()); !errors.Is(err, http.ErrServerClosed) {
 						panic(err)
 					}
 				}(serverController)
-				defer func(c *zotapi.Controller) {
-					_ = c.Server.Shutdown(context.TODO())
+				defer func(ctrl *zotapi.Controller) {
+					_ = ctrl.Server.Shutdown(context.TODO())
 				}(serverController)
 				// wait till ready
 				for {

--- a/pkg/extensions/extension_search_disabled.go
+++ b/pkg/extensions/extension_search_disabled.go
@@ -13,9 +13,17 @@ import (
 	"zotregistry.io/zot/pkg/storage"
 )
 
+type CveInfo interface{}
+
+func GetCVEInfo(config *config.Config, storeController storage.StoreController,
+	repoDB repodb.RepoDB, log log.Logger,
+) CveInfo {
+	return nil
+}
+
 // EnableSearchExtension ...
 func EnableSearchExtension(config *config.Config, storeController storage.StoreController,
-	repoDB repodb.RepoDB, log log.Logger,
+	repoDB repodb.RepoDB, cveInfo CveInfo, log log.Logger,
 ) {
 	log.Warn().Msg("skipping enabling search extension because given zot binary doesn't include this feature," +
 		"please build a binary that does so")
@@ -23,7 +31,7 @@ func EnableSearchExtension(config *config.Config, storeController storage.StoreC
 
 // SetupSearchRoutes ...
 func SetupSearchRoutes(config *config.Config, router *mux.Router, storeController storage.StoreController,
-	repoDB repodb.RepoDB, log log.Logger,
+	repoDB repodb.RepoDB, cveInfo CveInfo, log log.Logger,
 ) {
 	log.Warn().Msg("skipping setting up search routes because given zot binary doesn't include this feature," +
 		"please build a binary that does so")

--- a/pkg/extensions/search/common/common_test.go
+++ b/pkg/extensions/search/common/common_test.go
@@ -20,6 +20,7 @@ import (
 
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/gobwas/glob"
+	regTypes "github.com/google/go-containerregistry/pkg/v1/types"
 	godigest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -34,6 +35,8 @@ import (
 	extconf "zotregistry.io/zot/pkg/extensions/config"
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/extensions/search/common"
+	cveinfo "zotregistry.io/zot/pkg/extensions/search/cve"
+	cvemodel "zotregistry.io/zot/pkg/extensions/search/cve/model"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/meta/repodb"
 	"zotregistry.io/zot/pkg/storage"
@@ -354,6 +357,155 @@ func uploadNewRepoTag(tag string, repoName string, baseURL string, layers [][]by
 	return err
 }
 
+func getMockCveInfo(repoDB repodb.RepoDB, log log.Logger) cveinfo.CveInfo {
+	// RepoDB loaded with initial data, mock the scanner
+	severities := map[string]int{
+		"UNKNOWN":  0,
+		"LOW":      1,
+		"MEDIUM":   2,
+		"HIGH":     3,
+		"CRITICAL": 4,
+	}
+
+	// Setup test CVE data in mock scanner
+	scanner := mocks.CveScannerMock{
+		ScanImageFn: func(image string) (map[string]cvemodel.CVE, error) {
+			if image == "zot-cve-test:0.0.1" || image == "a/zot-cve-test:0.0.1" {
+				return map[string]cvemodel.CVE{
+					"CVE1": {
+						ID:          "CVE1",
+						Severity:    "MEDIUM",
+						Title:       "Title CVE1",
+						Description: "Description CVE1",
+					},
+					"CVE2": {
+						ID:          "CVE2",
+						Severity:    "HIGH",
+						Title:       "Title CVE2",
+						Description: "Description CVE2",
+					},
+					"CVE3": {
+						ID:          "CVE3",
+						Severity:    "LOW",
+						Title:       "Title CVE3",
+						Description: "Description CVE3",
+					},
+				}, nil
+			}
+
+			if image == "zot-test:0.0.1" || image == "a/zot-test:0.0.1" {
+				return map[string]cvemodel.CVE{
+					"CVE3": {
+						ID:          "CVE3",
+						Severity:    "LOW",
+						Title:       "Title CVE3",
+						Description: "Description CVE3",
+					},
+					"CVE4": {
+						ID:          "CVE4",
+						Severity:    "CRITICAL",
+						Title:       "Title CVE4",
+						Description: "Description CVE4",
+					},
+				}, nil
+			}
+
+			if image == "test-repo:latest" {
+				return map[string]cvemodel.CVE{
+					"CVE1": {
+						ID:          "CVE1",
+						Severity:    "MEDIUM",
+						Title:       "Title CVE1",
+						Description: "Description CVE1",
+					},
+					"CVE2": {
+						ID:          "CVE2",
+						Severity:    "HIGH",
+						Title:       "Title CVE2",
+						Description: "Description CVE2",
+					},
+					"CVE3": {
+						ID:          "CVE3",
+						Severity:    "LOW",
+						Title:       "Title CVE3",
+						Description: "Description CVE3",
+					},
+					"CVE4": {
+						ID:          "CVE4",
+						Severity:    "CRITICAL",
+						Title:       "Title CVE4",
+						Description: "Description CVE4",
+					},
+				}, nil
+			}
+
+			// By default the image has no vulnerabilities
+			return map[string]cvemodel.CVE{}, nil
+		},
+		CompareSeveritiesFn: func(severity1, severity2 string) int {
+			return severities[severity2] - severities[severity1]
+		},
+		IsImageFormatScannableFn: func(image string) (bool, error) {
+			// Almost same logic compared to actual Trivy specific implementation
+			var imageDir string
+
+			var inputTag string
+
+			if strings.Contains(image, ":") {
+				imageDir, inputTag, _ = strings.Cut(image, ":")
+			} else {
+				imageDir = image
+			}
+
+			repoMeta, err := repoDB.GetRepoMeta(imageDir)
+			if err != nil {
+				return false, err
+			}
+
+			manifestDigestStr, ok := repoMeta.Tags[inputTag]
+			if !ok {
+				return false, zerr.ErrTagMetaNotFound
+			}
+
+			manifestDigest, err := godigest.Parse(manifestDigestStr.Digest)
+			if err != nil {
+				return false, err
+			}
+
+			manifestData, err := repoDB.GetManifestData(manifestDigest)
+			if err != nil {
+				return false, err
+			}
+
+			var manifestContent ispec.Manifest
+
+			err = json.Unmarshal(manifestData.ManifestBlob, &manifestContent)
+			if err != nil {
+				return false, zerr.ErrScanNotSupported
+			}
+
+			for _, imageLayer := range manifestContent.Layers {
+				switch imageLayer.MediaType {
+				case ispec.MediaTypeImageLayerGzip, ispec.MediaTypeImageLayer, string(regTypes.DockerLayer):
+
+					return true, nil
+				default:
+
+					return false, zerr.ErrScanNotSupported
+				}
+			}
+
+			return false, nil
+		},
+	}
+
+	return &cveinfo.BaseCveInfo{
+		Log:     log,
+		Scanner: scanner,
+		RepoDB:  repoDB,
+	}
+}
+
 func TestRepoListWithNewestImage(t *testing.T) {
 	Convey("Test repoListWithNewestImage by tag with HTTP", t, func() {
 		subpath := "/a"
@@ -671,9 +823,21 @@ func TestRepoListWithNewestImage(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlr.Log.Logger = ctlr.Log.Output(writers)
 
-		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
-		defer ctlrManager.StopServer()
+		ctx := context.Background()
+
+		if err := ctlr.Init(ctx); err != nil {
+			panic(err)
+		}
+
+		ctlr.CveInfo = getMockCveInfo(ctlr.RepoDB, ctlr.Log)
+
+		go func() {
+			if err := ctlr.Run(ctx); !errors.Is(err, http.ErrServerClosed) {
+				panic(err)
+			}
+		}()
+
+		defer ctlr.Shutdown()
 
 		substring := "{\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":3600000000000,\"Trivy\":{\"DBRepository\":\"ghcr.io/project-zot/trivy-db\"}}}" //nolint: lll
 		found, err := readFileAndSearchString(logPath, substring, 2*time.Minute)
@@ -688,12 +852,9 @@ func TestRepoListWithNewestImage(t *testing.T) {
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
 
-		resp, err := resty.R().Get(baseURL + "/v2/")
-		So(resp, ShouldNotBeNil)
-		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, 200)
+		WaitTillServerReady(baseURL)
 
-		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix)
+		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix)
 		So(resp, ShouldNotBeNil)
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, 422)
@@ -2866,9 +3027,21 @@ func TestGlobalSearch(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlr.Log.Logger = ctlr.Log.Output(writers)
 
-		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
-		defer ctlrManager.StopServer()
+		ctx := context.Background()
+
+		if err := ctlr.Init(ctx); err != nil {
+			panic(err)
+		}
+
+		ctlr.CveInfo = getMockCveInfo(ctlr.RepoDB, ctlr.Log)
+
+		go func() {
+			if err := ctlr.Run(ctx); !errors.Is(err, http.ErrServerClosed) {
+				panic(err)
+			}
+		}()
+
+		defer ctlr.Shutdown()
 
 		// Wait for trivy db to download
 		substring := "{\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":3600000000000,\"Trivy\":{\"DBRepository\":\"ghcr.io/project-zot/trivy-db\"}}}" //nolint: lll
@@ -2883,6 +3056,8 @@ func TestGlobalSearch(t *testing.T) {
 		found, err = readFileAndSearchString(logPath, "DB update completed, next update scheduled", 4*time.Minute)
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
+
+		WaitTillServerReady(baseURL)
 
 		// push test images to repo 1 image 1
 		config1, layers1, manifest1, err := GetImageComponents(100)
@@ -5114,9 +5289,24 @@ func TestImageSummary(t *testing.T) {
 		configBlob, errConfig := json.Marshal(config)
 		configDigest := godigest.FromBytes(configBlob)
 		So(errConfig, ShouldBeNil) // marshall success, config is valid JSON
-		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
-		defer ctlrManager.StopServer()
+
+		ctx := context.Background()
+
+		if err := ctlr.Init(ctx); err != nil {
+			panic(err)
+		}
+
+		ctlr.CveInfo = getMockCveInfo(ctlr.RepoDB, ctlr.Log)
+
+		go func() {
+			if err := ctlr.Run(ctx); !errors.Is(err, http.ErrServerClosed) {
+				panic(err)
+			}
+		}()
+
+		defer ctlr.Shutdown()
+
+		WaitTillServerReady(baseURL)
 
 		manifestBlob, errMarsal := json.Marshal(manifest)
 		So(errMarsal, ShouldBeNil)
@@ -5174,8 +5364,8 @@ func TestImageSummary(t *testing.T) {
 		So(imgSummary.Platform.Arch, ShouldEqual, "amd64")
 		So(len(imgSummary.History), ShouldEqual, 1)
 		So(imgSummary.History[0].HistoryDescription.Created, ShouldEqual, createdTime)
-		So(imgSummary.Vulnerabilities.Count, ShouldEqual, 0)
+		So(imgSummary.Vulnerabilities.Count, ShouldEqual, 4)
 		// There are 0 vulnerabilities this data used in tests
-		So(imgSummary.Vulnerabilities.MaxSeverity, ShouldEqual, "NONE")
+		So(imgSummary.Vulnerabilities.MaxSeverity, ShouldEqual, "CRITICAL")
 	})
 }

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -784,6 +784,10 @@ func TestConfigReloader(t *testing.T) {
 
 		go func() {
 			// this blocks
+			if err := dctlr.Init(reloadCtx); err != nil {
+				return
+			}
+
 			if err := dctlr.Run(reloadCtx); err != nil {
 				return
 			}


### PR DESCRIPTION
- refactor(cve): remove the global of type cveinfo.CveInfo from the extensions package Replace it with an attribute on controller level
- refactor(controller): extract initialization logic from controller.Run()
- test(cve): mock cve scanner in cli tests

Signed-off-by: Andrei Aaron <aaaron@luxoft.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
