### PR TITLE
chore(codecov): use a token to authenticate to codecov

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -117,6 +117,8 @@ jobs:
           ARCH: ${{ matrix.arch }}
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Generate GraphQL Introspection JSON on Release
         if: github.event_name == 'release' && github.event.action == 'published' && matrix.os == 'linux' && matrix.arch == 'amd64'


### PR DESCRIPTION
This should not be necessary for public repos,
but should help with rate limiting

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
