### PR TITLE
bug(cve): fix trivyDB being downloaded multiple times in a loop

### DIFF
--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -91,7 +91,7 @@ func (gen *trivyTaskGenerator) GenerateTask() (scheduler.Task, error) {
 
 	gen.lock.Lock()
 
-	if gen.status != running && time.Since(gen.lastTaskTime) >= gen.waitTime {
+	if gen.status == pending && time.Since(gen.lastTaskTime) >= gen.waitTime {
 		newTask = newTrivyTask(gen.interval, gen.cveInfo, gen, gen.log)
 		gen.status = running
 	}


### PR DESCRIPTION
The condition to generate trivyDB download tasks was bugged, and new tasks were generated in case the download had already been successful (state `done`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
