### PR TITLE
bug(zli): fix compatibility with servers not returning Content-Length for the /manifests API

### DIFF
--- a/pkg/cli/client.go
+++ b/pkg/cli/client.go
@@ -416,7 +416,7 @@ func fetchManifestStruct(ctx context.Context, repo, manifestReference string, se
 
 	manifestSize, err := strconv.ParseInt(header.Get("Content-Length"), 10, 64)
 	if err != nil {
-		return manifestStruct{}, err
+		manifestSize = 0
 	}
 
 	var imageSize int64


### PR DESCRIPTION
This is the case of older zot servers running without graphql support, and which do not have the fix: https://github.com/project-zot/zot/pull/1019

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
