### PR TITLE
fix(repodb): GQL request for ExpandedRepoInfo errors when artifacts w…

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -78,6 +78,7 @@ var (
 	ErrLimitIsNegative          = errors.New("pageturner: limit has negative value")
 	ErrOffsetIsNegative         = errors.New("pageturner: offset has negative value")
 	ErrSortCriteriaNotSupported = errors.New("pageturner: the sort criteria is not supported")
+	ErrMediaTypeNotSupported    = errors.New("repodb: media type is not supported")
 	ErrTimeout                  = errors.New("operation timeout")
 	ErrNotImplemented           = errors.New("not implemented")
 )

--- a/pkg/extensions/search/convert/repodb.go
+++ b/pkg/extensions/search/convert/repodb.go
@@ -13,6 +13,7 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/vektah/gqlparser/v2/gqlerror"
 
+	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/extensions/search/common"
 	cveinfo "zotregistry.io/zot/pkg/extensions/search/cve"
 	cvemodel "zotregistry.io/zot/pkg/extensions/search/cve/model"
@@ -164,7 +165,7 @@ func Descriptor2ImageSummary(ctx context.Context, descriptor repodb.Descriptor, 
 		return ImageIndex2ImageSummary(ctx, repo, tag, godigest.Digest(descriptor.Digest), skipCVE,
 			repoMeta, indexDataMap[descriptor.Digest], manifestMetaMap, cveInfo)
 	default:
-		return &gql_generated.ImageSummary{}, map[string]int64{}, nil
+		return &gql_generated.ImageSummary{}, map[string]int64{}, zerr.ErrMediaTypeNotSupported
 	}
 }
 

--- a/pkg/meta/repodb/boltdb-wrapper/boltdb_wrapper.go
+++ b/pkg/meta/repodb/boltdb-wrapper/boltdb_wrapper.go
@@ -1090,6 +1090,8 @@ func (bdw *DBWrapper) SearchRepos(ctx context.Context, searchText string, filter
 						indexDataMap[indexDigest] = indexData
 					default:
 						bdw.Log.Error().Msgf("Unsupported type: %s", descriptor.MediaType)
+
+						continue
 					}
 				}
 
@@ -1415,6 +1417,8 @@ func (bdw *DBWrapper) FilterTags(ctx context.Context, filter repodb.FilterFunc,
 					indexDataMap[indexDigest] = indexData
 				default:
 					bdw.Log.Error().Msgf("Unsupported type: %s", descriptor.MediaType)
+
+					continue
 				}
 			}
 
@@ -1602,6 +1606,8 @@ func (bdw *DBWrapper) SearchTags(ctx context.Context, searchText string, filter 
 						indexDataMap[indexDigest] = indexData
 					default:
 						bdw.Log.Error().Msgf("Unsupported type: %s", descriptor.MediaType)
+
+						continue
 					}
 				}
 

--- a/pkg/meta/repodb/dynamodb-wrapper/dynamo_wrapper.go
+++ b/pkg/meta/repodb/dynamodb-wrapper/dynamo_wrapper.go
@@ -971,6 +971,8 @@ func (dwr *DBWrapper) SearchRepos(ctx context.Context, searchText string, filter
 					indexDataMap[indexDigest] = indexData
 				default:
 					dwr.Log.Error().Msgf("Unsupported type: %s", descriptor.MediaType)
+
+					continue
 				}
 			}
 
@@ -1245,6 +1247,8 @@ func (dwr *DBWrapper) FilterTags(ctx context.Context, filter repodb.FilterFunc,
 				indexDataMap[indexDigest] = indexData
 			default:
 				dwr.Log.Error().Msgf("Unsupported type: %s", descriptor.MediaType)
+
+				continue
 			}
 		}
 
@@ -1409,6 +1413,8 @@ func (dwr *DBWrapper) SearchTags(ctx context.Context, searchText string, filter 
 					indexDataMap[indexDigest] = indexData
 				default:
 					dwr.Log.Error().Msgf("Unsupported type: %s", descriptor.MediaType)
+
+					continue
 				}
 			}
 

--- a/pkg/test/common.go
+++ b/pkg/test/common.go
@@ -958,19 +958,22 @@ func DeleteImage(repo, reference, baseURL string) (int, error) {
 }
 
 // UploadArtifactManifest is used in tests where we don't need to upload the blobs of the artifact.
-func UploadArtifactManifest(artifactManifest *ispec.Artifact, baseURL, repo string) error {
+func UploadArtifactManifest(artifactManifest *ispec.Artifact, ref *string, baseURL, repo string) error {
 	// put manifest
 	artifactManifestBlob, err := json.Marshal(artifactManifest)
 	if err != nil {
 		return err
 	}
+	reference := godigest.FromBytes(artifactManifestBlob).String()
 
-	artifactManifestDigest := godigest.FromBytes(artifactManifestBlob)
+	if ref != nil {
+		reference = *ref
+	}
 
 	_, err = resty.R().
 		SetHeader("Content-type", ispec.MediaTypeArtifactManifest).
 		SetBody(artifactManifestBlob).
-		Put(baseURL + "/v2/" + repo + "/manifests/" + artifactManifestDigest.String())
+		Put(baseURL + "/v2/" + repo + "/manifests/" + reference)
 
 	return err
 }

--- a/pkg/test/common_test.go
+++ b/pkg/test/common_test.go
@@ -241,7 +241,7 @@ func TestUploadArtifact(t *testing.T) {
 
 		artifact := ispec.Artifact{}
 
-		err := test.UploadArtifactManifest(&artifact, baseURL, "test")
+		err := test.UploadArtifactManifest(&artifact, nil, baseURL, "test")
 		So(err, ShouldNotBeNil)
 	})
 }


### PR DESCRIPTION
…ith tags are present

If we push an artifact and give it a tag, repodb would crash because of the null pointer dereferencing

Now when iterating over the tags of a repo and stumbling upon a unsupported media type, it's being ignored

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1263 

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
