### PR TITLE
fix(zap): add Content-Security-Policy to the UI routes

### DIFF
--- a/.zap/rules.tsv
+++ b/.zap/rules.tsv
@@ -37,7 +37,7 @@
 10050	WARN	(Retrieved from Cache)
 10052	WARN	(X-ChromeLogger-Data (XCOLD) Header Information Leak)
 10054	WARN	(Cookie without SameSite Attribute)
-10055	WARN	(CSP)
+10055	IGNORE	(CSP)  We set CSP in both UI (with *) and backend (no *), unfortunately the UI needs to use * in case it is deployed separately
 10056	WARN	(X-Debug-Token Information Leak)
 10057	WARN	(Username Hash Found)
 10061	WARN	(X-AspNet-Version Response Header)

--- a/pkg/extensions/extension_ui.go
+++ b/pkg/extensions/extension_ui.go
@@ -7,6 +7,7 @@ import (
 	"embed"
 	"io/fs"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/mux"
 
@@ -39,6 +40,18 @@ func addUISecurityHeaders(h http.Handler) http.HandlerFunc { //nolint:varnamelen
 		w.Header().Set("Permissions-Policy", permissionsPolicy)
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.Header().Set("X-Frame-Options", "DENY")
+
+		cspDirectives := []string{
+			"default-src 'none'",
+			"script-src 'self' 'unsafe-inline'",
+			"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/",
+			"font-src 'self' https://fonts.googleapis.com/ https://fonts.gstatic.com/",
+			"connect-src 'self'",
+			"img-src 'self'",
+			"manifest-src 'self'",
+			"base-uri 'self'",
+		}
+		w.Header().Set("Content-Security-Policy", strings.Join(cspDirectives, "; "))
 
 		h.ServeHTTP(w, r)
 	}


### PR DESCRIPTION
The zap scanner started to check the csp header, which is causing a warning.

We also need to ignore the rule, as both settings are read by the scanner.

Per https://w3c.github.io/webappsec-csp/#example-7bb4ce67 we can have multiple
Content-Security-Policy headers, and the most restrictive policies apply.
This rule doesn't seem to be applied by zap.

* URL: http://localhost:8080/
  * Method: `GET`
  * Parameter: `content-security-policy`
  * Attack: ``
  * Evidence: ` default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/; font-src 'self' https://fonts.googleapis.com/ https://fonts.gstatic.com/; connect-src *; img-src 'self'; manifest-src 'self'; base-uri 'self'`
* URL: http://localhost:8080/
  * Method: `GET`
  * Parameter: `Content-Security-Policy`
  * Attack: ``
  * Evidence: `default-src 'none'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com/; font-src 'self' https://fonts.googleapis.com/ https://fonts.gstatic.com/; connect-src 'self'; img-src 'self'; manifest-src 'self'; base-uri 'self'`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
