### PR TITLE
fix: non-distributable layers may not exist

### DIFF
--- a/pkg/storage/common_test.go
+++ b/pkg/storage/common_test.go
@@ -104,6 +104,35 @@ func TestValidateManifest(t *testing.T) {
 			_, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, body)
 			So(err, ShouldNotBeNil)
 		})
+
+		Convey("manifest with non-distributable layers", func() {
+			content := []byte("this blob doesn't exist")
+			digest := godigest.FromBytes(content)
+			So(digest, ShouldNotBeNil)
+
+			manifest := ispec.Manifest{
+				Config: ispec.Descriptor{
+					MediaType: ispec.MediaTypeImageConfig,
+					Digest:    cdigest,
+					Size:      int64(len(cblob)),
+				},
+				Layers: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageLayerNonDistributable,
+						Digest:    digest,
+						Size:      int64(len(content)),
+					},
+				},
+			}
+
+			manifest.SchemaVersion = 2
+
+			body, err := json.Marshal(manifest)
+			So(err, ShouldBeNil)
+
+			_, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, body)
+			So(err, ShouldBeNil)
+		})
 	})
 }
 


### PR DESCRIPTION
Currently, when pushing an image, validation is performed to check that a layer/blob in the manifest already exists. For non-distributable layers, that check needs to be skipped.

Fixes issue #1394

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
