### PR TITLE
fix(zb): fixed remote repositories cleanup

### DIFF
--- a/cmd/zb/main.go
+++ b/cmd/zb/main.go
@@ -18,6 +18,8 @@ func NewPerfRootCmd() *cobra.Command {
 
 	var concurrency, requests int
 
+	var skipCleanup bool
+
 	rootCmd := &cobra.Command{
 		Use:   "zb <url>",
 		Short: "`zb`",
@@ -46,7 +48,7 @@ func NewPerfRootCmd() *cobra.Command {
 
 			requests = concurrency * (requests / concurrency)
 
-			Perf(workdir, url, auth, repo, concurrency, requests, outFmt, srcIPs, srcCIDR)
+			Perf(workdir, url, auth, repo, concurrency, requests, outFmt, srcIPs, srcCIDR, skipCleanup)
 		},
 	}
 
@@ -66,6 +68,8 @@ func NewPerfRootCmd() *cobra.Command {
 		"Number of requests to perform")
 	rootCmd.Flags().StringVarP(&outFmt, "output-format", "o", "",
 		"Output format of test results: stdout (default), json, ci-cd")
+	rootCmd.Flags().BoolVar(&skipCleanup, "skip-cleanup", false,
+		"Clean up pushed repos from remote registry after running benchmark (default true)")
 
 	// "version"
 	rootCmd.Flags().BoolVarP(&showVersion, "version", "v", false, "Show the version and exit")

--- a/cmd/zb/perf.go
+++ b/cmd/zb/perf.go
@@ -270,6 +270,7 @@ type testFunc func(
 	config testConfig,
 	statsCh chan statsRecord,
 	client *resty.Client,
+	skipCleanup bool,
 ) error
 
 //nolint:gosec
@@ -279,6 +280,7 @@ func GetCatalog(
 	config testConfig,
 	statsCh chan statsRecord,
 	client *resty.Client,
+	skipCleanup bool,
 ) error {
 	var repos []string
 
@@ -336,9 +338,11 @@ func GetCatalog(
 	}
 
 	// clean up
-	err = deleteTestRepo(repos, url, client)
-	if err != nil {
-		return err
+	if !skipCleanup {
+		err = deleteTestRepo(repos, url, client)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -350,6 +354,7 @@ func PushMonolithStreamed(
 	config testConfig,
 	statsCh chan statsRecord,
 	client *resty.Client,
+	skipCleanup bool,
 ) error {
 	var repos []string
 
@@ -363,9 +368,11 @@ func PushMonolithStreamed(
 	}
 
 	// clean up
-	err := deleteTestRepo(repos, url, client)
-	if err != nil {
-		return err
+	if !skipCleanup {
+		err := deleteTestRepo(repos, url, client)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -377,6 +384,7 @@ func PushChunkStreamed(
 	config testConfig,
 	statsCh chan statsRecord,
 	client *resty.Client,
+	skipCleanup bool,
 ) error {
 	var repos []string
 
@@ -390,9 +398,11 @@ func PushChunkStreamed(
 	}
 
 	// clean up
-	err := deleteTestRepo(repos, url, client)
-	if err != nil {
-		return err
+	if !skipCleanup {
+		err := deleteTestRepo(repos, url, client)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -404,6 +414,7 @@ func Pull(
 	config testConfig,
 	statsCh chan statsRecord,
 	client *resty.Client,
+	skipCleanup bool,
 ) error {
 	var repos []string
 
@@ -472,9 +483,11 @@ func Pull(
 	}
 
 	// clean up
-	err := deleteTestRepo(repos, url, client)
-	if err != nil {
-		return err
+	if !skipCleanup {
+		err := deleteTestRepo(repos, url, client)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -486,6 +499,7 @@ func MixedPullAndPush(
 	config testConfig,
 	statsCh chan statsRecord,
 	client *resty.Client,
+	skipCleanup bool,
 ) error {
 	var repos []string
 
@@ -519,9 +533,11 @@ func MixedPullAndPush(
 	}
 
 	// clean up
-	err = deleteTestRepo(repos, url, client)
-	if err != nil {
-		return err
+	if !skipCleanup {
+		err = deleteTestRepo(repos, url, client)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -633,7 +649,7 @@ var testSuite = []testConfig{ //nolint:gochecknoglobals // used only in this tes
 func Perf(
 	workdir, url, auth, repo string,
 	concurrency int, requests int,
-	outFmt string, srcIPs string, srcCIDR string,
+	outFmt string, srcIPs string, srcCIDR string, skipCleanup bool,
 ) {
 	json := jsoniter.ConfigCompatibleWithStandardLibrary
 	// logging
@@ -702,7 +718,10 @@ func Perf(
 					log.Fatal(err)
 				}
 
-				_ = tconfig.tfunc(workdir, url, repo, requests/concurrency, tconfig, statsCh, httpClient)
+				err = tconfig.tfunc(workdir, url, repo, requests/concurrency, tconfig, statsCh, httpClient, skipCleanup)
+				if err != nil {
+					log.Fatal(err)
+				}
 			}()
 		}
 		wg.Wait()

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -1045,6 +1045,13 @@ retry:
 			}
 		}
 
+		// also put dedupe blob in cache
+		if err := is.cache.PutBlob(dstDigest, dst); err != nil {
+			is.log.Error().Err(err).Str("blobPath", dst).Msg("dedupe: unable to insert blob record")
+
+			return err
+		}
+
 		if err := os.Remove(src); err != nil {
 			is.log.Error().Err(err).Str("src", src).Msg("dedupe: uname to remove blob")
 

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -1358,11 +1358,13 @@ func (is *ObjectStorage) DeleteBlob(repo string, digest godigest.Digest) error {
 		}
 
 		// remove cache entry and move blob contents to the next candidate if there is any
-		if err := is.cache.DeleteBlob(digest, blobPath); err != nil {
-			is.log.Error().Err(err).Str("digest", digest.String()).Str("blobPath", blobPath).
-				Msg("unable to remove blob path from cache")
+		if ok := is.cache.HasBlob(digest, blobPath); ok {
+			if err := is.cache.DeleteBlob(digest, blobPath); err != nil {
+				is.log.Error().Err(err).Str("digest", digest.String()).Str("blobPath", blobPath).
+					Msg("unable to remove blob path from cache")
 
-			return err
+				return err
+			}
 		}
 
 		// if the deleted blob is one with content

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -1400,6 +1400,16 @@ func TestS3Dedupe(t *testing.T) {
 		// deduped blob should be of size 0
 		So(fi2.Size(), ShouldEqual, 0)
 
+		Convey("delete blobs from storage/cache should work when dedupe is true", func() {
+			So(blobDigest1, ShouldEqual, blobDigest2)
+
+			err = imgStore.DeleteBlob("dedupe1", blobDigest1)
+			So(err, ShouldBeNil)
+
+			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
+			So(err, ShouldBeNil)
+		})
+
 		Convey("Check that delete blobs moves the real content to the next contenders", func() {
 			// if we delete blob1, the content should be moved to blob2
 			err = imgStore.DeleteBlob("dedupe1", blobDigest1)
@@ -1536,6 +1546,19 @@ func TestS3Dedupe(t *testing.T) {
 
 			// the new blob with dedupe false should be equal with the origin blob from dedupe1
 			So(fi1.Size(), ShouldEqual, fi3.Size())
+
+			Convey("delete blobs from storage/cache should work when dedupe is false", func() {
+				So(blobDigest1, ShouldEqual, blobDigest2)
+
+				err = imgStore.DeleteBlob("dedupe1", blobDigest1)
+				So(err, ShouldBeNil)
+
+				err = imgStore.DeleteBlob("dedupe2", blobDigest2)
+				So(err, ShouldBeNil)
+
+				err = imgStore.DeleteBlob("dedupe3", blobDigest2)
+				So(err, ShouldBeNil)
+			})
 
 			Convey("rebuild s3 dedupe index from true to false", func() { //nolint: dupl
 				taskScheduler, cancel := runAndGetScheduler()
@@ -1749,6 +1772,16 @@ func TestS3Dedupe(t *testing.T) {
 		// deduped blob should be of size 0
 		So(fi2.Size(), ShouldEqual, 0)
 
+		Convey("delete blobs from storage/cache should work when dedupe is true", func() {
+			So(blobDigest1, ShouldEqual, blobDigest2)
+
+			err = imgStore.DeleteBlob("dedupe1", blobDigest1)
+			So(err, ShouldBeNil)
+
+			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
+			So(err, ShouldBeNil)
+		})
+
 		Convey("rebuild s3 dedupe index from true to false", func() { //nolint: dupl
 			taskScheduler, cancel := runAndGetScheduler()
 
@@ -1776,6 +1809,16 @@ func TestS3Dedupe(t *testing.T) {
 			blobContent, err := imgStore.GetBlobContent("dedupe2", blobDigest2)
 			So(err, ShouldBeNil)
 			So(len(blobContent), ShouldEqual, fi1.Size())
+
+			Convey("delete blobs from storage/cache should work when dedupe is false", func() {
+				So(blobDigest1, ShouldEqual, blobDigest2)
+
+				err = imgStore.DeleteBlob("dedupe1", blobDigest1)
+				So(err, ShouldBeNil)
+
+				err = imgStore.DeleteBlob("dedupe2", blobDigest2)
+				So(err, ShouldBeNil)
+			})
 
 			Convey("rebuild s3 dedupe index from false to true", func() {
 				taskScheduler, cancel := runAndGetScheduler()


### PR DESCRIPTION
fix(storage): also put deduped blobs in cache, not just origin blobs

this caused an error when trying to delete deduped blobs from multiple repositories

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
