### PR TITLE
fix(sync): fixed skipping docker images when they already synced

### DIFF
--- a/test/blackbox/sync_docker.bats
+++ b/test/blackbox/sync_docker.bats
@@ -129,6 +129,15 @@ function teardown_file() {
     run curl http://127.0.0.1:8090/v2/registry/tags/list
     [ "$status" -eq 0 ]
     [ $(echo "${lines[-1]}" | jq '.tags[]') = '"latest"' ]
+
+    # make sure image is skipped when synced again
+    run skopeo --insecure-policy copy --multi-arch=all --src-tls-verify=false \
+        docker://127.0.0.1:8090/registry \
+        oci:${TEST_DATA_DIR}
+    [ "$status" -eq 0 ]
+
+    run $("cat /tmp/blackbox.log | grep -q registry:latest.*.skipping image because it's already synced")
+    [ "$status" -eq 0 ]
 }
 
 @test "sync docker image on demand" {
@@ -143,6 +152,15 @@ function teardown_file() {
     run curl http://127.0.0.1:8090/v2/archlinux/tags/list
     [ "$status" -eq 0 ]
     [ $(echo "${lines[-1]}" | jq '.tags[]') = '"latest"' ]
+
+    # make sure image is skipped when synced again
+    run skopeo --insecure-policy copy --src-tls-verify=false \
+        docker://127.0.0.1:8090/archlinux \
+        oci:${TEST_DATA_DIR}
+    [ "$status" -eq 0 ]
+
+    run $("cat /tmp/blackbox.log | grep -q archlinux:latest.*.skipping image because it's already synced")
+    [ "$status" -eq 0 ]
 }
 
 @test "sync k8s image list on demand" {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
https://github.com/project-zot/zot/issues/1490

**What does this PR do / Why do we need it**:
currently docker images are downloaded every time, because comparison between remote and local is done before conversion of docker images to oci.
convert docker manifests to oci manifests before syncing, compare with local one and skip if it's already synced

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**
no

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
