### PR TITLE
refactor: split AuthZ mdw in 2 different parts, each for a specific purpose

### DIFF
--- a/pkg/extensions/README.md
+++ b/pkg/extensions/README.md
@@ -20,6 +20,19 @@ package extensions
 - when adding a new tag, specify the new order in which multiple tags should be used (bottom of this page)
 
 - for each and every new file that contains functions (functionalities) specific to an extension, one should create a corresponding file that  <b>must contain the exact same functions, but no functionalities included</b>. This file must begin with an  "anti-tag" (e.g. // +build !sync) which will include this file in binaries that don't include this extension ( in this example, the file won't be used in binaries that include sync extension ). See [extension-sync-disabled.go](extension-sync-disabled.go) for an example.
+- each extension  is responsible with implementing authorization for newly added HTTP endpoints. zot will provide the necessary data, including user permissions, to the extension, but actual enforcement of these permissions is the responsibility of each extension. Each extension http.Handler has access to a context previously populated by <b>BaseAuthzHandler</b> with relevant user info. That info has the following structure:
+  ```
+  type AccessControlContext struct {
+    // read method action
+    ReadGlobPatterns map[string]bool
+    // detectManifestCollision behaviour action
+    DmcGlobPatterns map[string]bool
+    IsAdmin         bool
+    Username        string
+    Groups          []string
+    } 
+    ```
+  This data can then be accessed from the request context so that <b>every extension can apply its own authorization logic, if needed </b>. 
 
 - when a new extension comes out, the developer should also write some blackbox tests, where a binary that contains the new extension should be tested in a real usage scenario. See [test/blackbox](test/blackbox/sync.bats) folder for multiple extensions examples.
 
@@ -28,4 +41,5 @@ package extensions
 - with every new extension, you should modify the EXTENSIONS variable in Makefile by adding the new extension. The EXTENSIONS variable represents all extensions and is used in Make targets that require them all (e.g make test).
 
 - the available extensions that can be used at the moment are: <b>sync, scrub, metrics, search </b>.
-NOTE: When multiple extensions are used, they should be enlisted in the above presented order.
+NOTE: When multiple extensions are used, they should be listed in the above presented order.
+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
- AuthzHandler has now been split in BaseAuthzHandler and DistSpecAuthzHandler
The former populates context with user specific data needed in most handlers, while
the latter executes access logic specific to distribution-spec handlers.


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
