### PR TITLE
fix(CVE): attempt to scan now returns early with an error if trivyDB metadata json is missing

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -46,6 +46,7 @@ var (
 	ErrEmptyValue                     = errors.New("cache: empty value")
 	ErrEmptyRepoList                  = errors.New("search: no repository found")
 	ErrCVESearchDisabled              = errors.New("search: CVE search is disabled")
+	ErrCVEDBNotFound                  = errors.New("cve: CVE DB is not present")
 	ErrInvalidRepositoryName          = errors.New("repository: not a valid repository name")
 	ErrSyncMissingCatalog             = errors.New("sync: couldn't fetch upstream registry's catalog")
 	ErrMethodNotSupported             = errors.New("storage: method not supported")

--- a/pkg/cli/service.go
+++ b/pkg/cli/service.go
@@ -943,7 +943,7 @@ func isContextDone(ctx context.Context) bool {
 	}
 }
 
-// Query using JQL, the query string is passed as a parameter
+// Query using GQL, the query string is passed as a parameter
 // errors are returned in the stringResult channel, the unmarshalled payload is in resultPtr.
 func (service searchService) makeGraphQLQuery(ctx context.Context,
 	config searchConfig, username, password, query string,


### PR DESCRIPTION
Without the changes to check if the CVE DB is already downloaded, relying on the trivy library itself for error handling had some issues, as sometimes the files it opens (the cache DB, different from the CVE DB - called fanal.db) were not closed.
This was causing issues on subsequent calls, even if the CVE DB was downloaded in the meantime.

zli will now make repeated attempts to search in case of this error. This will take care of the flaky CVE test in the ecosystem tools.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
