### PR TITLE
feat(sync): sync can include self url in registry.URLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,12 +386,14 @@ test-bats-sync: BUILD_LABELS=sync
 test-bats-sync: binary binary-minimal bench check-skopeo $(BATS) $(NOTATION) $(COSIGN)
 	$(BATS) --trace --print-output-on-failure test/blackbox/sync.bats
 	$(BATS) --trace --print-output-on-failure test/blackbox/sync_docker.bats
+	$(BATS) --trace --print-output-on-failure test/blackbox/sync_replica_cluster.bats
 	
 .PHONY: test-bats-sync-verbose
 test-bats-sync-verbose: BUILD_LABELS=sync
 test-bats-sync-verbose: binary binary-minimal bench check-skopeo $(BATS) $(NOTATION) $(COSIGN)
 	$(BATS) --trace -t -x -p --verbose-run --print-output-on-failure --show-output-of-passing-tests test/blackbox/sync.bats
 	$(BATS) --trace -t -x -p --verbose-run --print-output-on-failure --show-output-of-passing-tests test/blackbox/sync_docker.bats
+	$(BATS) --trace -t -x -p --verbose-run --print-output-on-failure --show-output-of-passing-tests test/blackbox/sync_replica_cluster.bats
 
 .PHONY: test-bats-cve
 test-bats-cve: BUILD_LABELS=search

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -107,4 +107,5 @@ var (
 	ErrInvalidTruststoreName          = errors.New("signatures: invalid truststore name")
 	ErrInvalidCertificateContent      = errors.New("signatures: invalid certificate content")
 	ErrInvalidStateCookie             = errors.New("auth: state cookie not present or differs from original state")
+	ErrSyncNoURLsLeft                 = errors.New("sync: no valid registry urls left after filtering local ones")
 )

--- a/pkg/extensions/extension_sync.go
+++ b/pkg/extensions/extension_sync.go
@@ -4,7 +4,13 @@
 package extensions
 
 import (
+	"net"
+	"net/url"
+	"strings"
+
+	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api/config"
+	syncconf "zotregistry.io/zot/pkg/extensions/config/sync"
 	"zotregistry.io/zot/pkg/extensions/sync"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/meta/repodb"
@@ -19,6 +25,19 @@ func EnableSyncExtension(config *config.Config, repoDB repodb.RepoDB,
 		onDemand := sync.NewOnDemand(log)
 
 		for _, registryConfig := range config.Extensions.Sync.Registries {
+			registryConfig := registryConfig
+			if len(registryConfig.URLs) > 1 {
+				if err := removeSelfURLs(config, &registryConfig, log); err != nil {
+					return nil, err
+				}
+			}
+
+			if len(registryConfig.URLs) == 0 {
+				log.Error().Err(zerr.ErrSyncNoURLsLeft).Msg("unable to start sync extension")
+
+				return nil, zerr.ErrSyncNoURLsLeft
+			}
+
 			isPeriodical := len(registryConfig.Content) != 0 && registryConfig.PollInterval != 0
 			isOnDemand := registryConfig.OnDemand
 
@@ -48,4 +67,107 @@ func EnableSyncExtension(config *config.Config, repoDB repodb.RepoDB,
 	log.Info().Msg("Sync registries config not provided or disabled, skipping sync")
 
 	return nil, nil //nolint: nilnil
+}
+
+func getLocalIPs() ([]string, error) {
+	var localIPs []string
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return []string{}, err
+	}
+
+	for _, i := range ifaces {
+		addrs, err := i.Addrs()
+		if err != nil {
+			return localIPs, err
+		}
+
+		for _, addr := range addrs {
+			if localIP, ok := addr.(*net.IPNet); ok {
+				localIPs = append(localIPs, localIP.IP.String())
+			}
+		}
+	}
+
+	return localIPs, nil
+}
+
+func getIPFromHostName(host string) ([]string, error) {
+	addrs, err := net.LookupIP(host)
+	if err != nil {
+		return []string{}, err
+	}
+
+	ips := make([]string, 0, len(addrs))
+
+	for _, ip := range addrs {
+		ips = append(ips, ip.String())
+	}
+
+	return ips, nil
+}
+
+func removeSelfURLs(config *config.Config, registryConfig *syncconf.RegistryConfig, log log.Logger) error {
+	// get IP from config
+	port := config.HTTP.Port
+	selfAddress := net.JoinHostPort(config.HTTP.Address, port)
+
+	// get all local IPs from interfaces
+	localIPs, err := getLocalIPs()
+	if err != nil {
+		return err
+	}
+
+	for idx := len(registryConfig.URLs) - 1; idx >= 0; idx-- {
+		registryURL := registryConfig.URLs[idx]
+
+		url, err := url.Parse(registryURL)
+		if err != nil {
+			log.Error().Str("url", registryURL).Msg("failed to parse sync registry url, removing it")
+
+			registryConfig.URLs = append(registryConfig.URLs[:idx], registryConfig.URLs[idx+1:]...)
+
+			continue
+		}
+
+		// check self address
+		if strings.Contains(registryURL, selfAddress) {
+			log.Info().Str("url", registryURL).Msg("removing local registry url")
+
+			registryConfig.URLs = append(registryConfig.URLs[:idx], registryConfig.URLs[idx+1:]...)
+
+			continue
+		}
+
+		// check dns
+		ips, err := getIPFromHostName(url.Hostname())
+		if err != nil {
+			// will not remove, maybe it will get resolved later after multiple retries
+			log.Warn().Str("url", registryURL).Msg("failed to lookup sync registry url's hostname")
+
+			continue
+		}
+
+		var removed bool
+
+		for _, localIP := range localIPs {
+			// if ip resolved from hostname/dns is equal with any local ip
+			for _, ip := range ips {
+				if net.JoinHostPort(ip, url.Port()) == net.JoinHostPort(localIP, port) {
+					registryConfig.URLs = append(registryConfig.URLs[:idx], registryConfig.URLs[idx+1:]...)
+
+					removed = true
+
+					break
+				}
+			}
+
+			if removed {
+				break
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -125,7 +125,7 @@ func (service *BaseService) SetNextAvailableClient() error {
 		}
 
 		if err != nil {
-			return err
+			continue
 		}
 
 		if !service.client.IsAvailable() {

--- a/test/blackbox/sync_replica_cluster.bats
+++ b/test/blackbox/sync_replica_cluster.bats
@@ -1,0 +1,155 @@
+load helpers_sync
+
+function setup_file() {
+    # Verify prerequisites are available
+    if ! verify_prerequisites; then
+        exit 1
+    fi
+
+    # Download test data to folder common for the entire suite, not just this file
+    skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.20 oci:${TEST_DATA_DIR}/golang:1.20
+    # Setup zot server
+    local zot_sync_one_root_dir=${BATS_FILE_TMPDIR}/zot-one
+    local zot_sync_two_root_dir=${BATS_FILE_TMPDIR}/zot-two
+
+    local zot_sync_one_config_file=${BATS_FILE_TMPDIR}/zot_sync_one_config.json
+    local zot_sync_two_config_file=${BATS_FILE_TMPDIR}/zot_sync_two_config.json
+
+    mkdir -p ${zot_sync_one_root_dir}
+    mkdir -p ${zot_sync_two_root_dir}
+
+    cat >${zot_sync_one_config_file} <<EOF
+{
+    "distSpecVersion": "1.1.0",
+    "storage": {
+        "rootDirectory": "${zot_sync_one_root_dir}"
+    },
+    "http": {
+        "address": "0.0.0.0",
+        "port": "8081"
+    },
+    "log": {
+        "level": "debug"
+    },
+    "extensions": {
+        "sync": {
+            "registries": [
+                {
+                    "urls": [
+                        "http://localhost:8081",
+                        "http://localhost:8082"
+                    ],
+                    "onDemand": false,
+                    "tlsVerify": false,
+                    "PollInterval": "1s",
+                    "content": [
+                        {
+                            "prefix": "**"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+EOF
+
+    cat >${zot_sync_two_config_file} <<EOF
+{
+    "distSpecVersion": "1.1.0",
+    "storage": {
+        "rootDirectory": "${zot_sync_two_root_dir}"
+    },
+    "http": {
+        "address": "0.0.0.0",
+        "port": "8082"
+    },
+    "log": {
+        "level": "debug"
+    },
+    "extensions": {
+        "sync": {
+            "registries": [
+                {
+                    "urls": [
+                        "http://localhost:8081",
+                        "http://localhost:8082"
+                    ],
+                    "onDemand": false,
+                    "tlsVerify": false,
+                    "PollInterval": "1s",
+                    "content": [
+                        {
+                            "prefix": "**"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+EOF
+
+    git -C ${BATS_FILE_TMPDIR} clone https://github.com/project-zot/helm-charts.git
+
+    setup_zot_file_level ${zot_sync_one_config_file}
+    wait_zot_reachable "http://127.0.0.1:8081/v2/_catalog"
+
+    setup_zot_file_level ${zot_sync_two_config_file}
+    wait_zot_reachable "http://127.0.0.1:8082/v2/_catalog"
+}
+
+function teardown_file() {
+    local zot_sync_one_root_dir=${BATS_FILE_TMPDIR}/zot-per
+    local zot_sync_two_root_dir=${BATS_FILE_TMPDIR}/zot-ondemand
+    teardown_zot_file_level
+    rm -rf ${zot_sync_one_root_dir}
+    rm -rf ${zot_sync_two_root_dir}
+}
+
+# sync image
+@test "push one image to zot one, zot two should sync it" {
+    run skopeo --insecure-policy copy --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/golang:1.20 \
+        docker://127.0.0.1:8081/golang:1.20
+    [ "$status" -eq 0 ]
+    run curl http://127.0.0.1:8081/v2/_catalog
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.repositories[]') = '"golang"' ]
+    run curl http://127.0.0.1:8081/v2/golang/tags/list
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.20"' ]
+    
+    run sleep 30s
+    
+    run curl http://127.0.0.1:8082/v2/_catalog
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.repositories[]') = '"golang"' ]
+
+    run curl http://127.0.0.1:8082/v2/golang/tags/list
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.20"' ]
+}
+
+@test "push one image to zot-two, zot-one should sync it" {
+    run skopeo --insecure-policy copy --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/golang:1.20 \
+        docker://127.0.0.1:8082/anothergolang:1.20
+    [ "$status" -eq 0 ]
+    run curl http://127.0.0.1:8082/v2/_catalog
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.repositories[0]') = '"anothergolang"' ]
+    run curl http://127.0.0.1:8082/v2/anothergolang/tags/list
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.20"' ]
+    
+    run sleep 30s
+    
+    run curl http://127.0.0.1:8081/v2/_catalog
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.repositories[0]') = '"anothergolang"' ]
+
+    run curl http://127.0.0.1:8081/v2/anothergolang/tags/list
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.20"' ]
+}


### PR DESCRIPTION
sync now ignores self referencing urls, this will help in clustering mode where we can have the same config for multiple zots

closes #1335

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
