### PR TITLE
fix(storage): do not open/download blobs when validating manifests

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3439,7 +3439,12 @@ func TestCrossRepoMount(t *testing.T) {
 		}
 
 		dir := t.TempDir()
-		ctlr := makeController(conf, dir, "../../test/data")
+		err := os.MkdirAll(path.Join(dir, "zot-cve-test"), storageConstants.DefaultDirPerms)
+		So(err, ShouldBeNil)
+
+		ctlr := makeController(conf, path.Join(dir, "zot-cve-test"), "../../test/data/zot-cve-test")
+
+		ctlr.Config.Storage.RootDirectory = dir
 		ctlr.Config.Storage.RemoteCache = false
 		ctlr.Config.Storage.Dedupe = false
 
@@ -3551,7 +3556,7 @@ func TestCrossRepoMount(t *testing.T) {
 		cm.StartAndWait(port)
 
 		// wait for dedupe task to run
-		time.Sleep(15 * time.Second)
+		time.Sleep(10 * time.Second)
 
 		params["mount"] = string(manifestDigest)
 		postResponse, err = client.R().

--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -138,8 +138,8 @@ func validateOCIManifest(imgStore storageTypes.ImageStore, repo, reference strin
 			continue
 		}
 
-		_, err := imgStore.GetBlobContent(repo, layer.Digest)
-		if err != nil {
+		ok, _, err := imgStore.StatBlob(repo, layer.Digest)
+		if err != nil || !ok {
 			return layer.Digest, zerr.ErrBlobNotFound
 		}
 	}

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -2191,7 +2191,15 @@ func TestGarbageCollect(t *testing.T) {
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
+			hasBlob, _, err = imgStore.StatBlob(repoName, odigest)
+			So(err, ShouldNotBeNil)
+			So(hasBlob, ShouldEqual, false)
+
 			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
+			So(err, ShouldBeNil)
+			So(hasBlob, ShouldEqual, true)
+
+			hasBlob, _, err = imgStore.StatBlob(repoName, bdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 

--- a/pkg/storage/s3/s3.go
+++ b/pkg/storage/s3/s3.go
@@ -974,7 +974,11 @@ func (is *ObjectStorage) BlobPath(repo string, digest godigest.Digest) string {
 	return path.Join(is.rootDir, repo, "blobs", digest.Algorithm().String(), digest.Encoded())
 }
 
-// CheckBlob verifies a blob and returns true if the blob is correct.
+/*
+	CheckBlob verifies a blob and returns true if the blob is correct
+
+If the blob is not found but it's found in cache then it will be copied over.
+*/
 func (is *ObjectStorage) CheckBlob(repo string, digest godigest.Digest) (bool, int64, error) {
 	var lockLatency time.Time
 
@@ -1021,6 +1025,47 @@ func (is *ObjectStorage) CheckBlob(repo string, digest godigest.Digest) (bool, i
 	}
 
 	return true, blobSize, nil
+}
+
+// StatBlob verifies if a blob is present inside a repository. The caller function SHOULD lock from outside.
+func (is *ObjectStorage) StatBlob(repo string, digest godigest.Digest) (bool, int64, error) {
+	if err := digest.Validate(); err != nil {
+		return false, -1, err
+	}
+
+	blobPath := is.BlobPath(repo, digest)
+
+	binfo, err := is.store.Stat(context.Background(), blobPath)
+	if err == nil && binfo.Size() > 0 {
+		is.log.Debug().Str("blob path", blobPath).Msg("blob path found")
+
+		return true, binfo.Size(), nil
+	}
+
+	if err != nil {
+		is.log.Error().Err(err).Str("blob", blobPath).Msg("failed to stat blob")
+
+		return false, -1, zerr.ErrBlobNotFound
+	}
+
+	// then it's a 'deduped' blob
+
+	// Check blobs in cache
+	dstRecord, err := is.checkCacheBlob(digest)
+	if err != nil {
+		is.log.Error().Err(err).Str("digest", digest.String()).Msg("cache: not found")
+
+		return false, -1, zerr.ErrBlobNotFound
+	}
+
+	binfo, err = is.store.Stat(context.Background(), dstRecord)
+	if err != nil {
+		is.log.Error().Err(err).Str("blob", blobPath).Msg("failed to stat blob")
+
+		return false, -1, zerr.ErrBlobNotFound
+	}
+
+	return true, binfo.Size(), nil
 }
 
 func (is *ObjectStorage) checkCacheBlob(digest godigest.Digest) (string, error) {
@@ -1243,7 +1288,7 @@ func (is *ObjectStorage) GetBlob(repo string, digest godigest.Digest, mediaType 
 	return blobReadCloser, binfo.Size(), nil
 }
 
-// GetBlobContent returns blob contents, SHOULD lock from outside.
+// GetBlobContent returns blob contents, the caller function SHOULD lock from outside.
 func (is *ObjectStorage) GetBlobContent(repo string, digest godigest.Digest) ([]byte, error) {
 	if err := digest.Validate(); err != nil {
 		return []byte{}, err
@@ -1308,7 +1353,7 @@ func (is *ObjectStorage) GetOrasReferrers(repo string, gdigest godigest.Digest, 
 	return common.GetOrasReferrers(is, repo, gdigest, artifactType, is.log)
 }
 
-// GetIndexContent returns index.json contents, SHOULD lock from outside.
+// GetIndexContent returns index.json contents, the caller function SHOULD lock from outside.
 func (is *ObjectStorage) GetIndexContent(repo string) ([]byte, error) {
 	dir := path.Join(is.rootDir, repo)
 

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -890,6 +890,9 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 
 			_, _, err = imgStore.CheckBlob(testImage, digest)
 			So(err, ShouldNotBeNil)
+
+			_, _, err = imgStore.StatBlob(testImage, digest)
+			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Test ValidateRepo", func(c C) {
@@ -1270,7 +1273,13 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		_, checkBlobSize1, err := imgStore.CheckBlob("dedupe1", digest)
+		ok, checkBlobSize1, err := imgStore.CheckBlob("dedupe1", digest)
+		So(ok, ShouldBeTrue)
+		So(checkBlobSize1, ShouldBeGreaterThan, 0)
+		So(err, ShouldBeNil)
+
+		ok, checkBlobSize1, err = imgStore.StatBlob("dedupe1", digest)
+		So(ok, ShouldBeTrue)
 		So(checkBlobSize1, ShouldBeGreaterThan, 0)
 		So(err, ShouldBeNil)
 
@@ -3617,6 +3626,9 @@ func TestS3DedupeErr(t *testing.T) {
 		_, err = imgStore.GetBlobContent("repo2", digest)
 		So(err, ShouldNotBeNil)
 
+		_, _, err = imgStore.StatBlob("repo2", digest)
+		So(err, ShouldNotBeNil)
+
 		_, _, _, err = imgStore.GetBlobPartial("repo2", digest, "application/vnd.oci.image.layer.v1.tar+gzip", 0, 1)
 		So(err, ShouldNotBeNil)
 	})
@@ -3699,6 +3711,9 @@ func TestS3DedupeErr(t *testing.T) {
 		So(err, ShouldNotBeNil)
 
 		_, err = imgStore.GetBlobContent("repo2", digest)
+		So(err, ShouldNotBeNil)
+
+		_, _, err = imgStore.StatBlob("repo2", digest)
 		So(err, ShouldNotBeNil)
 
 		_, _, _, err = imgStore.GetBlobPartial("repo2", digest, "application/vnd.oci.image.layer.v1.tar+gzip", 0, 1)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -259,6 +259,10 @@ func TestStorageAPIs(t *testing.T) {
 						_, _, err = imgStore.CheckBlob("test", digest)
 						So(err, ShouldBeNil)
 
+						ok, _, err := imgStore.StatBlob("test", digest)
+						So(ok, ShouldBeTrue)
+						So(err, ShouldBeNil)
+
 						blob, _, err := imgStore.GetBlob("test", digest, "application/vnd.oci.image.layer.v1.tar+gzip")
 						So(err, ShouldBeNil)
 
@@ -401,6 +405,10 @@ func TestStorageAPIs(t *testing.T) {
 							So(err, ShouldNotBeNil)
 							So(hasBlob, ShouldEqual, false)
 
+							hasBlob, _, err = imgStore.StatBlob("test", digest)
+							So(err, ShouldNotBeNil)
+							So(hasBlob, ShouldEqual, false)
+
 							err = imgStore.DeleteBlob("test", "inexistent")
 							So(err, ShouldNotBeNil)
 
@@ -457,7 +465,12 @@ func TestStorageAPIs(t *testing.T) {
 						err = imgStore.FinishBlobUpload("test", bupload, buf, digest)
 						So(err, ShouldBeNil)
 
-						_, _, err = imgStore.CheckBlob("test", digest)
+						ok, _, err := imgStore.CheckBlob("test", digest)
+						So(ok, ShouldBeTrue)
+						So(err, ShouldBeNil)
+
+						ok, _, err = imgStore.StatBlob("test", digest)
+						So(ok, ShouldBeTrue)
 						So(err, ShouldBeNil)
 
 						_, _, err = imgStore.GetBlob("test", "inexistent", "application/vnd.oci.image.layer.v1.tar+gzip")
@@ -485,6 +498,9 @@ func TestStorageAPIs(t *testing.T) {
 							So(err, ShouldNotBeNil)
 
 							_, _, err = imgStore.CheckBlob("test", "inexistent")
+							So(err, ShouldNotBeNil)
+
+							_, _, err = imgStore.StatBlob("test", "inexistent")
 							So(err, ShouldNotBeNil)
 						})
 

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -38,6 +38,7 @@ type ImageStore interface { //nolint:interfacebloat
 	DeleteBlobUpload(repo, uuid string) error
 	BlobPath(repo string, digest godigest.Digest) string
 	CheckBlob(repo string, digest godigest.Digest) (bool, int64, error)
+	StatBlob(repo string, digest godigest.Digest) (bool, int64, error)
 	GetBlob(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error)
 	GetBlobPartial(repo string, digest godigest.Digest, mediaType string, from, to int64,
 	) (io.ReadCloser, int64, int64, error)

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -35,6 +35,7 @@ type MockedImageStore struct {
 	DeleteBlobUploadFn     func(repo string, uuid string) error
 	BlobPathFn             func(repo string, digest godigest.Digest) string
 	CheckBlobFn            func(repo string, digest godigest.Digest) (bool, int64, error)
+	StatBlobFn             func(repo string, digest godigest.Digest) (bool, int64, error)
 	GetBlobPartialFn       func(repo string, digest godigest.Digest, mediaType string, from, to int64,
 	) (io.ReadCloser, int64, int64, error)
 	GetBlobFn          func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error)
@@ -246,6 +247,14 @@ func (is MockedImageStore) BlobPath(repo string, digest godigest.Digest) string 
 func (is MockedImageStore) CheckBlob(repo string, digest godigest.Digest) (bool, int64, error) {
 	if is.CheckBlobFn != nil {
 		return is.CheckBlobFn(repo, digest)
+	}
+
+	return true, 0, nil
+}
+
+func (is MockedImageStore) StatBlob(repo string, digest godigest.Digest) (bool, int64, error) {
+	if is.StatBlobFn != nil {
+		return is.StatBlobFn(repo, digest)
 	}
 
 	return true, 0, nil


### PR DESCRIPTION
when pushing manifests, zot will validate blobs (layers + config blob) are present in repo, currently it opens(in case of filesystem storage) or download( in case of cloud storage) each blob.

fixed that by adding a new method ImageStore.CheckBlobPresence() on storage to check blobs presence without checking the cache like ImageStore.CheckBlob() method does.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
