### PR TITLE
fix(ci/cd): stop localstack after ci/cd pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -134,6 +134,11 @@ jobs:
           OS: ${{ matrix.os }}
           ARCH: ${{ matrix.arch }}
 
+      - if: matrix.os == 'linux' && matrix.arch == 'amd64'
+        name: Stop localstack
+        run: |
+            localstack stop
+
       - name: Check disk space after build
         if: always()
         run: |


### PR DESCRIPTION
this should clean localstack persisted data in tests

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

**What does this PR do / Why do we need it**:
clean test data persisted in localstack in s3/dynamodb tests

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
