### PR TITLE
build: fix mgmt and userprefs when building them separately

### DIFF
--- a/pkg/common/http_server.go
+++ b/pkg/common/http_server.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"time"
@@ -80,6 +81,16 @@ func WriteData(w http.ResponseWriter, status int, mediaType string, data []byte)
 	w.Header().Set("Content-Type", mediaType)
 	w.WriteHeader(status)
 	_, _ = w.Write(data)
+}
+
+func QueryHasParams(values url.Values, params []string) bool {
+	for _, param := range params {
+		if !values.Has(param) {
+			return false
+		}
+	}
+
+	return true
 }
 
 /*

--- a/pkg/extensions/extension_mgmt.go
+++ b/pkg/extensions/extension_mgmt.go
@@ -99,7 +99,7 @@ func (mgmt *mgmt) handler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var resource string
 
-		if queryHasParams(r.URL.Query(), []string{"resource"}) {
+		if zcommon.QueryHasParams(r.URL.Query(), []string{"resource"}) {
 			resource = r.URL.Query().Get("resource")
 		} else {
 			resource = ConfigResource // default value of "resource" query param
@@ -181,7 +181,7 @@ func (mgmt *mgmt) HandleGetConfig(w http.ResponseWriter, r *http.Request) {
 // @Failure 400 {string} 	string 				"bad request".
 // @Failure 500 {string} 	string 				"internal server error".
 func HandleCertificatesAndPublicKeysUploads(response http.ResponseWriter, request *http.Request) {
-	if !queryHasParams(request.URL.Query(), []string{"tool"}) {
+	if !zcommon.QueryHasParams(request.URL.Query(), []string{"tool"}) {
 		response.WriteHeader(http.StatusBadRequest)
 
 		return
@@ -207,13 +207,13 @@ func HandleCertificatesAndPublicKeysUploads(response http.ResponseWriter, reques
 	case signatures.NotationSignature:
 		var truststoreType string
 
-		if !queryHasParams(request.URL.Query(), []string{"truststoreName"}) {
+		if !zcommon.QueryHasParams(request.URL.Query(), []string{"truststoreName"}) {
 			response.WriteHeader(http.StatusBadRequest)
 
 			return
 		}
 
-		if queryHasParams(request.URL.Query(), []string{"truststoreType"}) {
+		if zcommon.QueryHasParams(request.URL.Query(), []string{"truststoreType"}) {
 			truststoreType = request.URL.Query().Get("truststoreType")
 		} else {
 			truststoreType = "ca" // default value of "truststoreType" query param

--- a/pkg/extensions/extension_userprefs.go
+++ b/pkg/extensions/extension_userprefs.go
@@ -6,7 +6,6 @@ package extensions
 import (
 	"errors"
 	"net/http"
-	"net/url"
 
 	"github.com/gorilla/mux"
 
@@ -59,7 +58,7 @@ func SetupUserPreferencesRoutes(config *config.Config, router *mux.Router, store
 // @Failure 400 {string} 	string 				"bad request".
 func HandleUserPrefs(repoDB repodb.RepoDB, log log.Logger) func(w http.ResponseWriter, r *http.Request) {
 	return func(rsp http.ResponseWriter, req *http.Request) {
-		if !queryHasParams(req.URL.Query(), []string{"action"}) {
+		if !zcommon.QueryHasParams(req.URL.Query(), []string{"action"}) {
 			rsp.WriteHeader(http.StatusBadRequest)
 
 			return
@@ -85,7 +84,7 @@ func HandleUserPrefs(repoDB repodb.RepoDB, log log.Logger) func(w http.ResponseW
 }
 
 func PutStar(rsp http.ResponseWriter, req *http.Request, repoDB repodb.RepoDB, log log.Logger) {
-	if !queryHasParams(req.URL.Query(), []string{"repo"}) {
+	if !zcommon.QueryHasParams(req.URL.Query(), []string{"repo"}) {
 		rsp.WriteHeader(http.StatusBadRequest)
 
 		return
@@ -120,7 +119,7 @@ func PutStar(rsp http.ResponseWriter, req *http.Request, repoDB repodb.RepoDB, l
 }
 
 func PutBookmark(rsp http.ResponseWriter, req *http.Request, repoDB repodb.RepoDB, log log.Logger) {
-	if !queryHasParams(req.URL.Query(), []string{"repo"}) {
+	if !zcommon.QueryHasParams(req.URL.Query(), []string{"repo"}) {
 		rsp.WriteHeader(http.StatusBadRequest)
 
 		return
@@ -152,14 +151,4 @@ func PutBookmark(rsp http.ResponseWriter, req *http.Request, repoDB repodb.RepoD
 	}
 
 	rsp.WriteHeader(http.StatusOK)
-}
-
-func queryHasParams(values url.Values, params []string) bool {
-	for _, param := range params {
-		if !values.Has(param) {
-			return false
-		}
-	}
-
-	return true
 }


### PR DESCRIPTION
move queryHasParams in common package
fixes building mgmt and userprefs separately

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
currently mgmt can not be built without userprefs extension
fix that by moving queryHasParams into common package

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
