### PR TITLE
fix(ci): trivy test to expect 3 CVEs instead of 2 in the vulnerable test layer

### DIFF
--- a/pkg/extensions/search/cve/trivy/scanner_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_test.go
@@ -73,6 +73,7 @@ func TestScanningByDigest(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(cveMap, ShouldContainKey, test.Vulnerability1ID)
 		So(cveMap, ShouldContainKey, test.Vulnerability2ID)
+		So(cveMap, ShouldContainKey, test.Vulnerability3ID)
 
 		cveMap, err = scanner.ScanImage("multi-arch@" + simpleDigest.String())
 		So(err, ShouldBeNil)
@@ -82,11 +83,13 @@ func TestScanningByDigest(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(cveMap, ShouldContainKey, test.Vulnerability1ID)
 		So(cveMap, ShouldContainKey, test.Vulnerability2ID)
+		So(cveMap, ShouldContainKey, test.Vulnerability3ID)
 
 		cveMap, err = scanner.ScanImage("multi-arch:multi-arch-tag")
 		So(err, ShouldBeNil)
 		So(cveMap, ShouldContainKey, test.Vulnerability1ID)
 		So(cveMap, ShouldContainKey, test.Vulnerability2ID)
+		So(cveMap, ShouldContainKey, test.Vulnerability3ID)
 	})
 }
 
@@ -181,6 +184,9 @@ func TestVulnerableLayer(t *testing.T) {
 
 		cveMap, err := scanner.ScanImage("repo@" + imgDigest.String())
 		So(err, ShouldBeNil)
-		So(len(cveMap), ShouldEqual, 2)
+		t.Logf("cveMap: %v", cveMap)
+		// As of July 15 2023 there are 3 CVEs: CVE-2023-1255, CVE-2023-2650, CVE-2023-2975
+		// There may be more discovered in the future
+		So(len(cveMap), ShouldBeGreaterThanOrEqualTo, 3)
 	})
 }

--- a/pkg/test/common.go
+++ b/pkg/test/common.go
@@ -639,10 +639,11 @@ func GetRandomImageComponents(layerSize int) (ispec.Image, [][]byte, ispec.Manif
 	return config, layers, manifest, nil
 }
 
-// These are the 2 vulnerabilities found for the returned image by the GetVulnImage function.
+// These are the 3 vulnerabilities found for the returned image by the GetVulnImage function.
 const (
 	Vulnerability1ID = "CVE-2023-2650"
 	Vulnerability2ID = "CVE-2023-1255"
+	Vulnerability3ID = "CVE-2023-2975"
 )
 
 func GetVulnImage(ref string) (Image, error) {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
