### PR TITLE
fix(conformance): OCI-Filters-Applied should return a literal

### DIFF
--- a/.github/workflows/oci-conformance-action.yml
+++ b/.github/workflows/oci-conformance-action.yml
@@ -38,8 +38,8 @@ jobs:
       with:
         # TODO: change to upstream once the foloowing PR is merged:
         # https://github.com/opencontainers/distribution-spec/pull/436
-        repository: opencontainers/distribution-spec
-        ref: main
+        repository: rchincha/distribution-spec
+        ref: fix-ref
         path: distribution-spec
     - name: build conformance binary from main
       run: |

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -5924,7 +5924,7 @@ func TestArtifactReferences(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 				So(resp.Header().Get("Content-Type"), ShouldEqual, ispec.MediaTypeImageIndex)
-				So(resp.Header().Get("OCI-Filters-Applied"), ShouldEqual, artifactType)
+				So(resp.Header().Get("OCI-Filters-Applied"), ShouldEqual, "artifactType")
 
 				resp, err = resty.R().SetQueryParams(map[string]string{"artifactType": artifactType +
 					",otherArtType"}).Get(baseURL + fmt.Sprintf("/v2/%s/referrers/%s", repoName,
@@ -5932,7 +5932,7 @@ func TestArtifactReferences(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 				So(resp.Header().Get("Content-Type"), ShouldEqual, ispec.MediaTypeImageIndex)
-				So(resp.Header().Get("OCI-Filters-Applied"), ShouldEqual, artifactType+",otherArtType")
+				So(resp.Header().Get("OCI-Filters-Applied"), ShouldEqual, "artifactType")
 			})
 		})
 	})

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -624,7 +624,8 @@ func (rh *RouteHandler) GetReferrers(response http.ResponseWriter, request *http
 	}
 
 	if len(artifactTypes) > 0 {
-		response.Header().Set("OCI-Filters-Applied", strings.Join(artifactTypes, ","))
+		// currently, the only filter supported and on this end-point
+		response.Header().Set("OCI-Filters-Applied", "artifactType")
 	}
 
 	zcommon.WriteData(response, http.StatusOK, ispec.MediaTypeImageIndex, out)


### PR DESCRIPTION
https://github.com/opencontainers/distribution-spec/issues/448

Should only indicate what filter-type was applied and not what exact values it was filtered on.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
