### PR TITLE
fix: freebsd build support

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -75,7 +75,7 @@ func DumpRuntimeParams(log log.Logger) {
 
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err == nil {
-		evt = evt.Uint64("max. open files", rLimit.Cur)
+		evt = evt.Uint64("max. open files", uint64(rLimit.Cur)) //nolint: unconvert // required for *BSD
 	}
 
 	if content, err := os.ReadFile("/proc/sys/net/core/somaxconn"); err == nil {

--- a/test/scripts/fuzzAll.sh
+++ b/test/scripts/fuzzAll.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test/scripts/gen_certs.sh
+++ b/test/scripts/gen_certs.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash
+
+set -xe
 
 openssl req \
     -newkey rsa:2048 \

--- a/test/scripts/gen_nameless_certs.sh
+++ b/test/scripts/gen_nameless_certs.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash
+
+set -xe
 
 openssl req \
     -newkey rsa:2048 \


### PR DESCRIPTION
- Avoid hard-coding the path for bash - this typically is installed as /usr/local/bin/bash

- Allow for the fact that FreeBSD's rlimit uses signed integers

Almost all of the test suite passes with three test failures that I haven't tried to debug yet.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

cleanup

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:



**Testing done on this change**:

Running zot test suite on FreeBSD, ad-hoc testing using zot as a local registry.

**Automation added to e2e**:

None

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:

No

```release-note
None
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
