### PR TITLE
feat: propagate detailed error msgs to client (OCI dist-spec format)

### DIFF
--- a/.github/workflows/oci-conformance-action.yml
+++ b/.github/workflows/oci-conformance-action.yml
@@ -36,8 +36,6 @@ jobs:
           echo "SERVER_URL=http://${IP}:8080" >> $GITHUB_ENV
     - uses: actions/checkout@v3
       with:
-        # TODO: change to upstream once the foloowing PR is merged:
-        # https://github.com/opencontainers/distribution-spec/pull/436
         repository: opencontainers/distribution-spec
         ref: main
         path: distribution-spec

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,16 +1,57 @@
 package errors
 
-import "errors"
+import (
+	"errors"
+)
+
+type Error struct {
+	err     error
+	details map[string]string
+}
+
+func (e *Error) Error() string {
+	return e.err.Error()
+}
+
+func (e *Error) Is(target error) bool {
+	return errors.Is(e.err, target)
+}
+
+func (e *Error) AddDetail(key, value string) *Error {
+	e.details[key] = value
+
+	return e
+}
+
+func (e *Error) GetDetails() map[string]string {
+	return e.details
+}
+
+func NewError(err error) *Error {
+	return &Error{
+		err:     err,
+		details: GetDetails(err), // preserve details if chained error
+	}
+}
+
+func GetDetails(err error) map[string]string {
+	var internalErr *Error
+	details := make(map[string]string)
+
+	if errors.As(err, &internalErr) {
+		details = internalErr.GetDetails()
+	}
+
+	return details
+}
 
 var (
 	ErrBadConfig                      = errors.New("config: invalid config")
 	ErrCliBadConfig                   = errors.New("cli: bad config")
 	ErrRepoNotFound                   = errors.New("repository: not found")
-	ErrRepoIsNotDir                   = errors.New("repository: not a directory")
 	ErrRepoBadVersion                 = errors.New("repository: unsupported layout version")
 	ErrManifestNotFound               = errors.New("manifest: not found")
 	ErrBadManifest                    = errors.New("manifest: invalid contents")
-	ErrBadIndex                       = errors.New("index: invalid contents")
 	ErrUploadNotFound                 = errors.New("uploads: not found")
 	ErrBadUploadRange                 = errors.New("uploads: bad range")
 	ErrBlobNotFound                   = errors.New("blob: not found")

--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -36,7 +36,7 @@ import (
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"
 	apiErr "zotregistry.io/zot/pkg/api/errors"
-	"zotregistry.io/zot/pkg/common"
+	zcommon "zotregistry.io/zot/pkg/common"
 	"zotregistry.io/zot/pkg/log"
 	localCtx "zotregistry.io/zot/pkg/requestcontext"
 	storageConstants "zotregistry.io/zot/pkg/storage/constants"
@@ -463,7 +463,7 @@ func bearerAuthHandler(ctlr *Controller) mux.MiddlewareFunc {
 			if err != nil {
 				ctlr.Log.Error().Err(err).Msg("issue parsing Authorization header")
 				response.Header().Set("Content-Type", "application/json")
-				common.WriteJSON(response, http.StatusInternalServerError, apiErr.NewErrorList(apiErr.NewError(apiErr.UNSUPPORTED)))
+				zcommon.WriteJSON(response, http.StatusInternalServerError, apiErr.NewError(apiErr.UNSUPPORTED))
 
 				return
 			}
@@ -472,8 +472,7 @@ func bearerAuthHandler(ctlr *Controller) mux.MiddlewareFunc {
 				response.Header().Set("Content-Type", "application/json")
 				response.Header().Set("WWW-Authenticate", permissions.WWWAuthenticateHeader)
 
-				common.WriteJSON(response, http.StatusUnauthorized,
-					apiErr.NewErrorList(apiErr.NewError(apiErr.UNAUTHORIZED)))
+				zcommon.WriteJSON(response, http.StatusUnauthorized, apiErr.NewError(apiErr.UNAUTHORIZED))
 
 				return
 			}
@@ -591,7 +590,7 @@ func getRelyingPartyArgs(cfg *config.Config, provider string) (
 
 	scopes := cfg.HTTP.Auth.OpenID.Providers[provider].Scopes
 	// openid scope must be the first one in list
-	if !common.Contains(scopes, oidc.ScopeOpenID) && config.IsOpenIDSupported(provider) {
+	if !zcommon.Contains(scopes, oidc.ScopeOpenID) && config.IsOpenIDSupported(provider) {
 		scopes = append([]string{oidc.ScopeOpenID}, scopes...)
 	}
 
@@ -663,7 +662,7 @@ func authFail(w http.ResponseWriter, r *http.Request, realm string, delay int) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	common.WriteJSON(w, http.StatusUnauthorized, apiErr.NewErrorList(apiErr.NewError(apiErr.UNAUTHORIZED)))
+	zcommon.WriteJSON(w, http.StatusUnauthorized, apiErr.NewError(apiErr.UNAUTHORIZED))
 }
 
 func isAuthorizationHeaderEmpty(request *http.Request) bool {

--- a/pkg/api/errors/errors.go
+++ b/pkg/api/errors/errors.go
@@ -5,16 +5,10 @@ import (
 )
 
 type Error struct {
-	Code        string      `json:"code"`
-	Message     string      `json:"message"`
-	Description string      `json:"description"`
-	Detail      interface{} `json:"detail,omitempty"`
-}
-
-func (e Error) WithMessage(msg string) Error {
-	e.Message = msg
-
-	return e
+	Code        string            `json:"code"`
+	Message     string            `json:"message"`
+	Description string            `json:"-"`
+	Detail      map[string]string `json:"detail"`
 }
 
 type ErrorList struct {
@@ -66,7 +60,7 @@ func (e ErrorCode) String() string {
 	return errMap[e]
 }
 
-func NewError(code ErrorCode, detail ...interface{}) Error {
+func NewError(code ErrorCode) *Error {
 	errMap := map[ErrorCode]Error{
 		BLOB_UNKNOWN: {
 			Message: "blob unknown to registry",
@@ -77,12 +71,12 @@ func NewError(code ErrorCode, detail ...interface{}) Error {
 
 		BLOB_UPLOAD_INVALID: {
 			Message:     "blob upload invalid",
-			Description: `The blob upload encountered an error and can no longer proceed.`,
+			Description: "The blob upload encountered an error and can no longer proceed.",
 		},
 
 		BLOB_UPLOAD_UNKNOWN: {
 			Message:     "blob upload unknown to registry",
-			Description: `If a blob upload has been cancelled or was never started, this error code MAY be returned.`,
+			Description: "If a blob upload has been cancelled or was never started, this error code MAY be returned.",
 		},
 
 		DIGEST_INVALID: {
@@ -94,71 +88,68 @@ func NewError(code ErrorCode, detail ...interface{}) Error {
 		},
 
 		MANIFEST_BLOB_UNKNOWN: {
-			Message: "blob unknown to registry",
-			Description: `This error MAY be returned when a manifest blob is unknown
-			to the registry.`,
+			Message:     "blob unknown to registry",
+			Description: "This error MAY be returned when a manifest blob is unknown to the registry.",
 		},
 
 		MANIFEST_INVALID: {
 			Message: "manifest invalid",
-			Description: `During upload, manifests undergo several checks ensuring
-			validity. If those checks fail, this error MAY be returned, unless a more
-			specific error is included. The detail will contain information the failed
-			validation.`,
+			Description: "During upload, manifests undergo several checks ensuring " +
+				"validity. If those checks fail, this error MAY be returned, unless a more " +
+				"specific error is included. The detail will contain information the failed validation.",
 		},
 
 		MANIFEST_UNKNOWN: {
 			Message: "manifest unknown",
-			Description: `This error is returned when the manifest, identified by name
-			and tag is unknown to the repository.`,
+			Description: "This error is returned when the manifest, identified by name " +
+				"and tag is unknown to the repository.",
 		},
 
 		MANIFEST_UNVERIFIED: {
 			Message: "manifest failed signature verification",
-			Description: `During manifest upload, if the manifest fails signature
-			verification, this error will be returned.`,
+			Description: "During manifest upload, if the manifest fails signature " +
+				"verification, this error will be returned.",
 		},
 
 		NAME_INVALID: {
 			Message: "invalid repository name",
-			Description: `Invalid repository name encountered either during manifest
-			validation or any API operation.`,
+			Description: "Invalid repository name encountered either during manifest " +
+				"validation or any API operation.",
 		},
 
 		NAME_UNKNOWN: {
 			Message:     "repository name not known to registry",
-			Description: `This is returned if the name used during an operation is unknown to the registry.`,
+			Description: "This is returned if the name used during an operation is unknown to the registry.",
 		},
 
 		SIZE_INVALID: {
 			Message: "provided length did not match content length",
-			Description: "When a layer is uploaded, the provided size will be checked against the uploaded " +
-				"content. If they do not match, this error will be returned.",
+			Description: "When a layer is uploaded, the provided size will be checked against " +
+				"the uploaded content. If they do not match, this error will be returned.",
 		},
 
 		TAG_INVALID: {
 			Message: "manifest tag did not match URI",
-			Description: `During a manifest upload, if the tag in the manifest does
-			not match the uri tag, this error will be returned.`,
+			Description: "During a manifest upload, if the tag in the manifest does " +
+				"not match the uri tag, this error will be returned.",
 		},
 
 		UNAUTHORIZED: {
 			Message: "authentication required",
-			Description: `The access controller was unable to authenticate the client.
-			Often this will be accompanied by a Www-Authenticate HTTP response header
-			indicating how to authenticate.`,
+			Description: "The access controller was unable to authenticate the client." +
+				"Often this will be accompanied by a Www-Authenticate HTTP response header " +
+				"indicating how to authenticate.",
 		},
 
 		DENIED: {
-			Message: "requested access to the resource is denied",
-			Description: `The access controller denied access for the operation on a
-			resource.`,
+			Message:     "requested access to the resource is denied",
+			Description: "The access controller denied access for the operation on a resource.",
 		},
 
 		UNSUPPORTED: {
 			Message: "The operation is unsupported.",
-			Description: `The operation was unsupported due to a missing
-			implementation or invalid set of parameters.`,
+			Description: "The operation was unsupported due to a missing " +
+				"implementation or invalid set of parameters.",
 		},
 
 		INVALID_INDEX: {
@@ -173,19 +164,24 @@ func NewError(code ErrorCode, detail ...interface{}) Error {
 	}
 
 	err.Code = code.String()
-	err.Detail = detail
+	err.Detail = map[string]string{
+		"description": err.Description,
+	}
+
+	return &err
+}
+
+func (err *Error) AddDetail(m map[string]string) *Error {
+	for k, v := range m {
+		err.Detail[k] = v
+	}
 
 	return err
 }
 
-func NewErrorList(errors ...Error) ErrorList {
-	errList := make([]*Error, 0)
-	err := Error{}
-
-	for _, e := range errors {
-		err = e
-		errList = append(errList, &err)
-	}
+func NewErrorList(errors ...*Error) ErrorList {
+	var errList []*Error
+	errList = append(errList, errors...)
 
 	return ErrorList{errList}
 }

--- a/pkg/api/errors/errors_test.go
+++ b/pkg/api/errors/errors_test.go
@@ -10,6 +10,6 @@ import (
 
 func TestUnknownCodeError(t *testing.T) {
 	Convey("Retrieve a new error with unknown code", t, func() {
-		So(func() { _ = apiErr.NewError(123456789, nil) }, ShouldPanic)
+		So(func() { _ = apiErr.NewError(123456789) }, ShouldPanic)
 	})
 }

--- a/pkg/extensions/extensions_lint_disabled.go
+++ b/pkg/extensions/extensions_lint_disabled.go
@@ -10,7 +10,7 @@ import (
 )
 
 func GetLinter(config *config.Config, log log.Logger) *lint.Linter {
-	log.Warn().Msg("lint extension is disabled because given zot binary doesn't" +
+	log.Warn().Msg("lint extension is disabled because given zot binary doesn't " +
 		"include this feature please build a binary that does so")
 
 	return nil

--- a/pkg/extensions/lint/lint.go
+++ b/pkg/extensions/lint/lint.go
@@ -105,7 +105,7 @@ func (linter *Linter) CheckMandatoryAnnotations(repo string, manifestDigest godi
 			string(manifestDigest), string(configDigest), missingAnnotations)
 		linter.log.Error().Msg(msg)
 
-		return false, fmt.Errorf("%s: %w", msg, zerr.ErrImageLintAnnotations)
+		return false, zerr.NewError(zerr.ErrImageLintAnnotations).AddDetail("missingAnnotations", msg)
 	}
 
 	return true, nil


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
https://github.com/project-zot/zot/issues/1418


**What does this PR do / Why do we need it**:
Adds jsonSchema validation errors from image-spec to errors.details returned to the client: https://github.com/opencontainers/distribution-spec/blob/main/spec.md#error-codes


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
Added UTs

**Automation added to e2e**:

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
