### PR TITLE
feat(authn): add generic oidc and allow customizable name

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -228,7 +228,7 @@ To configure zot as a client in dex (assuming zot is hosted at 127.0.0.1:8080), 
 staticClients:
   - id: zot-client
     redirectURIs:
-      - 'http://127.0.0.1:8080/auth/callback/dex'
+      - 'http://127.0.0.1:8080/auth/callback/oidc'
     name: 'zot'
     secret: ZXhhbXBsZS1hcHAtc2VjcmV0
 ```
@@ -240,7 +240,8 @@ zot can be configured to use dex with:
     "auth": {
       "openid": {
         "providers": {
-          "dex": {
+          "oidc": {
+            "name": "Corporate SSO",
             "clientid": "zot-client",
             "clientsecret": "ZXhhbXBsZS1hcHAtc2VjcmV0",
             "keypath": "",
@@ -253,7 +254,7 @@ zot can be configured to use dex with:
   }
 ```
 
-To login using openid dex provider use http://127.0.0.1:8080/auth/login?provider=dex
+To login using openid dex provider use http://127.0.0.1:8080/auth/login?provider=oidc
 
 NOTE: Social login is not supported by command line tools, or other software responsible for pushing/pulling
 images to/from zot.
@@ -313,7 +314,9 @@ To activate API keys use:
 ```
   "http": {
     "auth": {
-      "apikey: true
+      "apikey": true
+    }
+  }
 ```
 
 ##### How to create an API Key
@@ -384,6 +387,8 @@ Should authentication fail, to prevent automated attacks, a delayed response can
   "http": {
     "auth": {
       "failDelay": 5
+    }
+  }
 ```
 
 ## Identity-based Authorization
@@ -473,7 +478,7 @@ The number of workers for the task scheduler has the default value of runtime.Nu
 ```
  "scheduler": {
         "numWorkers": 3
-    
+ }
 ```
 
 ## Logging

--- a/examples/config-openid.json
+++ b/examples/config-openid.json
@@ -34,7 +34,8 @@
             "clientsecret": "client_secret",
             "scopes": ["openid", "read_api", "read_user", "profile", "email"]
           },
-          "dex": {
+          "oidc": {
+            "name": "Corporate SSO",
             "issuer": "http://127.0.0.1:5556/dex",
             "clientid": "client_id",
             "clientsecret": "client_secret",

--- a/pkg/api/authn_test.go
+++ b/pkg/api/authn_test.go
@@ -95,7 +95,7 @@ func TestAPIKeys(t *testing.T) {
 			},
 			OpenID: &config.OpenIDConfig{
 				Providers: map[string]config.OpenIDProviderConfig{
-					"dex": {
+					"oidc": {
 						ClientID:     mockOIDCConfig.ClientID,
 						ClientSecret: mockOIDCConfig.ClientSecret,
 						KeyPath:      "",
@@ -188,7 +188,7 @@ func TestAPIKeys(t *testing.T) {
 			// first login user
 			resp, err := client.R().
 				SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
@@ -303,7 +303,7 @@ func TestAPIKeys(t *testing.T) {
 			// first login user
 			resp, err = client.R().
 				SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
@@ -406,7 +406,7 @@ func TestAPIKeys(t *testing.T) {
 			// login again
 			resp, err = client.R().
 				SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
@@ -533,7 +533,7 @@ func TestAPIKeysOpenDBError(t *testing.T) {
 
 			OpenID: &config.OpenIDConfig{
 				Providers: map[string]config.OpenIDProviderConfig{
-					"dex": {
+					"oidc": {
 						ClientID:     mockOIDCConfig.ClientID,
 						ClientSecret: mockOIDCConfig.ClientSecret,
 						KeyPath:      "",

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -17,8 +17,8 @@ var (
 	BinaryType string //nolint: gochecknoglobals
 	GoVersion  string //nolint: gochecknoglobals
 
-	openIDSupportedProviders = [...]string{"google", "gitlab", "dex"} //nolint: gochecknoglobals
-	oauth2SupportedProviders = [...]string{"github"}                  //nolint: gochecknoglobals
+	openIDSupportedProviders = [...]string{"google", "gitlab", "oidc"} //nolint: gochecknoglobals
+	oauth2SupportedProviders = [...]string{"github"}                   //nolint: gochecknoglobals
 
 )
 
@@ -64,6 +64,7 @@ type OpenIDConfig struct {
 }
 
 type OpenIDProviderConfig struct {
+	Name         string
 	ClientID     string
 	ClientSecret string
 	KeyPath      string

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -459,7 +459,7 @@ func TestObjectStorageController(t *testing.T) {
 		conf.HTTP.Auth = &config.AuthConfig{
 			OpenID: &config.OpenIDConfig{
 				Providers: map[string]config.OpenIDProviderConfig{
-					"dex": {
+					"oidc": {
 						ClientID:     mockOIDCConfig.ClientID,
 						ClientSecret: mockOIDCConfig.ClientSecret,
 						KeyPath:      "",
@@ -2535,7 +2535,7 @@ func TestNewRelyingPartyOIDC(t *testing.T) {
 		conf.HTTP.Auth = &config.AuthConfig{
 			OpenID: &config.OpenIDConfig{
 				Providers: map[string]config.OpenIDProviderConfig{
-					"dex": {
+					"oidc": {
 						ClientID:     mockOIDCConfig.ClientID,
 						ClientSecret: mockOIDCConfig.ClientSecret,
 						KeyPath:      "",
@@ -2551,11 +2551,11 @@ func TestNewRelyingPartyOIDC(t *testing.T) {
 		})
 
 		Convey("key path not found on disk", func() {
-			dexProviderCfg := conf.HTTP.Auth.OpenID.Providers["dex"]
-			dexProviderCfg.KeyPath = "path/to/file"
-			conf.HTTP.Auth.OpenID.Providers["dex"] = dexProviderCfg
+			oidcProviderCfg := conf.HTTP.Auth.OpenID.Providers["oidc"]
+			oidcProviderCfg.KeyPath = "path/to/file"
+			conf.HTTP.Auth.OpenID.Providers["oidc"] = oidcProviderCfg
 
-			So(func() { _ = api.NewRelyingPartyOIDC(conf, "dex") }, ShouldPanic)
+			So(func() { _ = api.NewRelyingPartyOIDC(conf, "oidc") }, ShouldPanic)
 		})
 
 		Convey("https callback", func() {
@@ -2564,25 +2564,25 @@ func TestNewRelyingPartyOIDC(t *testing.T) {
 				Key:  ServerKey,
 			}
 
-			rp := api.NewRelyingPartyOIDC(conf, "dex")
+			rp := api.NewRelyingPartyOIDC(conf, "oidc")
 			So(rp, ShouldNotBeNil)
 		})
 
 		Convey("no client secret in config", func() {
-			dexProvider := conf.HTTP.Auth.OpenID.Providers["dex"]
-			dexProvider.ClientSecret = ""
-			conf.HTTP.Auth.OpenID.Providers["dex"] = dexProvider
+			oidcProvider := conf.HTTP.Auth.OpenID.Providers["oidc"]
+			oidcProvider.ClientSecret = ""
+			conf.HTTP.Auth.OpenID.Providers["oidc"] = oidcProvider
 
-			rp := api.NewRelyingPartyOIDC(conf, "dex")
+			rp := api.NewRelyingPartyOIDC(conf, "oidc")
 			So(rp, ShouldNotBeNil)
 		})
 
 		Convey("provider issuer unreachable", func() {
-			dexProvider := conf.HTTP.Auth.OpenID.Providers["dex"]
-			dexProvider.Issuer = ""
-			conf.HTTP.Auth.OpenID.Providers["dex"] = dexProvider
+			oidcProvider := conf.HTTP.Auth.OpenID.Providers["oidc"]
+			oidcProvider.Issuer = ""
+			conf.HTTP.Auth.OpenID.Providers["oidc"] = oidcProvider
 
-			So(func() { _ = api.NewRelyingPartyOIDC(conf, "dex") }, ShouldPanic)
+			So(func() { _ = api.NewRelyingPartyOIDC(conf, "oidc") }, ShouldPanic)
 		})
 	})
 }
@@ -2657,7 +2657,7 @@ func TestOpenIDMiddleware(t *testing.T) {
 		},
 		OpenID: &config.OpenIDConfig{
 			Providers: map[string]config.OpenIDProviderConfig{
-				"dex": {
+				"oidc": {
 					ClientID:     mockOIDCConfig.ClientID,
 					ClientSecret: mockOIDCConfig.ClientSecret,
 					KeyPath:      "",
@@ -2727,7 +2727,7 @@ func TestOpenIDMiddleware(t *testing.T) {
 						// first login user
 						resp, err := client.R().
 							SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-							SetQueryParam("provider", "dex").
+							SetQueryParam("provider", "oidc").
 							SetQueryParam("callback_ui", baseURL+"/v2/").
 							Get(baseURL + constants.LoginPath)
 						So(err, ShouldBeNil)
@@ -2738,7 +2738,7 @@ func TestOpenIDMiddleware(t *testing.T) {
 					// first login user
 					resp, err := client.R().
 						SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-						SetQueryParam("provider", "dex").
+						SetQueryParam("provider", "oidc").
 						Get(baseURL + constants.LoginPath)
 					So(err, ShouldBeNil)
 					So(resp, ShouldNotBeNil)
@@ -3081,7 +3081,7 @@ func TestAuthnSessionErrors(t *testing.T) {
 			},
 			OpenID: &config.OpenIDConfig{
 				Providers: map[string]config.OpenIDProviderConfig{
-					"dex": {
+					"oidc": {
 						ClientID:     mockOIDCConfig.ClientID,
 						ClientSecret: mockOIDCConfig.ClientSecret,
 						KeyPath:      "",
@@ -3161,7 +3161,7 @@ func TestAuthnSessionErrors(t *testing.T) {
 
 			resp, err := client.R().
 				SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
@@ -3182,7 +3182,7 @@ func TestAuthnSessionErrors(t *testing.T) {
 			// first login user
 			resp, err := client.R().
 				SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
@@ -3242,7 +3242,7 @@ func TestAuthnSessionErrors(t *testing.T) {
 
 			// call endpoint with session (added to client after previous request)
 			resp, err := client.R().
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
@@ -3264,7 +3264,7 @@ func TestAuthnSessionErrors(t *testing.T) {
 			// first login user
 			resp, err := client.R().
 				SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
@@ -3311,7 +3311,7 @@ func TestAuthnSessionErrors(t *testing.T) {
 			// first login user
 			resp, err := client.R().
 				SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
@@ -3463,7 +3463,7 @@ func TestAuthnMetaDBErrors(t *testing.T) {
 			},
 			OpenID: &config.OpenIDConfig{
 				Providers: map[string]config.OpenIDProviderConfig{
-					"dex": {
+					"oidc": {
 						ClientID:     mockOIDCConfig.ClientID,
 						ClientSecret: mockOIDCConfig.ClientSecret,
 						KeyPath:      "",
@@ -3513,7 +3513,7 @@ func TestAuthnMetaDBErrors(t *testing.T) {
 			// first login user
 			resp, err := client.R().
 				SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
@@ -3591,7 +3591,7 @@ func TestAuthorization(t *testing.T) {
 			conf.HTTP.Auth = &config.AuthConfig{
 				OpenID: &config.OpenIDConfig{
 					Providers: map[string]config.OpenIDProviderConfig{
-						"dex": {
+						"oidc": {
 							ClientID:     mockOIDCConfig.ClientID,
 							ClientSecret: mockOIDCConfig.ClientSecret,
 							KeyPath:      "",
@@ -3625,7 +3625,7 @@ func TestAuthorization(t *testing.T) {
 			// first login user
 			resp, err := client.R().
 				SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
@@ -4212,7 +4212,7 @@ func TestAuthorizationWithMultiplePolicies(t *testing.T) {
 			conf.HTTP.Auth = &config.AuthConfig{
 				OpenID: &config.OpenIDConfig{
 					Providers: map[string]config.OpenIDProviderConfig{
-						"dex": {
+						"oidc": {
 							ClientID:     mockOIDCConfig.ClientID,
 							ClientSecret: mockOIDCConfig.ClientSecret,
 							KeyPath:      "",
@@ -4246,7 +4246,7 @@ func TestAuthorizationWithMultiplePolicies(t *testing.T) {
 			// first login user
 			resp, err := testUserClient.R().
 				SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
@@ -4267,7 +4267,7 @@ func TestAuthorizationWithMultiplePolicies(t *testing.T) {
 			// first login user
 			resp, err = bobUserClient.R().
 				SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
-				SetQueryParam("provider", "dex").
+				SetQueryParam("provider", "oidc").
 				Get(baseURL + constants.LoginPath)
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -66,7 +66,7 @@ func TestRoutes(t *testing.T) {
 			},
 			OpenID: &config.OpenIDConfig{
 				Providers: map[string]config.OpenIDProviderConfig{
-					"dex": {
+					"oidc": {
 						ClientID:     mockOIDCConfig.ClientID,
 						ClientSecret: mockOIDCConfig.ClientSecret,
 						KeyPath:      "",

--- a/pkg/cli/root_test.go
+++ b/pkg/cli/root_test.go
@@ -958,7 +958,7 @@ func TestVerify(t *testing.T) {
 		defer os.Remove(tmpfile.Name()) // clean up
 		content := []byte(`{"distSpecVersion":"1.1.0-dev","storage":{"rootDirectory":"/tmp/zot"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
-							"auth":{"openid":{"providers":{"dex":{"issuer":"http://127.0.0.1:5556/dex"}}}}},
+							"auth":{"openid":{"providers":{"oidc":{"issuer":"http://127.0.0.1:5556/dex"}}}}},
 							"log":{"level":"debug"}}`)
 		_, err = tmpfile.Write(content)
 		So(err, ShouldBeNil)
@@ -1006,7 +1006,7 @@ func TestVerify(t *testing.T) {
 		defer os.Remove(tmpfile.Name()) // clean up
 		content := []byte(`{"distSpecVersion":"1.1.0-dev","storage":{"rootDirectory":"/tmp/zot"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
-							"auth":{"openid":{"providers":{"dex":{"issuer":"http://127.0.0.1:5556/dex",
+							"auth":{"openid":{"providers":{"oidc":{"issuer":"http://127.0.0.1:5556/dex",
 						    "clientid":"client_id","scopes":["openid"]}}}}},
 							"log":{"level":"debug"}}`)
 		_, err = tmpfile.Write(content)
@@ -1225,7 +1225,7 @@ func TestApiKeyConfig(t *testing.T) {
 
 		content := []byte(`{"distSpecVersion":"1.1.0-dev","storage":{"rootDirectory":"/tmp/zot"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
-							"auth":{"openid":{"providers":{"dex":{"issuer":"http://127.0.0.1:5556/dex",
+							"auth":{"openid":{"providers":{"oidc":{"issuer":"http://127.0.0.1:5556/dex",
 						    "clientid":"client_id","scopes":["openid"]}}}}},
 							"log":{"level":"debug"}}`)
 

--- a/pkg/extensions/extension_mgmt.go
+++ b/pkg/extensions/extension_mgmt.go
@@ -24,7 +24,9 @@ type BearerConfig struct {
 	Service string `json:"service,omitempty"`
 }
 
-type OpenIDProviderConfig struct{}
+type OpenIDProviderConfig struct {
+	Name string `json:"name,omitempty" mapstructure:"name"`
+}
 
 type OpenIDConfig struct {
 	Providers map[string]OpenIDProviderConfig `json:"providers,omitempty" mapstructure:"providers"`

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -566,7 +566,7 @@ func TestMgmtExtension(t *testing.T) {
 		conf.HTTP.Auth.Bearer = nil
 
 		openIDProviders := make(map[string]config.OpenIDProviderConfig)
-		openIDProviders["dex"] = config.OpenIDProviderConfig{
+		openIDProviders["oidc"] = config.OpenIDProviderConfig{
 			ClientID:     mockOIDCConfig.ClientID,
 			ClientSecret: mockOIDCConfig.ClientSecret,
 			Issuer:       mockOIDCConfig.Issuer,

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -1345,7 +1345,12 @@ const docTemplate = `{
             }
         },
         "extensions.OpenIDProviderConfig": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
         },
         "extensions.StrippedConfig": {
             "type": "object",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1336,7 +1336,12 @@
             }
         },
         "extensions.OpenIDProviderConfig": {
-            "type": "object"
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            }
         },
         "extensions.StrippedConfig": {
             "type": "object",

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -144,6 +144,9 @@ definitions:
         type: object
     type: object
   extensions.OpenIDProviderConfig:
+    properties:
+      name:
+        type: string
     type: object
   extensions.StrippedConfig:
     properties:

--- a/test/blackbox/cloud-only.bats
+++ b/test/blackbox/cloud-only.bats
@@ -50,7 +50,7 @@ function setup() {
         "auth": {
             "openid": {
                 "providers": {
-                    "dex": {
+                    "oidc": {
                         "issuer": "http://127.0.0.1:5556/dex",
                         "clientid": "zot-client",
                         "clientsecret": "ZXhhbXBsZS1hcHAtc2VjcmV0",
@@ -103,9 +103,9 @@ function teardown() {
 }
 
 dex_session () {
-    STATE=$(curl -L -f -s http://localhost:8080/openid/auth/login?provider=dex | grep -m 1 -oP '(?<=state=)[^ ]*"' | cut -d \" -f1)
+    STATE=$(curl -L -f -s http://localhost:8080/openid/auth/login?provider=oidc | grep -m 1 -oP '(?<=state=)[^ ]*"' | cut -d \" -f1)
     echo $STATE >&3
-    curl -L -f -s "http://127.0.0.1:5556/dex/auth/mock?client_id=zot-client&redirect_uri=http%3A%2F%2F127.0.0.1%3A8080%2Fopenid%2Fauth%2Fcallback%2Fdex&response_type=code&scope=profile+email+groups+openid&state=$STATE"
+    curl -L -f -s "http://127.0.0.1:5556/dex/auth/mock?client_id=zot-client&redirect_uri=http%3A%2F%2F127.0.0.1%3A8080%2Fopenid%2Fauth%2Fcallback%2Foidc&response_type=code&scope=profile+email+groups+openid&state=$STATE"
 }
 
 @test "check dex is working" {

--- a/test/dex/config-dev.yaml
+++ b/test/dex/config-dev.yaml
@@ -17,7 +17,7 @@ grpc:
 staticClients:
   - id: zot-client
     redirectURIs:
-      - 'http://127.0.0.1:8080/openid/auth/callback/dex'
+      - 'http://127.0.0.1:8080/openid/auth/callback/oidc'
     name: 'zot'
     secret: ZXhhbXBsZS1hcHAtc2VjcmV0
 


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:

none

**What does this PR do / Why do we need it**:

This PR allow admin to add generic OIDC provider and customize it's name (linked with zui: https://github.com/project-zot/zui/pull/375)

**Will this break upgrades or downgrades?**

Won't break on upgrade / downgrades

**Does this PR introduce any user-facing change?**:

It allows the display of a customizable login button with the proper patch on zui (PR https://github.com/project-zot/zui/pull/375)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
