### PR TITLE
fix: swagger Makefile target broken on darwin

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Install other dependencies
         run: |
           cd $GITHUB_WORKSPACE
-          go install github.com/swaggo/swag/cmd/swag@v1.6.3
+          go install github.com/swaggo/swag/cmd/swag@v1.8.12
           sudo apt-get update
           sudo apt-get install rpm
           sudo apt-get install snapd
@@ -77,7 +77,7 @@ jobs:
             sudo cp bin/skopeo /usr/bin && \
             rm -rf $GITHUB_WORKSPACE/src/github.com/containers/skopeo
           cd $GITHUB_WORKSPACE
-          curl -Lo notation.tar.gz https://github.com/notaryproject/notation/releases/download/v0.7.1-alpha.1/notation_0.7.1-alpha.1_linux_amd64.tar.gz
+          curl -Lo notation.tar.gz https://github.com/notaryproject/notation/releases/download/v1.0.0-rc.4/notation_1.0.0-rc.4_linux_amd64.tar.gz
           sudo tar xvzf notation.tar.gz -C /usr/bin notation
           rm -f notation.tar.gz
           go install github.com/wadey/gocovmerge@latest

--- a/Makefile
+++ b/Makefile
@@ -216,12 +216,10 @@ check: ./golangcilint.yaml $(GOLINTER)
 	$(GOLINTER) --config ./golangcilint.yaml run --enable-all --out-format=colored-line-number --build-tags stress,$(BUILD_LABELS),containers_image_openpgp ./...
 	rm pkg/extensions/build/.empty
 
-swagger/docs.go: 
+.PHONY: swagger
+swagger:
 	swag -v || go install github.com/swaggo/swag/cmd/swag@$(SWAGGER_VERSION)
 	swag init --parseDependency -o swagger -g pkg/api/routes.go -q
-
-.PHONY: swagger
-swagger: swagger/docs.go pkg/api/routes.go
 
 .PHONY: update-licenses
 update-licenses:
@@ -274,7 +272,7 @@ verify-config: _verify-config verify-config-warnings verify-config-commited
 
 .PHONY: _verify-config
 _verify-config: binary
-	rm -f output.txt	
+	rm -f output.txt
 	$(foreach file, $(wildcard examples/config-*), ./bin/zot-$(OS)-$(ARCH) verify $(file) 2>&1 | tee -a output.txt || exit 1;)
 
 .PHONY: verify-config-warnings
@@ -318,7 +316,7 @@ binary-container:
 .PHONY: run-container
 run-container:
 	${CONTAINER_RUNTIME} run --rm --security-opt label=disable -v $$(pwd):/go/src/github.com/project-zot/zot \
-		zot-build:latest 
+		zot-build:latest
 
 .PHONY: binary-stacker
 binary-stacker: $(STACKER)
@@ -396,7 +394,7 @@ test-bats-sync: binary binary-minimal bench check-skopeo $(BATS) $(NOTATION) $(C
 	$(BATS) --trace --print-output-on-failure test/blackbox/sync.bats
 	$(BATS) --trace --print-output-on-failure test/blackbox/sync_docker.bats
 	$(BATS) --trace --print-output-on-failure test/blackbox/sync_replica_cluster.bats
-	
+
 .PHONY: test-bats-sync-verbose
 test-bats-sync-verbose: BUILD_LABELS=sync
 test-bats-sync-verbose: binary binary-minimal bench check-skopeo $(BATS) $(NOTATION) $(COSIGN)

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -401,7 +401,7 @@ func (rh *RouteHandler) ListTags(response http.ResponseWriter, request *http.Req
 // @Param   name     			path    string     true        "repository name"
 // @Param   reference     path    string     true        "image reference or digest"
 // @Success 200 {string} string	"ok"
-// @Header  200 {object} cosntants.DistContentDigestKey
+// @Header  200 {object} constants.DistContentDigestKey
 // @Failure 404 {string} string "not found"
 // @Failure 500 {string} string "internal server error".
 func (rh *RouteHandler) CheckManifest(response http.ResponseWriter, request *http.Request) {

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -1005,7 +1005,7 @@ const docTemplate = `{
                             "type": "string"
                         },
                         "headers": {
-                            "cosntants.DistContentDigestKey": {
+                            "constants.DistContentDigestKey": {
                                 "type": "object"
                             }
                         }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -996,7 +996,7 @@
                             "type": "string"
                         },
                         "headers": {
-                            "cosntants.DistContentDigestKey": {
+                            "constants.DistContentDigestKey": {
                                 "type": "object"
                             }
                         }

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -858,7 +858,7 @@ paths:
         "200":
           description: ok
           headers:
-            cosntants.DistContentDigestKey:
+            constants.DistContentDigestKey:
               type: object
           schema:
             type: string


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
On Mac OS the swagger target does nothing (because of using . or DOT in makefile target name)

**If an issue # is not available please add repro steps and logs showing the issue**:
```
aiandus-MacBook-Pro:zot aiandu$ make swagger
make: Nothing to be done for `swagger'.
```

**Testing done on this change**:
```
make swagger
```

**Automation added to e2e**:

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
