### PR TITLE
feat: automated detection of OS and ARCH if unset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,9 @@ SWAGGER_VERSION := v1.8.12
 STACKER := $(TOOLSDIR)/bin/stacker
 BATS := $(TOOLSDIR)/bin/bats
 TESTDATA := $(TOP_LEVEL)/test/data
-OS ?= linux
-ARCH ?= amd64
+OS ?= $(shell go env GOOS)
+ARCH ?= $(shell go env GOARCH)
+
 BENCH_OUTPUT ?= stdout
 ALL_EXTENSIONS = debug,imagetrust,lint,metrics,mgmt,scrub,search,sync,ui,userprefs
 EXTENSIONS ?= sync,search,scrub,metrics,lint,ui,mgmt,userprefs,imagetrust


### PR DESCRIPTION
**What type of PR is this?**
feature


**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
When user tries "make binary" or "make binary-minimal" on darwin for example, the Makefile correctly detects OS and ARCH and creates a proper binary instead of default one for linux/amd64


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
Manual testing on Linux amd64, Mac OS Ventura with Intel chipset,  FreeBSD v13.2 amd64.
To be tested on Mac OS with M1 chipset.


**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:


```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
