### PR TITLE
refactor: move /pkg/meta/signatures under /pkg/extensions/imagetrust

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -19,6 +19,10 @@ const (
 	clientCertFilename = "client.cert"
 	clientKeyFilename  = "client.key"
 	caCertFilename     = "ca.crt"
+
+	CosignSignature   = "cosign"
+	CosignSigKey      = "dev.cosignproject.cosign/signature"
+	NotationSignature = "notation"
 )
 
 func Contains[T comparable](elems []T, v T) bool {

--- a/pkg/extensions/extension_image_trust.go
+++ b/pkg/extensions/extension_image_trust.go
@@ -15,8 +15,8 @@ import (
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"
 	zcommon "zotregistry.io/zot/pkg/common"
+	"zotregistry.io/zot/pkg/extensions/imagetrust"
 	"zotregistry.io/zot/pkg/log"
-	"zotregistry.io/zot/pkg/meta/signatures"
 	mTypes "zotregistry.io/zot/pkg/meta/types"
 	"zotregistry.io/zot/pkg/scheduler"
 )
@@ -93,7 +93,7 @@ func (trust *ImageTrust) HandleCosignPublicKeyUpload(response http.ResponseWrite
 		return
 	}
 
-	err = signatures.UploadPublicKey(body)
+	err = imagetrust.UploadPublicKey(body)
 	if err != nil {
 		if errors.Is(err, zerr.ErrInvalidPublicKeyContent) {
 			response.WriteHeader(http.StatusBadRequest)
@@ -151,7 +151,7 @@ func (trust *ImageTrust) HandleNotationCertificateUpload(response http.ResponseW
 		return
 	}
 
-	err = signatures.UploadCertificate(body, truststoreType, truststoreName)
+	err = imagetrust.UploadCertificate(body, truststoreType, truststoreName)
 	if err != nil {
 		if errors.Is(err, zerr.ErrInvalidTruststoreType) ||
 			errors.Is(err, zerr.ErrInvalidTruststoreName) ||
@@ -175,7 +175,7 @@ func EnableImageTrustVerification(conf *config.Config, taskScheduler *scheduler.
 		return
 	}
 
-	generator := signatures.NewTaskGenerator(metaDB, log)
+	generator := imagetrust.NewTaskGenerator(metaDB, log)
 
 	numberOfHours := 2
 	interval := time.Duration(numberOfHours) * time.Minute

--- a/pkg/extensions/imagetrust/cosign.go
+++ b/pkg/extensions/imagetrust/cosign.go
@@ -1,4 +1,7 @@
-package signatures
+//go:build imagetrust
+// +build imagetrust
+
+package imagetrust
 
 import (
 	"bytes"
@@ -19,10 +22,7 @@ import (
 	zerr "zotregistry.io/zot/errors"
 )
 
-const (
-	CosignSigKey          = "dev.cosignproject.cosign/signature"
-	cosignDirRelativePath = "_cosign"
-)
+const cosignDirRelativePath = "_cosign"
 
 var cosignDir = "" //nolint:gochecknoglobals
 

--- a/pkg/extensions/imagetrust/image_trust_disabled.go
+++ b/pkg/extensions/imagetrust/image_trust_disabled.go
@@ -1,0 +1,29 @@
+//go:build !imagetrust
+// +build !imagetrust
+
+package imagetrust
+
+import (
+	"time"
+
+	godigest "github.com/opencontainers/go-digest"
+)
+
+func InitCosignAndNotationDirs(rootDir string) error {
+	return nil
+}
+
+func InitCosignDir(rootDir string) error {
+	return nil
+}
+
+func InitNotationDir(rootDir string) error {
+	return nil
+}
+
+func VerifySignature(
+	signatureType string, rawSignature []byte, sigKey string, manifestDigest godigest.Digest, manifestContent []byte,
+	repo string,
+) (string, time.Time, bool, error) {
+	return "", time.Time{}, false, nil
+}

--- a/pkg/extensions/imagetrust/image_trust_disabled_test.go
+++ b/pkg/extensions/imagetrust/image_trust_disabled_test.go
@@ -1,0 +1,47 @@
+//go:build !imagetrust
+
+package imagetrust_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.io/zot/pkg/extensions/imagetrust"
+)
+
+func TestImageTrust(t *testing.T) {
+	Convey("binary doesn't include imagetrust", t, func() {
+		rootDir := t.TempDir()
+
+		err := imagetrust.InitCosignDir(rootDir)
+		So(err, ShouldBeNil)
+
+		cosignDir := path.Join(rootDir, "_cosign")
+		_, err = os.Stat(cosignDir)
+		So(os.IsNotExist(err), ShouldBeTrue)
+
+		err = imagetrust.InitNotationDir(rootDir)
+		So(err, ShouldBeNil)
+
+		notationDir := path.Join(rootDir, "_notation")
+		_, err = os.Stat(notationDir)
+		So(os.IsNotExist(err), ShouldBeTrue)
+
+		err = imagetrust.InitCosignAndNotationDirs(rootDir)
+		So(err, ShouldBeNil)
+
+		_, err = os.Stat(cosignDir)
+		So(os.IsNotExist(err), ShouldBeTrue)
+		_, err = os.Stat(notationDir)
+		So(os.IsNotExist(err), ShouldBeTrue)
+
+		author, expTime, ok, err := imagetrust.VerifySignature("", []byte{}, "", "", []byte{}, "")
+		So(author, ShouldBeEmpty)
+		So(expTime, ShouldBeZeroValue)
+		So(ok, ShouldBeFalse)
+		So(err, ShouldBeNil)
+	})
+}

--- a/pkg/extensions/imagetrust/notation.go
+++ b/pkg/extensions/imagetrust/notation.go
@@ -1,4 +1,7 @@
-package signatures
+//go:build imagetrust
+// +build imagetrust
+
+package imagetrust
 
 import (
 	"context"

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -39,11 +39,11 @@ import (
 	"zotregistry.io/zot/pkg/api/config"
 	"zotregistry.io/zot/pkg/api/constants"
 	"zotregistry.io/zot/pkg/cli"
+	zcommon "zotregistry.io/zot/pkg/common"
 	extconf "zotregistry.io/zot/pkg/extensions/config"
 	syncconf "zotregistry.io/zot/pkg/extensions/config/sync"
 	"zotregistry.io/zot/pkg/extensions/sync"
 	"zotregistry.io/zot/pkg/log"
-	"zotregistry.io/zot/pkg/meta/signatures"
 	mTypes "zotregistry.io/zot/pkg/meta/types"
 	storageConstants "zotregistry.io/zot/pkg/storage/constants"
 	"zotregistry.io/zot/pkg/test"
@@ -872,7 +872,7 @@ func TestOnDemand(t *testing.T) {
 				AddManifestSignatureFn: func(repo string, signedManifestDigest godigest.Digest,
 					sm mTypes.SignatureMetadata,
 				) error {
-					if sm.SignatureType == signatures.CosignSignature || sm.SignatureType == signatures.NotationSignature {
+					if sm.SignatureType == zcommon.CosignSignature || sm.SignatureType == zcommon.NotationSignature {
 						return sync.ErrTestError
 					}
 
@@ -4511,10 +4511,10 @@ func TestSyncedSignaturesMetaDB(t *testing.T) {
 		So(repoMeta.Signatures, ShouldContainKey, signedImage.DigestStr())
 
 		imageSignatures := repoMeta.Signatures[signedImage.DigestStr()]
-		So(imageSignatures, ShouldContainKey, signatures.CosignSignature)
-		So(len(imageSignatures[signatures.CosignSignature]), ShouldEqual, 1)
-		So(imageSignatures, ShouldContainKey, signatures.NotationSignature)
-		So(len(imageSignatures[signatures.NotationSignature]), ShouldEqual, 1)
+		So(imageSignatures, ShouldContainKey, zcommon.CosignSignature)
+		So(len(imageSignatures[zcommon.CosignSignature]), ShouldEqual, 1)
+		So(imageSignatures, ShouldContainKey, zcommon.NotationSignature)
+		So(len(imageSignatures[zcommon.NotationSignature]), ShouldEqual, 1)
 	})
 }
 

--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -14,9 +14,9 @@ import (
 
 	zerr "zotregistry.io/zot/errors"
 	zcommon "zotregistry.io/zot/pkg/common"
+	"zotregistry.io/zot/pkg/extensions/imagetrust"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/meta/common"
-	"zotregistry.io/zot/pkg/meta/signatures"
 	mTypes "zotregistry.io/zot/pkg/meta/types"
 	"zotregistry.io/zot/pkg/meta/version"
 	localCtx "zotregistry.io/zot/pkg/requestcontext"
@@ -778,7 +778,7 @@ func (bdw *BoltDB) UpdateSignaturesValidity(repo string, manifestDigest godigest
 				layersInfo := []mTypes.LayerInfo{}
 
 				for _, layerInfo := range sigInfo.LayersInfo {
-					author, date, isTrusted, _ := signatures.VerifySignature(sigType, layerInfo.LayerContent, layerInfo.SignatureKey,
+					author, date, isTrusted, _ := imagetrust.VerifySignature(sigType, layerInfo.LayerContent, layerInfo.SignatureKey,
 						manifestDigest, blob, repo)
 
 					if isTrusted {
@@ -869,12 +869,12 @@ func (bdw *BoltDB) AddManifestSignature(repo string, signedManifestDigest godige
 
 		signatureSlice := manifestSignatures[sygMeta.SignatureType]
 		if !common.SignatureAlreadyExists(signatureSlice, sygMeta) {
-			if sygMeta.SignatureType == signatures.NotationSignature {
+			if sygMeta.SignatureType == zcommon.NotationSignature {
 				signatureSlice = append(signatureSlice, mTypes.SignatureInfo{
 					SignatureManifestDigest: sygMeta.SignatureDigest,
 					LayersInfo:              sygMeta.LayersInfo,
 				})
-			} else if sygMeta.SignatureType == signatures.CosignSignature {
+			} else if sygMeta.SignatureType == zcommon.CosignSignature {
 				signatureSlice = []mTypes.SignatureInfo{{
 					SignatureManifestDigest: sygMeta.SignatureDigest,
 					LayersInfo:              sygMeta.LayersInfo,

--- a/pkg/meta/boltdb/boltdb_test.go
+++ b/pkg/meta/boltdb/boltdb_test.go
@@ -14,9 +14,9 @@ import (
 	"go.etcd.io/bbolt"
 
 	zerr "zotregistry.io/zot/errors"
+	zcommon "zotregistry.io/zot/pkg/common"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/meta/boltdb"
-	"zotregistry.io/zot/pkg/meta/signatures"
 	mTypes "zotregistry.io/zot/pkg/meta/types"
 	localCtx "zotregistry.io/zot/pkg/requestcontext"
 	"zotregistry.io/zot/pkg/test"
@@ -545,9 +545,9 @@ func TestWrapperErrors(t *testing.T) {
 
 			repoData, err := boltdbWrapper.GetRepoMeta("repo1")
 			So(err, ShouldBeNil)
-			So(len(repoData.Signatures[string(digest.FromString("dig"))][signatures.CosignSignature]),
+			So(len(repoData.Signatures[string(digest.FromString("dig"))][zcommon.CosignSignature]),
 				ShouldEqual, 1)
-			So(repoData.Signatures[string(digest.FromString("dig"))][signatures.CosignSignature][0].SignatureManifestDigest,
+			So(repoData.Signatures[string(digest.FromString("dig"))][zcommon.CosignSignature][0].SignatureManifestDigest,
 				ShouldEqual, "digest2")
 
 			err = boltdbWrapper.AddManifestSignature("repo1", digest.FromString("dig"),

--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -17,9 +17,9 @@ import (
 
 	zerr "zotregistry.io/zot/errors"
 	zcommon "zotregistry.io/zot/pkg/common"
+	"zotregistry.io/zot/pkg/extensions/imagetrust"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/meta/common"
-	"zotregistry.io/zot/pkg/meta/signatures"
 	mTypes "zotregistry.io/zot/pkg/meta/types"
 	"zotregistry.io/zot/pkg/meta/version"
 	localCtx "zotregistry.io/zot/pkg/requestcontext"
@@ -658,7 +658,7 @@ func (dwr *DynamoDB) UpdateSignaturesValidity(repo string, manifestDigest godige
 			layersInfo := []mTypes.LayerInfo{}
 
 			for _, layerInfo := range sigInfo.LayersInfo {
-				author, date, isTrusted, _ := signatures.VerifySignature(sigType, layerInfo.LayerContent, layerInfo.SignatureKey,
+				author, date, isTrusted, _ := imagetrust.VerifySignature(sigType, layerInfo.LayerContent, layerInfo.SignatureKey,
 					manifestDigest, blob, repo)
 
 				if isTrusted {
@@ -727,12 +727,12 @@ func (dwr *DynamoDB) AddManifestSignature(repo string, signedManifestDigest godi
 
 	signatureSlice := manifestSignatures[sygMeta.SignatureType]
 	if !common.SignatureAlreadyExists(signatureSlice, sygMeta) {
-		if sygMeta.SignatureType == signatures.NotationSignature {
+		if sygMeta.SignatureType == zcommon.NotationSignature {
 			signatureSlice = append(signatureSlice, mTypes.SignatureInfo{
 				SignatureManifestDigest: sygMeta.SignatureDigest,
 				LayersInfo:              sygMeta.LayersInfo,
 			})
-		} else if sygMeta.SignatureType == signatures.CosignSignature {
+		} else if sygMeta.SignatureType == zcommon.CosignSignature {
 			signatureSlice = []mTypes.SignatureInfo{{
 				SignatureManifestDigest: sygMeta.SignatureDigest,
 				LayersInfo:              sygMeta.LayersInfo,

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -6,10 +6,10 @@ import (
 
 	"zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/api/config"
+	"zotregistry.io/zot/pkg/extensions/imagetrust"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/meta/boltdb"
 	mdynamodb "zotregistry.io/zot/pkg/meta/dynamodb"
-	"zotregistry.io/zot/pkg/meta/signatures"
 	mTypes "zotregistry.io/zot/pkg/meta/types"
 )
 
@@ -33,7 +33,7 @@ func New(storageConfig config.StorageConfig, log log.Logger) (mTypes.MetaDB, err
 		return nil, err
 	}
 
-	err = signatures.InitCosignAndNotationDirs(params.RootDir)
+	err = imagetrust.InitCosignAndNotationDirs(params.RootDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1,3 +1,6 @@
+//go:build imagetrust
+// +build imagetrust
+
 package meta_test
 
 import (
@@ -20,12 +23,12 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	"zotregistry.io/zot/pkg/api/config"
+	"zotregistry.io/zot/pkg/extensions/imagetrust"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/meta"
 	"zotregistry.io/zot/pkg/meta/boltdb"
 	"zotregistry.io/zot/pkg/meta/common"
 	mdynamodb "zotregistry.io/zot/pkg/meta/dynamodb"
-	"zotregistry.io/zot/pkg/meta/signatures"
 	mTypes "zotregistry.io/zot/pkg/meta/types"
 	localCtx "zotregistry.io/zot/pkg/requestcontext"
 	"zotregistry.io/zot/pkg/test"
@@ -1208,7 +1211,7 @@ func RunMetaDBTests(t *testing.T, metaDB mTypes.MetaDB, preparationFuncs ...func
 				})
 				So(err, ShouldBeNil)
 
-				err = signatures.InitNotationDir(tdir)
+				err = imagetrust.InitNotationDir(tdir)
 				So(err, ShouldBeNil)
 
 				trustpolicyPath := path.Join(tdir, "_notation/trustpolicy.json")

--- a/pkg/meta/parse.go
+++ b/pkg/meta/parse.go
@@ -11,7 +11,6 @@ import (
 	zerr "zotregistry.io/zot/errors"
 	zcommon "zotregistry.io/zot/pkg/common"
 	"zotregistry.io/zot/pkg/log"
-	"zotregistry.io/zot/pkg/meta/signatures"
 	mTypes "zotregistry.io/zot/pkg/meta/types"
 	"zotregistry.io/zot/pkg/storage"
 	storageTypes "zotregistry.io/zot/pkg/storage/types"
@@ -225,9 +224,9 @@ func GetSignatureLayersInfo(repo, tag, manifestDigest, signatureType string, man
 	imageStore storageTypes.ImageStore, log log.Logger,
 ) ([]mTypes.LayerInfo, error) {
 	switch signatureType {
-	case signatures.CosignSignature:
+	case zcommon.CosignSignature:
 		return getCosignSignatureLayersInfo(repo, tag, manifestDigest, manifestBlob, imageStore, log)
-	case signatures.NotationSignature:
+	case zcommon.NotationSignature:
 		return getNotationSignatureLayersInfo(repo, manifestDigest, manifestBlob, imageStore, log)
 	default:
 		return []mTypes.LayerInfo{}, nil
@@ -256,7 +255,7 @@ func getCosignSignatureLayersInfo(
 			return layers, err
 		}
 
-		layerSigKey, ok := layer.Annotations[signatures.CosignSigKey]
+		layerSigKey, ok := layer.Annotations[zcommon.CosignSigKey]
 		if !ok {
 			log.Error().Err(err).Str("repository", repo).Str("reference", tag).Str("layerDigest", layer.Digest.String()).Msg(
 				"load-repo: unable to get specific annotation of cosign signature")

--- a/pkg/meta/parse_test.go
+++ b/pkg/meta/parse_test.go
@@ -14,12 +14,12 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	zerr "zotregistry.io/zot/errors"
+	zcommon "zotregistry.io/zot/pkg/common"
 	"zotregistry.io/zot/pkg/extensions/monitoring"
 	"zotregistry.io/zot/pkg/log"
 	"zotregistry.io/zot/pkg/meta"
 	"zotregistry.io/zot/pkg/meta/boltdb"
 	"zotregistry.io/zot/pkg/meta/dynamodb"
-	"zotregistry.io/zot/pkg/meta/signatures"
 	mTypes "zotregistry.io/zot/pkg/meta/types"
 	"zotregistry.io/zot/pkg/storage"
 	"zotregistry.io/zot/pkg/storage/local"
@@ -611,11 +611,11 @@ func TestGetSignatureLayersInfo(t *testing.T) {
 	})
 
 	Convey("error while unmarshaling manifest content", t, func() {
-		_, err := meta.GetSignatureLayersInfo("repo", "tag", "123", signatures.CosignSignature, []byte("bad manifest"),
+		_, err := meta.GetSignatureLayersInfo("repo", "tag", "123", zcommon.CosignSignature, []byte("bad manifest"),
 			nil, log.NewLogger("debug", ""))
 		So(err, ShouldNotBeNil)
 
-		_, err = meta.GetSignatureLayersInfo("repo", "tag", "123", signatures.NotationSignature, []byte("bad manifest"),
+		_, err = meta.GetSignatureLayersInfo("repo", "tag", "123", zcommon.NotationSignature, []byte("bad manifest"),
 			nil, log.NewLogger("debug", ""))
 		So(err, ShouldNotBeNil)
 	})

--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -17,7 +17,6 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	oras "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"github.com/rs/zerolog"
-	"github.com/sigstore/cosign/v2/pkg/oci/remote"
 
 	zerr "zotregistry.io/zot/errors"
 	zcommon "zotregistry.io/zot/pkg/common"
@@ -26,7 +25,11 @@ import (
 	storageTypes "zotregistry.io/zot/pkg/storage/types"
 )
 
-const manifestWithEmptyLayersErrMsg = "layers: Array must have at least 1 items"
+const (
+	manifestWithEmptyLayersErrMsg = "layers: Array must have at least 1 items"
+
+	cosignSignatureTagSuffix = "sig"
+)
 
 func GetTagsByIndex(index ispec.Index) []string {
 	tags := make([]string, 0)
@@ -559,7 +562,7 @@ func IsSignature(descriptor ispec.Descriptor) bool {
 	switch descriptor.MediaType {
 	case ispec.MediaTypeImageManifest:
 		// is cosgin signature
-		if strings.HasPrefix(tag, "sha256-") && strings.HasSuffix(tag, remote.SignatureTagSuffix) {
+		if strings.HasPrefix(tag, "sha256-") && strings.HasSuffix(tag, cosignSignatureTagSuffix) {
 			return true
 		}
 

--- a/pkg/storage/local/local.go
+++ b/pkg/storage/local/local.go
@@ -26,7 +26,6 @@ import (
 	"github.com/opencontainers/umoci/oci/casext"
 	oras "github.com/oras-project/artifacts-spec/specs-go/v1"
 	"github.com/rs/zerolog"
-	"github.com/sigstore/cosign/v2/pkg/oci/remote"
 
 	zerr "zotregistry.io/zot/errors"
 	zcommon "zotregistry.io/zot/pkg/common"
@@ -39,6 +38,11 @@ import (
 	storageConstants "zotregistry.io/zot/pkg/storage/constants"
 	storageTypes "zotregistry.io/zot/pkg/storage/types"
 	"zotregistry.io/zot/pkg/test/inject"
+)
+
+const (
+	cosignSignatureTagSuffix = "sig"
+	SBOMTagSuffix            = "sbom"
 )
 
 // ImageStoreLocal provides the image storage operations.
@@ -1547,8 +1551,8 @@ func (is *ImageStoreLocal) garbageCollect(dir string, repo string) error {
 			tag, ok := desc.Annotations[ispec.AnnotationRefName]
 			if ok {
 				// gather cosign references
-				if strings.HasPrefix(tag, "sha256-") && (strings.HasSuffix(tag, remote.SignatureTagSuffix) ||
-					strings.HasSuffix(tag, remote.SBOMTagSuffix)) {
+				if strings.HasPrefix(tag, "sha256-") && (strings.HasSuffix(tag, cosignSignatureTagSuffix) ||
+					strings.HasSuffix(tag, SBOMTagSuffix)) {
 					cosignDescriptors = append(cosignDescriptors, desc)
 
 					continue
@@ -1680,13 +1684,13 @@ func gcCosignReferences(imgStore *ImageStoreLocal, oci casext.Engine, index *isp
 		// check if we can find the manifest which the reference points to
 		for _, desc := range index.Manifests {
 			// signature
-			subject := fmt.Sprintf("sha256-%s.%s", desc.Digest.Encoded(), remote.SignatureTagSuffix)
+			subject := fmt.Sprintf("sha256-%s.%s", desc.Digest.Encoded(), cosignSignatureTagSuffix)
 			if subject == cosignDesc.Annotations[ispec.AnnotationRefName] {
 				foundSubject = true
 			}
 
 			// sbom
-			subject = fmt.Sprintf("sha256-%s.%s", desc.Digest.Encoded(), remote.SBOMTagSuffix)
+			subject = fmt.Sprintf("sha256-%s.%s", desc.Digest.Encoded(), SBOMTagSuffix)
 			if subject == cosignDesc.Annotations[ispec.AnnotationRefName] {
 				foundSubject = true
 			}


### PR DESCRIPTION
- the size of the binary-minimal becomes 32MB
- "signatures" package is renamed into "imagetrust" and moved under extensions
- if the binary is not built using "imagetrust" tag then the signatures verification will not be performed

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
