### PR TITLE
feat(mgmt): mgmt extention no longer depends on UI being enabled

### DIFF
--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -326,7 +326,7 @@ func (c *Config) AreUserPrefsEnabled() bool {
 }
 
 func (c *Config) IsMgmtEnabled() bool {
-	return c.IsSearchEnabled() && c.IsUIEnabled()
+	return c.IsSearchEnabled()
 }
 
 func (c *Config) IsImageTrustEnabled() bool {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -8538,17 +8538,17 @@ func TestDistSpecExtensions(t *testing.T) {
 		So(err, ShouldBeNil)
 		t.Log(extensionList.Extensions)
 		So(len(extensionList.Extensions), ShouldEqual, 1)
-		So(len(extensionList.Extensions[0].Endpoints), ShouldEqual, 1)
+		So(len(extensionList.Extensions[0].Endpoints), ShouldEqual, 2)
 		So(extensionList.Extensions[0].Name, ShouldEqual, "_zot")
 		So(extensionList.Extensions[0].URL, ShouldContainSubstring, "_zot.md")
 		So(extensionList.Extensions[0].Description, ShouldNotBeEmpty)
 		// Verify the endpoints below are enabled by search
 		So(extensionList.Extensions[0].Endpoints, ShouldContain, constants.FullSearchPrefix)
+		So(extensionList.Extensions[0].Endpoints, ShouldContain, constants.FullMgmt)
 		// Verify the endpoints below are not enabled since trust is not enabled
 		So(extensionList.Extensions[0].Endpoints, ShouldNotContain, constants.FullCosign)
 		So(extensionList.Extensions[0].Endpoints, ShouldNotContain, constants.FullNotation)
 		// Verify the endpoints below are not enabled since the UI is not enabled
-		So(extensionList.Extensions[0].Endpoints, ShouldNotContain, constants.FullMgmt)
 		So(extensionList.Extensions[0].Endpoints, ShouldNotContain, constants.FullUserPrefs)
 	})
 

--- a/pkg/cli/extensions_test.go
+++ b/pkg/cli/extensions_test.go
@@ -813,9 +813,6 @@ func TestServeMgmtExtension(t *testing.T) {
 						"output": "%s"
 					},
 					"extensions": {
-						"ui": {
-							"enable": true
-						},
 						"search": {
 							"enable": true
 						}
@@ -837,7 +834,7 @@ func TestServeMgmtExtension(t *testing.T) {
 		So(found, ShouldBeTrue)
 	})
 
-	Convey("Mgmt disabled - UI unconfigured", t, func(c C) {
+	Convey("Mgmt disabled - search unconfigured", t, func(c C) {
 		content := `{
 					"storage": {
 						"rootDirectory": "%s"
@@ -852,7 +849,7 @@ func TestServeMgmtExtension(t *testing.T) {
 					},
 					"extensions": {
 						"search": {
-							"enable": true
+							"enable": false
 						}
 					}
 				}`


### PR DESCRIPTION
It is now enabled based only on search configuration

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
