### PR TITLE
fix(sync): ping func should not try to read response body

### DIFF
--- a/examples/config-popular-registries.json
+++ b/examples/config-popular-registries.json
@@ -17,7 +17,7 @@
         "registries": [
         {
           "urls": [
-            "https://docker.io/library"
+            "https://index.docker.io"
           ],
           "content": [
           {

--- a/examples/config-sync.json
+++ b/examples/config-sync.json
@@ -63,7 +63,7 @@
 				},
 				{
 					"urls": [
-						"https://docker.io/library"
+						"https://index.docker.io"
 					],
 					"onDemand": true,
 					"tlsVerify": true,

--- a/pkg/common/http_client.go
+++ b/pkg/common/http_client.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -138,6 +137,8 @@ func MakeHTTPGetRequest(ctx context.Context, httpClient *http.Client,
 		return nil, "", -1, err
 	}
 
+	defer resp.Body.Close()
+
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Error().Str("errorType", TypeOf(err)).
@@ -146,12 +147,7 @@ func MakeHTTPGetRequest(ctx context.Context, httpClient *http.Client,
 		return nil, "", resp.StatusCode, err
 	}
 
-	defer resp.Body.Close()
-
 	if resp.StatusCode != http.StatusOK {
-		log.Error().Str("status code", fmt.Sprint(resp.StatusCode)).
-			Err(err).Str("blobURL", blobURL).Msg("couldn't get blob")
-
 		return nil, "", resp.StatusCode, errors.New(string(body)) //nolint:goerr113
 	}
 
@@ -159,9 +155,6 @@ func MakeHTTPGetRequest(ctx context.Context, httpClient *http.Client,
 	if len(body) > 0 {
 		err = json.Unmarshal(body, &resultPtr)
 		if err != nil {
-			log.Error().Str("errorType", TypeOf(err)).Str("blobURL", blobURL).
-				Err(err).Msg("couldn't unmarshal remote blob")
-
 			return body, "", resp.StatusCode, err
 		}
 	}

--- a/pkg/extensions/sync/references/cosign.go
+++ b/pkg/extensions/sync/references/cosign.go
@@ -198,10 +198,6 @@ func (ref CosignReference) getManifest(ctx context.Context, repo, cosignTag stri
 			return nil, nil, zerr.ErrSyncReferrerNotFound
 		}
 
-		ref.log.Error().Str("errorType", common.TypeOf(err)).
-			Str("repository", repo).Str("tag", cosignTag).Int("statusCode", statusCode).
-			Err(err).Msg("couldn't get cosign manifest for image")
-
 		return nil, nil, err
 	}
 

--- a/pkg/extensions/sync/references/oci.go
+++ b/pkg/extensions/sync/references/oci.go
@@ -184,10 +184,6 @@ func (ref OciReferences) getIndex(ctx context.Context, repo, subjectDigestStr st
 			return index, zerr.ErrSyncReferrerNotFound
 		}
 
-		ref.log.Error().Str("errorType", common.TypeOf(err)).
-			Err(err).Str("repository", repo).Str("subject", subjectDigestStr).Int("statusCode", statusCode).
-			Msg("couldn't get oci reference for image")
-
 		return index, err
 	}
 

--- a/pkg/extensions/sync/references/oras.go
+++ b/pkg/extensions/sync/references/oras.go
@@ -186,9 +186,6 @@ func (ref ORASReferences) getReferenceList(ctx context.Context, repo, subjectDig
 			return referrers, zerr.ErrSyncReferrerNotFound
 		}
 
-		ref.log.Error().Err(err).Str("repository", repo).Str("subject", subjectDigestStr).
-			Msg("couldn't get ORAS artifacts for image")
-
 		return referrers, err
 	}
 

--- a/pkg/extensions/sync/references/references.go
+++ b/pkg/extensions/sync/references/references.go
@@ -79,7 +79,7 @@ func (refs References) syncAll(ctx context.Context, localRepo, upstreamRepo,
 	for _, ref := range refs.referenceList {
 		syncedRefsDigests, err = ref.SyncReferences(ctx, localRepo, upstreamRepo, subjectDigestStr)
 		if err != nil {
-			refs.log.Debug().Err(err).
+			refs.log.Error().Err(err).
 				Str("reference type", ref.Name()).
 				Str("image", fmt.Sprintf("%s:%s", upstreamRepo, subjectDigestStr)).
 				Msg("couldn't sync image referrer")

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -95,7 +95,7 @@ func New(opts syncconf.RegistryConfig, credentialsFilepath string,
 }
 
 func (service *BaseService) SetNextAvailableClient() error {
-	if service.client != nil && service.client.IsAvailable() {
+	if service.client != nil && service.client.Ping() {
 		return nil
 	}
 
@@ -125,10 +125,12 @@ func (service *BaseService) SetNextAvailableClient() error {
 		}
 
 		if err != nil {
+			service.log.Error().Err(err).Str("url", url).Msg("sync: failed to initialize http client")
+
 			continue
 		}
 
-		if !service.client.IsAvailable() {
+		if !service.client.Ping() {
 			continue
 		}
 	}
@@ -252,9 +254,6 @@ func (service *BaseService) SyncImage(ctx context.Context, repo, reference strin
 
 	err = service.references.SyncAll(ctx, repo, remoteRepo, manifestDigest.String())
 	if err != nil && !errors.Is(err, zerr.ErrSyncReferrerNotFound) {
-		service.log.Error().Err(err).Str("remote", remoteURL).Str("repo", repo).Str("reference", reference).
-			Msg("error while syncing references for image")
-
 		return err
 	}
 

--- a/test/blackbox/sync_docker.bats
+++ b/test/blackbox/sync_docker.bats
@@ -54,7 +54,7 @@ function setup_file() {
             "registries": [
                 {
                     "urls": [
-                        "https://docker.io/library"
+                        "https://index.docker.io"
                     ],
                     "content": [
                         {
@@ -330,7 +330,7 @@ function teardown_file() {
     [ $(echo "${lines[-1]}" | jq '.tags[]') = '"v2.0.0-rc5"' ]
 }
 
-@test "run docker with image synced from docker.io/library" {
+@test "run docker with image synced from docker.io" {
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     run rm -rf ${zot_root_dir}
     [ "$status" -eq 0 ]


### PR DESCRIPTION
closes: #1703

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
Sync spams with json parsing errors in log messages, everytime it tries to ping docker, because it read the response body.

**What does this PR do / Why do we need it**:
improve ping func()

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
