### PR TITLE
fix: DATA RACE in TestNewExporter

### DIFF
--- a/pkg/extensions/monitoring/common.go
+++ b/pkg/extensions/monitoring/common.go
@@ -3,7 +3,10 @@ package monitoring
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 )
+
+var re = regexp.MustCompile(`\/v2\/(.*?)\/(blobs|tags|manifests)\/(.*)$`)
 
 type MetricServer interface {
 	SendMetric(interface{})

--- a/pkg/extensions/monitoring/extension.go
+++ b/pkg/extensions/monitoring/extension.go
@@ -5,7 +5,6 @@ package monitoring
 
 import (
 	"path"
-	"regexp"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -147,7 +146,6 @@ func IncHTTPConnRequests(ms MetricServer, lvalues ...string) {
 
 func ObserveHTTPRepoLatency(ms MetricServer, path string, latency time.Duration) {
 	ms.SendMetric(func() {
-		re := regexp.MustCompile(`\/v2\/(.*?)\/(blobs|tags|manifests)\/(.*)$`)
 		match := re.FindStringSubmatch(path)
 
 		if len(match) > 1 {


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
[DATA RACE in TestNewExporter](https://pipelines.actions.githubusercontent.com/serviceHosts/40249189-1287-49ef-b1f7-d89623a7edfc/_apis/pipelines/1/runs/96903/signedlogcontent/3?urlExpires=2023-09-06T09%3A32%3A21.2171590Z&urlSigningMethod=HMACV1&urlSignature=x%2Bn1ChpphggaDdVOdBaMjqdjB8MRVHBBCFkvp1%2BpqO0%3D)

**What does this PR do / Why do we need it**:
enabling/disabling logic of metrics server for zot minimal (with zot exporter) moved to metrics server processing logic (inside Run() that uses channelized 1-request at a time logic- so no DATA RACE is expected...)


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:


**Automation added to e2e**:


**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
