### PR TITLE
ci(dco-check): exclude dependabot emails from dco-check

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -21,4 +21,4 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         pip3 install -U dco-check
-        dco-check
+        dco-check --exclude-pattern "dependabot\[bot\]@users\.noreply\.github.com"


### PR DESCRIPTION
This is the official solution from the dco-check maintainers for dependabot failures

See:
https://github.com/christophebedard/dco-check/issues/123
https://github.com/christophebedard/dco-check/pull/126

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
