### PR TITLE
chore(dependabot): increase the limit of dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,11 @@ version: 2
 updates:
   - package-ecosystem: "gomod" # See documentation for possible values
     directory: "/" # Location of package manifests
+    open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
+    open-pull-requests-limit: 10
     schedule:
       interval: "weekly"


### PR DESCRIPTION
Given the default limit is 5 and some packages like AWS release daily, having a weekly schedule results in the same packages being flagged for update most of the time.

Let's increase to 10 to make sure there are no issues in other libraries

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
