### PR TITLE
fix(cve): cumulative fixes and improvements for CVE scanning logic

### DIFF
--- a/pkg/cli/client/cve_cmd_internal_test.go
+++ b/pkg/cli/client/cve_cmd_internal_test.go
@@ -59,7 +59,7 @@ func TestSearchCVECmd(t *testing.T) {
 	ctlr := api.NewController(conf)
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartServer()
+	cm.StartAndWait(port)
 	defer cm.StopServer()
 
 	Convey("Test CVE help", t, func() {
@@ -947,21 +947,10 @@ func TestCVESort(t *testing.T) {
 		panic(err)
 	}
 
-	severities := map[string]int{
-		"UNKNOWN":  0,
-		"LOW":      1,
-		"MEDIUM":   2,
-		"HIGH":     3,
-		"CRITICAL": 4,
-	}
-
 	ctlr.CveInfo = cveinfo.BaseCveInfo{
 		Log:    ctlr.Log,
 		MetaDB: mocks.MetaDBMock{},
 		Scanner: mocks.CveScannerMock{
-			CompareSeveritiesFn: func(severity1, severity2 string) int {
-				return severities[severity2] - severities[severity1]
-			},
 			ScanImageFn: func(image string) (map[string]cvemodel.CVE, error) {
 				return map[string]cvemodel.CVE{
 					"CVE-2023-1255": {
@@ -1385,15 +1374,7 @@ func TestCVECommandErrors(t *testing.T) {
 }
 
 func getMockCveInfo(metaDB mTypes.MetaDB, log log.Logger) cveinfo.CveInfo {
-	// MetaDB loaded with initial data, mock the scanner
-	severities := map[string]int{
-		"UNKNOWN":  0,
-		"LOW":      1,
-		"MEDIUM":   2,
-		"HIGH":     3,
-		"CRITICAL": 4,
-	}
-
+	// MetaDB loaded with initial data now mock the scanner
 	// Setup test CVE data in mock scanner
 	scanner := mocks.CveScannerMock{
 		ScanImageFn: func(image string) (map[string]cvemodel.CVE, error) {
@@ -1435,9 +1416,6 @@ func getMockCveInfo(metaDB mTypes.MetaDB, log log.Logger) cveinfo.CveInfo {
 
 			// By default the image has no vulnerabilities
 			return map[string]cvemodel.CVE{}, nil
-		},
-		CompareSeveritiesFn: func(severity1, severity2 string) int {
-			return severities[severity2] - severities[severity1]
 		},
 		IsImageFormatScannableFn: func(repo string, reference string) (bool, error) {
 			// Almost same logic compared to actual Trivy specific implementation

--- a/pkg/extensions/extension_search_test.go
+++ b/pkg/extensions/extension_search_test.go
@@ -70,7 +70,7 @@ func TestTrivyDBGenerator(t *testing.T) {
 
 		// Wait for trivy db to download
 		found, err := ReadLogFileAndCountStringOccurence(logPath,
-			"DB update completed, next update scheduled", 120*time.Second, 2)
+			"DB update completed, next update scheduled", 140*time.Second, 2)
 		So(err, ShouldBeNil)
 		So(found, ShouldBeTrue)
 	})

--- a/pkg/extensions/search/convert/annotations.go
+++ b/pkg/extensions/search/convert/annotations.go
@@ -134,9 +134,10 @@ func GetAnnotations(annotations, labels map[string]string) ImageAnnotations {
 	}
 }
 
-func GetIndexAnnotations(indexAnnotations, manifestAnnotations, manifestLabels map[string]string) ImageAnnotations {
-	annotationsFromManifest := GetAnnotations(manifestAnnotations, manifestLabels)
-
+func GetIndexAnnotations(
+	indexAnnotations map[string]string,
+	annotationsFromManifest *ImageAnnotations,
+) ImageAnnotations {
 	description := GetDescription(indexAnnotations)
 	if description == "" {
 		description = annotationsFromManifest.Description

--- a/pkg/extensions/search/convert/convert_internal_test.go
+++ b/pkg/extensions/search/convert/convert_internal_test.go
@@ -1,0 +1,302 @@
+//go:build search
+
+package convert
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/99designs/gqlgen/graphql"
+	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	. "github.com/smartystreets/goconvey/convey"
+
+	cvemodel "zotregistry.io/zot/pkg/extensions/search/cve/model"
+	"zotregistry.io/zot/pkg/extensions/search/gql_generated"
+	"zotregistry.io/zot/pkg/log"
+	"zotregistry.io/zot/pkg/meta/boltdb"
+	mTypes "zotregistry.io/zot/pkg/meta/types"
+	"zotregistry.io/zot/pkg/test/mocks"
+)
+
+var ErrTestError = errors.New("TestError")
+
+func TestCVEConvert(t *testing.T) {
+	Convey("Test adding CVE information to Summary objects", t, func() {
+		params := boltdb.DBParameters{
+			RootDir: t.TempDir(),
+		}
+		boltDB, err := boltdb.GetBoltDriver(params)
+		So(err, ShouldBeNil)
+
+		metaDB, err := boltdb.New(boltDB, log.NewLogger("debug", ""))
+		So(err, ShouldBeNil)
+
+		configBlob, err := json.Marshal(ispec.Image{})
+		So(err, ShouldBeNil)
+
+		manifestBlob, err := json.Marshal(ispec.Manifest{
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: ispec.MediaTypeImageLayerGzip,
+					Size:      0,
+					Digest:    godigest.NewDigestFromEncoded(godigest.SHA256, "digest"),
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+
+		repoMeta11 := mTypes.ManifestMetadata{
+			ManifestBlob: manifestBlob,
+			ConfigBlob:   configBlob,
+		}
+
+		digest11 := godigest.FromString("abc1")
+		err = metaDB.SetManifestMeta("repo1", digest11, repoMeta11)
+		So(err, ShouldBeNil)
+		err = metaDB.SetRepoReference("repo1", "0.1.0", digest11, ispec.MediaTypeImageManifest)
+		So(err, ShouldBeNil)
+
+		reposMeta, manifestMetaMap, _, err := metaDB.SearchRepos(context.Background(), "")
+		So(err, ShouldBeNil)
+
+		ctx := graphql.WithResponseContext(context.Background(),
+			graphql.DefaultErrorPresenter, graphql.DefaultRecover)
+
+		Convey("Add CVE Summary to ImageSummary", func() {
+			var imageSummary *gql_generated.ImageSummary
+
+			So(imageSummary, ShouldBeNil)
+
+			updateImageSummaryVulnerabilities(ctx,
+				imageSummary,
+				SkipQGLField{
+					Vulnerabilities: false,
+				},
+				mocks.CveInfoMock{
+					GetCVESummaryForImageMediaFn: func(repo string, digest, mediaType string,
+					) (cvemodel.ImageCVESummary, error) {
+						return cvemodel.ImageCVESummary{}, ErrTestError
+					},
+				},
+			)
+
+			So(imageSummary, ShouldBeNil)
+			So(graphql.GetErrors(ctx), ShouldBeNil)
+
+			imageSummary, _, err = ImageManifest2ImageSummary(ctx, "repo1", "0.1.0", digest11, reposMeta[0],
+				manifestMetaMap[digest11.String()])
+			So(err, ShouldBeNil)
+
+			So(imageSummary, ShouldNotBeNil)
+			So(imageSummary.Vulnerabilities, ShouldBeNil)
+
+			updateImageSummaryVulnerabilities(ctx,
+				imageSummary,
+				SkipQGLField{
+					Vulnerabilities: true,
+				},
+				mocks.CveInfoMock{},
+			)
+
+			So(imageSummary.Vulnerabilities, ShouldNotBeNil)
+			So(*imageSummary.Vulnerabilities.Count, ShouldEqual, 0)
+			So(*imageSummary.Vulnerabilities.MaxSeverity, ShouldEqual, "")
+			So(graphql.GetErrors(ctx), ShouldBeNil)
+
+			imageSummary.Vulnerabilities = nil
+
+			updateImageSummaryVulnerabilities(ctx,
+				imageSummary,
+				SkipQGLField{
+					Vulnerabilities: false,
+				},
+				mocks.CveInfoMock{
+					GetCVESummaryForImageMediaFn: func(repo string, digest, mediaType string,
+					) (cvemodel.ImageCVESummary, error) {
+						return cvemodel.ImageCVESummary{
+							Count:       1,
+							MaxSeverity: "HIGH",
+						}, nil
+					},
+				},
+			)
+
+			So(imageSummary.Vulnerabilities, ShouldNotBeNil)
+			So(*imageSummary.Vulnerabilities.Count, ShouldEqual, 1)
+			So(*imageSummary.Vulnerabilities.MaxSeverity, ShouldEqual, "HIGH")
+			So(graphql.GetErrors(ctx), ShouldBeNil)
+			So(len(imageSummary.Manifests), ShouldEqual, 1)
+			So(imageSummary.Manifests[0].Vulnerabilities, ShouldNotBeNil)
+			So(*imageSummary.Manifests[0].Vulnerabilities.Count, ShouldEqual, 1)
+			So(*imageSummary.Manifests[0].Vulnerabilities.MaxSeverity, ShouldEqual, "HIGH")
+
+			imageSummary.Vulnerabilities = nil
+
+			updateImageSummaryVulnerabilities(ctx,
+				imageSummary,
+				SkipQGLField{
+					Vulnerabilities: false,
+				},
+				mocks.CveInfoMock{
+					GetCVESummaryForImageMediaFn: func(repo string, digest, mediaType string,
+					) (cvemodel.ImageCVESummary, error) {
+						return cvemodel.ImageCVESummary{}, ErrTestError
+					},
+				},
+			)
+
+			So(imageSummary.Vulnerabilities, ShouldNotBeNil)
+			So(*imageSummary.Vulnerabilities.Count, ShouldEqual, 0)
+			So(*imageSummary.Vulnerabilities.MaxSeverity, ShouldEqual, "")
+			So(graphql.GetErrors(ctx).Error(), ShouldContainSubstring, "unable to run vulnerability scan on tag")
+		})
+
+		Convey("Add CVE Summary to RepoSummary", func() {
+			var repoSummary *gql_generated.RepoSummary
+			So(repoSummary, ShouldBeNil)
+
+			updateRepoSummaryVulnerabilities(ctx,
+				repoSummary,
+				SkipQGLField{
+					Vulnerabilities: false,
+				},
+				mocks.CveInfoMock{
+					GetCVESummaryForImageMediaFn: func(repo string, digest, mediaType string,
+					) (cvemodel.ImageCVESummary, error) {
+						return cvemodel.ImageCVESummary{
+							Count:       1,
+							MaxSeverity: "HIGH",
+						}, nil
+					},
+				},
+			)
+
+			So(repoSummary, ShouldBeNil)
+			So(graphql.GetErrors(ctx), ShouldBeNil)
+
+			imageSummary, _, err := ImageManifest2ImageSummary(ctx, "repo1", "0.1.0", digest11, reposMeta[0],
+				manifestMetaMap[digest11.String()])
+			So(err, ShouldBeNil)
+
+			So(imageSummary, ShouldNotBeNil)
+
+			repoSummary = &gql_generated.RepoSummary{}
+			repoSummary.NewestImage = imageSummary
+
+			So(repoSummary.NewestImage.Vulnerabilities, ShouldBeNil)
+
+			updateImageSummaryVulnerabilities(ctx,
+				imageSummary,
+				SkipQGLField{
+					Vulnerabilities: false,
+				},
+				mocks.CveInfoMock{
+					GetCVESummaryForImageMediaFn: func(repo string, digest, mediaType string,
+					) (cvemodel.ImageCVESummary, error) {
+						return cvemodel.ImageCVESummary{
+							Count:       1,
+							MaxSeverity: "HIGH",
+						}, nil
+					},
+				},
+			)
+
+			So(repoSummary.NewestImage.Vulnerabilities, ShouldNotBeNil)
+			So(*repoSummary.NewestImage.Vulnerabilities.Count, ShouldEqual, 1)
+			So(*repoSummary.NewestImage.Vulnerabilities.MaxSeverity, ShouldEqual, "HIGH")
+			So(graphql.GetErrors(ctx), ShouldBeNil)
+		})
+
+		Convey("Add CVE Summary to ManifestSummary", func() {
+			var manifestSummary *gql_generated.ManifestSummary
+
+			So(manifestSummary, ShouldBeNil)
+
+			updateManifestSummaryVulnerabilities(ctx,
+				manifestSummary,
+				"repo1",
+				SkipQGLField{
+					Vulnerabilities: false,
+				},
+				mocks.CveInfoMock{
+					GetCVESummaryForImageMediaFn: func(repo string, digest, mediaType string,
+					) (cvemodel.ImageCVESummary, error) {
+						return cvemodel.ImageCVESummary{
+							Count:       1,
+							MaxSeverity: "HIGH",
+						}, nil
+					},
+				},
+			)
+
+			So(manifestSummary, ShouldBeNil)
+			So(graphql.GetErrors(ctx), ShouldBeNil)
+
+			imageSummary, _, err := ImageManifest2ImageSummary(ctx, "repo1", "0.1.0", digest11, reposMeta[0],
+				manifestMetaMap[digest11.String()])
+			So(err, ShouldBeNil)
+			manifestSummary = imageSummary.Manifests[0]
+
+			updateManifestSummaryVulnerabilities(ctx,
+				manifestSummary,
+				"repo1",
+				SkipQGLField{
+					Vulnerabilities: true,
+				},
+				mocks.CveInfoMock{},
+			)
+
+			So(manifestSummary, ShouldNotBeNil)
+			So(manifestSummary.Vulnerabilities, ShouldNotBeNil)
+			So(*manifestSummary.Vulnerabilities.Count, ShouldEqual, 0)
+			So(*manifestSummary.Vulnerabilities.MaxSeverity, ShouldEqual, "")
+
+			manifestSummary.Vulnerabilities = nil
+
+			updateManifestSummaryVulnerabilities(ctx,
+				manifestSummary,
+				"repo1",
+				SkipQGLField{
+					Vulnerabilities: false,
+				},
+				mocks.CveInfoMock{
+					GetCVESummaryForImageMediaFn: func(repo string, digest, mediaType string,
+					) (cvemodel.ImageCVESummary, error) {
+						return cvemodel.ImageCVESummary{
+							Count:       1,
+							MaxSeverity: "HIGH",
+						}, nil
+					},
+				},
+			)
+
+			So(manifestSummary.Vulnerabilities, ShouldNotBeNil)
+			So(*manifestSummary.Vulnerabilities.Count, ShouldEqual, 1)
+			So(*manifestSummary.Vulnerabilities.MaxSeverity, ShouldEqual, "HIGH")
+
+			manifestSummary.Vulnerabilities = nil
+
+			updateManifestSummaryVulnerabilities(ctx,
+				manifestSummary,
+				"repo1",
+				SkipQGLField{
+					Vulnerabilities: false,
+				},
+				mocks.CveInfoMock{
+					GetCVESummaryForImageMediaFn: func(repo string, digest, mediaType string,
+					) (cvemodel.ImageCVESummary, error) {
+						return cvemodel.ImageCVESummary{}, ErrTestError
+					},
+				},
+			)
+
+			So(manifestSummary.Vulnerabilities, ShouldNotBeNil)
+			So(*manifestSummary.Vulnerabilities.Count, ShouldEqual, 0)
+			So(*manifestSummary.Vulnerabilities.MaxSeverity, ShouldEqual, "")
+			So(graphql.GetErrors(ctx).Error(), ShouldContainSubstring, "unable to run vulnerability scan in repo")
+		})
+	})
+}

--- a/pkg/extensions/search/convert/cve.go
+++ b/pkg/extensions/search/convert/cve.go
@@ -1,0 +1,109 @@
+package convert
+
+import (
+	"context"
+
+	"github.com/99designs/gqlgen/graphql"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/vektah/gqlparser/v2/gqlerror"
+
+	cveinfo "zotregistry.io/zot/pkg/extensions/search/cve"
+	cvemodel "zotregistry.io/zot/pkg/extensions/search/cve/model"
+	"zotregistry.io/zot/pkg/extensions/search/gql_generated"
+)
+
+func updateRepoSummaryVulnerabilities(
+	ctx context.Context,
+	repoSummary *gql_generated.RepoSummary,
+	skip SkipQGLField,
+	cveInfo cveinfo.CveInfo,
+) {
+	if repoSummary == nil {
+		return
+	}
+
+	updateImageSummaryVulnerabilities(ctx, repoSummary.NewestImage, skip, cveInfo)
+}
+
+func updateImageSummaryVulnerabilities(
+	ctx context.Context,
+	imageSummary *gql_generated.ImageSummary,
+	skip SkipQGLField,
+	cveInfo cveinfo.CveInfo,
+) {
+	if imageSummary == nil {
+		return
+	}
+
+	imageCveSummary := cvemodel.ImageCVESummary{}
+
+	imageSummary.Vulnerabilities = &gql_generated.ImageVulnerabilitySummary{
+		MaxSeverity: &imageCveSummary.MaxSeverity,
+		Count:       &imageCveSummary.Count,
+	}
+
+	// Check if vulnerability scanning is disabled
+	if cveInfo == nil || skip.Vulnerabilities {
+		return
+	}
+
+	imageCveSummary, err := cveInfo.GetCVESummaryForImageMedia(*imageSummary.RepoName, *imageSummary.Digest,
+		*imageSummary.MediaType)
+	if err != nil {
+		// Log the error, but we should still include the image in results
+		graphql.AddError(
+			ctx,
+			gqlerror.Errorf(
+				"unable to run vulnerability scan on tag %s in repo %s: error: %s",
+				*imageSummary.Tag, *imageSummary.RepoName, err.Error(),
+			),
+		)
+	}
+
+	imageSummary.Vulnerabilities.MaxSeverity = &imageCveSummary.MaxSeverity
+	imageSummary.Vulnerabilities.Count = &imageCveSummary.Count
+
+	for _, manifestSummary := range imageSummary.Manifests {
+		updateManifestSummaryVulnerabilities(ctx, manifestSummary, *imageSummary.RepoName, skip, cveInfo)
+	}
+}
+
+func updateManifestSummaryVulnerabilities(
+	ctx context.Context,
+	manifestSummary *gql_generated.ManifestSummary,
+	repoName string,
+	skip SkipQGLField,
+	cveInfo cveinfo.CveInfo,
+) {
+	if manifestSummary == nil {
+		return
+	}
+
+	imageCveSummary := cvemodel.ImageCVESummary{}
+
+	manifestSummary.Vulnerabilities = &gql_generated.ImageVulnerabilitySummary{
+		MaxSeverity: &imageCveSummary.MaxSeverity,
+		Count:       &imageCveSummary.Count,
+	}
+
+	// Check if vulnerability scanning is disabled
+	if cveInfo == nil || skip.Vulnerabilities {
+		return
+	}
+
+	imageCveSummary, err := cveInfo.GetCVESummaryForImageMedia(repoName, *manifestSummary.Digest,
+		ispec.MediaTypeImageManifest)
+	if err != nil {
+		// Log the error, but we should still include the manifest in results
+		graphql.AddError(
+			ctx,
+			gqlerror.Errorf(
+				"unable to run vulnerability scan in repo %s: manifest digest: %s, error: %s",
+				repoName, *manifestSummary.Digest, err.Error(),
+			),
+		)
+	}
+
+	manifestSummary.Vulnerabilities.MaxSeverity = &imageCveSummary.MaxSeverity
+	manifestSummary.Vulnerabilities.Count = &imageCveSummary.Count
+}

--- a/pkg/extensions/search/cve/cve_internal_test.go
+++ b/pkg/extensions/search/cve/cve_internal_test.go
@@ -1,3 +1,5 @@
+//go:build search
+
 package cveinfo
 
 import (

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -1029,15 +1029,7 @@ func TestCVEStruct(t *testing.T) {
 		err = metaDB.SetRepoReference("repoIndex", "tagIndex", indexDigest, ispec.MediaTypeImageIndex)
 		So(err, ShouldBeNil)
 
-		// MetaDB loaded with initial data, mock the scanner
-		severities := map[string]int{
-			"UNKNOWN":  0,
-			"LOW":      1,
-			"MEDIUM":   2,
-			"HIGH":     3,
-			"CRITICAL": 4,
-		}
-
+		// MetaDB loaded with initial data, now mock the scanner
 		// Setup test CVE data in mock scanner
 		scanner := mocks.CveScannerMock{
 			ScanImageFn: func(image string) (map[string]cvemodel.CVE, error) {
@@ -1123,9 +1115,6 @@ func TestCVEStruct(t *testing.T) {
 
 				// By default the image has no vulnerabilities
 				return map[string]cvemodel.CVE{}, nil
-			},
-			CompareSeveritiesFn: func(severity1, severity2 string) int {
-				return severities[severity2] - severities[severity1]
 			},
 			IsImageFormatScannableFn: func(repo string, reference string) (bool, error) {
 				if repo == "repoIndex" {

--- a/pkg/extensions/search/cve/model/models.go
+++ b/pkg/extensions/search/cve/model/models.go
@@ -28,23 +28,50 @@ type Package struct {
 }
 
 const (
-	None = iota
-	Low
-	Medium
-	High
-	Critical
+	unScanned = iota
+	none
+	unknown
+	low
+	medium
+	high
+	critical
 )
 
-func SeverityValue(severity string) int {
+// Values from https://www.first.org/cvss/v3.0/specification-document
+const (
+	SeverityNotScanned = ""         // scanning was not done or was not complete
+	SeverityNone       = "NONE"     // no vulnerabilities were detected at all
+	SeverityUnknown    = "UNKNOWN"  // coresponds to CVSS 3 score NONE
+	SeverityLow        = "LOW"      // coresponds to CVSS 3 score LOW
+	SeverityMedium     = "MEDIUM"   // coresponds to CVSS 3 score MEDIUM
+	SeverityHigh       = "HIGH"     // coresponds to CVSS 3 score HIGH
+	SeverityCritical   = "CRITICAL" // coresponds to CVSS 3 score CRITICAL
+)
+
+func severityInt(severity string) int {
 	sevMap := map[string]int{
-		"NONE":     None,
-		"LOW":      Low,
-		"MEDIUM":   Medium,
-		"HIGH":     High,
-		"CRITICAL": Critical,
+		SeverityNotScanned: unScanned,
+		SeverityNone:       none,
+		SeverityUnknown:    unknown,
+		SeverityLow:        low,
+		SeverityMedium:     medium,
+		SeverityHigh:       high,
+		SeverityCritical:   critical,
 	}
 
-	return sevMap[severity]
+	severityInt, ok := sevMap[severity]
+
+	if !ok {
+		// In the unlikely case the key is not in the map we
+		// return the unknown severity level
+		return unknown
+	}
+
+	return severityInt
+}
+
+func CompareSeverities(sev1, sev2 string) int {
+	return severityInt(sev2) - severityInt(sev1)
 }
 
 type Descriptor struct {

--- a/pkg/extensions/search/cve/pagination_test.go
+++ b/pkg/extensions/search/cve/pagination_test.go
@@ -146,30 +146,27 @@ func TestCVEPagination(t *testing.T) {
 				// By default the image has no vulnerabilities
 				return cveMap, nil
 			},
-			CompareSeveritiesFn: func(severity1, severity2 string) int {
-				return severityToInt[severity2] - severityToInt[severity1]
-			},
 		}
 
 		log := log.NewLogger("debug", "")
 		cveInfo := cveinfo.BaseCveInfo{Log: log, Scanner: scanner, MetaDB: metaDB}
 
 		Convey("create new paginator errors", func() {
-			paginator, err := cveinfo.NewCvePageFinder(-1, 10, cveinfo.AlphabeticAsc, cveInfo)
+			paginator, err := cveinfo.NewCvePageFinder(-1, 10, cveinfo.AlphabeticAsc)
 			So(paginator, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 
-			paginator, err = cveinfo.NewCvePageFinder(2, -1, cveinfo.AlphabeticAsc, cveInfo)
+			paginator, err = cveinfo.NewCvePageFinder(2, -1, cveinfo.AlphabeticAsc)
 			So(paginator, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 
-			paginator, err = cveinfo.NewCvePageFinder(2, 1, "wrong sorting criteria", cveInfo)
+			paginator, err = cveinfo.NewCvePageFinder(2, 1, "wrong sorting criteria")
 			So(paginator, ShouldBeNil)
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Reset", func() {
-			paginator, err := cveinfo.NewCvePageFinder(1, 0, cveinfo.AlphabeticAsc, cveInfo)
+			paginator, err := cveinfo.NewCvePageFinder(1, 0, cveinfo.AlphabeticAsc)
 			So(err, ShouldBeNil)
 			So(paginator, ShouldNotBeNil)
 

--- a/pkg/extensions/search/cve/trivy/scanner_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_test.go
@@ -1,3 +1,5 @@
+//go:build search
+
 package trivy_test
 
 import (

--- a/pkg/extensions/search/pagination/pagination_test.go
+++ b/pkg/extensions/search/pagination/pagination_test.go
@@ -1,3 +1,5 @@
+//go:build search
+
 package pagination_test
 
 import (

--- a/pkg/extensions/search/schema.resolvers.go
+++ b/pkg/extensions/search/schema.resolvers.go
@@ -10,6 +10,7 @@ import (
 	"github.com/vektah/gqlparser/v2/gqlerror"
 	zerr "zotregistry.io/zot/errors"
 	"zotregistry.io/zot/pkg/common"
+	"zotregistry.io/zot/pkg/extensions/search/convert"
 	"zotregistry.io/zot/pkg/extensions/search/gql_generated"
 )
 
@@ -133,7 +134,11 @@ func (r *queryResolver) Image(ctx context.Context, image string) (*gql_generated
 		return &gql_generated.ImageSummary{}, gqlerror.Errorf("no reference provided")
 	}
 
-	return getImageSummary(ctx, repo, tag, nil, r.metaDB, r.cveInfo, r.log)
+	skip := convert.SkipQGLField{
+		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Vulnerabilities"),
+	}
+
+	return getImageSummary(ctx, repo, tag, nil, skip, r.metaDB, r.cveInfo, r.log)
 }
 
 // Referrers is the resolver for the Referrers field.

--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -222,14 +222,6 @@ func uploadNewRepoTag(tag string, repoName string, baseURL string, layers [][]by
 
 func getMockCveInfo(metaDB mTypes.MetaDB, log log.Logger) cveinfo.CveInfo {
 	// MetaDB loaded with initial data, mock the scanner
-	severities := map[string]int{
-		"UNKNOWN":  0,
-		"LOW":      1,
-		"MEDIUM":   2,
-		"HIGH":     3,
-		"CRITICAL": 4,
-	}
-
 	// Setup test CVE data in mock scanner
 	scanner := mocks.CveScannerMock{
 		ScanImageFn: func(image string) (map[string]cvemodel.CVE, error) {
@@ -309,9 +301,6 @@ func getMockCveInfo(metaDB mTypes.MetaDB, log log.Logger) cveinfo.CveInfo {
 
 			// By default the image has no vulnerabilities
 			return map[string]cvemodel.CVE{}, nil
-		},
-		CompareSeveritiesFn: func(severity1, severity2 string) int {
-			return severities[severity2] - severities[severity1]
 		},
 		IsImageFormatScannableFn: func(repo string, reference string) (bool, error) {
 			// Almost same logic compared to actual Trivy specific implementation

--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -465,7 +465,7 @@ func (bdw *BoltDB) SetRepoReference(repo string, reference string, manifestDiges
 func (bdw *BoltDB) GetRepoMeta(repo string) (mTypes.RepoMetadata, error) {
 	var repoMeta mTypes.RepoMetadata
 
-	err := bdw.DB.Update(func(tx *bbolt.Tx) error {
+	err := bdw.DB.View(func(tx *bbolt.Tx) error {
 		buck := tx.Bucket([]byte(RepoMetadataBucket))
 
 		repoMetaBlob := buck.Get([]byte(repo))
@@ -490,7 +490,7 @@ func (bdw *BoltDB) GetRepoMeta(repo string) (mTypes.RepoMetadata, error) {
 func (bdw *BoltDB) GetUserRepoMeta(ctx context.Context, repo string) (mTypes.RepoMetadata, error) {
 	var repoMeta mTypes.RepoMetadata
 
-	err := bdw.DB.Update(func(tx *bbolt.Tx) error {
+	err := bdw.DB.View(func(tx *bbolt.Tx) error {
 		buck := tx.Bucket([]byte(RepoMetadataBucket))
 		userBookmarks := getUserBookmarks(ctx, tx)
 		userStars := getUserStars(ctx, tx)

--- a/pkg/meta/parse.go
+++ b/pkg/meta/parse.go
@@ -20,6 +20,8 @@ import (
 // ParseStorage will sync all repos found in the rootdirectory of the oci layout that zot was deployed on with the
 // ParseStorage database.
 func ParseStorage(metaDB mTypes.MetaDB, storeController storage.StoreController, log log.Logger) error {
+	log.Info().Msg("Started parsing storage and updating MetaDB")
+
 	allRepos, err := getAllRepos(storeController)
 	if err != nil {
 		rootDir := storeController.DefaultStore.RootDir()
@@ -37,6 +39,8 @@ func ParseStorage(metaDB mTypes.MetaDB, storeController storage.StoreController,
 			return err
 		}
 	}
+
+	log.Info().Msg("Done parsing storage and updating MetaDB")
 
 	return nil
 }

--- a/pkg/test/mocks/cve_mock.go
+++ b/pkg/test/mocks/cve_mock.go
@@ -14,8 +14,7 @@ type CveInfoMock struct {
 	) (cvemodel.ImageCVESummary, error)
 	GetCVESummaryForImageMediaFn func(repo string, digest, mediaType string,
 	) (cvemodel.ImageCVESummary, error)
-	CompareSeveritiesFn func(severity1, severity2 string) int
-	UpdateDBFn          func() error
+	UpdateDBFn func() error
 }
 
 func (cveInfo CveInfoMock) GetImageListForCVE(repo, cveID string) ([]cvemodel.TagInfo, error) {
@@ -66,14 +65,6 @@ func (cveInfo CveInfoMock) GetCVESummaryForImageMedia(repo, digest, mediaType st
 	return cvemodel.ImageCVESummary{}, nil
 }
 
-func (cveInfo CveInfoMock) CompareSeverities(severity1, severity2 string) int {
-	if cveInfo.CompareSeveritiesFn != nil {
-		return cveInfo.CompareSeveritiesFn(severity1, severity2)
-	}
-
-	return 0
-}
-
 func (cveInfo CveInfoMock) UpdateDB() error {
 	if cveInfo.UpdateDBFn != nil {
 		return cveInfo.UpdateDBFn()
@@ -86,7 +77,6 @@ type CveScannerMock struct {
 	IsImageFormatScannableFn func(repo string, reference string) (bool, error)
 	IsImageMediaScannableFn  func(repo string, digest, mediaType string) (bool, error)
 	ScanImageFn              func(image string) (map[string]cvemodel.CVE, error)
-	CompareSeveritiesFn      func(severity1, severity2 string) int
 	UpdateDBFn               func() error
 }
 
@@ -112,14 +102,6 @@ func (scanner CveScannerMock) ScanImage(image string) (map[string]cvemodel.CVE, 
 	}
 
 	return map[string]cvemodel.CVE{}, nil
-}
-
-func (scanner CveScannerMock) CompareSeverities(severity1, severity2 string) int {
-	if scanner.CompareSeveritiesFn != nil {
-		return scanner.CompareSeveritiesFn(severity1, severity2)
-	}
-
-	return 0
 }
 
 func (scanner CveScannerMock) UpdateDB() error {


### PR DESCRIPTION
1. Only scan CVEs for images returned by graphql calls
Since pagination was refactored to account for image indexes, we had started
to run the CVE scanner before pagination was applied, resulting in
decreased ZOT performance if CVE information was requested

2. Increase in medory-cache of cve results to 1m, from 10k digests.

3. Update CVE model to use CVSS severity values in our code.
Previously we relied upon the strings returned by trivy directly,
and the sorting they implemented.
Since CVE severities are standardized, we don't need to pass around
an adapter object just for pagination and sorting purposes anymore.
This also improves our testing since we don't mock the sorting functions anymore.

4. Fix a flaky CLI test not waiting for the zot service to start.

5. Add the search build label on search/cve tests which were missing it.

6. The boltdb update method was used in a few places where view was supposed to be called.

7. Add logs for start and finish of parsing MetaDB.

8. Avoid unmarshalling twice to obtain annotations for multiarch images

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
