### PR TITLE
fix(dedupe): run dedupe only for repositories found at startup

### DIFF
--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -1176,6 +1176,17 @@ func TestDedupeLinks(t *testing.T) {
 				imgStore = local.NewImageStore(dir, testCase.dedupe, true, log, metrics, nil, nil)
 			}
 
+			// run on empty image store
+			// switch dedupe to true from false
+			taskScheduler, cancel := runAndGetScheduler()
+
+			// rebuild with dedupe true
+			imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
+			// wait until rebuild finishes
+			time.Sleep(1 * time.Second)
+
+			cancel()
+
 			// manifest1
 			upload, err := imgStore.NewBlobUpload("dedupe1")
 			So(err, ShouldBeNil)

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -2289,14 +2289,11 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 			},
 		})
 
-		taskScheduler, cancel := runAndGetScheduler()
-		defer cancel()
+		digest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+		So(err, ShouldBeNil)
 
-		// rebuild with dedupe false, should have all blobs with content
-		imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
-
-		// wait until rebuild finishes
-		time.Sleep(200 * time.Millisecond)
+		err = imgStore.RunDedupeForDigest(digest, false, duplicateBlobs)
+		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Trigger GetContent error in restoreDedupedBlobs()", t, func() {
@@ -2341,14 +2338,11 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 			},
 		})
 
-		taskScheduler, cancel := runAndGetScheduler()
-		defer cancel()
+		digest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+		So(err, ShouldBeNil)
 
-		// rebuild with dedupe false, should have all blobs with content
-		imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
-
-		// wait until rebuild finishes
-		time.Sleep(200 * time.Millisecond)
+		err = imgStore.RunDedupeForDigest(digest, false, duplicateBlobs)
+		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Trigger GetContent error in restoreDedupedBlobs()", t, func() {
@@ -2393,14 +2387,11 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 			},
 		})
 
-		taskScheduler, cancel := runAndGetScheduler()
-		defer cancel()
+		digest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+		So(err, ShouldBeNil)
 
-		// rebuild with dedupe false, should have all blobs with content
-		imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
-
-		// wait until rebuild finishes
-		time.Sleep(200 * time.Millisecond)
+		err = imgStore.RunDedupeForDigest(digest, false, duplicateBlobs)
+		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Trigger Stat() error in restoreDedupedBlobs()", t, func() {
@@ -2442,19 +2433,13 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 			},
 		})
 
-		taskScheduler, cancel := runAndGetScheduler()
-		defer cancel()
+		digest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+		So(err, ShouldBeNil)
 
-		// rebuild with dedupe false, should have all blobs with content
-		imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
-
-		// wait until rebuild finishes
-		time.Sleep(200 * time.Millisecond)
+		err = imgStore.RunDedupeForDigest(digest, false, duplicateBlobs)
+		So(err, ShouldNotBeNil)
 
 		Convey("Trigger Stat() error in dedupeBlobs()", func() {
-			taskScheduler, cancel := runAndGetScheduler()
-			defer cancel()
-
 			imgStore := createMockStorage(testDir, t.TempDir(), true, &StorageDriverMock{
 				StatFn: func(ctx context.Context, path string) (driver.FileInfo, error) {
 					if path == fmt.Sprintf("path/to/%s", validDigest.Encoded()) {
@@ -2493,11 +2478,11 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 				},
 			})
 
-			// rebuild with dedupe false, should have all blobs with content
-			imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
+			digest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+			So(err, ShouldBeNil)
 
-			// wait until rebuild finishes
-			time.Sleep(500 * time.Millisecond)
+			err = imgStore.RunDedupeForDigest(digest, false, duplicateBlobs)
+			So(err, ShouldNotBeNil)
 		})
 	})
 
@@ -2544,14 +2529,11 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 			},
 		})
 
-		taskScheduler, cancel := runAndGetScheduler()
-		defer cancel()
+		digest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+		So(err, ShouldBeNil)
 
-		// rebuild with dedupe false, should have all blobs with content
-		imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
-
-		// wait until rebuild finishes
-		time.Sleep(200 * time.Millisecond)
+		err = imgStore.RunDedupeForDigest(digest, true, duplicateBlobs)
+		So(err, ShouldNotBeNil)
 	})
 
 	//nolint: dupl
@@ -2595,14 +2577,11 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 			},
 		})
 
-		taskScheduler, cancel := runAndGetScheduler()
-		defer cancel()
+		digest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+		So(err, ShouldBeNil)
 
-		// rebuild with dedupe false, should have all blobs with content
-		imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
-
-		// wait until rebuild finishes
-		time.Sleep(200 * time.Millisecond)
+		err = imgStore.RunDedupeForDigest(digest, true, duplicateBlobs)
+		So(err, ShouldNotBeNil)
 	})
 
 	//nolint: dupl
@@ -2646,14 +2625,11 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 			},
 		})
 
-		taskScheduler, cancel := runAndGetScheduler()
-		defer cancel()
+		digest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+		So(err, ShouldBeNil)
 
-		// rebuild with dedupe false, should have all blobs with content
-		imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
-
-		// wait until rebuild finishes
-		time.Sleep(200 * time.Millisecond)
+		err = imgStore.RunDedupeForDigest(digest, true, duplicateBlobs)
+		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Trigger getNextDigestWithBlobPaths err", t, func() {
@@ -2664,14 +2640,8 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 			},
 		})
 
-		taskScheduler, cancel := runAndGetScheduler()
-		defer cancel()
-
-		// rebuild with dedupe false, should have all blobs with content
-		imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
-
-		// wait until rebuild finishes
-		time.Sleep(200 * time.Millisecond)
+		_, _, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Trigger cache errors", t, func() {
@@ -2762,14 +2732,11 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 					},
 				})
 
-			taskScheduler, cancel := runAndGetScheduler()
-			defer cancel()
+			digest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+			So(err, ShouldBeNil)
 
-			// rebuild with dedupe false, should have all blobs with content
-			imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
-
-			// wait until rebuild finishes
-			time.Sleep(200 * time.Millisecond)
+			err = imgStore.RunDedupeForDigest(digest, true, duplicateBlobs)
+			So(err, ShouldNotBeNil)
 		})
 
 		Convey("on dedupe blob", func() {
@@ -2787,14 +2754,11 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 					},
 				})
 
-			taskScheduler, cancel := runAndGetScheduler()
-			defer cancel()
+			digest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+			So(err, ShouldBeNil)
 
-			// rebuild with dedupe false, should have all blobs with content
-			imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
-
-			// wait until rebuild finishes
-			time.Sleep(200 * time.Millisecond)
+			err = imgStore.RunDedupeForDigest(digest, true, duplicateBlobs)
+			So(err, ShouldNotBeNil)
 		})
 
 		Convey("on else branch", func() {
@@ -2808,14 +2772,11 @@ func TestRebuildDedupeMockStoreDriver(t *testing.T) {
 					},
 				})
 
-			taskScheduler, cancel := runAndGetScheduler()
-			defer cancel()
+			digest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths([]string{"path/to"}, []godigest.Digest{})
+			So(err, ShouldBeNil)
 
-			// rebuild with dedupe false, should have all blobs with content
-			imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
-
-			// wait until rebuild finishes
-			time.Sleep(200 * time.Millisecond)
+			err = imgStore.RunDedupeForDigest(digest, true, duplicateBlobs)
+			So(err, ShouldNotBeNil)
 		})
 	})
 }

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -52,7 +52,7 @@ type ImageStore interface { //nolint:interfacebloat
 	GetOrasReferrers(repo string, digest godigest.Digest, artifactType string) ([]artifactspec.Descriptor, error)
 	RunDedupeBlobs(interval time.Duration, sch *scheduler.Scheduler)
 	RunDedupeForDigest(digest godigest.Digest, dedupe bool, duplicateBlobs []string) error
-	GetNextDigestWithBlobPaths(lastDigests []godigest.Digest) (godigest.Digest, []string, error)
+	GetNextDigestWithBlobPaths(repos []string, lastDigests []godigest.Digest) (godigest.Digest, []string, error)
 	GetAllBlobs(repo string) ([]string, error)
 }
 

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -50,7 +50,7 @@ type MockedImageStore struct {
 	RunGCPeriodicallyFn          func(interval time.Duration, sch *scheduler.Scheduler)
 	RunDedupeBlobsFn             func(interval time.Duration, sch *scheduler.Scheduler)
 	RunDedupeForDigestFn         func(digest godigest.Digest, dedupe bool, duplicateBlobs []string) error
-	GetNextDigestWithBlobPathsFn func(lastDigests []godigest.Digest) (godigest.Digest, []string, error)
+	GetNextDigestWithBlobPathsFn func(repos []string, lastDigests []godigest.Digest) (godigest.Digest, []string, error)
 	GetAllBlobsFn                func(repo string) ([]string, error)
 	CleanupRepoFn                func(repo string, blobs []godigest.Digest, removeRepo bool) (int, error)
 	PutIndexContentFn            func(repo string, index ispec.Index) error
@@ -372,10 +372,10 @@ func (is MockedImageStore) RunDedupeForDigest(digest godigest.Digest, dedupe boo
 	return nil
 }
 
-func (is MockedImageStore) GetNextDigestWithBlobPaths(lastDigests []godigest.Digest,
+func (is MockedImageStore) GetNextDigestWithBlobPaths(repos []string, lastDigests []godigest.Digest,
 ) (godigest.Digest, []string, error) {
 	if is.GetNextDigestWithBlobPathsFn != nil {
-		return is.GetNextDigestWithBlobPathsFn(lastDigests)
+		return is.GetNextDigestWithBlobPathsFn(repos, lastDigests)
 	}
 
 	return "", []string{}, nil


### PR DESCRIPTION
no need to run dedupe/restore blobs for images being pushed or synced while running dedupe task, they are already deduped/restored inline.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#1843 

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
