### PR TITLE
refactor(tests): Migrate some of the older tests to the new image-utils library

### DIFF
--- a/pkg/cli/client/image_cmd_internal_test.go
+++ b/pkg/cli/client/image_cmd_internal_test.go
@@ -35,7 +35,6 @@ import (
 	zlog "zotregistry.io/zot/pkg/log"
 	stypes "zotregistry.io/zot/pkg/storage/types"
 	test "zotregistry.io/zot/pkg/test/common"
-	"zotregistry.io/zot/pkg/test/deprecated"
 	. "zotregistry.io/zot/pkg/test/image-utils"
 	ociutils "zotregistry.io/zot/pkg/test/oci-utils"
 	"zotregistry.io/zot/pkg/test/signature"
@@ -1324,11 +1323,11 @@ func runDisplayIndexTests(baseURL string) {
 		actual := strings.TrimSpace(str)
 		// Actual cli output should be something similar to (order of images may differ):
 		// REPOSITORY    TAG        OS/ARCH           DIGEST    SIGNED  SIZE
-		// repo          multi-arch *                 28665f71  false   1.5kB
+		// repo          multi-arch *                 4780eafe  false   1.5kB
 		//                          linux/amd64       02e0ac42  false   644B
 		//                          windows/arm64/v6  5e09b7f9  false   444B
 		So(actual, ShouldContainSubstring, "REPOSITORY TAG OS/ARCH DIGEST SIGNED SIZE")
-		So(actual, ShouldContainSubstring, "repo multi-arch * 28665f71 false 1.5kB ")
+		So(actual, ShouldContainSubstring, "repo multi-arch * 4780eafe false 1.5kB ")
 		So(actual, ShouldContainSubstring, "linux/amd64 02e0ac42 false 644B ")
 		So(actual, ShouldContainSubstring, "windows/arm64/v6 5e09b7f9 false 506B")
 	})
@@ -1346,14 +1345,14 @@ func runDisplayIndexTests(baseURL string) {
 		actual := strings.TrimSpace(str)
 		// Actual cli output should be something similar to (order of images may differ):
 		// REPOSITORY    TAG        OS/ARCH           DIGEST    CONFIG    SIGNED  LAYERS    SIZE
-		// repo          multi-arch *                 28665f71            false             1.5kB
+		// repo          multi-arch *                 4780eafe            false             1.5kB
 		//                          linux/amd64       02e0ac42  58cc9abe  false             644B
 		//                                                                        cbb5b121  4B
 		//                                                                        a00291e8  4B
 		//                          windows/arm64/v6  5e09b7f9  5132a1cd  false             506B
 		//                                                                        7d08ce29  4B
 		So(actual, ShouldContainSubstring, "REPOSITORY TAG OS/ARCH DIGEST CONFIG SIGNED LAYERS SIZE")
-		So(actual, ShouldContainSubstring, "repo multi-arch * 28665f71 false 1.5kB")
+		So(actual, ShouldContainSubstring, "repo multi-arch * 4780eafe false 1.5kB")
 		So(actual, ShouldContainSubstring, "linux/amd64 02e0ac42 58cc9abe false 644B")
 		So(actual, ShouldContainSubstring, "cbb5b121 4B")
 		So(actual, ShouldContainSubstring, "a00291e8 4B")
@@ -2012,7 +2011,7 @@ func uploadTestMultiarch(baseURL string) {
 
 	// ------- Upload The multiarch image
 
-	multiarch := deprecated.GetMultiarchImageForImages([]Image{image1, image2}) //nolint:staticcheck
+	multiarch := CreateMultiarchWith().Images([]Image{image1, image2}).Build()
 
 	err := UploadMultiarchImage(multiarch, baseURL, "repo", "multi-arch")
 	So(err, ShouldBeNil)

--- a/pkg/compliance/v1_0_0/check.go
+++ b/pkg/compliance/v1_0_0/check.go
@@ -23,7 +23,6 @@ import (
 	"zotregistry.io/zot/pkg/api/constants"
 	"zotregistry.io/zot/pkg/compliance"
 	test "zotregistry.io/zot/pkg/test/common"
-	"zotregistry.io/zot/pkg/test/deprecated"
 	"zotregistry.io/zot/pkg/test/image-utils"
 )
 
@@ -486,46 +485,17 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			So(err, ShouldBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
 
-			cfg, layers, manifest, err := deprecated.GetImageComponents(1) //nolint:staticcheck
-			So(err, ShouldBeNil)
+			img := image.CreateDefaultImage()
+			digest = img.ManifestDescriptor.Digest
 
 			repoName := "repo7"
-			err = image.UploadImage(
-				image.Image{
-					Config:   cfg,
-					Layers:   layers,
-					Manifest: manifest,
-				}, baseURL, repoName, "test:1.0")
+			err = image.UploadImage(img, baseURL, repoName, "test:1.0")
 			So(err, ShouldBeNil)
 
-			content, err = json.Marshal(manifest)
-			So(err, ShouldBeNil)
-			digest = godigest.FromBytes(content)
-			So(digest, ShouldNotBeNil)
-
-			err = image.UploadImage(
-				image.Image{
-					Config:   cfg,
-					Layers:   layers,
-					Manifest: manifest,
-				}, baseURL, repoName, "test:1.0.1")
+			err = image.UploadImage(img, baseURL, repoName, "test:1.0.1")
 			So(err, ShouldBeNil)
 
-			content = []byte("this is a blob5")
-			digest = godigest.FromBytes(content)
-			So(digest, ShouldNotBeNil)
-
-			content, err = json.Marshal(manifest)
-			So(err, ShouldBeNil)
-			digest = godigest.FromBytes(content)
-			So(digest, ShouldNotBeNil)
-
-			err = image.UploadImage(
-				image.Image{
-					Config:   cfg,
-					Layers:   layers,
-					Manifest: manifest,
-				}, baseURL, repoName, "test:2.0")
+			err = image.UploadImage(img, baseURL, repoName, "test:2.0")
 			So(err, ShouldBeNil)
 
 			// check/get by tag
@@ -593,23 +563,13 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 		Convey("Pagination", func() {
 			_, _ = Print("\nPagination")
 
+			img := image.CreateDefaultImage()
+
 			for index := 0; index <= 4; index++ {
-				cfg, layers, manifest, err := deprecated.GetImageComponents(1) //nolint:staticcheck
-				So(err, ShouldBeNil)
-
 				repoName := "page0"
-				err = image.UploadImage(
-					image.Image{
-						Config:   cfg,
-						Layers:   layers,
-						Manifest: manifest,
-					}, baseURL, repoName, fmt.Sprintf("test:%d.0", index))
+				err := image.UploadImage(
+					img, baseURL, repoName, fmt.Sprintf("test:%d.0", index))
 				So(err, ShouldBeNil)
-
-				content, err := json.Marshal(manifest)
-				So(err, ShouldBeNil)
-				digest := godigest.FromBytes(content)
-				So(digest, ShouldNotBeNil)
 			}
 
 			resp, err := resty.R().Get(baseURL + "/v2/page0/tags/list")
@@ -734,62 +694,23 @@ func CheckWorkflows(t *testing.T, config *compliance.Config) {
 			So(err, ShouldBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
 
-			cfg, layers, manifest, err := deprecated.GetImageComponents(1) //nolint:staticcheck
+			img := image.CreateDefaultImage()
+			digest = img.ManifestDescriptor.Digest
+
+			// subpath firsttest
+			err = image.UploadImage(img, baseURL, "firsttest/first", "test:1.0")
+			So(err, ShouldBeNil)
+
+			// subpath secondtest
+			err = image.UploadImage(img, baseURL, "secondtest/second", "test:1.0")
 			So(err, ShouldBeNil)
 
 			// subpath firsttest
-			err = image.UploadImage(
-				image.Image{
-					Config:   cfg,
-					Layers:   layers,
-					Manifest: manifest,
-				}, baseURL, "firsttest/first", "test:1.0")
+			err = image.UploadImage(img, baseURL, "firsttest/first", "test:2.0")
 			So(err, ShouldBeNil)
-
-			content, err = json.Marshal(manifest)
-			So(err, ShouldBeNil)
-			digest = godigest.FromBytes(content)
-			So(digest, ShouldNotBeNil)
 
 			// subpath secondtest
-			err = image.UploadImage(
-				image.Image{
-					Config:   cfg,
-					Layers:   layers,
-					Manifest: manifest,
-				}, baseURL, "secondtest/second", "test:1.0")
-			So(err, ShouldBeNil)
-
-			content, err = json.Marshal(manifest)
-			So(err, ShouldBeNil)
-			digest = godigest.FromBytes(content)
-			So(digest, ShouldNotBeNil)
-
-			content = []byte("this is a blob5")
-			digest = godigest.FromBytes(content)
-			So(digest, ShouldNotBeNil)
-
-			// subpath firsttest
-			err = image.UploadImage(
-				image.Image{
-					Config:   cfg,
-					Layers:   layers,
-					Manifest: manifest,
-				}, baseURL, "firsttest/first", "test:2.0")
-			So(err, ShouldBeNil)
-
-			content, err = json.Marshal(manifest)
-			So(err, ShouldBeNil)
-			digest = godigest.FromBytes(content)
-			So(digest, ShouldNotBeNil)
-
-			// subpath secondtest
-			err = image.UploadImage(
-				image.Image{
-					Config:   cfg,
-					Layers:   layers,
-					Manifest: manifest,
-				}, baseURL, "secondtest/second", "test:2.0")
+			err = image.UploadImage(img, baseURL, "secondtest/second", "test:2.0")
 			So(err, ShouldBeNil)
 
 			// check/get by tag

--- a/pkg/extensions/extension_ui_test.go
+++ b/pkg/extensions/extension_ui_test.go
@@ -17,7 +17,6 @@ import (
 	"zotregistry.io/zot/pkg/api/config"
 	extconf "zotregistry.io/zot/pkg/extensions/config"
 	test "zotregistry.io/zot/pkg/test/common"
-	"zotregistry.io/zot/pkg/test/deprecated"
 	. "zotregistry.io/zot/pkg/test/image-utils"
 )
 
@@ -59,19 +58,13 @@ func TestUIExtension(t *testing.T) {
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
 
-		cfg, layers, manifest, err := deprecated.GetImageComponents(1) //nolint:staticcheck
-		So(err, ShouldBeNil)
+		image := CreateRandomImage()
 
 		repoName := "test-repo"
 		tagName := "test-tag"
 
 		// Upload a test image
-		err = UploadImage(
-			Image{
-				Config:   cfg,
-				Layers:   layers,
-				Manifest: manifest,
-			}, baseURL, repoName, tagName)
+		err = UploadImage(image, baseURL, repoName, tagName)
 		So(err, ShouldBeNil)
 
 		resp, err := resty.R().Get(baseURL + "/home")

--- a/pkg/extensions/imagetrust/image_trust_disabled_test.go
+++ b/pkg/extensions/imagetrust/image_trust_disabled_test.go
@@ -3,7 +3,6 @@
 package imagetrust_test
 
 import (
-	"encoding/json"
 	"os"
 	"path"
 	"testing"
@@ -11,7 +10,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	"zotregistry.io/zot/pkg/extensions/imagetrust"
-	"zotregistry.io/zot/pkg/test/deprecated"
+	. "zotregistry.io/zot/pkg/test/image-utils"
 )
 
 func TestImageTrust(t *testing.T) {
@@ -28,13 +27,9 @@ func TestImageTrust(t *testing.T) {
 
 		repo := "repo"
 
-		image, err := deprecated.GetRandomImage() //nolint:staticcheck
-		So(err, ShouldBeNil)
-
-		manifestContent, err := json.Marshal(image.Manifest)
-		So(err, ShouldBeNil)
-
-		manifestDigest := image.Digest()
+		image := CreateRandomImage() //nolint:staticcheck
+		manifestContent := image.ManifestDescriptor.Data
+		manifestDigest := image.ManifestDescriptor.Digest
 
 		localImgTrustStore, err := imagetrust.NewLocalImageTrustStore(rootDir)
 		So(err, ShouldBeNil)

--- a/pkg/extensions/imagetrust/image_trust_test.go
+++ b/pkg/extensions/imagetrust/image_trust_test.go
@@ -38,7 +38,6 @@ import (
 	extconf "zotregistry.io/zot/pkg/extensions/config"
 	"zotregistry.io/zot/pkg/extensions/imagetrust"
 	test "zotregistry.io/zot/pkg/test/common"
-	"zotregistry.io/zot/pkg/test/deprecated"
 	. "zotregistry.io/zot/pkg/test/image-utils"
 	"zotregistry.io/zot/pkg/test/mocks"
 	"zotregistry.io/zot/pkg/test/signature"
@@ -156,50 +155,40 @@ func TestVerifySignatures(t *testing.T) {
 	})
 
 	Convey("empty manifest digest", t, func() {
-		image, err := deprecated.GetRandomImage() //nolint:staticcheck
-		So(err, ShouldBeNil)
-
-		manifestContent, err := json.Marshal(image.Manifest)
-		So(err, ShouldBeNil)
+		image := CreateRandomImage()
+		manifestContent := image.ManifestDescriptor.Data
 
 		imgTrustStore := &imagetrust.ImageTrustStore{}
-		_, _, _, err = imgTrustStore.VerifySignature("", []byte(""), "", "", manifestContent, "repo")
+		_, _, _, err := imgTrustStore.VerifySignature("", []byte(""), "", "", manifestContent, "repo")
 		So(err, ShouldNotBeNil)
 		So(err, ShouldEqual, zerr.ErrBadManifestDigest)
 	})
 
 	Convey("wrong signature type", t, func() {
-		image, err := deprecated.GetRandomImage() //nolint:staticcheck
-		So(err, ShouldBeNil)
-
-		manifestContent, err := json.Marshal(image.Manifest)
-		So(err, ShouldBeNil)
-
-		manifestDigest := image.Digest()
+		image := CreateRandomImage()
+		manifestContent := image.ManifestDescriptor.Data
+		manifestDigest := image.ManifestDescriptor.Digest
 
 		imgTrustStore := &imagetrust.ImageTrustStore{}
-		_, _, _, err = imgTrustStore.VerifySignature("wrongType", []byte(""), "", manifestDigest, manifestContent, "repo")
+		_, _, _, err := imgTrustStore.VerifySignature("wrongType", []byte(""), "", manifestDigest, manifestContent, "repo")
 		So(err, ShouldNotBeNil)
 		So(err, ShouldEqual, zerr.ErrInvalidSignatureType)
 	})
 
 	Convey("verify cosign signature", t, func() {
-		repo := "repo"                            //nolint:goconst
-		tag := "test"                             //nolint:goconst
-		image, err := deprecated.GetRandomImage() //nolint:staticcheck
-		So(err, ShouldBeNil)
+		repo := "repo" //nolint:goconst
+		tag := "test"  //nolint:goconst
 
-		manifestContent, err := json.Marshal(image.Manifest)
-		So(err, ShouldBeNil)
-
-		manifestDigest := image.Digest()
+		image := CreateRandomImage()
+		manifestContent := image.ManifestDescriptor.Data
+		manifestDigest := image.ManifestDescriptor.Digest
 
 		Convey("cosignDir is not set", func() {
 			imgTrustStore := &imagetrust.ImageTrustStore{
 				CosignStorage: &imagetrust.PublicKeyLocalStorage{},
 			}
 
-			_, _, _, err = imgTrustStore.VerifySignature("cosign", []byte(""), "", manifestDigest, manifestContent, repo)
+			_, _, _, err := imgTrustStore.VerifySignature("cosign", []byte(""), "", manifestDigest, manifestContent, repo)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, zerr.ErrSignConfigDirNotSet)
 		})
@@ -336,22 +325,18 @@ func TestVerifySignatures(t *testing.T) {
 	})
 
 	Convey("verify notation signature", t, func() {
-		repo := "repo"                            //nolint:goconst
-		tag := "test"                             //nolint:goconst
-		image, err := deprecated.GetRandomImage() //nolint:staticcheck
-		So(err, ShouldBeNil)
-
-		manifestContent, err := json.Marshal(image.Manifest)
-		So(err, ShouldBeNil)
-
-		manifestDigest := image.Digest()
+		repo := "repo" //nolint:goconst
+		tag := "test"  //nolint:goconst
+		image := CreateRandomImage()
+		manifestContent := image.ManifestDescriptor.Data
+		manifestDigest := image.ManifestDescriptor.Digest
 
 		Convey("notationDir is not set", func() {
 			imgTrustStore := &imagetrust.ImageTrustStore{
 				NotationStorage: &imagetrust.CertificateLocalStorage{},
 			}
 
-			_, _, _, err = imgTrustStore.VerifySignature("notation", []byte("signature"), "", manifestDigest,
+			_, _, _, err := imgTrustStore.VerifySignature("notation", []byte("signature"), "", manifestDigest,
 				manifestContent, repo)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, zerr.ErrSignConfigDirNotSet)
@@ -920,10 +905,8 @@ func TestAWSTrustStore(t *testing.T) {
 		repo := "repo"
 		image := CreateRandomImage()
 
-		manifestContent, err := json.Marshal(image.Manifest)
-		So(err, ShouldBeNil)
-
-		manifestDigest := image.Digest()
+		manifestContent := image.ManifestDescriptor.Data
+		manifestDigest := image.ManifestDescriptor.Digest
 
 		secretsManagerMock := mocks.SecretsManagerMock{
 			CreateSecretFn: func(ctx context.Context, params *secretsmanager.CreateSecretInput,
@@ -955,10 +938,8 @@ func TestAWSTrustStore(t *testing.T) {
 		repo := "repo"
 		image := CreateRandomImage()
 
-		manifestContent, err := json.Marshal(image.Manifest)
-		So(err, ShouldBeNil)
-
-		manifestDigest := image.Digest()
+		manifestContent := image.ManifestDescriptor.Data
+		manifestDigest := image.ManifestDescriptor.Digest
 
 		secretsManagerMock := mocks.SecretsManagerMock{
 			CreateSecretFn: func(ctx context.Context, params *secretsmanager.CreateSecretInput,
@@ -1183,13 +1164,9 @@ func RunVerificationTests(t *testing.T, dbDriverParams map[string]interface{}) {
 		tag := "test"  //nolint:goconst
 
 		Convey("verify cosign signature is trusted", func() {
-			image, err := deprecated.GetRandomImage() //nolint:staticcheck
-			So(err, ShouldBeNil)
-
-			manifestContent, err := json.Marshal(image.Manifest)
-			So(err, ShouldBeNil)
-
-			manifestDigest := image.Digest()
+			image := CreateRandomImage()
+			manifestContent := image.ManifestDescriptor.Data
+			manifestDigest := image.ManifestDescriptor.Digest
 
 			err = UploadImage(image, baseURL, repo, tag)
 			So(err, ShouldBeNil)
@@ -1267,13 +1244,9 @@ func RunVerificationTests(t *testing.T, dbDriverParams map[string]interface{}) {
 		})
 
 		Convey("verify notation signature is trusted", func() {
-			image, err := deprecated.GetRandomImage() //nolint:staticcheck
-			So(err, ShouldBeNil)
-
-			manifestContent, err := json.Marshal(image.Manifest)
-			So(err, ShouldBeNil)
-
-			manifestDigest := image.Digest()
+			image := CreateRandomImage()
+			manifestContent := image.ManifestDescriptor.Data
+			manifestDigest := image.ManifestDescriptor.Digest
 
 			err = UploadImage(image, baseURL, repo, tag)
 			So(err, ShouldBeNil)

--- a/pkg/test/image-utils/multiarch.go
+++ b/pkg/test/image-utils/multiarch.go
@@ -112,6 +112,7 @@ func (mb *BaseMultiarchBuilder) Build() MultiarchImage {
 	for i := range manifests {
 		manifests[i] = ispec.Descriptor{
 			Digest:    mb.images[i].ManifestDescriptor.Digest,
+			Size:      mb.images[i].ManifestDescriptor.Size,
 			MediaType: ispec.MediaTypeImageManifest,
 		}
 	}


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
