### PR TITLE
fix(cve): trivy is leaking FDs for the Java DB file - disable the feature by default

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -514,3 +514,5 @@ require (
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/aquasecurity/trivy v0.45.1 => github.com/project-zot/trivy v0.45.1-disable-analyzers

--- a/go.sum
+++ b/go.sum
@@ -396,8 +396,6 @@ github.com/aquasecurity/table v1.8.0/go.mod h1:eqOmvjjB7AhXFgFqpJUEE/ietg7RrMSJZ
 github.com/aquasecurity/testdocker v0.0.0-20230111101738-e741bda259da h1:pj/adfN0Wbzc0H8YkI1nX5K92wOU5/1/1TRuuc0y5Nw=
 github.com/aquasecurity/tml v0.6.1 h1:y2ZlGSfrhnn7t4ZJ/0rotuH+v5Jgv6BDDO5jB6A9gwo=
 github.com/aquasecurity/tml v0.6.1/go.mod h1:OnYMWY5lvI9ejU7yH9LCberWaaTBW7hBFsITiIMY2yY=
-github.com/aquasecurity/trivy v0.45.1 h1:JjkrawgNpVUV6mxtFX635I3MhzDqmGkze46SnygkYN0=
-github.com/aquasecurity/trivy v0.45.1/go.mod h1:3cawI6q9o32pPGXhuGEIWWwUCSMAzRk/FhsEdA4eW1k=
 github.com/aquasecurity/trivy-db v0.0.0-20230831170347-f732860d4917 h1:MQd7h7yUyA8UlUzhjNMzpUX0NpD7jfxmRfSKwp/Ji3E=
 github.com/aquasecurity/trivy-db v0.0.0-20230831170347-f732860d4917/go.mod h1:WJ5Qnk5ZNGWvks07GOZe2IOsuXrPfSC5c8hYGOGfrsU=
 github.com/aquasecurity/trivy-java-db v0.0.0-20230209231723-7cddb1406728 h1:0eS+V7SXHgqoT99tV1mtMW6HL4HdoB9qGLMCb1fZp8A=
@@ -1438,6 +1436,8 @@ github.com/proglottis/gpgme v0.1.3 h1:Crxx0oz4LKB3QXc5Ea0J19K/3ICfy3ftr5exgUK1AU
 github.com/proglottis/gpgme v0.1.3/go.mod h1:fPbW/EZ0LvwQtH8Hy7eixhp1eF3G39dtx7GUN+0Gmy0=
 github.com/project-zot/mockoidc v0.0.0-20230307111146-f607b4b5fb97 h1:V6z9y0Yx2sQs4WSKx79mgkKJWwjbu/lHQg1yza5bmQE=
 github.com/project-zot/mockoidc v0.0.0-20230307111146-f607b4b5fb97/go.mod h1:46X30UrCsiwicZcg5L098Pyilaj94AO39mvS5PEyPn8=
+github.com/project-zot/trivy v0.45.1-disable-analyzers h1:mrCqhX8rbYdM8WUXW6xledo5kZ0kVHiUnGkAMeniYcQ=
+github.com/project-zot/trivy v0.45.1-disable-analyzers/go.mod h1:3cawI6q9o32pPGXhuGEIWWwUCSMAzRk/FhsEdA4eW1k=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=

--- a/golangcilint.yaml
+++ b/golangcilint.yaml
@@ -50,7 +50,8 @@ linters-settings:
         checks: argument,case,condition,operation,return,assign
         ignored-numbers: 10,64
   gomoddirectives:
-    replace-allow-list: []
+    replace-allow-list:
+      - github.com/aquasecurity/trivy
 issues:
   exclude-rules:
     - path: pkg/extensions/search/schema.resolvers.go

--- a/pkg/cli/server/extensions_test.go
+++ b/pkg/cli/server/extensions_test.go
@@ -1031,7 +1031,7 @@ func TestServeSearchEnabledCVE(t *testing.T) {
 
 		// The default config handling logic will convert the 1h interval to a 2h interval
 		substring := "\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":7200000000000,\"Trivy\":" +
-			"{\"DBRepository\":\"ghcr.io/aquasecurity/trivy-db\",\"JavaDBRepository\":\"ghcr.io/aquasecurity/trivy-java-db\"}}}"
+			"{\"DBRepository\":\"ghcr.io/aquasecurity/trivy-db\",\"JavaDBRepository\":\"\"}}}"
 
 		found, err := ReadLogFileAndSearchString(logPath, substring, readLogFileTimeout)
 

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -551,9 +551,10 @@ func applyDefaultValues(config *config.Config, viperInstance *viper.Viper, log z
 
 				if config.Extensions.Search.CVE.Trivy.JavaDBRepository == "" {
 					defaultJavaDBDownloadURL := "ghcr.io/aquasecurity/trivy-java-db"
-					log.Info().Str("trivyJavaDownloadURL", defaultJavaDBDownloadURL).
-						Msg("Config: using default Trivy Java DB download URL.")
-					config.Extensions.Search.CVE.Trivy.JavaDBRepository = defaultJavaDBDownloadURL
+					log.Info().Str("trivyJavaDownloadURL", "").
+						Str("suggestedTrivyJavaDownloadURL", defaultJavaDBDownloadURL).
+						Msg("Config: Trivy DB javaDBRepository configuration key was not provided, " +
+							"will skip scanning java packages")
 				}
 			}
 		}

--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -12,6 +12,7 @@ import (
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/commands/artifact"
 	"github.com/aquasecurity/trivy/pkg/commands/operation"
+	"github.com/aquasecurity/trivy/pkg/fanal/analyzer"
 	fanalTypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	"github.com/aquasecurity/trivy/pkg/javadb"
@@ -36,10 +37,18 @@ const cacheSize = 1000000
 // getNewScanOptions sets trivy configuration values for our scans and returns them as
 // a trivy Options structure.
 func getNewScanOptions(dir, dbRepository, javaDBRepository string) *flag.Options {
+	disabledAnalizers := []analyzer.Type{}
+	if javaDBRepository == "" {
+		disabledAnalizers = append(disabledAnalizers, analyzer.TypeJar)
+		disabledAnalizers = append(disabledAnalizers, analyzer.TypePom)
+		disabledAnalizers = append(disabledAnalizers, analyzer.TypeGradleLock)
+	}
+
 	scanOptions := flag.Options{
 		GlobalOptions: flag.GlobalOptions{
 			CacheDir: dir,
 		},
+		DisabledAnalyzers: disabledAnalizers,
 		ScanOptions: flag.ScanOptions{
 			Scanners:    types.Scanners{types.VulnerabilityScanner},
 			OfflineScan: true,


### PR DESCRIPTION
And use a trivy fork which allows us to disable analyzers if we need to. In our case Java specific analyzers

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
