### PR TITLE
fix(cache): make dynamoDB aware of orignal/deduped blobs

### DIFF
--- a/pkg/storage/cache/boltdb_test.go
+++ b/pkg/storage/cache/boltdb_test.go
@@ -60,5 +60,65 @@ func TestBoltDBCache(t *testing.T) {
 		err = cacheDriver.PutBlob("key", "")
 		So(err, ShouldNotBeNil)
 		So(err, ShouldEqual, errors.ErrEmptyValue)
+
+		cacheDriver, _ = storage.Create("boltdb", cache.BoltDBDriverParameters{t.TempDir(), "cache_test", false}, log)
+		So(cacheDriver, ShouldNotBeNil)
+
+		err = cacheDriver.PutBlob("key1", "originalBlobPath")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.PutBlob("key1", "duplicateBlobPath")
+		So(err, ShouldBeNil)
+
+		val, err = cacheDriver.GetBlob("key1")
+		So(val, ShouldEqual, "originalBlobPath")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.DeleteBlob("key1", "duplicateBlobPath")
+		So(err, ShouldBeNil)
+
+		val, err = cacheDriver.GetBlob("key1")
+		So(val, ShouldEqual, "originalBlobPath")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.PutBlob("key1", "duplicateBlobPath")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.DeleteBlob("key1", "originalBlobPath")
+		So(err, ShouldBeNil)
+
+		val, err = cacheDriver.GetBlob("key1")
+		So(val, ShouldEqual, "duplicateBlobPath")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.DeleteBlob("key1", "duplicateBlobPath")
+		So(err, ShouldBeNil)
+
+		// should be empty
+		val, err = cacheDriver.GetBlob("key1")
+		So(err, ShouldNotBeNil)
+		So(val, ShouldBeEmpty)
+
+		// try to add three same values
+		err = cacheDriver.PutBlob("key2", "duplicate")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.PutBlob("key2", "duplicate")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.PutBlob("key2", "duplicate")
+		So(err, ShouldBeNil)
+
+		val, err = cacheDriver.GetBlob("key2")
+		So(val, ShouldEqual, "duplicate")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.DeleteBlob("key2", "duplicate")
+		So(err, ShouldBeNil)
+
+		// should be empty
+		val, err = cacheDriver.GetBlob("key2")
+		So(err, ShouldNotBeNil)
+		So(val, ShouldBeEmpty)
 	})
 }

--- a/pkg/storage/cache/dynamodb_test.go
+++ b/pkg/storage/cache/dynamodb_test.go
@@ -100,5 +100,62 @@ func TestDynamoDB(t *testing.T) {
 
 		err = cacheDriver.DeleteBlob(keyDigest, path.Join(dir, "value2"))
 		So(err, ShouldBeNil)
+
+		err = cacheDriver.PutBlob("key1", "originalBlobPath")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.PutBlob("key1", "duplicateBlobPath")
+		So(err, ShouldBeNil)
+
+		val, err = cacheDriver.GetBlob("key1")
+		So(val, ShouldEqual, "originalBlobPath")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.DeleteBlob("key1", "duplicateBlobPath")
+		So(err, ShouldBeNil)
+
+		val, err = cacheDriver.GetBlob("key1")
+		So(val, ShouldEqual, "originalBlobPath")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.PutBlob("key1", "duplicateBlobPath")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.DeleteBlob("key1", "originalBlobPath")
+		So(err, ShouldBeNil)
+
+		val, err = cacheDriver.GetBlob("key1")
+		So(val, ShouldEqual, "duplicateBlobPath")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.DeleteBlob("key1", "duplicateBlobPath")
+		So(err, ShouldBeNil)
+
+		// should be empty
+		val, err = cacheDriver.GetBlob("key1")
+		So(err, ShouldNotBeNil)
+		So(val, ShouldBeEmpty)
+
+		// try to add three same values
+		err = cacheDriver.PutBlob("key2", "duplicate")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.PutBlob("key2", "duplicate")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.PutBlob("key2", "duplicate")
+		So(err, ShouldBeNil)
+
+		val, err = cacheDriver.GetBlob("key2")
+		So(val, ShouldEqual, "duplicate")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.DeleteBlob("key2", "duplicate")
+		So(err, ShouldBeNil)
+
+		// should be empty
+		val, err = cacheDriver.GetBlob("key2")
+		So(err, ShouldNotBeNil)
+		So(val, ShouldBeEmpty)
 	})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
