### PR TITLE
fix: Makefile 'run' target should not depend on running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ clean:
 	rm -rf pkg/extensions/build
 
 .PHONY: run
-run: binary test
+run: binary
 	./bin/zot-$(OS)-$(ARCH) serve examples/config-test.json
 
 .PHONY: verify-config


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:

**Automation added to e2e**:


**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
