### PR TITLE
fix: handle pathnotfound for walk call

### DIFF
--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -392,6 +392,14 @@ func (is *ImageStore) GetNextRepository(repo string) (string, error) {
 
 	driverErr := &driver.Error{}
 
+	// some s3 implementations (eg, digitalocean spaces) will return pathnotfounderror for walk but not list
+	// therefore, we must also catch that error here.
+	if errors.As(err, &driver.PathNotFoundError{}) {
+		is.log.Debug().Msg("empty rootDir")
+
+		return "", nil
+	}
+
 	if errors.Is(err, io.EOF) ||
 		(errors.As(err, driverErr) && errors.Is(driverErr.Enclosed, io.EOF)) {
 		return store, nil


### PR DESCRIPTION
bug

**Which issue does this PR fix**:

i didn't make an issue. I can

**What does this PR do / Why do we need it**:

some s3 stores will return PathNotFoundError on storeDriver.Walk but not storeDriver.List on the root directory

this adds a case to handle that  

**If an issue # is not available please add repro steps and logs showing the issue**:

enable "scrub" while using digitalocean spaces as your s3 provider for storageDriver. dont't specify a root directory for the storageDriver, and if the bucket is empty, you'll see a bunch of errors from the scheduled task. Note that this only happens on the main branch, not the 1.4.3 release. 

```
distSpecVersion: 1.0.1
storage:
  rootDirectory: /tmp/zot
  gc: false
  dedupe: false
  storageDriver:
    name: s3
    region: nyc3
    regionendpoint: "nyc3.digitaloceanspaces.com"
    bucket: <bucket>
    accesskey: <key>
    secretkey: <secret>
http:
  address: 0.0.0.0
  port: "8080"
log:
  level: trace
extensions:
  scrub:
    enable: true
    interval: "24h"
```

logs will show:

```
{"level":"error","component":"scheduler","error":"s3aws: Path not found: /","goroutine":74,"caller":"/home/a/repo/github.com/project-zot/zot/pkg/scheduler/scheduler.go:311","time":"2023-11-03T17:39:26.558547439-05:00","message":"scheduler: error while executing generator"}
```

repeatedly

**Testing done on this change**:

the log is not there once the patch is added

**Automation added to e2e**:
 
 n/a

**Will this break upgrades or downgrades?**

no


```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
