### PR TITLE
build(workflows): make sure we install the crio package matching the correct ubuntu version

### DIFF
--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -36,10 +36,10 @@ jobs:
           sudo cp bin/skopeo /usr/bin
           skopeo -v
           # install cri-o (for crictl)
-          OS=xUbuntu_20.04
+          OS=xUbuntu_22.04
           CRIO_VERSION=1.26
           echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/ /"|sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-          echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$CRIO_VERSION/$OS/ /"|sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable:cri-o:$CRIO_VERSION.list
+          echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$CRIO_VERSION/$OS/ /"|sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable:cri-o:$CRIO_VERSION.list
           curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable:/cri-o:/$CRIO_VERSION/$OS/Release.key | sudo apt-key add -
           curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/$OS/Release.key | sudo apt-key add -
           sudo apt update


### PR DESCRIPTION
The GH runner with name ubuntu-latest is at the moment running Ubuntu 22.04, The workflow was picking the package for Ubuntu 20.04

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
