### PR TITLE
docs: Fix Examples Readme to use proper field `repositories` instead of `repoNames`

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -125,7 +125,7 @@ pushedWithin: x hours - tags pushed in the last x hours
 
 If ANY of these rules are met by a tag, then it will be retained, in other words there is an OR logic between them
 
-repoNames uses glob patterns
+repositories uses glob patterns
 tag patterns uses regex
 
 ```
@@ -134,7 +134,7 @@ tag patterns uses regex
             "delay": "24h",   // is applied on untagged and referrers, will remove them only if they are older than 24h
             "policies": [     // a repo will match a policy if it matches any repoNames[] glob pattern, it will select the first policy it can matches
                 {
-                    "repoNames": ["infra/*", "prod/*"], // patterns to match
+                    "repositories": ["infra/*", "prod/*"], // patterns to match
                     "deleteReferrers": false,           // delete manifests with missing Subject (default is false)
                     "deleteUntagged": true,             // delete untagged manifests (default is true)
                     "KeepTags": [{                      // same as repo, the first pattern(this time regex) matched is the policy applied
@@ -146,7 +146,7 @@ tag patterns uses regex
                     }]
                 },                                      // all tags under infra/* and prod/* will be removed! because they don't match any retention policy
                 {
-                    "repoNames": ["tmp/**"],            // matches recursively all repos under tmp/
+                    "repositories": ["tmp/**"],            // matches recursively all repos under tmp/
                     "deleteReferrers": true,
                     "deleteUntagged": true,
                     "KeepTags": [{                      // will retain all tags starting with v1 and pulled within the last 168h
@@ -156,7 +156,7 @@ tag patterns uses regex
                     }]
                 },
                 {
-                    "repoNames": ["**"],
+                    "repositories": ["**"],
                     "deleteReferrers": true,
                     "deleteUntagged": true,
                     "keepTags": [{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

Documentation

**Which issue does this PR fix**:

N/A

**What does this PR do / Why do we need it**:

Fix documentation to use proper field called repositories instead of repoNames. This looks like an accidental mix up with the variable name used in code vs configuration field in this change  https://github.com/project-zot/zot/pull/1866 .

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

None this is a documentaion change.

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**

Nope only a documentation change.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Fix Examples Readme to use correct field storage.retention.policies.repositories.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
