### PR TITLE
fix(nightly): increase wait time for dedupe nightly build

### DIFF
--- a/test/blackbox/helpers_zot.bash
+++ b/test/blackbox/helpers_zot.bash
@@ -42,10 +42,10 @@ function wait_zot_reachable() {
     local zot_port=${1}
     local zot_url=http://127.0.0.1:${zot_port}/v2/_catalog
     curl --connect-timeout 3 \
-        --max-time 3 \
-        --retry 10 \
-        --retry-delay 0 \
-        --retry-max-time 120 \
+        --max-time 5 \
+        --retry 20 \
+        --retry-delay 1 \
+        --retry-max-time 180 \
         --retry-connrefused \
         ${zot_url}
 }

--- a/test/blackbox/pushpull_running_dedupe.bats
+++ b/test/blackbox/pushpull_running_dedupe.bats
@@ -120,6 +120,9 @@ function teardown_file() {
 
     zot_serve ${ZOT_PATH} ${zot_config_file}
 
+    # sleep a bit before running wait_zot_reachable(curl)
+    sleep 5
+
     wait_zot_reachable 8080
     # deduping will now run in background (task scheduler) while we push images, shouldn't interfere
 }


### PR DESCRIPTION
in this nightly test we restart zot for changing dedupe option because zot storage is already populated it will take some time to startup because of dedupe startup task which is run before starting the server.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
