### PR TITLE
fix: Fix example configs and README.md file

### DIFF
--- a/.github/workflows/verify-config.yaml
+++ b/.github/workflows/verify-config.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Cache go dependencies
         id: cache-go-dependencies
         uses: actions/cache@v4

--- a/.github/workflows/verify-config.yaml
+++ b/.github/workflows/verify-config.yaml
@@ -1,0 +1,46 @@
+name: "Verify Example Config Files"
+
+# Validate all example config files are relevant and valid.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [main]
+  release:
+    types:
+      - published
+
+permissions: read-all
+
+jobs:
+  verify-config:
+    name: Verify Config Files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install go
+        uses: actions/setup-go@v5
+        with:
+          cache: false
+          go-version: 1.20.x
+      - name: Cache go dependencies
+        id: cache-go-dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Install go dependencies
+        if: steps.cache-go-dependencies.outputs.cache-hit != 'true'
+        run: |
+          cd $GITHUB_WORKSPACE
+          go mod download
+      - uses: ./.github/actions/setup-localstack
+      - name: run verify-config
+        run: |
+          cd $GITHUB_WORKSPACE
+          make verify-config

--- a/.github/workflows/verify-config.yaml
+++ b/.github/workflows/verify-config.yaml
@@ -39,7 +39,6 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE
           go mod download
-      - uses: ./.github/actions/setup-localstack
       - name: run verify-config
         run: |
           cd $GITHUB_WORKSPACE

--- a/Makefile
+++ b/Makefile
@@ -392,7 +392,7 @@ verify-config: _verify-config verify-config-warnings verify-config-commited
 .PHONY: _verify-config
 _verify-config: binary
 	rm -f output.txt
-	$(foreach file, $(wildcard examples/config-*), ./bin/zot-$(OS)-$(ARCH) verify $(file) 2>&1 | tee -a output.txt || exit 1;)
+	$(foreach file, $(filter-out examples/config-ldap-credentials.json, $(wildcard examples/config-*)), ./bin/zot-$(OS)-$(ARCH) verify $(file) 2>&1 | tee -a output.txt || exit 1;)
 
 .PHONY: verify-config-warnings
 verify-config-warnings: _verify-config

--- a/examples/README.md
+++ b/examples/README.md
@@ -225,14 +225,14 @@ authentication:
         "startTLS":false,
         "baseDN":"ou=Users,dc=example,dc=org",
         "userAttribute":"uid",
-        "bindDN":"cn=ldap-searcher,ou=Users,dc=example,dc=org",
-        "bindPassword":"ldap-searcher-password",
+        "credentialsFile": "config-ldap-credentials.json",
         "skipVerify":false,
         "subtreeSearch":true
       },
 ```
 
 NOTE: When both htpasswd and LDAP configuration are specified, LDAP authentication is given preference.
+NOTE: The separate file for storing DN and password credentials must be created. You can see example in `examples/config-ldap-credentials.json` file.
 
 **OAuth2 authentication** (client credentials grant type) support via _Bearer Token_ configured with:
 

--- a/examples/config-example.json
+++ b/examples/config-example.json
@@ -18,8 +18,7 @@
         "startTLS": false,
         "baseDN": "ou=Users,dc=example,dc=org",
         "userAttribute": "uid",
-        "bindDN": "cn=ldap-searcher,ou=Users,dc=example,dc=org",
-        "bindPassword": "ldap-searcher-password",
+        "credentialsFile": "examples/config-ldap-credentials.json",
         "skipVerify": false,
         "subtreeSearch": true
       },

--- a/examples/config-example.yaml
+++ b/examples/config-example.yaml
@@ -8,8 +8,7 @@ http:
     ldap:
       address: ldap.example.org
       basedn: ou=Users,dc=example,dc=org
-      binddn: cn=ldap-searcher,ou=Users,dc=example,dc=org
-      bindpassword: ldap-searcher-password
+      credentialsFile: examples/config-ldap-credentials.json
       port: 389
       skipverify: false
       starttls: false

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -856,7 +857,7 @@ func readLDAPCredentials(ldapConfigPath string) (config.LDAPCredentials, error) 
 	if err := viperInstance.ReadInConfig(); err != nil {
 		log.Error().Err(err).Msg("failed to read configuration")
 
-		return config.LDAPCredentials{}, err
+		return config.LDAPCredentials{}, errors.Join(zerr.ErrBadConfig, err)
 	}
 
 	var ldapCredentials config.LDAPCredentials
@@ -865,7 +866,7 @@ func readLDAPCredentials(ldapConfigPath string) (config.LDAPCredentials, error) 
 	if err := viperInstance.UnmarshalExact(&ldapCredentials, metadataConfig(metaData)); err != nil {
 		log.Error().Err(err).Msg("failed to unmarshal ldap credentials config")
 
-		return config.LDAPCredentials{}, err
+		return config.LDAPCredentials{}, errors.Join(zerr.ErrBadConfig, err)
 	}
 
 	if len(metaData.Keys) == 0 {

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -861,8 +861,8 @@ func readLDAPCredentials(ldapConfigPath string) (config.LDAPCredentials, error) 
 
 	var ldapCredentials config.LDAPCredentials
 
-	if err := viperInstance.Unmarshal(&ldapCredentials); err != nil {
-		log.Error().Err(err).Msg("failed to unmarshal new config")
+	if err := viperInstance.UnmarshalExact(&ldapCredentials); err != nil {
+		log.Error().Err(err).Msg("failed to unmarshal ldap credentials config")
 
 		return config.LDAPCredentials{}, err
 	}

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -1236,6 +1236,83 @@ storage:
 		err = cli.NewServerRootCmd().Execute()
 		So(err, ShouldBeNil)
 	})
+
+	Convey("Test verify good ldap config", t, func(c C) {
+		tmpFile, err := os.CreateTemp("", "zot-test*.json")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpFile.Name())
+
+		tmpCredsFile, err := os.CreateTemp("", "zot-cred*.json")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpCredsFile.Name())
+
+		content := []byte(`{
+    		"bindDN":"cn=ldap-searcher,ou=Users,dc=example,dc=org",
+    		"bindPassword":"ldap-searcher-password"
+		}`)
+
+		_, err = tmpCredsFile.Write(content)
+		So(err, ShouldBeNil)
+		err = tmpCredsFile.Close()
+		So(err, ShouldBeNil)
+
+		content = []byte(fmt.Sprintf(`{ "distSpecVersion": "1.1.0-dev", 
+			"storage": { "rootDirectory": "/tmp/zot" }, "http": { "address": "127.0.0.1", "port": "8080", 
+			"auth": { "ldap": { "credentialsFile": "%v", "address": "ldap.example.org", "port": 389, 
+			"startTLS": false, "baseDN": "ou=Users,dc=example,dc=org", 
+			"userAttribute": "uid", "userGroupAttribute": "memberOf", "skipVerify": true, "subtreeSearch": true }, 
+			"failDelay": 5 } }, "log": { "level": "debug" } }`,
+			tmpCredsFile.Name()),
+		)
+
+		_, err = tmpFile.Write(content)
+		So(err, ShouldBeNil)
+		err = tmpFile.Close()
+		So(err, ShouldBeNil)
+
+		os.Args = []string{"cli_test", "verify", tmpFile.Name()}
+		err = cli.NewServerRootCmd().Execute()
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Test verify bad ldap config", t, func(c C) {
+		tmpFile, err := os.CreateTemp("", "zot-test*.json")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpFile.Name())
+
+		tmpCredsFile, err := os.CreateTemp("", "zot-cred*.json")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpCredsFile.Name())
+
+		// `bindDN` key is missing
+		content := []byte(`{
+    		"bindPassword":"ldap-searcher-password"
+		}`)
+
+		_, err = tmpCredsFile.Write(content)
+		So(err, ShouldBeNil)
+		err = tmpCredsFile.Close()
+		So(err, ShouldBeNil)
+
+		content = []byte(fmt.Sprintf(`{ "distSpecVersion": "1.1.0-dev", 
+			"storage": { "rootDirectory": "/tmp/zot" }, "http": { "address": "127.0.0.1", "port": "8080", 
+			"auth": { "ldap": { "credentialsFile": "%v", "address": "ldap.example.org", "port": 389, 
+			"startTLS": false, "baseDN": "ou=Users,dc=example,dc=org", 
+			"userAttribute": "uid", "userGroupAttribute": "memberOf", "skipVerify": true, "subtreeSearch": true }, 
+			"failDelay": 5 } }, "log": { "level": "debug" } }`,
+			tmpCredsFile.Name()),
+		)
+
+		_, err = tmpFile.Write(content)
+		So(err, ShouldBeNil)
+		err = tmpFile.Close()
+		So(err, ShouldBeNil)
+
+		os.Args = []string{"cli_test", "verify", tmpFile.Name()}
+		err = cli.NewServerRootCmd().Execute()
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "invalid server config")
+	})
 }
 
 func TestApiKeyConfig(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
documentation

**Which issue does this PR fix**:
Example LDAP configs do not represent the actual state of things and are outdated. 

```bash
# could also run $ make verify-config
# it's also the same problem with `examples/config-ldap-credentials.json`, so it's excluded from the Makefile
$ ./bin/zot-linux-amd64 verify examples/config-example.json 
{"level":"error","error":"1 error(s) decoding:\n\n* 'HTTP.Auth.LDAP' has invalid keys: binddn, bindpassword","time":"2024-01-16T23:36:27+02:00","message":"failed to unmarshaling new config"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
