### PR TITLE
fix(scheduler): the session cleanup generator is reset too often

### DIFF
--- a/pkg/api/cookiestore.go
+++ b/pkg/api/cookiestore.go
@@ -30,7 +30,11 @@ type CookieStore struct {
 
 func (c *CookieStore) RunSessionCleaner(sch *scheduler.Scheduler) {
 	if c.needsCleanup {
-		sch.SubmitGenerator(&SessionCleanup{rootDir: c.rootDir}, cookiesMaxAge, scheduler.LowPriority)
+		sch.SubmitGenerator(
+			&SessionCleanup{rootDir: c.rootDir},
+			cookiesMaxAge*time.Second,
+			scheduler.LowPriority,
+		)
 	}
 }
 
@@ -120,6 +124,10 @@ func getExpiredSessions(dir string) ([]string, error) {
 type SessionCleanup struct {
 	rootDir string
 	done    bool
+}
+
+func (gen *SessionCleanup) Name() string {
+	return "SessionCleanupGenerator"
 }
 
 func (gen *SessionCleanup) Next() (scheduler.Task, error) {

--- a/pkg/extensions/extension_scrub.go
+++ b/pkg/extensions/extension_scrub.go
@@ -55,6 +55,10 @@ type taskGenerator struct {
 	done     bool
 }
 
+func (gen *taskGenerator) Name() string {
+	return "ScrubGenerator"
+}
+
 func (gen *taskGenerator) Next() (scheduler.Task, error) {
 	repo, err := gen.imgStore.GetNextRepository(gen.lastRepo)
 	if err != nil {

--- a/pkg/extensions/imagetrust/image_trust.go
+++ b/pkg/extensions/imagetrust/image_trust.go
@@ -200,6 +200,10 @@ type sigValidityTaskGenerator struct {
 	log       log.Logger
 }
 
+func (gen *sigValidityTaskGenerator) Name() string {
+	return "SignatureValidationGenerator"
+}
+
 func (gen *sigValidityTaskGenerator) Next() (scheduler.Task, error) {
 	if len(gen.repos) == 0 {
 		ctx := context.Background()

--- a/pkg/extensions/search/cve/scan.go
+++ b/pkg/extensions/search/cve/scan.go
@@ -115,6 +115,10 @@ func (gen *scanTaskGenerator) isScheduled(digest string) bool {
 	return ok
 }
 
+func (gen *scanTaskGenerator) Name() string {
+	return "CVEScanGenerator"
+}
+
 func (gen *scanTaskGenerator) Next() (scheduler.Task, error) {
 	// metaRB requires us to use a context for authorization
 	userAc := reqCtx.NewUserAccessControl()

--- a/pkg/extensions/search/cve/update.go
+++ b/pkg/extensions/search/cve/update.go
@@ -46,6 +46,10 @@ type DBUpdateTaskGenerator struct {
 	lock         *sync.Mutex
 }
 
+func (gen *DBUpdateTaskGenerator) Name() string {
+	return "CVEDBUpdateGenerator"
+}
+
 func (gen *DBUpdateTaskGenerator) Next() (scheduler.Task, error) {
 	var newTask scheduler.Task
 

--- a/pkg/extensions/sync/sync.go
+++ b/pkg/extensions/sync/sync.go
@@ -90,6 +90,10 @@ func NewTaskGenerator(service Service, log log.Logger) *TaskGenerator {
 	}
 }
 
+func (gen *TaskGenerator) Name() string {
+	return "SyncGenerator"
+}
+
 func (gen *TaskGenerator) Next() (scheduler.Task, error) {
 	if err := gen.Service.SetNextAvailableURL(); err != nil {
 		return nil, err

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -304,7 +304,8 @@ func (scheduler *Scheduler) pushReadyGenerators() {
 				scheduler.waitingGenerators = append(scheduler.waitingGenerators[:i], scheduler.waitingGenerators[i+1:]...)
 				modified = true
 
-				scheduler.log.Debug().Msg("waiting generator is ready, pushing to ready generators")
+				scheduler.log.Debug().Str("generator", gen.taskGenerator.Name()).
+					Msg("waiting generator is ready, pushing to ready generators")
 
 				break
 			}
@@ -435,6 +436,7 @@ type TaskGenerator interface {
 	Next() (Task, error)
 	IsDone() bool
 	IsReady() bool
+	Name() string
 	Reset()
 }
 
@@ -459,7 +461,8 @@ func (gen *generator) generate(sch *Scheduler) {
 	if gen.remainingTask == nil {
 		nextTask, err := gen.taskGenerator.Next()
 		if err != nil {
-			sch.log.Error().Err(err).Msg("failed to execute generator")
+			sch.log.Error().Err(err).Str("generator", gen.taskGenerator.Name()).
+				Msg("failed to execute generator")
 
 			return
 		}
@@ -470,6 +473,9 @@ func (gen *generator) generate(sch *Scheduler) {
 			gen.lastRun = time.Now()
 			gen.taskCount = 0
 			gen.taskGenerator.Reset()
+
+			sch.log.Debug().Str("generator", gen.taskGenerator.Name()).
+				Msg("generator is done")
 
 			return
 		}

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -63,6 +63,10 @@ type generator struct {
 	taskDelay time.Duration
 }
 
+func (g *generator) Name() string {
+	return "TestGenerator"
+}
+
 func (g *generator) Next() (scheduler.Task, error) {
 	if g.step > g.limit {
 		g.done = true
@@ -105,6 +109,10 @@ type shortGenerator struct {
 	done     bool
 	index    int
 	step     int
+}
+
+func (g *shortGenerator) Name() string {
+	return "ShortTestGenerator"
 }
 
 func (g *shortGenerator) Next() (scheduler.Task, error) {

--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -972,6 +972,10 @@ type DedupeTaskGenerator struct {
 	Log         zlog.Logger
 }
 
+func (gen *DedupeTaskGenerator) Name() string {
+	return "DedupeTaskGenerator"
+}
+
 func (gen *DedupeTaskGenerator) Next() (scheduler.Task, error) {
 	var err error
 
@@ -1083,6 +1087,10 @@ type StorageMetricsInitGenerator struct {
 	rand     *rand.Rand
 	Log      zlog.Logger
 	MaxDelay int
+}
+
+func (gen *StorageMetricsInitGenerator) Name() string {
+	return "StorageMetricsInitGenerator"
 }
 
 func (gen *StorageMetricsInitGenerator) Next() (scheduler.Task, error) {

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -800,6 +800,10 @@ func (gen *GCTaskGenerator) getRandomDelay() int {
 	return gen.rand.Intn(maxDelay)
 }
 
+func (gen *GCTaskGenerator) Name() string {
+	return "GCTaskGenerator"
+}
+
 func (gen *GCTaskGenerator) Next() (scheduler.Task, error) {
 	if gen.lastRepo == "" && gen.nextRun.IsZero() {
 		gen.rand = rand.New(rand.NewSource(time.Now().UTC().UnixNano())) //nolint: gosec


### PR DESCRIPTION
This causes the "fair" scheduler to run it too often in the detriment of other generators. The intention was to run it every 2 hours but the measurement unit for 7200 was not specified.

Add more logs, including showing a generator name, in order to troubleshoot this kind of issues easier in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
