### PR TITLE
ci: stabilize ecosystem client tools workflow

### DIFF
--- a/test/blackbox/scrub.bats
+++ b/test/blackbox/scrub.bats
@@ -67,7 +67,7 @@ function teardown() {
     wait_zot_reachable ${zot_port}
 
     # wait for scrub to be done and logs to get populated
-    run sleep 20s
+    run sleep 30s
     run not_affected
     [ "$status" -eq 0 ]
     [ $(echo "${lines[0]}" ) = 'true' ]
@@ -82,7 +82,7 @@ function teardown() {
     wait_zot_reachable ${zot_port}
 
     # wait for scrub to be done and logs to get populated
-    run sleep 20s
+    run sleep 30s
     run affected
     [ "$status" -eq 0 ]
     [ $(echo "${lines[0]}" ) = 'true' ]


### PR DESCRIPTION
Since the scheduler no longer executes generators in a fixed order, and scrub logic refactoring, the scrub tasks may or may not complete in the expected time. Increase sleep times used to search for tasks results in zot logs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
