### PR TITLE
ci: release a checksums file with SHA256 hashes for release assets

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -119,6 +119,8 @@ jobs:
           patterns: z*
           method: sha256
           output: checksums.sha256.txt
+      - name: Add wildcard character prefix to filenames in checksum file
+        run: sed -i 's! ! \*!g' checksums.sha256.txt
       - name: Publish checksums on releases
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,3 +98,31 @@ jobs:
           tag: ${{ github.ref }}
           overwrite: true
           file_glob: true
+
+  release-checksums:
+    name: Release Artifact Checksums
+    needs: build-arch
+    if: github.event_name == 'release' && github.event.action == 'published'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Download Release Artifacts
+        uses: robinraju/release-downloader@v1.9
+        with:
+          tag: ${{ github.ref_name }}
+          fileName: "z*"
+      - name: Generate checksum
+        uses: jmgilman/actions-generate-checksum@v1
+        with:
+          patterns: z*
+          method: sha256
+          output: checksums.sha256.txt
+      - name: Publish checksums on releases
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: checksums.sha256.txt
+          tag: ${{ github.ref }}
+          overwrite: true


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Closes #715 

**What does this PR do / Why do we need it**:
This PR adds an additional job to the `build` workflow  to generate SHA256 hashes for all the released assets and releases a checksums text file containing all the hashes.
The checksum release job only runs during a `release` event with a `publish` action.

The logical operations are:
1. Download all the release assets
2. Generate hashes for each and place into a text file
3. Release the checksum file

**Testing done on this change**:
Tested with a tagged release on a fork:
https://github.com/vrajashkr/zot/releases/tag/1.0.2
<img width="1225" alt="image" src="https://github.com/project-zot/zot/assets/30438425/7f5179ef-35d9-4932-a2d3-3d9304151803">

Checked contents of hash file:
<img width="938" alt="image" src="https://github.com/project-zot/zot/assets/30438425/b68c7f42-1843-481e-97d1-c2ca8611c8d4">

Downloaded all the files from the release into a directory and cross-checked generated hashes:
(Tested on MacOS)
```
shasum -c checksums.sha256.txt
zot-darwin-amd64: OK
zb-linux-arm64: OK
zot-darwin-arm64-minimal: OK
zot-darwin-arm64-debug: OK
zli-freebsd-arm64: OK
zot-freebsd-amd64-debug: OK
zot-linux-arm64: OK
zot-linux-arm64-debug: OK
zli-freebsd-amd64: OK
zli-darwin-arm64: OK
zot-gql-introspection-result.json: OK
zot-darwin-amd64-debug: OK
zli-linux-amd64: OK
zxp-freebsd-arm64: OK
zxp-freebsd-amd64: OK
zot-linux-amd64-minimal: OK
zb-linux-amd64: OK
zot-linux-amd64-debug: OK
zot-darwin-arm64: OK
zxp-linux-amd64: OK
zb-darwin-arm64: OK
zli-darwin-amd64: OK
zot-freebsd-amd64-minimal: OK
zot-darwin-amd64-minimal: OK
zot-freebsd-arm64-debug: OK
zxp-darwin-arm64: OK
zot-linux-amd64: OK
zli-linux-arm64: OK
zot-freebsd-amd64: OK
zot-freebsd-arm64-minimal: OK
zb-freebsd-amd64: OK
zot-freebsd-arm64: OK
zb-freebsd-arm64: OK
zb-darwin-amd64: OK
zot-linux-arm64-minimal: OK
zxp-darwin-amd64: OK
zxp-linux-arm64: OK
```

**Automation added to e2e**:
N/A - CI only change

**Will this break upgrades or downgrades?**
N/A - CI only change

**Does this PR introduce any user-facing change?**:
No functional changes, however, users can now verify the integrity of downloaded assets.

```release-note
Users can now verify the integrity of the downloaded files by using the SHA256 hash value present in the published checksums.sha256.txt file.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
