### PR TITLE
test(blackbox): fix the scrub test sometimes deleting the image manifest from the layout

### DIFF
--- a/test/blackbox/helpers_scrub.bash
+++ b/test/blackbox/helpers_scrub.bash
@@ -7,7 +7,8 @@ function add_test_files() {
 
 function delete_blob() {
     local zot_test_files=${BATS_FILE_TMPDIR}/zot/alpine
-    find ${zot_test_files}/blobs/sha256 -maxdepth 1 -type f -name "*" -print0 |
+    # Delete one of the blobs which is not of type json, meaning not a manifest/config
+    find ${zot_test_files}/blobs/sha256 -maxdepth 1 -type f -name "*" -exec sh -c 'file -b "$1" | grep -iqv "json"' sh {} \; -print0|
         sort -z -R |
         head -z -n 1 | xargs -0 rm
     ls -al ${zot_test_files}/blobs/sha256/


### PR DESCRIPTION
If the manifest is not present, scrub no longer errors, so the test looking for errors in the log was not failing.

See the related scrub changes in: https://github.com/project-zot/zot/pull/2180

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
