### PR TITLE
ci(nightly): update go version used for prometheus tests

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
+          go-version: 1.21.x
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
