### PR TITLE
feat: Include PackagePath information in CVE results for image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -230,6 +230,7 @@ $(TESTDATA): check-skopeo
 	skopeo --insecure-policy copy -q docker://public.ecr.aws/t0x7q1g8/centos:8 oci:${TESTDATA}/zot-cve-test:0.0.1; \
 	skopeo --insecure-policy copy -q docker://ghcr.io/project-zot/test-images/java:0.0.1 oci:${TESTDATA}/zot-cve-java-test:0.0.1; \
 	skopeo --insecure-policy copy -q docker://ghcr.io/project-zot/test-images/alpine:3.17.3 oci:${TESTDATA}/alpine:3.17.3; \
+	skopeo --insecure-policy copy -q docker://ghcr.io/project-zot/test-images/spring-web:5.3.31 oci:${TESTDATA}/spring-web:5.3.31; \
 	chmod -R a=rwx ${TESTDATA}
 	ls -R -l ${TESTDATA}
 

--- a/pkg/cli/client/cve_cmd_internal_test.go
+++ b/pkg/cli/client/cve_cmd_internal_test.go
@@ -227,7 +227,7 @@ func TestSearchCVECmd(t *testing.T) {
 		So(buff.String(), ShouldEqual, `{"Tag":"dummyImageName:tag","CVEList":`+
 			`[{"Id":"dummyCVEID","Severity":"HIGH","Title":"Title of that CVE",`+
 			`"Description":"Description of the CVE","PackageList":[{"Name":"packagename",`+
-			`"InstalledVersion":"installedver","FixedVersion":"fixedver"}]}],"Summary":`+
+			`"PackagePath":"","InstalledVersion":"installedver","FixedVersion":"fixedver"}]}],"Summary":`+
 			`{"maxSeverity":"HIGH","unknownCount":0,"lowCount":0,"mediumCount":0,"highCount":1,`+
 			`"criticalCount":0,"count":1}}`+"\n")
 		So(err, ShouldBeNil)
@@ -247,7 +247,7 @@ func TestSearchCVECmd(t *testing.T) {
 		str := space.ReplaceAllString(buff.String(), " ")
 		So(strings.TrimSpace(str), ShouldEqual, `--- tag: dummyImageName:tag cvelist: - id: dummyCVEID`+
 			` severity: HIGH title: Title of that CVE description: Description of the CVE packagelist: `+
-			`- name: packagename installedversion: installedver fixedversion: fixedver `+
+			`- name: packagename packagepath: "" installedversion: installedver fixedversion: fixedver `+
 			`summary: maxseverity: HIGH unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 1 criticalcount: 0 count: 1`)
 		So(err, ShouldBeNil)
 	})

--- a/pkg/cli/client/service.go
+++ b/pkg/cli/client/service.go
@@ -308,7 +308,7 @@ func (service searchService) getCveByImageGQL(ctx context.Context, config Search
 			Tag
 			CVEList {
 				Id Title Severity Description
-				PackageList {Name InstalledVersion FixedVersion}
+				PackageList {Name PackagePath InstalledVersion FixedVersion}
 			}
 			Summary {
 				Count UnknownCount LowCount MediumCount HighCount CriticalCount MaxSeverity
@@ -732,6 +732,7 @@ type tagListResp struct {
 //nolint:tagliatelle // graphQL schema
 type packageList struct {
 	Name             string `json:"Name"`
+	PackagePath      string `json:"PackagePath"`
 	InstalledVersion string `json:"InstalledVersion"`
 	FixedVersion     string `json:"FixedVersion"`
 }

--- a/pkg/extensions/search/cve/cve_internal_test.go
+++ b/pkg/extensions/search/cve/cve_internal_test.go
@@ -25,6 +25,13 @@ func TestUtils(t *testing.T) {
 				PackageList: []cvemodel.Package{
 					{
 						Name:             "NameTest",
+						PackagePath:      "/usr/bin/artifacts/dummy.jar",
+						FixedVersion:     "FixedVersionTest",
+						InstalledVersion: "InstalledVersionTest",
+					},
+					{
+						Name:             "NameTest",
+						PackagePath:      "/usr/local/artifacts/dummy.gem",
 						FixedVersion:     "FixedVersionTest",
 						InstalledVersion: "InstalledVersionTest",
 					},
@@ -34,6 +41,10 @@ func TestUtils(t *testing.T) {
 			So(cve.ContainsStr("NameTest"), ShouldBeTrue)
 			So(cve.ContainsStr("FixedVersionTest"), ShouldBeTrue)
 			So(cve.ContainsStr("InstalledVersionTest"), ShouldBeTrue)
+			So(cve.ContainsStr("/usr/bin/artifacts/dummy.jar"), ShouldBeTrue)
+			So(cve.ContainsStr("dummy.jar"), ShouldBeTrue)
+			So(cve.ContainsStr("/usr/local/artifacts/dummy.gem"), ShouldBeTrue)
+			So(cve.ContainsStr("dummy.gem"), ShouldBeTrue)
 		})
 		Convey("getConfigAndDigest", func() {
 			_, _, err := getConfigAndDigest(mocks.MetaDBMock{}, "bad-digest")

--- a/pkg/extensions/search/cve/model/models.go
+++ b/pkg/extensions/search/cve/model/models.go
@@ -39,13 +39,15 @@ func (cve *CVE) ContainsStr(str string) bool {
 		slices.ContainsFunc(cve.PackageList, func(pack Package) bool {
 			return strings.Contains(strings.ToUpper(pack.Name), str) ||
 				strings.Contains(strings.ToUpper(pack.FixedVersion), str) ||
-				strings.Contains(strings.ToUpper(pack.InstalledVersion), str)
+				strings.Contains(strings.ToUpper(pack.InstalledVersion), str) ||
+				strings.Contains(strings.ToUpper(pack.PackagePath), str)
 		})
 }
 
 //nolint:tagliatelle // graphQL schema
 type Package struct {
 	Name             string `json:"Name"`
+	PackagePath      string `json:"PackagePath"`
 	InstalledVersion string `json:"InstalledVersion"`
 	FixedVersion     string `json:"FixedVersion"`
 }

--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -394,6 +394,13 @@ func (scanner Scanner) scanManifest(ctx context.Context, repo, digest string) (m
 				fixedVersion = "Not Specified"
 			}
 
+			var packagePath string
+			if vulnerability.PkgPath != "" {
+				packagePath = vulnerability.PkgPath
+			} else {
+				packagePath = "Not Specified"
+			}
+
 			_, ok := cveidMap[vulnerability.VulnerabilityID]
 			if ok {
 				cveDetailStruct := cveidMap[vulnerability.VulnerabilityID]
@@ -404,6 +411,7 @@ func (scanner Scanner) scanManifest(ctx context.Context, repo, digest string) (m
 					pkgList,
 					cvemodel.Package{
 						Name:             pkgName,
+						PackagePath:      packagePath,
 						InstalledVersion: installedVersion,
 						FixedVersion:     fixedVersion,
 					},
@@ -419,6 +427,7 @@ func (scanner Scanner) scanManifest(ctx context.Context, repo, digest string) (m
 					newPkgList,
 					cvemodel.Package{
 						Name:             pkgName,
+						PackagePath:      packagePath,
 						InstalledVersion: installedVersion,
 						FixedVersion:     fixedVersion,
 					},

--- a/pkg/extensions/search/gql_generated/generated.go
+++ b/pkg/extensions/search/gql_generated/generated.go
@@ -145,6 +145,7 @@ type ComplexityRoot struct {
 		FixedVersion     func(childComplexity int) int
 		InstalledVersion func(childComplexity int) int
 		Name             func(childComplexity int) int
+		PackagePath      func(childComplexity int) int
 	}
 
 	PageInfo struct {
@@ -737,6 +738,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.PackageInfo.Name(childComplexity), true
 
+	case "PackageInfo.PackagePath":
+		if e.complexity.PackageInfo.PackagePath == nil {
+			break
+		}
+
+		return e.complexity.PackageInfo.PackagePath(childComplexity), true
+
 	case "PageInfo.ItemCount":
 		if e.complexity.PageInfo.ItemCount == nil {
 			break
@@ -1274,6 +1282,10 @@ type PackageInfo {
     Name of the package affected by a CVE
     """
     Name: String
+    """
+    Path where the vulnerable package is located
+    """
+    PackagePath: String
     """
     Current version of the package, typically affected by the CVE
     """
@@ -2749,6 +2761,8 @@ func (ec *executionContext) fieldContext_CVE_PackageList(ctx context.Context, fi
 			switch field.Name {
 			case "Name":
 				return ec.fieldContext_PackageInfo_Name(ctx, field)
+			case "PackagePath":
+				return ec.fieldContext_PackageInfo_PackagePath(ctx, field)
 			case "InstalledVersion":
 				return ec.fieldContext_PackageInfo_InstalledVersion(ctx, field)
 			case "FixedVersion":
@@ -5419,6 +5433,47 @@ func (ec *executionContext) _PackageInfo_Name(ctx context.Context, field graphql
 }
 
 func (ec *executionContext) fieldContext_PackageInfo_Name(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "PackageInfo",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _PackageInfo_PackagePath(ctx context.Context, field graphql.CollectedField, obj *PackageInfo) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_PackageInfo_PackagePath(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.PackagePath, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_PackageInfo_PackagePath(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	fc = &graphql.FieldContext{
 		Object:     "PackageInfo",
 		Field:      field,
@@ -10318,6 +10373,8 @@ func (ec *executionContext) _PackageInfo(ctx context.Context, sel ast.SelectionS
 			out.Values[i] = graphql.MarshalString("PackageInfo")
 		case "Name":
 			out.Values[i] = ec._PackageInfo_Name(ctx, field, obj)
+		case "PackagePath":
+			out.Values[i] = ec._PackageInfo_PackagePath(ctx, field, obj)
 		case "InstalledVersion":
 			out.Values[i] = ec._PackageInfo_InstalledVersion(ctx, field, obj)
 		case "FixedVersion":

--- a/pkg/extensions/search/gql_generated/models_gen.go
+++ b/pkg/extensions/search/gql_generated/models_gen.go
@@ -209,6 +209,8 @@ type ManifestSummary struct {
 type PackageInfo struct {
 	// Name of the package affected by a CVE
 	Name *string `json:"Name,omitempty"`
+	// Path where the vulnerable package is located
+	PackagePath *string `json:"PackagePath,omitempty"`
 	// Current version of the package, typically affected by the CVE
 	InstalledVersion *string `json:"InstalledVersion,omitempty"`
 	// Minimum version of the package in which the CVE is fixed

--- a/pkg/extensions/search/resolver.go
+++ b/pkg/extensions/search/resolver.go
@@ -241,6 +241,7 @@ func getCVEListForImage(
 			pkgList = append(pkgList,
 				&gql_generated.PackageInfo{
 					Name:             &pkg.Name,
+					PackagePath:      &pkg.PackagePath,
 					InstalledVersion: &pkg.InstalledVersion,
 					FixedVersion:     &pkg.FixedVersion,
 				},

--- a/pkg/extensions/search/schema.graphql
+++ b/pkg/extensions/search/schema.graphql
@@ -73,6 +73,10 @@ type PackageInfo {
     """
     Name: String
     """
+    Path where the vulnerable package is located
+    """
+    PackagePath: String
+    """
     Current version of the package, typically affected by the CVE
     """
     InstalledVersion: String

--- a/pkg/test/image-utils/utils.go
+++ b/pkg/test/image-utils/utils.go
@@ -29,23 +29,34 @@ func GetLayerWithVulnerability() ([]byte, error) {
 	if vulnerableLayer != nil {
 		return vulnerableLayer, nil
 	}
+	// this is the path of the blob relative to the root of the zot folder
+	vulnBlobPath := "test/data/alpine/blobs/sha256/f56be85fc22e46face30e2c3de3f7fe7c15f8fd7c4e5add29d7f64b87abdaa09"
+	vulnerableLayer, err := GetLayerRelativeToProjectRoot(vulnBlobPath)
 
+	return vulnerableLayer, err
+}
+
+func GetLayerWithLanguageFileVulnerability() ([]byte, error) {
+	vulnBlobPath := "test/data/spring-web/blobs/sha256/506c47a6827e325a63d4b38c7ce656e07d5e98a09d748ec7ac989a45af7d6567"
+	vulnerableLayerWithLanguageFile, err := GetLayerRelativeToProjectRoot(vulnBlobPath)
+
+	return vulnerableLayerWithLanguageFile, err
+}
+
+func GetLayerRelativeToProjectRoot(pathToLayerBlob string) ([]byte, error) {
 	projectRootDir, err := tcommon.GetProjectRootDir()
 	if err != nil {
 		return nil, err
 	}
 
-	// this is the path of the blob relative to the root of the zot folder
-	vulnBlobPath := "test/data/alpine/blobs/sha256/f56be85fc22e46face30e2c3de3f7fe7c15f8fd7c4e5add29d7f64b87abdaa09"
+	absoluteBlobPath, _ := filepath.Abs(filepath.Join(projectRootDir, pathToLayerBlob))
 
-	absoluteVulnBlobPath, _ := filepath.Abs(filepath.Join(projectRootDir, vulnBlobPath))
-
-	vulnerableLayer, err := os.ReadFile(absoluteVulnBlobPath) //nolint: lll
+	layer, err := os.ReadFile(absoluteBlobPath) //nolint: lll
 	if err != nil {
 		return nil, err
 	}
 
-	return vulnerableLayer, nil
+	return layer, nil
 }
 
 func GetDefaultLayers() []Layer {


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Partially addresses #2175 

**What does this PR do / Why do we need it**:
This PR has changes that includes `PackagePath` information for a CVE. This informs the user about the path where the vulnerable package can be found in their image.

**Testing done on this change**:
Test image: https://hub.docker.com/r/fl73/spring4shell-vulnerable-app
Package information is not shown in ZLI CLI output today. However, other output formats include this data.
#### YAML
Command: `./bin/zli-linux-amd64 cve --config main list fl73/spring4shell-vulnerable-app:latest -f yaml`
Output:
```yaml
---
tag: latest
cvelist:
- id: CVE-2016-1000027
  severity: CRITICAL
  title: 'spring: HttpInvokerServiceExporter readRemoteInvocation method untrusted
    java deserialization'
  description: 'Pivotal Spring Framework through 5.3.16 suffers from a potential remote
    code execution (RCE) issue if used for Java deserialization of untrusted data.
    Depending on how the library is implemented within a product, this issue may or
    not occur, and authentication may be required. NOTE: the vendor''s position is
    that untrusted data is not an intended use case. The product''s behavior will
    not be changed because some users rely on deserialization of trusted data.'
  packagelist:
  - name: org.springframework:spring-web
    packagepath: usr/local/tomcat/webapps/spring4shell.war/WEB-INF/lib/spring-web-5.3.15.jar
    installedversion: 5.3.15
    fixedversion: 6.0.0
- id: CVE-2019-8457
  severity: CRITICAL
  title: heap out-of-bound read in function rtreenode()
  description: SQLite3 from 3.6.0 to and including 3.27.2 is vulnerable to heap out-of-bound
    read in the rtreenode() function when handling invalid rtree tables.
  packagelist:
  - name: libdb5.3
    packagepath: Not Specified
    installedversion: 5.3.28+dfsg1-0.8
    fixedversion: Not Specified
<TRUNCATED>
```
#### JSON
Command: `./bin/zli-linux-amd64 cve --config main list fl73/spring4shell-vulnerable-app:latest -f json | jq .`
Output:
```json
{
  "Tag": "latest",
  "CVEList": [
    {
      "Id": "CVE-2016-1000027",
      "Severity": "CRITICAL",
      "Title": "spring: HttpInvokerServiceExporter readRemoteInvocation method untrusted java deserialization",
      "Description": "Pivotal Spring Framework through 5.3.16 suffers from a potential remote code execution (RCE) issue if used for Java deserialization of untrusted data. Depending on how the li
brary is implemented within a product, this issue may or not occur, and authentication may be required. NOTE: the vendor's position is that untrusted data is not an intended use case. The product'
s behavior will not be changed because some users rely on deserialization of trusted data.",
      "PackageList": [
        {
          "Name": "org.springframework:spring-web",
          "PackagePath": "usr/local/tomcat/webapps/spring4shell.war/WEB-INF/lib/spring-web-5.3.15.jar",
          "InstalledVersion": "5.3.15",
          "FixedVersion": "6.0.0"
        }
      ]
    },
    {
      "Id": "CVE-2019-8457",
      "Severity": "CRITICAL",
      "Title": "heap out-of-bound read in function rtreenode()",
      "Description": "SQLite3 from 3.6.0 to and including 3.27.2 is vulnerable to heap out-of-bound read in the rtreenode() function when handling invalid rtree tables.",
      "PackageList": [
        {
          "Name": "libdb5.3",
          "PackagePath": "Not Specified",
          "InstalledVersion": "5.3.28+dfsg1-0.8",
          "FixedVersion": "Not Specified"
        }
      ]
    },
    {
      "Id": "CVE-2021-22945",
      "Severity": "CRITICAL",
      "Title": "curl: use-after-free and double-free in MQTT sending",
      "Description": "When sending data to an MQTT server, libcurl <= 7.73.0 and 7.78.0 could in some circumstances erroneously keep a pointer to an already freed memory area and both use that aga
in in a subsequent call to send data and also free it *again*.",
      "PackageList": [
        {
          "Name": "curl",
          "PackagePath": "Not Specified",
          "InstalledVersion": "7.74.0-1.3+deb11u1",
          "FixedVersion": "7.74.0-1.3+deb11u2"
        },
        {
          "Name": "libcurl3-gnutls",
          "PackagePath": "Not Specified",
          "InstalledVersion": "7.74.0-1.3+deb11u1",
          "FixedVersion": "7.74.0-1.3+deb11u2"
        },
        {
          "Name": "libcurl4",
          "PackagePath": "Not Specified",
          "InstalledVersion": "7.74.0-1.3+deb11u1",
          "FixedVersion": "7.74.0-1.3+deb11u2"
        }
      ]
    },
TRUNCATED
```
**Automation added to e2e**:
(Work in progress)
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
```release-note
Users can now see path information (if applicable and available) for vulnerable packages in JSON and YAML formatted output for an image's CVE listing in zli.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.