### PR TITLE
fix: ignore metadb errors if tag not found

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -514,7 +514,7 @@ func (rh *RouteHandler) GetManifest(response http.ResponseWriter, request *http.
 
 	if rh.c.MetaDB != nil {
 		err := meta.OnGetManifest(name, reference, mediaType, content, rh.c.StoreController, rh.c.MetaDB, rh.c.Log)
-		if err != nil {
+		if err != nil && !errors.Is(err, zerr.ErrImageMetaNotFound) {
 			response.WriteHeader(http.StatusInternalServerError)
 
 			return

--- a/pkg/meta/hooks.go
+++ b/pkg/meta/hooks.go
@@ -100,7 +100,7 @@ func OnDeleteManifest(repo, reference, mediaType string, digest godigest.Digest,
 	return nil
 }
 
-// OnDeleteManifest is called when a manifest is downloaded. It increments the download couter on that manifest.
+// OnGetManifest is called when a manifest is downloaded. It increments the download couter on that manifest.
 func OnGetManifest(name, reference, mediaType string, body []byte,
 	storeController storage.StoreController, metaDB mTypes.MetaDB, log log.Logger,
 ) error {

--- a/test/blackbox/annotations.bats
+++ b/test/blackbox/annotations.bats
@@ -136,6 +136,12 @@ function teardown_file() {
     [ "$status" -eq 0 ]
     local sigName=$(echo "${lines[-1]}" | jq '.[].critical.image."docker-manifest-digest"')
     [[ "$sigName" == *"${digest}"* ]]
+    tags=( $(oras repo tags --plain-http localhost:${zot_port}/annotations) )
+    [ "$status" -eq 0 ]
+    local sigdes=$(oras manifest fetch --descriptor localhost:${zot_port}/annotations:${tags[1]} | jq  .digest | tr -d \")
+    [ "$status" -eq 0 ]
+    run oras manifest fetch --plain-http localhost:${zot_port}/annotations@${sigdes}
+    [ "$status" -eq 0 ]
 }
 
 @test "sign/verify with cosign (only referrers)" {


### PR DESCRIPTION
Manifests cat be retrieved by digest but we maintain stats based only on tags. So ignore errors if not found.

Fixes issue #2299

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
