### PR TITLE
feat: add verbose mode for cves for image listing

### DIFF
--- a/pkg/cli/client/cve_cmd_internal_test.go
+++ b/pkg/cli/client/cve_cmd_internal_test.go
@@ -213,6 +213,43 @@ func TestSearchCVECmd(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 
+	Convey("Test CVE by image name - in text format - in verbose mode", t, func() {
+		args := []string{"list", "dummyImageName:tag", "--url", baseURL, "--verbose"}
+		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
+		defer os.Remove(configPath)
+		cveCmd := NewCVECommand(new(mockService))
+		buff := bytes.NewBufferString("")
+		cveCmd.SetOut(buff)
+		cveCmd.SetErr(buff)
+		cveCmd.SetArgs(args)
+		err := cveCmd.Execute()
+
+		outputLines := strings.Split(buff.String(), "\n")
+		expected := []string{
+			"CRITICAL 0, HIGH 1, MEDIUM 0, LOW 0, UNKNOWN 0, TOTAL 1",
+			"",
+			"dummyCVEID",
+			"Severity: HIGH",
+			"Title: Title of that CVE",
+			"Description:",
+			"Description of the CVE",
+			"",
+			"Vulnerable Packages:",
+			" Package Name: packagename",
+			" Package Path: ",
+			" Installed Version: installedver",
+			" Fixed Version: fixedver",
+			"",
+			"",
+		}
+
+		for index, expectedLine := range expected {
+			So(outputLines[index], ShouldEqual, expectedLine)
+		}
+
+		So(err, ShouldBeNil)
+	})
+
 	Convey("Test CVE by image name - in json format", t, func() {
 		args := []string{"list", "dummyImageName:tag", "--url", baseURL, "-f", "json"}
 		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)

--- a/pkg/cli/client/search_functions.go
+++ b/pkg/cli/client/search_functions.go
@@ -253,11 +253,13 @@ func SearchCVEForImageGQL(config SearchConfig, image, searchedCveID string) erro
 
 		fmt.Fprint(config.ResultWriter, statsStr)
 
-		printCVETableHeader(&builder)
-		fmt.Fprint(config.ResultWriter, builder.String())
+		if !config.Verbose {
+			printCVETableHeader(&builder)
+			fmt.Fprint(config.ResultWriter, builder.String())
+		}
 	}
 
-	out, err := cveList.string(config.OutputFormat)
+	out, err := cveList.string(config.OutputFormat, config.Verbose)
 	if err != nil {
 		return err
 	}
@@ -303,7 +305,7 @@ func SearchCVEDiffList(config SearchConfig, minuend, subtrahend ImageIdentifier)
 		fmt.Fprint(config.ResultWriter, builder.String())
 	}
 
-	out, err := result.string(config.OutputFormat)
+	out, err := result.string(config.OutputFormat, config.Verbose)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Towards #2175 

**What does this PR do / Why do we need it**:
This PR introduces a new verbose output for listing CVEs for a given image. In this mode, all the details of the CVE are shown in full including the CVE Description and package related details.

**Testing done on this change**:
![Screenshot from 2024-03-08 22-09-30](https://github.com/project-zot/zot/assets/30438425/b6b24e8c-804c-4058-b137-3624a6691553)
![Screenshot from 2024-03-08 22-10-53](https://github.com/project-zot/zot/assets/30438425/489d4945-c0a0-408f-80e9-0fbd88cf7726)
![Screenshot from 2024-03-08 22-17-15](https://github.com/project-zot/zot/assets/30438425/5fb52c7e-aacc-4985-bd4a-54b2c0f49243)


**Will this break upgrades or downgrades?**
No, there is no expected impact to upgrades or downgrades.

**Does this PR introduce any user-facing change?**:
Yes

```release-note
A new --verbose flag is available for users to view complete details about the CVE impacting the image. This includes the full description and a list of packages which are vulnerable to the CVE.
The verbose mode can be invoked with bin/zli-linux-amd64 --config <config> cve list <image name> --verbose
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
