### PR TITLE
chore: update to go 1.22

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       # Run benchmark with `go test -bench` and stores the output to a file
       - name: Run benchmark
         run: make BENCH_OUTPUT=ci-cd run-bench

--- a/.github/workflows/branch-cov.yaml
+++ b/.github/workflows/branch-cov.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Cache go dependencies
         id: cache-go-dependencies
         uses: actions/cache@v4

--- a/.github/workflows/cloc.yaml
+++ b/.github/workflows/cloc.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Check out source code
         uses: actions/checkout@v4
       - name: Install dependencies

--- a/.github/workflows/cluster.yaml
+++ b/.github/workflows/cluster.yaml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
       uses: actions/setup-go@v5
       with:
         cache: false
-        go-version: 1.21.x
+        go-version: 1.22.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/compare-binary-size.yaml
+++ b/.github/workflows/compare-binary-size.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Checkout zot (main branch)
         run: |
           mkdir -p $GITHUB_WORKSPACE/zot_main

--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/gc-stress-test.yaml
+++ b/.github/workflows/gc-stress-test.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Run zb
         id: bench
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
 
       - name: Run zb
         id: bench
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: ./.github/actions/setup-localstack
       - name: Setup minio service
         run: |
@@ -157,7 +157,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: ./.github/actions/setup-localstack
       - name: Setup minio service
         run: |

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: '1.21'
+          go-version: '1.22'
       - uses: actions/checkout@v4
       - name: Run linter with GH action
         uses: golangci/golangci-lint-action@v4

--- a/.github/workflows/gqlgen.yaml
+++ b/.github/workflows/gqlgen.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install go-licenses
         run: go install github.com/google/go-licenses@latest
       - name: Check for forbidden licenses

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: ./.github/actions/setup-localstack
 
       - name: Run zb
@@ -122,7 +122,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - uses: ./.github/actions/setup-localstack
 
       - name: Run zb
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/oci-conformance-action.yaml
+++ b/.github/workflows/oci-conformance-action.yaml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - name: Install go 1.21
+    - name: Install go 1.22
       uses: actions/setup-go@v5
       with:
         cache: false
-        go-version: 1.21.x
+        go-version: 1.22.x
     - name: Checkout this PR
       uses: actions/checkout@v4
     - name: Start zot server

--- a/.github/workflows/sync-3rdparty-images.yaml
+++ b/.github/workflows/sync-3rdparty-images.yaml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         golang_version:
-          - "1.21"
+          - "1.22"
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Docker Registry

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Cache go dependencies
         id: cache-go-dependencies
         uses: actions/cache@v4
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Cache go dependencies
         id: cache-go-dependencies
         uses: actions/cache@v4
@@ -99,7 +99,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Cache go dependencies
         id: cache-go-dependencies
         uses: actions/cache@v4
@@ -133,7 +133,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: download all workflow coverage files
         uses: actions/download-artifact@v4
       - name: merge code coverage

--- a/.github/workflows/tls.yaml
+++ b/.github/workflows/tls.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/web-scan.yaml
+++ b/.github/workflows/web-scan.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           cache: false
-          go-version: 1.21.x
+          go-version: 1.22.x
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build zot

--- a/Makefile
+++ b/Makefile
@@ -55,12 +55,11 @@ BENCH_OUTPUT ?= stdout
 ALL_EXTENSIONS = debug,imagetrust,lint,metrics,mgmt,profile,scrub,search,sync,ui,userprefs
 EXTENSIONS ?= sync,search,scrub,metrics,lint,ui,mgmt,profile,userprefs,imagetrust
 UI_DEPENDENCIES := search,mgmt,userprefs
-# freebsd/arm64 not supported for pie builds
+# freebsd is not supported for pie builds if CGO is disabled
+# see supported platforms at https://cs.opensource.google/go/go/+/master:src/internal/platform/supported.go;l=222-231;drc=d7fcb5cf80953f1d63246f1ae9defa60c5ce2d76
 BUILDMODE_FLAGS := -buildmode=pie
 ifeq ($(OS),freebsd)
-	ifeq ($(ARCH),arm64)
-		BUILDMODE_FLAGS=
-	endif
+	BUILDMODE_FLAGS=
 endif
 comma:= ,
 space := $(null) #

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
-FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.21 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.22 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-conformance
+++ b/build/Dockerfile-conformance
@@ -1,7 +1,7 @@
 # ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
-FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.21 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.22 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-minimal
+++ b/build/Dockerfile-minimal
@@ -1,7 +1,7 @@
 # ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
-FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.21 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.22 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-zb
+++ b/build/Dockerfile-zb
@@ -1,7 +1,7 @@
 # ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
-FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.21 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.22 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-zxp
+++ b/build/Dockerfile-zxp
@@ -1,7 +1,7 @@
 # ---
 # Stage 1: Build binary, create default config file
 # ---
-FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.21 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.22 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/stacker-conformance.yaml
+++ b/build/stacker-conformance.yaml
@@ -1,7 +1,7 @@
 build:
   from:
     type: docker
-    url: docker://ghcr.io/project-zot/golang:1.21
+    url: docker://ghcr.io/project-zot/golang:1.22
   binds:
     - ../. -> /zotcopy
   run: |

--- a/build/stacker-minimal.yaml
+++ b/build/stacker-minimal.yaml
@@ -1,7 +1,7 @@
 build:
   from:
     type: docker
-    url: docker://ghcr.io/project-zot/golang:1.21
+    url: docker://ghcr.io/project-zot/golang:1.22
   binds:
     - ../. -> /zotcopy
   run: |

--- a/build/stacker-zb.yaml
+++ b/build/stacker-zb.yaml
@@ -1,7 +1,7 @@
 build:
   from:
     type: docker
-    url: docker://ghcr.io/project-zot/golang:1.21
+    url: docker://ghcr.io/project-zot/golang:1.22
   binds:
     - ../. -> /zotcopy
   run: |

--- a/build/stacker-zxp.yaml
+++ b/build/stacker-zxp.yaml
@@ -1,7 +1,7 @@
 build:
   from:
     type: docker
-    url: docker://ghcr.io/project-zot/golang:1.21
+    url: docker://ghcr.io/project-zot/golang:1.22
   binds:
     - ../. -> /zotcopy
   run: |

--- a/build/stacker.yaml
+++ b/build/stacker.yaml
@@ -1,7 +1,7 @@
 build:
   from:
     type: docker
-    url: docker://ghcr.io/project-zot/golang:1.21
+    url: docker://ghcr.io/project-zot/golang:1.22
   binds:
     - ../. -> /zotcopy
   run: |

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module zotregistry.dev/zot
 
 go 1.21
 
-toolchain go1.21.4
+toolchain go1.22.1
 
 require (
 	github.com/99designs/gqlgen v0.17.45


### PR DESCRIPTION
1.
Only go toolchain version is updated.
We compile with go 1.22, but we allow others to compile using language version 1.21 if they wish to. If we also updated the go version in go.mod everyone would be forced to update, as that is enforced as a minimum allowed version.

This comment explains the difference well enough https://news.ycombinator.com/item?id=36455759

2.
 It looks like they made some cleanup in the logic allowing buildmode pie on various platforms.

Related to https://github.com/golang/go/issues/31544
See the code at: https://cs.opensource.google/go/go/+/master:src/internal/platform/supported.go;l=222-231;drc=d7fcb5cf80953f1d63246f1ae9defa60c5ce2d76;bpv=1;bpt=0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
