### PR TITLE
feat: show brief package list in image CVE listings

### DIFF
--- a/pkg/cli/client/cve_cmd_internal_test.go
+++ b/pkg/cli/client/cve_cmd_internal_test.go
@@ -140,9 +140,22 @@ func TestSearchCVECmd(t *testing.T) {
 		cmd.SetArgs(args)
 		err := cmd.Execute()
 		space := regexp.MustCompile(`\s+`)
-		str := space.ReplaceAllString(buff.String(), " ")
-		So(strings.TrimSpace(str), ShouldEqual, "CRITICAL 0, HIGH 1, MEDIUM 0, LOW 0, UNKNOWN 0, TOTAL 1 "+
-			"ID SEVERITY TITLE dummyCVEID HIGH Title of that CVE")
+		outputLines := strings.Split(buff.String(), "\n")
+
+		expected := []string{
+			"CRITICAL 0, HIGH 1, MEDIUM 0, LOW 0, UNKNOWN 0, TOTAL 1",
+			"",
+			"ID SEVERITY TITLE VULNERABLE PACKAGE PATH INSTALL-VER FIXED-VER",
+			"dummyCVEID HIGH Title of that CVE",
+			"packagename - installedver fixedver",
+		}
+
+		for expectedLineIndex, expectedLine := range expected {
+			currentOutputLine := outputLines[expectedLineIndex]
+			str := space.ReplaceAllString(currentOutputLine, " ")
+			So(strings.TrimSpace(str), ShouldEqual, expectedLine)
+		}
+
 		So(err, ShouldBeNil)
 	})
 
@@ -207,9 +220,22 @@ func TestSearchCVECmd(t *testing.T) {
 		cveCmd.SetArgs(args)
 		err := cveCmd.Execute()
 		space := regexp.MustCompile(`\s+`)
-		str := space.ReplaceAllString(buff.String(), " ")
-		So(strings.TrimSpace(str), ShouldEqual, "CRITICAL 0, HIGH 1, MEDIUM 0, LOW 0, UNKNOWN 0, TOTAL 1 "+
-			"ID SEVERITY TITLE dummyCVEID HIGH Title of that CVE")
+		outputLines := strings.Split(buff.String(), "\n")
+
+		expected := []string{
+			"CRITICAL 0, HIGH 1, MEDIUM 0, LOW 0, UNKNOWN 0, TOTAL 1",
+			"",
+			"ID SEVERITY TITLE VULNERABLE PACKAGE PATH INSTALL-VER FIXED-VER",
+			"dummyCVEID HIGH Title of that CVE",
+			"packagename - installedver fixedver",
+		}
+
+		for expectedLineIndex, expectedLine := range expected {
+			currentOutputLine := outputLines[expectedLineIndex]
+			str := space.ReplaceAllString(currentOutputLine, " ")
+			So(strings.TrimSpace(str), ShouldEqual, expectedLine)
+		}
+
 		So(err, ShouldBeNil)
 	})
 

--- a/pkg/cli/client/cve_cmd_test.go
+++ b/pkg/cli/client/cve_cmd_test.go
@@ -901,15 +901,25 @@ func TestCVESort(t *testing.T) {
 		cmd.SetArgs(args)
 		err := cmd.Execute()
 		So(err, ShouldBeNil)
-		str := space.ReplaceAllString(buff.String(), " ")
-		actual := strings.TrimSpace(str)
-		So(actual, ShouldResemble,
-			"CRITICAL 1, HIGH 1, MEDIUM 2, LOW 1, UNKNOWN 0, TOTAL 5 ID SEVERITY TITLE "+
-				"CVE-2023-3446 CRITICAL Excessive time spent checking DH keys and par... "+
-				"CVE-2023-2975 HIGH AES-SIV cipher implementation contains a bug ... "+
-				"CVE-2023-2650 MEDIUM Possible DoS translating ASN.1 object identif... "+
-				"CVE-2023-3817 MEDIUM Excessive time spent checking DH q parameter ... "+
-				"CVE-2023-1255 LOW Input buffer over-read in AES-XTS implementat...")
+
+		outputLines := strings.Split(buff.String(), "\n")
+
+		expected := []string{
+			"CRITICAL 1, HIGH 1, MEDIUM 2, LOW 1, UNKNOWN 0, TOTAL 5",
+			"",
+			"ID SEVERITY TITLE VULNERABLE PACKAGE PATH INSTALL-VER FIXED-VER",
+			"CVE-2023-3446 CRITICAL Excessive time spent checking DH keys and par...",
+			"CVE-2023-2975 HIGH AES-SIV cipher implementation contains a bug ...",
+			"CVE-2023-2650 MEDIUM Possible DoS translating ASN.1 object identif...",
+			"CVE-2023-3817 MEDIUM Excessive time spent checking DH q parameter ...",
+			"CVE-2023-1255 LOW Input buffer over-read in AES-XTS implementat...",
+		}
+
+		for expectedLineIndex, expectedLine := range expected {
+			currentOutputLine := outputLines[expectedLineIndex]
+			str := space.ReplaceAllString(currentOutputLine, " ")
+			So(strings.TrimSpace(str), ShouldResemble, expectedLine)
+		}
 
 		args = []string{"list", "repo:tag", "--sort-by", "alpha-asc", "--url", baseURL}
 		cmd = client.NewCVECommand(client.NewSearchService())
@@ -919,15 +929,25 @@ func TestCVESort(t *testing.T) {
 		cmd.SetArgs(args)
 		err = cmd.Execute()
 		So(err, ShouldBeNil)
-		str = space.ReplaceAllString(buff.String(), " ")
-		actual = strings.TrimSpace(str)
-		So(actual, ShouldResemble,
-			"CRITICAL 1, HIGH 1, MEDIUM 2, LOW 1, UNKNOWN 0, TOTAL 5 ID SEVERITY TITLE "+
-				"CVE-2023-1255 LOW Input buffer over-read in AES-XTS implementat... "+
-				"CVE-2023-2650 MEDIUM Possible DoS translating ASN.1 object identif... "+
-				"CVE-2023-2975 HIGH AES-SIV cipher implementation contains a bug ... "+
-				"CVE-2023-3446 CRITICAL Excessive time spent checking DH keys and par... "+
-				"CVE-2023-3817 MEDIUM Excessive time spent checking DH q parameter ...")
+
+		outputLines = strings.Split(buff.String(), "\n")
+
+		expected = []string{
+			"CRITICAL 1, HIGH 1, MEDIUM 2, LOW 1, UNKNOWN 0, TOTAL 5",
+			"",
+			"ID SEVERITY TITLE VULNERABLE PACKAGE PATH INSTALL-VER FIXED-VER",
+			"CVE-2023-1255 LOW Input buffer over-read in AES-XTS implementat...",
+			"CVE-2023-2650 MEDIUM Possible DoS translating ASN.1 object identif...",
+			"CVE-2023-2975 HIGH AES-SIV cipher implementation contains a bug ...",
+			"CVE-2023-3446 CRITICAL Excessive time spent checking DH keys and par...",
+			"CVE-2023-3817 MEDIUM Excessive time spent checking DH q parameter ...",
+		}
+
+		for expectedLineIndex, expectedLine := range expected {
+			currentOutputLine := outputLines[expectedLineIndex]
+			str := space.ReplaceAllString(currentOutputLine, " ")
+			So(strings.TrimSpace(str), ShouldResemble, expectedLine)
+		}
 
 		args = []string{"list", "repo:tag", "--sort-by", "alpha-dsc", "--url", baseURL}
 		cmd = client.NewCVECommand(client.NewSearchService())
@@ -937,15 +957,25 @@ func TestCVESort(t *testing.T) {
 		cmd.SetArgs(args)
 		err = cmd.Execute()
 		So(err, ShouldBeNil)
-		str = space.ReplaceAllString(buff.String(), " ")
-		actual = strings.TrimSpace(str)
-		So(actual, ShouldResemble,
-			"CRITICAL 1, HIGH 1, MEDIUM 2, LOW 1, UNKNOWN 0, TOTAL 5 ID SEVERITY TITLE "+
-				"CVE-2023-3817 MEDIUM Excessive time spent checking DH q parameter ... "+
-				"CVE-2023-3446 CRITICAL Excessive time spent checking DH keys and par... "+
-				"CVE-2023-2975 HIGH AES-SIV cipher implementation contains a bug ... "+
-				"CVE-2023-2650 MEDIUM Possible DoS translating ASN.1 object identif... "+
-				"CVE-2023-1255 LOW Input buffer over-read in AES-XTS implementat...")
+
+		outputLines = strings.Split(buff.String(), "\n")
+
+		expected = []string{
+			"CRITICAL 1, HIGH 1, MEDIUM 2, LOW 1, UNKNOWN 0, TOTAL 5",
+			"",
+			"ID SEVERITY TITLE VULNERABLE PACKAGE PATH INSTALL-VER FIXED-VER",
+			"CVE-2023-3817 MEDIUM Excessive time spent checking DH q parameter ...",
+			"CVE-2023-3446 CRITICAL Excessive time spent checking DH keys and par...",
+			"CVE-2023-2975 HIGH AES-SIV cipher implementation contains a bug ...",
+			"CVE-2023-2650 MEDIUM Possible DoS translating ASN.1 object identif...",
+			"CVE-2023-1255 LOW Input buffer over-read in AES-XTS implementat...",
+		}
+
+		for expectedLineIndex, expectedLine := range expected {
+			currentOutputLine := outputLines[expectedLineIndex]
+			str := space.ReplaceAllString(currentOutputLine, " ")
+			So(strings.TrimSpace(str), ShouldResemble, expectedLine)
+		}
 	})
 }
 

--- a/pkg/cli/client/search_functions_internal_test.go
+++ b/pkg/cli/client/search_functions_internal_test.go
@@ -390,9 +390,12 @@ func TestSearchCVEForImageGQL(t *testing.T) {
 		expected := []string{
 			"CRITICAL 0, HIGH 2, MEDIUM 0, LOW 0, UNKNOWN 0, TOTAL 2",
 			"",
-			"ID SEVERITY TITLE",
+			"ID SEVERITY TITLE VULNERABLE PACKAGE PATH INSTALL-VER FIXED-VER",
 			"dummyCVEID HIGH Title of that CVE",
+			"packagename - installedver fixedver",
 			"test-cve-id2 HIGH Test CVE 2",
+			"packagename /usr/bin/dummy.jar installedver fixedver",
+			"packagename /usr/bin/dummy.gem installedver fixedver",
 		}
 
 		space := regexp.MustCompile(`\s+`)

--- a/pkg/cli/client/service.go
+++ b/pkg/cli/client/service.go
@@ -877,21 +877,45 @@ func (cve cveResult) stringPlainText() string {
 
 	table := getCVETableWriter(&builder)
 
-	for _, c := range cve.Data.CVEListForImage.CVEList {
-		id := ellipsize(c.ID, cveIDWidth, ellipsis)
-		title := ellipsize(c.Title, cveTitleWidth, ellipsis)
-		severity := ellipsize(c.Severity, cveSeverityWidth, ellipsis)
+	for _, cveListItem := range cve.Data.CVEListForImage.CVEList {
+		id := ellipsize(cveListItem.ID, cveIDWidth, ellipsis)
+		title := ellipsize(cveListItem.Title, cveTitleWidth, ellipsis)
+		severity := ellipsize(cveListItem.Severity, cveSeverityWidth, ellipsis)
 		row := make([]string, 3) //nolint:gomnd
 		row[colCVEIDIndex] = id
 		row[colCVESeverityIndex] = severity
 		row[colCVETitleIndex] = title
 
 		table.Append(row)
+
+		for _, pkg := range cveListItem.PackageList {
+			pkgRow := generateTableRowForVulnerablePackage(pkg)
+			table.Append(pkgRow)
+		}
 	}
 
 	table.Render()
 
 	return builder.String()
+}
+
+func generateTableRowForVulnerablePackage(pkg packageList) []string {
+	row := make([]string, cveColTotalCount)
+	pkgName := ellipsize(pkg.Name, cveVulnPkgNameWidth, ellipsis)
+	pkgPath := "-"
+
+	if pkg.PackagePath != "" {
+		pkgPath = ellipsize(pkg.PackagePath, cveVulnPkgPathWidth, ellipsis)
+	}
+	pkgInstalledVer := ellipsize(pkg.InstalledVersion, cveVulnPkgInstalledVerWidth, ellipsis)
+	pkgFixedVer := ellipsize(pkg.FixedVersion, cveVulnPkgFixedVerWidth, ellipsis)
+
+	row[colCVEVulnPkgNameIndex] = pkgName
+	row[colCVEVulnPkgPathIndex] = pkgPath
+	row[colCVEVulnPkgInstalledVerIndex] = pkgInstalledVer
+	row[colCVEVulnPkgFixedVerIndex] = pkgFixedVer
+
+	return row
 }
 
 func (cve cveResult) stringJSON() (string, error) {
@@ -1362,6 +1386,10 @@ func getCVETableWriter(writer io.Writer) *tablewriter.Table {
 	table.SetColMinWidth(colCVEIDIndex, cveIDWidth)
 	table.SetColMinWidth(colCVESeverityIndex, cveSeverityWidth)
 	table.SetColMinWidth(colCVETitleIndex, cveTitleWidth)
+	table.SetColMinWidth(colCVEVulnPkgNameIndex, cveVulnPkgNameWidth)
+	table.SetColMinWidth(colCVEVulnPkgPathIndex, cveVulnPkgPathWidth)
+	table.SetColMinWidth(colCVEVulnPkgInstalledVerIndex, cveVulnPkgInstalledVerWidth)
+	table.SetColMinWidth(colCVEVulnPkgFixedVerIndex, cveVulnPkgFixedVerWidth)
 
 	return table
 }
@@ -1459,13 +1487,23 @@ const (
 	layersWidth      = 8
 	ellipsis         = "..."
 
-	cveIDWidth       = 16
-	cveSeverityWidth = 8
-	cveTitleWidth    = 48
+	cveIDWidth                  = 16
+	cveSeverityWidth            = 8
+	cveTitleWidth               = 48
+	cveVulnPkgNameWidth         = 35
+	cveVulnPkgPathWidth         = 30
+	cveVulnPkgInstalledVerWidth = 20
+	cveVulnPkgFixedVerWidth     = 20
 
-	colCVEIDIndex       = 0
-	colCVESeverityIndex = 1
-	colCVETitleIndex    = 2
+	colCVEIDIndex                  = 0
+	colCVESeverityIndex            = 1
+	colCVETitleIndex               = 2
+	colCVEVulnPkgNameIndex         = 3
+	colCVEVulnPkgPathIndex         = 4
+	colCVEVulnPkgInstalledVerIndex = 5
+	colCVEVulnPkgFixedVerIndex     = 6
+
+	cveColTotalCount = 7
 
 	defaultOutputFormat = "text"
 )

--- a/pkg/cli/client/utils.go
+++ b/pkg/cli/client/utils.go
@@ -184,12 +184,12 @@ func printImageTableHeader(writer io.Writer, verbose bool, maxImageNameLen, maxT
 
 func printCVETableHeader(writer io.Writer) {
 	table := getCVETableWriter(writer)
-	row := make([]string, 3) //nolint:gomnd
-	row[colCVEIDIndex] = "ID"
-	row[colCVESeverityIndex] = "SEVERITY"
-	row[colCVETitleIndex] = "TITLE"
+	columnHeadingsRow := []string{
+		"ID", "SEVERITY", "TITLE",
+		"VULNERABLE PACKAGE", "PATH", "INSTALL-VER", "FIXED-VER",
+	}
 
-	table.Append(row)
+	table.Append(columnHeadingsRow)
 	table.Render()
 }
 


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Towards #2175 
Addresses this comment: https://github.com/project-zot/zot/issues/2175#issuecomment-1979322270

**What does this PR do / Why do we need it**:
This PR adds a brief listing of vulnerable packages to the CVE list view. This will give the user an overall picture of the impacted packages. It displays the name, path (if available), installed version, and fixed version.

**Testing done on this change**:
Image with few vulnerable packages:
![Screenshot from 2024-03-24 12-30-55](https://github.com/project-zot/zot/assets/30438425/f2fd3e18-f950-4f52-970d-d251e54110dc)

Image with many vulnerable packages with and without paths:
![Screenshot from 2024-03-24 12-31-47](https://github.com/project-zot/zot/assets/30438425/0732d602-5734-4901-bd3a-bae09ea4fa5b)

Image with smaller terminal window displaying line wrapping (Gnome terminal):
![Screenshot from 2024-03-24 12-32-56](https://github.com/project-zot/zot/assets/30438425/9fb63eec-0ebc-4d1e-a102-f66148fac55f)

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades?**
No, it is not expected to impact upgrade or downgrades as the data is already available via GraphQL and this is only a presentation change to add more data.

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Users can now view a brief vulnerable package list for each CVE in the CVE list view in non-verbose mode.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
