### PR TITLE
fix(cli/server): serve command expected positional args

### DIFF
--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -47,6 +47,7 @@ func newServeCmd(conf *config.Config) *cobra.Command {
 		Aliases: []string{"serve"},
 		Short:   "`serve` stores and distributes OCI images",
 		Long:    "`serve` stores and distributes OCI images",
+		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
 				if err := LoadConfiguration(conf, args[0]); err != nil {

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -48,6 +48,18 @@ func TestServe(t *testing.T) {
 	})
 
 	Convey("Test serve config", t, func(c C) {
+		Convey("no config arg", func(c C) {
+			os.Args = []string{"cli_test", "serve"}
+			err := cli.NewServerRootCmd().Execute()
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("two args", func(c C) {
+			os.Args = []string{"cli_test", "serve", "config", "second arg"}
+			err := cli.NewServerRootCmd().Execute()
+			So(err, ShouldNotBeNil)
+		})
+
 		Convey("unknown config", func(c C) {
 			os.Args = []string{"cli_test", "serve", path.Join(os.TempDir(), "/x")}
 			err := cli.NewServerRootCmd().Execute()


### PR DESCRIPTION
Expect exactly one positional argument for the serve command with the path to the config file.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

bug

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

There's no reported issue AFAIK.

**What does this PR do / Why do we need it**:

This PR adds a check to the `serve` command to expect exactly one positional argument with the config file path. Improving the user experience.

**If an issue # is not available please add repro steps and logs showing the issue**:


Running `zot serve` (without passing a config file path) results in an index out-of-range error:

```
$ ./bin/zot-darwin-arm64 serve
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
zotregistry.dev/zot/pkg/cli/server.NewServerRootCmd.newServeCmd.func2(0x14002026800?, {0x10aede5e0, 0x0, 0x105f211c0?})
	zotregistry.dev/zot/pkg/cli/server/root.go:65 +0x1b0
github.com/spf13/cobra.(*Command).execute(0x14000354608, {0x10aede5e0, 0x0, 0x0})
	github.com/spf13/cobra@v1.8.0/command.go:983 +0x840
github.com/spf13/cobra.(*Command).ExecuteC(0x14000354308)
	github.com/spf13/cobra@v1.8.0/command.go:1115 +0x344
github.com/spf13/cobra.(*Command).Execute(0x10aab7538?)
	github.com/spf13/cobra@v1.8.0/command.go:1039 +0x1c
main.main()
	zotregistry.dev/zot/cmd/zot/main.go:10 +0x20
```

As a new user, I found this error to be misleading. I thought I had some error on the json file instead (I assumed that the `config.json` file would be used by default).

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

With the change included in this PR applied, this is the output you get instead:

```
$ ./bin/zot-darwin-arm64-minimal serve
Error: accepts 1 arg(s), received 0
Usage:
  zot serve <config> [flags]

Aliases:
  serve, serve

Flags:
  -h, --help   help for serve
```

Passing 1 argument works as expected:

```
$ ./bin/zot-darwin-arm64-minimal serve non-existent.json
{"level":"error","error":"open non-existent.json: no such file or directory","path":"non-existent.json","time":"2024-04-10T10:42:52+02:00","message":"failed to read configuration"}
Error: open non-existent.json: no such file or directory
Usage:
  zot serve <config> [flags]

Aliases:
  serve, serve

Flags:
  -h, --help   help for serve
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

I've added a unit test that checks for an error when not passing the expected positional argument.

Note: I tried running `make` locally, but it is failing on my machine even when running it on the `main` branch. I don't expect this change to impact other parts of the code.

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Running `zot serve` without the path to a config file won't result in an index out-of-range error anymore, it will show the help message of the command instead instructing to add the missing argument.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
