### PR TITLE
fix: additional input validation for CVE graphQL query

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -117,6 +117,7 @@ var (
 	ErrEmptyDigest                    = errors.New("digest can't be empty string")
 	ErrInvalidRepoRefFormat           = errors.New("invalid image reference format, use [repo:tag] or [repo@digest]")
 	ErrLimitIsNegative                = errors.New("pagination limit has negative value")
+	ErrLimitIsExcessive               = errors.New("pagination limit has excessive value")
 	ErrOffsetIsNegative               = errors.New("pagination offset has negative value")
 	ErrSortCriteriaNotSupported       = errors.New("the pagination sort criteria is not supported")
 	ErrMediaTypeNotSupported          = errors.New("media type is not supported")

--- a/pkg/extensions/search/cve/pagination.go
+++ b/pkg/extensions/search/cve/pagination.go
@@ -62,6 +62,8 @@ type CvePageFinder struct {
 	pageBuffer []cvemodel.CVE
 }
 
+const maxCvePageLimit = 4 * 1024
+
 func NewCvePageFinder(limit, offset int, sortBy cvemodel.SortCriteria) (*CvePageFinder, error) {
 	if sortBy == "" {
 		sortBy = SeverityDsc
@@ -69,6 +71,10 @@ func NewCvePageFinder(limit, offset int, sortBy cvemodel.SortCriteria) (*CvePage
 
 	if limit < 0 {
 		return nil, zerr.ErrLimitIsNegative
+	}
+
+	if limit > maxCvePageLimit {
+		return nil, zerr.ErrLimitIsExcessive
 	}
 
 	if offset < 0 {

--- a/pkg/extensions/search/cve/pagination_test.go
+++ b/pkg/extensions/search/cve/pagination_test.go
@@ -415,6 +415,23 @@ func TestCVEPagination(t *testing.T) {
 					previousSeverity = severityToInt[cve.Severity]
 				}
 			})
+			Convey("bad limits", func() {
+				_, _, _, err := cveInfo.GetCVEListForImage(ctx, "repo1", "0.1.0", "", "", "", cvemodel.PageInput{
+					Limit:  -1,
+					Offset: 3,
+					SortBy: cveinfo.AlphabeticAsc,
+				},
+				)
+				So(err, ShouldNotBeNil)
+
+				_, _, _, err = cveInfo.GetCVEListForImage(ctx, "repo1", "0.1.0", "", "", "", cvemodel.PageInput{
+					Limit:  4097,
+					Offset: 3,
+					SortBy: cveinfo.AlphabeticAsc,
+				},
+				)
+				So(err, ShouldNotBeNil)
+			})
 		})
 	})
 }


### PR DESCRIPTION
It is possible to ask for a very large limit size which can exhaust memory.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
