### PR TITLE
fix(ui): fix image details view

### DIFF
--- a/pkg/extensions/search/resolver.go
+++ b/pkg/extensions/search/resolver.go
@@ -1439,7 +1439,11 @@ func expandedRepoInfo(ctx context.Context, repo string, metaDB mTypes.MetaDB, cv
 			continue
 		}
 
-		tagsDigests = append(tagsDigests, repoMeta.Tags[i].Digest)
+		digest := repoMeta.Tags[i].Digest
+
+		if !zcommon.Contains(tagsDigests, digest) {
+			tagsDigests = append(tagsDigests, digest)
+		}
 	}
 
 	imageMetaMap, err := metaDB.FilterImageMeta(ctx, tagsDigests)

--- a/pkg/meta/dynamodb/dynamodb_test.go
+++ b/pkg/meta/dynamodb/dynamodb_test.go
@@ -236,6 +236,16 @@ func TestWrapperErrors(t *testing.T) {
 			})
 		})
 		Convey("FilterImageMeta", func() {
+			Convey("FilterImageMeta with duplicate digests", func() {
+				image := CreateRandomImage()
+
+				err := dynamoWrapper.SetRepoReference(ctx, "repo", "tag", image.AsImageMeta())
+				So(err, ShouldBeNil)
+
+				_, err = dynamoWrapper.FilterImageMeta(ctx, []string{image.DigestStr(), image.DigestStr()})
+				So(err, ShouldNotBeNil)
+			})
+
 			Convey("manifest meta unmarshal error", func() {
 				err = setImageMeta(image.Digest(), badProtoBlob, dynamoWrapper) //nolint: contextcheck
 				So(err, ShouldBeNil)
@@ -243,6 +253,7 @@ func TestWrapperErrors(t *testing.T) {
 				_, err = dynamoWrapper.FilterImageMeta(ctx, []string{image.DigestStr()})
 				So(err, ShouldNotBeNil)
 			})
+
 			Convey("MediaType ImageIndex, getProtoImageMeta fails", func() {
 				err := dynamoWrapper.SetImageMeta(multiarchImageMeta.Digest, multiarchImageMeta) //nolint: contextcheck
 				So(err, ShouldBeNil)


### PR DESCRIPTION
when a UI client tries to view image details
for an image with multiple tags pointing to the same digest we make a query to dynamodb having duplicate keys (same digest) resulting in an error and the client is redirect back to image overview.

closes: #2464

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
