### PR TITLE
fix(authn): make hashing/encryption keys used to secure cookies

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -370,6 +370,36 @@ Using that cookie on subsequent calls will authenticate them, asumming the cooki
 In case of using filesystem storage sessions are saved in zot's root directory.
 In case of using cloud storage sessions are saved in memory.
 
+
+### Securing session based login
+
+In order to secure session cookies used in session based authentication process you need to set the path to a file containg keys used to hash and encrypt the cookies:
+
+`sessionKeysFile`
+
+```
+    "auth": {
+      "htpasswd": {
+        "path": "test/data/htpasswd"
+      },
+      "sessionKeysFile": "/home/user/keys",
+      "apikey": true,
+    }
+```
+
+```
+user@host:~/zot$ cat ../keys  | jq
+{
+  "hashKey": "my-very-secret",
+  "encryptKey": "another-secret"
+}
+```
+
+- hashKey  -  used to authenticate the cookie value using HMAC. It is recommended to use a key with exactly 32 or 64 bytes. 
+- encryptKey - this is optional, used to encrypt the cookie value. If set, the length must correspond to the block size of the encryption algorithm. For AES, used by default, valid lengths are 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256.
+
+If at least hashKey is not set zot will create a random one which on zot restarts it will invalidate all currently valid cookies and their sessions, requiring all users to login again.
+
 #### API keys
 
 zot allows authentication for REST API calls using your API key as an alternative to your password.

--- a/examples/config-openid.json
+++ b/examples/config-openid.json
@@ -13,6 +13,7 @@
       "htpasswd": {
         "path": "test/data/htpasswd"
       },
+      "sessionKeysFile": "examples/sessionKeys.json",
       "apikey": true,
       "openid": {
         "providers": {

--- a/examples/sessionKeys.json
+++ b/examples/sessionKeys.json
@@ -1,0 +1,4 @@
+{
+    "hashKey": "3lrioGLGO2RfG9Y7HQGgWa3ayBjMLw2auMXqEWcSXjQKc9SoQ3fKTIbO+toPYa7e",
+    "encryptKey": "KOzt01JrDz2uC//UBC5ZikxQw4owfmI8"
+}

--- a/pkg/api/authn_test.go
+++ b/pkg/api/authn_test.go
@@ -960,7 +960,7 @@ func TestCookiestoreCleanup(t *testing.T) {
 			DefaultStore: imgStore,
 		}
 
-		cookieStore, err := api.NewCookieStore(storeController)
+		cookieStore, err := api.NewCookieStore(storeController, nil, nil)
 		So(err, ShouldBeNil)
 
 		cookieStore.RunSessionCleaner(taskScheduler)
@@ -995,7 +995,7 @@ func TestCookiestoreCleanup(t *testing.T) {
 			DefaultStore: imgStore,
 		}
 
-		cookieStore, err := api.NewCookieStore(storeController)
+		cookieStore, err := api.NewCookieStore(storeController, []byte("secret"), nil)
 		So(err, ShouldBeNil)
 
 		err = os.Chmod(rootDir, 0o000)

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -67,18 +67,26 @@ type AuthHTPasswd struct {
 }
 
 type AuthConfig struct {
-	FailDelay int
-	HTPasswd  AuthHTPasswd
-	LDAP      *LDAPConfig
-	Bearer    *BearerConfig
-	OpenID    *OpenIDConfig
-	APIKey    bool
+	FailDelay         int
+	HTPasswd          AuthHTPasswd
+	LDAP              *LDAPConfig
+	Bearer            *BearerConfig
+	OpenID            *OpenIDConfig
+	APIKey            bool
+	SessionKeysFile   string
+	SessionHashKey    []byte `json:"-"`
+	SessionEncryptKey []byte `json:"-"`
 }
 
 type BearerConfig struct {
 	Realm   string
 	Service string
 	Cert    string
+}
+
+type SessionKeys struct {
+	HashKey    string
+	EncryptKey string `mapstructure:",omitempty"`
 }
 
 type OpenIDConfig struct {

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -1350,6 +1350,77 @@ storage:
 		So(err, ShouldBeNil)
 	})
 
+	Convey("Test verify good session keys config with both keys", t, func(c C) {
+		tmpFile, err := os.CreateTemp("", "zot-test*.json")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpFile.Name())
+
+		tmpCredsFile, err := os.CreateTemp("", "zot-cred*.json")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpCredsFile.Name())
+
+		content := []byte(`{
+			"hashKey":"very-secret",
+			"encryptKey":"another-secret"
+		}`)
+
+		_, err = tmpCredsFile.Write(content)
+		So(err, ShouldBeNil)
+		err = tmpCredsFile.Close()
+		So(err, ShouldBeNil)
+
+		content = []byte(fmt.Sprintf(`{ "distSpecVersion": "1.1.0-dev", 
+			"storage": { "rootDirectory": "/tmp/zot" }, "http": { "address": "127.0.0.1", "port": "8080", 
+			"auth":{"htpasswd":{"path":"test/data/htpasswd"}, "sessionKeysFile": "%s", 
+			"failDelay": 5 } }, "log": { "level": "debug" } }`,
+			tmpCredsFile.Name()),
+		)
+
+		_, err = tmpFile.Write(content)
+		So(err, ShouldBeNil)
+		err = tmpFile.Close()
+		So(err, ShouldBeNil)
+
+		os.Args = []string{"cli_test", "verify", tmpFile.Name()}
+		err = cli.NewServerRootCmd().Execute()
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Test verify good session keys config with one key", t, func(c C) {
+		tmpFile, err := os.CreateTemp("", "zot-test*.json")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpFile.Name())
+
+		tmpCredsFile, err := os.CreateTemp("", "zot-cred*.json")
+		So(err, ShouldBeNil)
+		defer os.Remove(tmpCredsFile.Name())
+
+		content := []byte(`{
+			"hashKey":"very-secret"
+		}`)
+
+		_, err = tmpCredsFile.Write(content)
+		So(err, ShouldBeNil)
+		err = tmpCredsFile.Close()
+		So(err, ShouldBeNil)
+
+		content = []byte(fmt.Sprintf(`{ "distSpecVersion": "1.1.0-dev", 
+			"storage": { "rootDirectory": "/tmp/zot" }, "http": { "address": "127.0.0.1", "port": "8080", 
+			"auth":{"htpasswd":{"path":"test/data/htpasswd"}, "sessionKeysFile": "%s", 
+			"failDelay": 5 } }, "log": { "level": "debug" } }`,
+			tmpCredsFile.Name()),
+		)
+
+		_, err = tmpFile.Write(content)
+		So(err, ShouldBeNil)
+		err = tmpFile.Close()
+		So(err, ShouldBeNil)
+
+		os.Args = []string{"cli_test", "verify", tmpFile.Name()}
+		err = cli.NewServerRootCmd().Execute()
+		So(err, ShouldBeNil)
+	})
+
 	Convey("Test verify good ldap config", t, func(c C) {
 		tmpFile, err := os.CreateTemp("", "zot-test*.json")
 		So(err, ShouldBeNil)


### PR DESCRIPTION
If they are not configured zot will generate a random hashing key at startup, invalidating all cookies if zot is restarted. closes: #2526

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
restarting zot invalidates currently active sessions.

**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:
https://github.com/project-zot/zot/issues/2526

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**
no

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
modified configuration file, client can specify hashing and encrypt keys to secure web session cookies.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
