### PR TITLE
Fix sync extension logging

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -87,6 +87,7 @@ var (
 	ErrDuplicateConfigName            = errors.New("cli config name already added")
 	ErrInvalidRoute                   = errors.New("invalid route prefix")
 	ErrImgStoreNotFound               = errors.New("image store not found corresponding to given route")
+	ErrLocalImgStoreNotFound          = errors.New("local image store not found corresponding to given route")
 	ErrEmptyValue                     = errors.New("empty cache value")
 	ErrEmptyRepoList                  = errors.New("no repository found")
 	ErrCVESearchDisabled              = errors.New("cve search is disabled")

--- a/pkg/extensions/sync/destination.go
+++ b/pkg/extensions/sync/destination.go
@@ -92,7 +92,7 @@ func (registry *DestinationRegistry) GetImageReference(repo, reference string) (
 func (registry *DestinationRegistry) CommitImage(imageReference types.ImageReference, repo, reference string) error {
 	imageStore := registry.storeController.GetImageStore(repo)
 
-	tempImageStore := getImageStoreFromImageReference(imageReference, repo, reference)
+	tempImageStore := getImageStoreFromImageReference(imageReference, repo, reference, registry.log)
 
 	defer os.RemoveAll(tempImageStore.RootDir())
 
@@ -282,11 +282,11 @@ func (registry *DestinationRegistry) copyBlob(repo string, blobDigest digest.Dig
 }
 
 // use only with local imageReferences.
-func getImageStoreFromImageReference(imageReference types.ImageReference, repo, reference string,
+func getImageStoreFromImageReference(imageReference types.ImageReference, repo, reference string, log log.Logger,
 ) storageTypes.ImageStore {
 	tmpRootDir := getTempRootDirFromImageReference(imageReference, repo, reference)
 
-	return getImageStore(tmpRootDir)
+	return getImageStore(tmpRootDir, log)
 }
 
 func getTempRootDirFromImageReference(imageReference types.ImageReference, repo, reference string) string {
@@ -301,8 +301,8 @@ func getTempRootDirFromImageReference(imageReference types.ImageReference, repo,
 	return tmpRootDir
 }
 
-func getImageStore(rootDir string) storageTypes.ImageStore {
-	metrics := monitoring.NewMetricsServer(false, log.Logger{})
+func getImageStore(rootDir string, log log.Logger) storageTypes.ImageStore {
+	metrics := monitoring.NewMetricsServer(false, log)
 
-	return local.NewImageStore(rootDir, false, false, log.Logger{}, metrics, nil, nil)
+	return local.NewImageStore(rootDir, false, false, log, metrics, nil, nil)
 }

--- a/pkg/extensions/sync/oci_layout.go
+++ b/pkg/extensions/sync/oci_layout.go
@@ -40,6 +40,9 @@ func (oci OciLayoutStorageImpl) GetContext() *types.SystemContext {
 
 func (oci OciLayoutStorageImpl) GetImageReference(repo string, reference string) (types.ImageReference, error) {
 	localImageStore := oci.storeController.GetImageStore(repo)
+	if localImageStore == nil {
+		return nil, fmt.Errorf("no image store found for repo %s", repo)
+	}
 	tempSyncPath := path.Join(localImageStore.RootDir(), repo, constants.SyncBlobUploadDir)
 
 	// create session folder

--- a/pkg/extensions/sync/oci_layout.go
+++ b/pkg/extensions/sync/oci_layout.go
@@ -12,6 +12,7 @@ import (
 	"github.com/containers/image/v5/types"
 	"github.com/gofrs/uuid"
 
+	zerr "zotregistry.dev/zot/errors"
 	"zotregistry.dev/zot/pkg/extensions/sync/constants"
 	"zotregistry.dev/zot/pkg/storage"
 	storageConstants "zotregistry.dev/zot/pkg/storage/constants"
@@ -41,7 +42,7 @@ func (oci OciLayoutStorageImpl) GetContext() *types.SystemContext {
 func (oci OciLayoutStorageImpl) GetImageReference(repo string, reference string) (types.ImageReference, error) {
 	localImageStore := oci.storeController.GetImageStore(repo)
 	if localImageStore == nil {
-		return nil, fmt.Errorf("no image store found for repo %s", repo)
+		return nil, zerr.ErrLocalImgStoreNotFound
 	}
 	tempSyncPath := path.Join(localImageStore.RootDir(), repo, constants.SyncBlobUploadDir)
 

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -83,7 +83,7 @@ func New(
 		service.destination = NewDestinationRegistry(
 			storeController,
 			storage.StoreController{
-				DefaultStore: getImageStore(tmpDir),
+				DefaultStore: getImageStore(tmpDir, log),
 			},
 			metadb,
 			log,

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -214,7 +214,7 @@ func TestDestinationRegistry(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(imageReference, ShouldNotBeNil)
 
-		imgStore := getImageStoreFromImageReference(imageReference, repoName, "1.0")
+		imgStore := getImageStoreFromImageReference(imageReference, repoName, "1.0", log)
 
 		// create a blob/layer
 		upload, err := imgStore.NewBlobUpload(repoName)
@@ -393,7 +393,7 @@ func TestDestinationRegistry(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(imageReference, ShouldNotBeNil)
 
-			imgStore := getImageStoreFromImageReference(imageReference, repoName, "2.0")
+			imgStore := getImageStoreFromImageReference(imageReference, repoName, "2.0", log)
 
 			// upload image
 

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -83,6 +83,14 @@ func TestInjectSyncUtils(t *testing.T) {
 	})
 }
 
+func TestNilDefaultStore(t *testing.T) {
+	Convey("Nil default store", t, func() {
+		ols := NewOciLayoutStorage(storage.StoreController{})
+		_, err := ols.GetImageReference(testImage, testImageTag)
+		So(err, ShouldEqual, zerr.ErrLocalImgStoreNotFound)
+	})
+}
+
 func TestSyncInternal(t *testing.T) {
 	Convey("Verify parseRepositoryReference func", t, func() {
 		repositoryReference := fmt.Sprintf("%s/%s", host, testImage)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

bug

**Which issue does this PR fix**:

closes https://github.com/project-zot/zot/issues/2527

**What does this PR do / Why do we need it**:

It does two very small things.
First: it ensures that Zot doesn't panic with a nil pointer dereference on incorrectly configured local storage in the sync extension, and instead returns an error when `localImageStore` is nil.
Second: (and arguably more important) it enables logging for the sync extension image store.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:

I have manually tested this on my cluster, and can confirm that logging accurately shows my configuration error in #2527 (I had configured Zot to use a read-only filesystem, which obviously doesn't work since it needs permissions to write to the download directory used in the sync extension) and the panic instead just returns an error which is logged to stdout.

**Automation added to e2e**:

**Will this break upgrades or downgrades?**

No.

**Does this PR introduce any user-facing change?**:

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
