### PR TITLE
ci: use smaller runners for CI pipelines

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-go@v5
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   test-run-minimal:
     name: Running zot without extensions tests
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
       - uses: actions/checkout@v4
       - name: Install go
@@ -54,7 +54,7 @@ jobs:
       - uses: ./.github/actions/teardown-localstack
   test-run-extensions:
     name: Run zot with extensions tests
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -93,7 +93,7 @@ jobs:
       - uses: ./.github/actions/teardown-localstack
   test-run-devmode:
     name: Running privileged tests on Linux
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
CNCF has been nice to us to offer larger runners, but we need to be careful not to abuse them.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
