### PR TITLE
feat/scale-out: support for proxying GQL queries

### DIFF
--- a/examples/scale-out-cluster-local/config-cluster-member0.json
+++ b/examples/scale-out-cluster-local/config-cluster-member0.json
@@ -1,0 +1,31 @@
+{
+  "distSpecVersion": "1.1.0",
+  "storage": {
+    "rootDirectory": "/tmp/zot0",
+    "dedupe": false
+  },
+  "http": {
+    "address": "127.0.0.1",
+    "port": "9000"
+  },
+  "log": {
+    "level": "debug"
+  },
+  "cluster": {
+    "members": [
+      "127.0.0.1:9000",
+      "127.0.0.1:9001"
+    ],
+    "hashKey": "loremipsumdolors"
+  },
+  "extensions": {
+    "search": {
+      "cve": {
+        "updateInterval": "2h"
+      }
+    },
+    "ui": {
+      "enable": true
+    }
+  }
+}

--- a/examples/scale-out-cluster-local/config-cluster-member1.json
+++ b/examples/scale-out-cluster-local/config-cluster-member1.json
@@ -1,0 +1,31 @@
+{
+  "distSpecVersion": "1.1.0",
+  "storage": {
+    "rootDirectory": "/tmp/zot1",
+    "dedupe": false
+  },
+  "http": {
+    "address": "127.0.0.1",
+    "port": "9001"
+  },
+  "log": {
+    "level": "debug"
+  },
+  "cluster": {
+    "members": [
+      "127.0.0.1:9000",
+      "127.0.0.1:9001"
+    ],
+    "hashKey": "loremipsumdolors"
+  },
+  "extensions": {
+    "search": {
+      "cve": {
+        "updateInterval": "2h"
+      }
+    },
+    "ui": {
+      "enable": true
+    }
+  }
+}

--- a/examples/scale-out-cluster-local/haproxy.cfg
+++ b/examples/scale-out-cluster-local/haproxy.cfg
@@ -1,0 +1,25 @@
+global
+        log /tmp/log local0
+        log /tmp/log local1 notice
+        maxconn 2000
+        stats timeout 30s
+        daemon
+
+defaults
+        log     global
+        mode    http
+        option  httplog
+        option  dontlognull
+        timeout connect 5000
+        timeout client  50000
+        timeout server  50000
+
+frontend zot
+    bind *:8080
+    default_backend zot-cluster
+
+backend zot-cluster
+    balance roundrobin
+    cookie SERVER insert indirect nocache
+    server zot0 127.0.0.1:9000 cookie zot0
+    server zot1 127.0.0.1:9001 cookie zot1

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -520,3 +520,12 @@ func IsOauth2Supported(provider string) bool {
 
 	return false
 }
+
+func (c *Config) IsClusteringEnabled() bool {
+	return c.Cluster != nil
+}
+
+func (c *Config) IsSharedStorageEnabled() bool {
+	return c.Storage.RemoteCache &&
+		c.Storage.StorageDriver != nil && c.Storage.CacheDriver != nil
+}

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -129,4 +129,42 @@ func TestConfig(t *testing.T) {
 
 		So(conf.IsRetentionEnabled(), ShouldBeTrue)
 	})
+
+	Convey("Test IsClusteringEnabled()", t, func() {
+		conf := config.New()
+		So(conf.Cluster, ShouldBeNil)
+		So(conf.IsClusteringEnabled(), ShouldBeFalse)
+
+		conf.Cluster = &config.ClusterConfig{
+			Members: []string{
+				"127.0.0.1:9090",
+				"127.0.0.1:9001",
+			},
+			HashKey: "loremipsumdolors",
+		}
+
+		So(conf.IsClusteringEnabled(), ShouldBeTrue)
+	})
+
+	Convey("Test IsSharedStorageEnabled()", t, func() {
+		conf := config.New()
+		So(conf.Storage.RemoteCache, ShouldBeFalse)
+		So(conf.Storage.CacheDriver, ShouldBeNil)
+		So(conf.Storage.StorageDriver, ShouldBeNil)
+		So(conf.IsSharedStorageEnabled(), ShouldBeFalse)
+
+		conf.Storage.RemoteCache = true
+		So(conf.Storage.RemoteCache, ShouldBeTrue)
+		So(conf.IsSharedStorageEnabled(), ShouldBeFalse)
+
+		storageDriver := map[string]interface{}{"name": "s3"}
+		conf.Storage.StorageDriver = storageDriver
+		So(conf.Storage.StorageDriver, ShouldNotBeNil)
+		So(conf.IsSharedStorageEnabled(), ShouldBeFalse)
+
+		cacheDriver := map[string]interface{}{"name": "dynamodb"}
+		conf.Storage.CacheDriver = cacheDriver
+		So(conf.Storage.CacheDriver, ShouldNotBeNil)
+		So(conf.IsSharedStorageEnabled(), ShouldBeTrue)
+	})
 }

--- a/pkg/api/proxy.go
+++ b/pkg/api/proxy.go
@@ -1,8 +1,6 @@
 package api
 
 import (
-	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"net"
@@ -13,6 +11,7 @@ import (
 	"zotregistry.dev/zot/pkg/api/constants"
 	"zotregistry.dev/zot/pkg/cluster"
 	"zotregistry.dev/zot/pkg/common"
+	"zotregistry.dev/zot/pkg/proxy"
 )
 
 // ClusterProxy wraps an http.HandlerFunc which requires proxying between zot instances to ensure
@@ -68,7 +67,7 @@ func ClusterProxy(ctrlr *Controller) func(http.HandlerFunc) http.HandlerFunc {
 
 			logger.Debug().Str(constants.RepositoryLogKey, name).Msg("proxying the request")
 
-			proxyResponse, err := proxyHTTPRequest(request.Context(), request, targetMember, ctrlr)
+			proxyResponse, err := proxy.ProxyHTTPRequest(request.Context(), request, targetMember, ctrlr.Config)
 			if err != nil {
 				logger.Error().Err(err).Str(constants.RepositoryLogKey, name).Msg("failed to proxy the request")
 				http.Error(response, err.Error(), http.StatusInternalServerError)
@@ -77,7 +76,7 @@ func ClusterProxy(ctrlr *Controller) func(http.HandlerFunc) http.HandlerFunc {
 			}
 			defer proxyResponse.Body.Close()
 
-			copyHeader(response.Header(), proxyResponse.Header)
+			proxy.CopyHeader(response.Header(), proxyResponse.Header)
 			response.WriteHeader(proxyResponse.StatusCode)
 			_, _ = io.Copy(response, proxyResponse.Body)
 		})
@@ -111,101 +110,6 @@ func getTargetMemberServerSockets(targetMemberSocket string) ([]string, error) {
 	}
 
 	return targetSockets, nil
-}
-
-// proxy the request to the target member and return a pointer to the response or an error.
-func proxyHTTPRequest(ctx context.Context, req *http.Request,
-	targetMember string, ctrlr *Controller,
-) (*http.Response, error) {
-	cloneURL := *req.URL
-
-	proxyQueryScheme := "http"
-	if ctrlr.Config.HTTP.TLS != nil {
-		proxyQueryScheme = "https"
-	}
-
-	cloneURL.Scheme = proxyQueryScheme
-	cloneURL.Host = targetMember
-
-	clonedBody := cloneRequestBody(req)
-
-	fwdRequest, err := http.NewRequestWithContext(ctx, req.Method, cloneURL.String(), clonedBody)
-	if err != nil {
-		return nil, err
-	}
-
-	copyHeader(fwdRequest.Header, req.Header)
-
-	// always set hop count to 1 for now.
-	// the handler wrapper above will terminate the process if it sees a request that
-	// already has a hop count but is due for proxying.
-	fwdRequest.Header.Set(constants.ScaleOutHopCountHeader, "1")
-
-	clientOpts := common.HTTPClientOptions{
-		TLSEnabled: ctrlr.Config.HTTP.TLS != nil,
-		VerifyTLS:  ctrlr.Config.HTTP.TLS != nil, // for now, always verify TLS when TLS mode is enabled
-		Host:       targetMember,
-	}
-
-	tlsConfig := ctrlr.Config.Cluster.TLS
-	if tlsConfig != nil {
-		clientOpts.CertOptions.ClientCertFile = tlsConfig.Cert
-		clientOpts.CertOptions.ClientKeyFile = tlsConfig.Key
-		clientOpts.CertOptions.RootCaCertFile = tlsConfig.CACert
-	}
-
-	httpClient, err := common.CreateHTTPClient(&clientOpts)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := httpClient.Do(fwdRequest)
-	if err != nil {
-		return nil, err
-	}
-
-	var clonedRespBody bytes.Buffer
-
-	// copy out the contents into a new buffer as the response body
-	// stream should be closed to get all the data out.
-	_, _ = io.Copy(&clonedRespBody, resp.Body)
-	resp.Body.Close()
-
-	// after closing the original body, substitute it with a new reader
-	// using the buffer that was just created.
-	// this buffer should be closed later by the consumer of the response.
-	resp.Body = io.NopCloser(bytes.NewReader(clonedRespBody.Bytes()))
-
-	return resp, nil
-}
-
-func cloneRequestBody(src *http.Request) io.Reader {
-	var bCloneForOriginal, bCloneForCopy bytes.Buffer
-	multiWriter := io.MultiWriter(&bCloneForOriginal, &bCloneForCopy)
-	numBytesCopied, _ := io.Copy(multiWriter, src.Body)
-
-	// if the body is a type of io.NopCloser and length is 0,
-	// the Content-Length header is not sent in the proxied request.
-	// explicitly returning http.NoBody allows the implementation
-	// to set the header.
-	// ref: https://github.com/golang/go/issues/34295
-	if numBytesCopied == 0 {
-		src.Body = http.NoBody
-
-		return http.NoBody
-	}
-
-	src.Body = io.NopCloser(&bCloneForOriginal)
-
-	return bytes.NewReader(bCloneForCopy.Bytes())
-}
-
-func copyHeader(dst, src http.Header) {
-	for k, vv := range src {
-		for _, v := range vv {
-			dst.Add(k, v)
-		}
-	}
 }
 
 // identifies and returns the cluster socket and index.

--- a/pkg/common/model.go
+++ b/pkg/common/model.go
@@ -15,16 +15,16 @@ type RepoInfo struct {
 }
 
 type RepoSummary struct {
-	Name          string       `json:"name"`
-	LastUpdated   time.Time    `json:"lastUpdated"`
-	Size          string       `json:"size"`
-	Platforms     []Platform   `json:"platforms"`
-	Vendors       []string     `json:"vendors"`
-	IsStarred     bool         `json:"isStarred"`
-	IsBookmarked  bool         `json:"isBookmarked"`
-	StarCount     int          `json:"starCount"`
-	DownloadCount int          `json:"downloadCount"`
-	NewestImage   ImageSummary `json:"newestImage"`
+	Name          string       `json:"Name"`          //nolint:tagliatelle // graphQL schema
+	LastUpdated   time.Time    `json:"LastUpdated"`   //nolint:tagliatelle // graphQL schema
+	Size          string       `json:"Size"`          //nolint:tagliatelle // graphQL schema
+	Platforms     []Platform   `json:"Platforms"`     //nolint:tagliatelle // graphQL schema
+	Vendors       []string     `json:"Vendors"`       //nolint:tagliatelle // graphQL schema
+	IsStarred     bool         `json:"IsStarred"`     //nolint:tagliatelle // graphQL schema
+	IsBookmarked  bool         `json:"IsBookmarked"`  //nolint:tagliatelle // graphQL schema
+	StarCount     int          `json:"StarCount"`     //nolint:tagliatelle // graphQL schema
+	DownloadCount int          `json:"DownloadCount"` //nolint:tagliatelle // graphQL schema
+	NewestImage   ImageSummary `json:"NewestImage"`   //nolint:tagliatelle // graphQL schema
 }
 
 type PaginatedImagesResult struct {
@@ -33,83 +33,83 @@ type PaginatedImagesResult struct {
 }
 
 type ImageSummary struct {
-	RepoName        string                    `json:"repoName"`
-	Tag             string                    `json:"tag"`
-	Digest          string                    `json:"digest"`
-	MediaType       string                    `json:"mediaType"`
-	Manifests       []ManifestSummary         `json:"manifests"`
-	Size            string                    `json:"size"`
-	DownloadCount   int                       `json:"downloadCount"`
-	LastUpdated     time.Time                 `json:"lastUpdated"`
-	Description     string                    `json:"description"`
-	IsSigned        bool                      `json:"isSigned"`
-	Licenses        string                    `json:"licenses"`
-	Labels          string                    `json:"labels"`
-	Title           string                    `json:"title"`
-	Source          string                    `json:"source"`
-	Documentation   string                    `json:"documentation"`
-	Authors         string                    `json:"authors"`
-	Vendor          string                    `json:"vendor"`
-	Vulnerabilities ImageVulnerabilitySummary `json:"vulnerabilities"`
-	Referrers       []Referrer                `json:"referrers"`
-	SignatureInfo   []SignatureSummary        `json:"signatureInfo"`
+	RepoName        string                    `json:"RepoName"`        //nolint:tagliatelle // graphQL schema
+	Tag             string                    `json:"Tag"`             //nolint:tagliatelle // graphQL schema
+	Digest          string                    `json:"Digest"`          //nolint:tagliatelle // graphQL schema
+	MediaType       string                    `json:"MediaType"`       //nolint:tagliatelle // graphQL schema
+	Manifests       []ManifestSummary         `json:"Manifests"`       //nolint:tagliatelle // graphQL schema
+	Size            string                    `json:"Size"`            //nolint:tagliatelle // graphQL schema
+	DownloadCount   int                       `json:"DownloadCount"`   //nolint:tagliatelle // graphQL schema
+	LastUpdated     time.Time                 `json:"LastUpdated"`     //nolint:tagliatelle // graphQL schema
+	Description     string                    `json:"Description"`     //nolint:tagliatelle // graphQL schema
+	IsSigned        bool                      `json:"IsSigned"`        //nolint:tagliatelle // graphQL schema
+	Licenses        string                    `json:"Licenses"`        //nolint:tagliatelle // graphQL schema
+	Labels          string                    `json:"Labels"`          //nolint:tagliatelle // graphQL schema
+	Title           string                    `json:"Title"`           //nolint:tagliatelle // graphQL schema
+	Source          string                    `json:"Source"`          //nolint:tagliatelle // graphQL schema
+	Documentation   string                    `json:"Documentation"`   //nolint:tagliatelle // graphQL schema
+	Authors         string                    `json:"Authors"`         //nolint:tagliatelle // graphQL schema
+	Vendor          string                    `json:"Vendor"`          //nolint:tagliatelle // graphQL schema
+	Vulnerabilities ImageVulnerabilitySummary `json:"Vulnerabilities"` //nolint:tagliatelle // graphQL schema
+	Referrers       []Referrer                `json:"Referrers"`       //nolint:tagliatelle // graphQL schema
+	SignatureInfo   []SignatureSummary        `json:"SignatureInfo"`   //nolint:tagliatelle // graphQL schema
 }
 
 type ManifestSummary struct {
-	Digest          string                    `json:"digest"`
-	ConfigDigest    string                    `json:"configDigest"`
-	LastUpdated     time.Time                 `json:"lastUpdated"`
-	Size            string                    `json:"size"`
-	Platform        Platform                  `json:"platform"`
-	IsSigned        bool                      `json:"isSigned"`
-	DownloadCount   int                       `json:"downloadCount"`
-	Layers          []LayerSummary            `json:"layers"`
-	History         []LayerHistory            `json:"history"`
-	Vulnerabilities ImageVulnerabilitySummary `json:"vulnerabilities"`
-	Referrers       []Referrer                `json:"referrers"`
-	ArtifactType    string                    `json:"artifactType"`
-	SignatureInfo   []SignatureSummary        `json:"signatureInfo"`
+	Digest          string                    `json:"Digest"`          //nolint:tagliatelle // graphQL schema
+	ConfigDigest    string                    `json:"ConfigDigest"`    //nolint:tagliatelle // graphQL schema
+	LastUpdated     time.Time                 `json:"LastUpdated"`     //nolint:tagliatelle // graphQL schema
+	Size            string                    `json:"Size"`            //nolint:tagliatelle // graphQL schema
+	Platform        Platform                  `json:"Platform"`        //nolint:tagliatelle // graphQL schema
+	IsSigned        bool                      `json:"IsSigned"`        //nolint:tagliatelle // graphQL schema
+	DownloadCount   int                       `json:"DownloadCount"`   //nolint:tagliatelle // graphQL schema
+	Layers          []LayerSummary            `json:"Layers"`          //nolint:tagliatelle // graphQL schema
+	History         []LayerHistory            `json:"History"`         //nolint:tagliatelle // graphQL schema
+	Vulnerabilities ImageVulnerabilitySummary `json:"Vulnerabilities"` //nolint:tagliatelle // graphQL schema
+	Referrers       []Referrer                `json:"Referrers"`       //nolint:tagliatelle // graphQL schema
+	ArtifactType    string                    `json:"ArtifactType"`    //nolint:tagliatelle // graphQL schema
+	SignatureInfo   []SignatureSummary        `json:"SignatureInfo"`   //nolint:tagliatelle // graphQL schema
 }
 
 type SignatureSummary struct {
-	Tool      string `json:"tool"`
-	IsTrusted bool   `json:"isTrusted"`
-	Author    string `json:"author"`
+	Tool      string `json:"Tool"`      //nolint:tagliatelle // graphQL schema
+	IsTrusted bool   `json:"IsTrusted"` //nolint:tagliatelle // graphQL schema
+	Author    string `json:"Author"`    //nolint:tagliatelle // graphQL schema
 }
 
 type Platform struct {
-	Os      string `json:"os"`
-	Arch    string `json:"arch"`
-	Variant string `json:"variant"`
+	Os      string `json:"Os"`      //nolint:tagliatelle // graphQL schema
+	Arch    string `json:"Arch"`    //nolint:tagliatelle // graphQL schema
+	Variant string `json:"Variant"` //nolint:tagliatelle // graphQL schema
 }
 
 type ImageVulnerabilitySummary struct {
-	MaxSeverity   string `json:"maxSeverity"`
-	UnknownCount  int    `json:"unknownCount"`
-	LowCount      int    `json:"lowCount"`
-	MediumCount   int    `json:"mediumCount"`
-	HighCount     int    `json:"highCount"`
-	CriticalCount int    `json:"criticalCount"`
-	Count         int    `json:"count"`
+	MaxSeverity   string `json:"MaxSeverity"`   //nolint:tagliatelle // graphQL schema
+	UnknownCount  int    `json:"UnknownCount"`  //nolint:tagliatelle // graphQL schema
+	LowCount      int    `json:"LowCount"`      //nolint:tagliatelle // graphQL schema
+	MediumCount   int    `json:"MediumCount"`   //nolint:tagliatelle // graphQL schema
+	HighCount     int    `json:"HighCount"`     //nolint:tagliatelle // graphQL schema
+	CriticalCount int    `json:"CriticalCount"` //nolint:tagliatelle // graphQL schema
+	Count         int    `json:"Count"`         //nolint:tagliatelle // graphQL schema
 }
 
 type LayerSummary struct {
-	Size   string `json:"size"`
-	Digest string `json:"digest"`
-	Score  int    `json:"score"`
+	Size   string `json:"Size"`   //nolint:tagliatelle // graphQL schema
+	Digest string `json:"Digest"` //nolint:tagliatelle // graphQL schema
+	Score  int    `json:"Score"`  //nolint:tagliatelle // graphQL schema
 }
 
 type LayerHistory struct {
-	Layer              LayerSummary       `json:"layer"`
-	HistoryDescription HistoryDescription `json:"historyDescription"`
+	Layer              LayerSummary       `json:"Layer"`              //nolint:tagliatelle // graphQL schema
+	HistoryDescription HistoryDescription `json:"HistoryDescription"` //nolint:tagliatelle // graphQL schema
 }
 
 type HistoryDescription struct {
-	Created    time.Time `json:"created"`
-	CreatedBy  string    `json:"createdBy"`
-	Author     string    `json:"author"`
-	Comment    string    `json:"comment"`
-	EmptyLayer bool      `json:"emptyLayer"`
+	Created    time.Time `json:"Created"`    //nolint:tagliatelle // graphQL schema
+	CreatedBy  string    `json:"CreatedBy"`  //nolint:tagliatelle // graphQL schema
+	Author     string    `json:"Author"`     //nolint:tagliatelle // graphQL schema
+	Comment    string    `json:"Comment"`    //nolint:tagliatelle // graphQL schema
+	EmptyLayer bool      `json:"EmptyLayer"` //nolint:tagliatelle // graphQL schema
 }
 
 type OsArch struct {
@@ -214,14 +214,14 @@ type GlobalSearchResultResp struct {
 }
 
 type GlobalSearchResult struct {
-	GlobalSearch `json:"globalSearch"`
+	GlobalSearch `json:"GlobalSearch"` //nolint:tagliatelle // graphQL schema
 }
 
 type GlobalSearch struct {
-	Images []ImageSummary `json:"images"`
-	Repos  []RepoSummary  `json:"repos"`
-	Layers []LayerSummary `json:"layers"`
-	Page   PageInfo       `json:"page"`
+	Images []ImageSummary `json:"Images"` //nolint:tagliatelle // graphQL schema
+	Repos  []RepoSummary  `json:"Repos"`  //nolint:tagliatelle // graphQL schema
+	Layers []LayerSummary `json:"Layers"` //nolint:tagliatelle // graphQL schema
+	Page   PageInfo       `json:"Page"`   //nolint:tagliatelle // graphQL schema
 }
 
 type ExpandedRepoInfo struct {

--- a/pkg/extensions/search/gql_proxy/global_search_handler.go
+++ b/pkg/extensions/search/gql_proxy/global_search_handler.go
@@ -1,0 +1,118 @@
+package gqlproxy
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+
+	"zotregistry.dev/zot/pkg/api/config"
+	"zotregistry.dev/zot/pkg/common"
+	"zotregistry.dev/zot/pkg/proxy"
+)
+
+const (
+	LoggerFieldOperation    = "operation"
+	LoggerFieldTargetMember = "targetMember"
+	HandlerOperation        = "GlobalSearch"
+)
+
+// This is a handler for all GlobalSearchResult GQL queries in proxy mode without shared storage.
+func HandleGlobalSearchResult(
+	config *config.Config, response http.ResponseWriter, request *http.Request, next http.Handler,
+) {
+	collatedResult := common.GlobalSearchResultResp{
+		Errors: []common.ErrorGQL{},
+	}
+
+	// Proxy to all members including self in order to get the data as calling next() won't return the
+	// aggregated data to this handler.
+	for _, targetMember := range config.Cluster.Members {
+		proxyResponse, err := proxy.ProxyHTTPRequest(request.Context(), request, targetMember, config)
+		if err != nil {
+			log.Error().Str(LoggerFieldOperation, HandlerOperation).
+				Str(LoggerFieldTargetMember, targetMember).
+				Err(err).Msg("failed to proxy request")
+			http.Error(response, "failed to process GQL request", http.StatusInternalServerError)
+
+			return
+		}
+
+		proxyBody, err := io.ReadAll(proxyResponse.Body)
+		proxyResponse.Body.Close()
+
+		if err != nil {
+			log.Error().Str(LoggerFieldOperation, HandlerOperation).
+				Str(LoggerFieldTargetMember, targetMember).
+				Err(err).Msg("failed to read proxy body")
+			http.Error(response, "failed to process GQL request", http.StatusInternalServerError)
+
+			return
+		}
+
+		var proxyRespData common.GlobalSearchResultResp
+		// Collate Results
+		err = json.Unmarshal(proxyBody, &proxyRespData)
+		if err != nil {
+			log.Error().Str(LoggerFieldOperation, HandlerOperation).
+				Str(LoggerFieldTargetMember, targetMember).
+				Str("responseBody", string(proxyBody)).
+				Err(err).
+				Msg("failed to unmarshal received response body")
+			http.Error(response, "failed to process GQL request", http.StatusInternalServerError)
+
+			return
+		}
+
+		// aggregate errors
+		collatedResult.Errors = append(collatedResult.Errors, proxyRespData.Errors...)
+
+		// aggregate pagination data
+		// TODO: currently, this doesn't support pagination limits. It will aggregate this data
+		// from all instances subject to existing behaviour of limits.
+		incomingItemCount := proxyRespData.GlobalSearchResult.GlobalSearch.Page.ItemCount
+		collatedResult.GlobalSearchResult.GlobalSearch.Page.ItemCount += incomingItemCount
+		incomingTotalCount := proxyRespData.GlobalSearchResult.GlobalSearch.Page.TotalCount
+		collatedResult.GlobalSearchResult.GlobalSearch.Page.TotalCount += incomingTotalCount
+
+		// aggregate results
+		// TODO: GraphQL by nature doesn't send all the data - only what the client requested.
+		// Because we are not yet parsing the Query, it is challenging to figure out what is to be
+		// returned and what is not to be returned.
+		// In this approach, all the fields are returned, but the GQL server will only have data for
+		// the fields in the query so there is no impact as such.
+		collatedResult.GlobalSearchResult.GlobalSearch.Images = append(
+			collatedResult.GlobalSearchResult.GlobalSearch.Images,
+			proxyRespData.GlobalSearchResult.GlobalSearch.Images...,
+		)
+		collatedResult.GlobalSearchResult.GlobalSearch.Repos = append(
+			collatedResult.GlobalSearchResult.GlobalSearch.Repos,
+			proxyRespData.GlobalSearchResult.GlobalSearch.Repos...,
+		)
+		collatedResult.GlobalSearchResult.GlobalSearch.Layers = append(
+			collatedResult.GlobalSearchResult.GlobalSearch.Layers,
+			proxyRespData.GlobalSearchResult.GlobalSearch.Layers...,
+		)
+	}
+
+	responseBody, err := json.Marshal(collatedResult)
+	if err != nil {
+		log.Error().
+			Str(LoggerFieldOperation, HandlerOperation).
+			Err(err).Msg("failed to marshal final response body")
+		http.Error(response, "failed to create final response body", http.StatusInternalServerError)
+
+		return
+	}
+
+	_, err = response.Write(responseBody)
+	if err != nil {
+		log.Error().
+			Str(LoggerFieldOperation, HandlerOperation).
+			Err(err).Msg("failed to write response")
+		http.Error(response, "failed to write response", http.StatusInternalServerError)
+
+		return
+	}
+}

--- a/pkg/extensions/search/gql_proxy/gql_proxy.go
+++ b/pkg/extensions/search/gql_proxy/gql_proxy.go
@@ -1,0 +1,95 @@
+package gqlproxy
+
+import (
+	"net/http"
+	"strings"
+
+	"zotregistry.dev/zot/pkg/api/config"
+	"zotregistry.dev/zot/pkg/api/constants"
+	"zotregistry.dev/zot/pkg/log"
+)
+
+// Returns a wrapped handler that can handle request proxying for GQL
+// queries when running in cluster mode without shared storage (each instance has its own metadata).
+// Requests are only proxied in local cluster mode as in this mode, each instance holds only the
+// metadata for the images that it serves, however, in shared storage mode,
+// all the instances have access to all the metadata so any can respond.
+func GqlProxyRequestHandler(config *config.Config, log log.Logger) func(handler http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+			// If not running in cluster mode, no op.
+			if !config.IsClusteringEnabled() {
+				next.ServeHTTP(response, request)
+
+				return
+			}
+			// If in cluster mode, but using shared-storage, no op.
+			if config.IsSharedStorageEnabled() {
+				next.ServeHTTP(response, request)
+
+				return
+			}
+
+			// If the request has already been proxied, don't re-proxy.
+			if request.Header.Get(constants.ScaleOutHopCountHeader) != "" {
+				next.ServeHTTP(response, request)
+
+				return
+			}
+
+			// General Structure for GQL Requests
+			// Query String contains the full GraphQL Request (it's NOT JSON)
+			// e.g. {(query:"", requestedPage: {limit:3 offset:0 sortBy: DOWNLOADS} )
+			// {Page {TotalCount ItemCount} Repos {Name LastUpdated Size Platforms { Os Arch }
+			// IsStarred IsBookmarked NewestImage { Tag Vulnerabilities {MaxSeverity Count}
+			// Description IsSigned SignGlobalSearchatureInfo { Tool IsTrusted Author } Licenses Vendor Labels }
+			// StarCount DownloadCount}}}
+
+			// General Payload Structure for GQL Response
+			/*
+				{
+					"errors": [CUSTOM_ERRORS_HERE],
+					"data": {
+						"NameOfQuery": {CUSTOM_SCHEMA_HERE}
+					}
+				}
+			*/
+
+			query := request.URL.Query().Get("query")
+
+			operation, ok := computeGqlOperation(query)
+			if !ok {
+				log.Error().Str("query", query).Msg("Failed to compute operation from query")
+				http.Error(response, "Failed to process GQL request", http.StatusInternalServerError)
+
+				return
+			}
+
+			// Each operation is individually handled as the schema and structs are different.
+			if operation == "GlobalSearch" {
+				HandleGlobalSearchResult(config, response, request, next)
+
+				return
+			} else {
+				// If the operation is not currently supported or is unknown,
+				// pass it on to the local GQL server to handle it.
+				next.ServeHTTP(response, request)
+
+				return
+			}
+		})
+	}
+}
+
+// Naively compute which operation is requested for GQL.
+// TODO: Need to replace this with better custom GQL parsing
+// or a parsing library that can conver the GQL query to
+// a struct where operations data and schema are available for reading.
+func computeGqlOperation(request string) (string, bool) {
+	openParenthesisIndex := strings.Index(request, "(")
+	if openParenthesisIndex == -1 {
+		return "", false
+	}
+
+	return request[1:openParenthesisIndex], true
+}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -1,0 +1,107 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+
+	"zotregistry.dev/zot/pkg/api/config"
+	"zotregistry.dev/zot/pkg/api/constants"
+	"zotregistry.dev/zot/pkg/common"
+)
+
+// proxy the request to the target member and return a pointer to the response or an error.
+func ProxyHTTPRequest(ctx context.Context, req *http.Request,
+	targetMember string, config *config.Config,
+) (*http.Response, error) {
+	cloneURL := *req.URL
+
+	proxyQueryScheme := "http"
+	if config.HTTP.TLS != nil {
+		proxyQueryScheme = "https"
+	}
+
+	cloneURL.Scheme = proxyQueryScheme
+	cloneURL.Host = targetMember
+
+	clonedBody := CloneRequestBody(req)
+
+	fwdRequest, err := http.NewRequestWithContext(ctx, req.Method, cloneURL.String(), clonedBody)
+	if err != nil {
+		return nil, err
+	}
+
+	CopyHeader(fwdRequest.Header, req.Header)
+
+	// always set hop count to 1 for now.
+	// the handler wrapper above will terminate the process if it sees a request that
+	// already has a hop count but is due for proxying.
+	fwdRequest.Header.Set(constants.ScaleOutHopCountHeader, "1")
+
+	clientOpts := common.HTTPClientOptions{
+		TLSEnabled: config.HTTP.TLS != nil,
+		VerifyTLS:  config.HTTP.TLS != nil, // for now, always verify TLS when TLS mode is enabled
+		Host:       targetMember,
+	}
+
+	tlsConfig := config.Cluster.TLS
+	if tlsConfig != nil {
+		clientOpts.CertOptions.ClientCertFile = tlsConfig.Cert
+		clientOpts.CertOptions.ClientKeyFile = tlsConfig.Key
+		clientOpts.CertOptions.RootCaCertFile = tlsConfig.CACert
+	}
+
+	httpClient, err := common.CreateHTTPClient(&clientOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := httpClient.Do(fwdRequest)
+	if err != nil {
+		return nil, err
+	}
+
+	var clonedRespBody bytes.Buffer
+
+	// copy out the contents into a new buffer as the response body
+	// stream should be closed to get all the data out.
+	_, _ = io.Copy(&clonedRespBody, resp.Body)
+	resp.Body.Close()
+
+	// after closing the original body, substitute it with a new reader
+	// using the buffer that was just created.
+	// this buffer should be closed later by the consumer of the response.
+	resp.Body = io.NopCloser(bytes.NewReader(clonedRespBody.Bytes()))
+
+	return resp, nil
+}
+
+func CloneRequestBody(src *http.Request) io.Reader {
+	var bCloneForOriginal, bCloneForCopy bytes.Buffer
+	multiWriter := io.MultiWriter(&bCloneForOriginal, &bCloneForCopy)
+	numBytesCopied, _ := io.Copy(multiWriter, src.Body)
+
+	// if the body is a type of io.NopCloser and length is 0,
+	// the Content-Length header is not sent in the proxied request.
+	// explicitly returning http.NoBody allows the implementation
+	// to set the header.
+	// ref: https://github.com/golang/go/issues/34295
+	if numBytesCopied == 0 {
+		src.Body = http.NoBody
+
+		return http.NoBody
+	}
+
+	src.Body = io.NopCloser(&bCloneForOriginal)
+
+	return bytes.NewReader(bCloneForCopy.Bytes())
+}
+
+func CopyHeader(dst, src http.Header) {
+	for k, vv := range src {
+		for _, v := range vv {
+			dst.Add(k, v)
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Towards #2434

**What does this PR do / Why do we need it**:
Previously, only dist-spec APIs were supported for scale-out as in a shared storage environment, the metadata was shared and any instance could correctly respond to the GQL queries as all the data is available.

In a local scale-out cluster deployment, the metadata store, in addition to the file storage is isolated to each member in the cluster. Due to this, there is a need to proxy the GQL queries as well for UI and client requests to work as expected.

This change introduces a new GQL proxy + a handler for the GlobalSearch request that proxies the request to all the members and collects them for response to the client.
Support for other GQL queries is pending.

**Testing done on this change**:
Unit Tests added.

**Will this break upgrades or downgrades?**
No, there shouldn't be any impact to upgrades and downgrades.

**Does this PR introduce any user-facing change?**:

```release-note
A zot scale-out cluster deployed without using shared storage is now supported. Client queries from the UI and other clients will be proxied amongst the cluster members to fetch data for the request.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
