### PR TITLE
fix(delete manifest): distinct behaviors for delete by tag vb delete by digest

### DIFF
--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -1239,11 +1239,11 @@ func TestDedupeLinks(t *testing.T) {
 			manifestBuf, err = json.Marshal(manifest)
 			So(err, ShouldBeNil)
 
-			digest = godigest.FromBytes(manifestBuf)
+			manifestDigest2 := godigest.FromBytes(manifestBuf)
 			_, _, err = imgStore.PutImageManifest("dedupe2", "1.0", ispec.MediaTypeImageManifest, manifestBuf)
 			So(err, ShouldBeNil)
 
-			_, _, _, err = imgStore.GetImageManifest("dedupe2", digest.String())
+			_, _, _, err = imgStore.GetImageManifest("dedupe2", manifestDigest2.String())
 			So(err, ShouldBeNil)
 
 			// verify that dedupe with hard links happened
@@ -1267,6 +1267,15 @@ func TestDedupeLinks(t *testing.T) {
 					err = imgStore.DeleteBlob("dedupe1", godigest.NewDigestFromEncoded(godigest.SHA256, blobDigest1))
 					So(err, ShouldBeNil)
 
+					// only the tag was removed, but not the digest, this call should error
+					err = imgStore.DeleteBlob("dedupe2", godigest.NewDigestFromEncoded(godigest.SHA256, blobDigest2))
+					So(err, ShouldNotBeNil)
+
+					// Delete the manifest
+					err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+					So(err, ShouldBeNil)
+
+					// The call should succeed
 					err = imgStore.DeleteBlob("dedupe2", godigest.NewDigestFromEncoded(godigest.SHA256, blobDigest2))
 					So(err, ShouldBeNil)
 				})
@@ -1422,6 +1431,15 @@ func TestDedupeLinks(t *testing.T) {
 				err = imgStore.DeleteBlob("dedupe1", godigest.NewDigestFromEncoded(godigest.SHA256, blobDigest1))
 				So(err, ShouldBeNil)
 
+				// only the tag was removed, but not the digest, this call should error
+				err = imgStore.DeleteBlob("dedupe2", godigest.NewDigestFromEncoded(godigest.SHA256, blobDigest2))
+				So(err, ShouldNotBeNil)
+
+				// Delete the manifest
+				err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+				So(err, ShouldBeNil)
+
+				// The call should succeed
 				err = imgStore.DeleteBlob("dedupe2", godigest.NewDigestFromEncoded(godigest.SHA256, blobDigest2))
 				So(err, ShouldBeNil)
 			})

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -1307,12 +1307,12 @@ func TestS3Dedupe(t *testing.T) {
 		manifestBuf, err = json.Marshal(manifest)
 		So(err, ShouldBeNil)
 
-		digest = godigest.FromBytes(manifestBuf)
+		manifestDigest2 := godigest.FromBytes(manifestBuf)
 		_, _, err = imgStore.PutImageManifest("dedupe2", "1.0", ispec.MediaTypeImageManifest,
 			manifestBuf)
 		So(err, ShouldBeNil)
 
-		_, _, _, err = imgStore.GetImageManifest("dedupe2", digest.String())
+		_, _, _, err = imgStore.GetImageManifest("dedupe2", manifestDigest2.String())
 		So(err, ShouldBeNil)
 
 		fi1, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe1", "blobs", "sha256",
@@ -1336,10 +1336,19 @@ func TestS3Dedupe(t *testing.T) {
 			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
+			// delete tag, but not manifest
 			err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
 			So(err, ShouldBeNil)
 
+			// delete should succeed as the manifest was deleted
 			err = imgStore.DeleteBlob("dedupe1", blobDigest1)
+			So(err, ShouldBeNil)
+
+			// delete should fail, as the blob is referenced by an untagged manifest
+			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
+			So(err, ShouldEqual, zerr.ErrBlobReferenced)
+
+			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
@@ -1351,7 +1360,7 @@ func TestS3Dedupe(t *testing.T) {
 			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			// if we delete blob1, the content should be moved to blob2
@@ -1470,12 +1479,12 @@ func TestS3Dedupe(t *testing.T) {
 			manifestBuf, err = json.Marshal(manifest)
 			So(err, ShouldBeNil)
 
-			digest = godigest.FromBytes(manifestBuf)
+			manifestDigest3 := godigest.FromBytes(manifestBuf)
 			_, _, err = imgStore.PutImageManifest("dedupe3", "1.0", ispec.MediaTypeImageManifest,
 				manifestBuf)
 			So(err, ShouldBeNil)
 
-			_, _, _, err = imgStore.GetImageManifest("dedupe3", digest.String())
+			_, _, _, err = imgStore.GetImageManifest("dedupe3", manifestDigest3.String())
 			So(err, ShouldBeNil)
 
 			fi1, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe1", "blobs", "sha256",
@@ -1500,10 +1509,10 @@ func TestS3Dedupe(t *testing.T) {
 				err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
 				So(err, ShouldBeNil)
 
-				err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+				err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
 				So(err, ShouldBeNil)
 
-				err = imgStore.DeleteImageManifest("dedupe3", "1.0", false)
+				err = imgStore.DeleteImageManifest("dedupe3", manifestDigest3.String(), false)
 				So(err, ShouldBeNil)
 
 				err = imgStore.DeleteBlob("dedupe1", blobDigest1)
@@ -1715,12 +1724,12 @@ func TestS3Dedupe(t *testing.T) {
 		manifestBuf, err = json.Marshal(manifest)
 		So(err, ShouldBeNil)
 
-		digest = godigest.FromBytes(manifestBuf)
+		manifestDigest2 := godigest.FromBytes(manifestBuf)
 		_, _, err = imgStore.PutImageManifest("dedupe2", "1.0", ispec.MediaTypeImageManifest,
 			manifestBuf)
 		So(err, ShouldBeNil)
 
-		_, _, _, err = imgStore.GetImageManifest("dedupe2", digest.String())
+		_, _, _, err = imgStore.GetImageManifest("dedupe2", manifestDigest2.String())
 		So(err, ShouldBeNil)
 
 		fi1, err := storeDriver.Stat(context.Background(), path.Join(testDir, "dedupe1", "blobs", "sha256",
@@ -1744,10 +1753,19 @@ func TestS3Dedupe(t *testing.T) {
 			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
+			// delete tag, but not manifest
 			err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
 			So(err, ShouldBeNil)
 
+			// Delete should succeed as the manifest was deleted
 			err = imgStore.DeleteBlob("dedupe1", blobDigest1)
+			So(err, ShouldBeNil)
+
+			// Delete should fail, as the blob is referenced by an untagged manifest
+			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
+			So(err, ShouldEqual, zerr.ErrBlobReferenced)
+
+			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
@@ -1790,10 +1808,19 @@ func TestS3Dedupe(t *testing.T) {
 				err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
 				So(err, ShouldBeNil)
 
+				// delete tag, but not manifest
 				err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
 				So(err, ShouldBeNil)
 
+				// delete should succeed as the manifest was deleted
 				err = imgStore.DeleteBlob("dedupe1", blobDigest1)
+				So(err, ShouldBeNil)
+
+				// delete should fail, as the blob is referenced by an untagged manifest
+				err = imgStore.DeleteBlob("dedupe2", blobDigest2)
+				So(err, ShouldEqual, zerr.ErrBlobReferenced)
+
+				err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
 				So(err, ShouldBeNil)
 
 				err = imgStore.DeleteBlob("dedupe2", blobDigest2)
@@ -1832,7 +1859,7 @@ func TestS3Dedupe(t *testing.T) {
 			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			err = imgStore.DeleteBlob("dedupe1", blobDigest1)


### PR DESCRIPTION
In case of delete by tag only the tag is removed, the manifest itself would continue to be accessible by digest. In case of delete by digest the manifest would be completely removed (provided it is not used by an index or another reference).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
