### PR TITLE
Stop using the non-free 4-core runners

### DIFF
--- a/.github/workflows/cluster.yaml
+++ b/.github/workflows/cluster.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   client-tools:
     name: Stateless zot with shared reliable storage
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     # services:
     #   minio:
     #     image: minio/minio:RELEASE.2024-07-16T23-46-41Z

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,7 +25,7 @@ permissions: read-all
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/gqlgen.yaml
+++ b/.github/workflows/gqlgen.yaml
@@ -19,7 +19,7 @@ permissions: read-all
 jobs:
   gqlgen:
     name: Check GQL generation
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,7 +16,7 @@ permissions: read-all
 jobs:
   dedupe:
     name: Dedupe/restore blobs
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -66,7 +66,7 @@ jobs:
 
   sync:
     name: Sync harness
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - name: Check out source code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   test-run-minimal:
     name: Running zot without extensions tests
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install go
@@ -93,7 +93,7 @@ jobs:
       - uses: ./.github/actions/teardown-localstack
   test-run-devmode:
     name: Running privileged tests on Linux
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/web-scan.yaml
+++ b/.github/workflows/web-scan.yaml
@@ -15,7 +15,7 @@ permissions:
 
 jobs:
   zap_scan:
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
     name: Scan ZOT using ZAP
     strategy:
       matrix:


### PR DESCRIPTION
**What type of PR is this?**
cleanup

**What does this PR do / Why do we need it**:
Optimizing GitHub Actions usage

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

Heya! Friendly neighborhood CNCF staffer here. The ubuntu-latest runner is already a 4-core runner, so using a hosted 4-core runner is unnecessary (and actually costs money). This PR just swaps any 4-core hosted runners to use ubuntu-latest. There should be zero change or impact, functionally this is a SKU change.

Please reach out to me in the CNCF/K8s slack(s) (jeefy) or via email (jsica@linuxfoundation.org) with any questions. 