### PR TITLE
test: add more tests for GCing indexes referencing other indexes referencing manifests

### DIFF
--- a/pkg/test/image-utils/multiarch.go
+++ b/pkg/test/image-utils/multiarch.go
@@ -37,6 +37,14 @@ func (mi *MultiarchImage) DigestStr() string {
 	return mi.Digest().String()
 }
 
+func (mi *MultiarchImage) DescriptorRef() *ispec.Descriptor {
+	return &ispec.Descriptor{
+		MediaType: mi.IndexDescriptor.MediaType,
+		Digest:    mi.IndexDescriptor.Digest,
+		Size:      mi.IndexDescriptor.Size,
+	}
+}
+
 func (mi *MultiarchImage) DigestForAlgorithm(digestAlgorithm godigest.Algorithm) godigest.Digest {
 	blob, err := json.Marshal(mi.Index)
 	if err != nil {


### PR DESCRIPTION
Looks like we didn't have many GC tests for retaining multiarch images. I added more data to the existing image retention tests, besides the new GC tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
