### PR TITLE
fix: max wait time on dynamodb

### DIFF
--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -2123,7 +2123,7 @@ func (dwr *DynamoDB) deleteTable(tableName string) error {
 }
 
 func (dwr *DynamoDB) waitTableToBeCreated(tableName string) error {
-	const maxWaitTime = 20 * time.Second
+	const maxWaitTime = 120 * time.Second
 
 	waiter := dynamodb.NewTableExistsWaiter(dwr.Client)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

bug fix

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

Fix zot unable to create dynamodb table. Upon starting zot with `cacheDriver` configured to dynamodb. Zot will panic with error `exceeded max wait time for TableExists waiter`.

Dynamodb table is successfully created but not seeded with Zot version


**What does this PR do / Why do we need it**:

Zot was unable to wait for dynamodb table to be created. This was due to `maxWaitTime` set too low. More to be reference on AWS SDK issue https://github.com/aws/aws-sdk-go-v2/issues/2551


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**

no

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

no

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.