### PR TITLE
chore: update go tests to use our hosted trivy-db and trivy-java-db images

### DIFF
--- a/.github/workflows/sync-3rdparty-images.yaml
+++ b/.github/workflows/sync-3rdparty-images.yaml
@@ -44,6 +44,8 @@ jobs:
         run: |
           oras login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
           oras copy ghcr.io/aquasecurity/trivy-db:2 ghcr.io/${{ github.repository_owner }}/trivy-db:2
+          oras copy ghcr.io/aquasecurity/trivy-db:latest ghcr.io/${{ github.repository_owner }}/trivy-db:latest
+          oras copy ghcr.io/aquasecurity/trivy-java-db:1 ghcr.io/${{ github.repository_owner }}/trivy-java-db:1
   sync-localstack:
     name: 'localstack'
     permissions:

--- a/pkg/cli/server/extensions_test.go
+++ b/pkg/cli/server/extensions_test.go
@@ -1070,7 +1070,7 @@ func TestServeSearchEnabled(t *testing.T) {
 	})
 }
 
-func TestServeSearchEnabledCVE(t *testing.T) {
+func TestServeSearchEnabledDefaultCVEDB(t *testing.T) {
 	oldArgs := os.Args
 
 	defer func() { os.Args = oldArgs }()

--- a/pkg/extensions/search/cve/trivy/scanner_internal_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_internal_test.go
@@ -319,7 +319,7 @@ func TestImageScannable(t *testing.T) {
 	storeController.DefaultStore = store
 
 	scanner := NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db",
-		"ghcr.io/aquasecurity/trivy-java-db", log)
+		"ghcr.io/project-zot/trivy-java-db", log)
 
 	Convey("Valid image should be scannable", t, func() {
 		result, err := scanner.IsImageFormatScannable("repo1", "valid")
@@ -352,8 +352,8 @@ func TestImageScannable(t *testing.T) {
 	})
 }
 
-func TestDefaultTrivyDBUrl(t *testing.T) {
-	Convey("Test trivy DB download from default location", t, func() {
+func TestTrivyDBUrl(t *testing.T) {
+	Convey("Test trivy DB download", t, func() {
 		// Create temporary directory
 		rootDir := t.TempDir()
 
@@ -385,8 +385,11 @@ func TestDefaultTrivyDBUrl(t *testing.T) {
 		err = meta.ParseStorage(metaDB, storeController, log)
 		So(err, ShouldBeNil)
 
-		scanner := NewScanner(storeController, metaDB, "ghcr.io/aquasecurity/trivy-db",
-			"ghcr.io/aquasecurity/trivy-java-db", log)
+		// Ideally we would want to also test the default urls
+		// But we are getting `response status code 429: toomanyrequests` from
+		// `ghcr.io/aquasecurity/trivy-db` and `ghcr.io/aquasecurity/trivy-java-db`
+		scanner := NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db",
+			"ghcr.io/project-zot/trivy-java-db", log)
 
 		ctx := context.Background()
 

--- a/pkg/extensions/search/cve/trivy/scanner_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_test.go
@@ -261,7 +261,7 @@ func TestVulnerableLayer(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db",
-			"ghcr.io/aquasecurity/trivy-java-db", log)
+			"ghcr.io/project-zot/trivy-java-db", log)
 
 		err = scanner.UpdateDB(context.Background())
 		So(err, ShouldBeNil)


### PR DESCRIPTION
This is to avoid errors such as:

```
Error: failed to resolve latest: GET "https://ghcr.io/v2/aquasecurity/trivy-db/manifests/latest": response status code 429: toomanyrequests: retry-after: 338.733µs, allowed: 44000/minute
```

or
```
Error: GET "https://ghcr.io/v2/aquasecurity/trivy-java-db/blobs/sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a": response status code 429: toomanyrequests: retry-after: 271.886µs, allowed: 44000/minute
```

There are 2 remaining exceptions that I am aware of:
1. The tests under test/blackbox/cve.bats
2. One of the cli tests checking the server attempts download of the databases from the default url

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
