### PR TITLE
chore: use go1.23 in the build environment of zot container images

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
-FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-conformance
+++ b/build/Dockerfile-conformance
@@ -1,7 +1,7 @@
 # ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
-FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-minimal
+++ b/build/Dockerfile-minimal
@@ -1,7 +1,7 @@
 # ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
-FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-zb
+++ b/build/Dockerfile-zb
@@ -1,7 +1,7 @@
 # ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
-FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-zxp
+++ b/build/Dockerfile-zxp
@@ -1,7 +1,7 @@
 # ---
 # Stage 1: Build binary, create default config file
 # ---
-FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.22 AS builder
+FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.23 AS builder
 
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/stacker-conformance.yaml
+++ b/build/stacker-conformance.yaml
@@ -1,7 +1,7 @@
 build:
   from:
     type: docker
-    url: docker://ghcr.io/project-zot/golang:1.22
+    url: docker://ghcr.io/project-zot/golang:1.23
   binds:
     - ../. -> /zotcopy
   run: |

--- a/build/stacker-minimal.yaml
+++ b/build/stacker-minimal.yaml
@@ -1,7 +1,7 @@
 build:
   from:
     type: docker
-    url: docker://ghcr.io/project-zot/golang:1.22
+    url: docker://ghcr.io/project-zot/golang:1.23
   binds:
     - ../. -> /zotcopy
   run: |

--- a/build/stacker-zb.yaml
+++ b/build/stacker-zb.yaml
@@ -1,7 +1,7 @@
 build:
   from:
     type: docker
-    url: docker://ghcr.io/project-zot/golang:1.22
+    url: docker://ghcr.io/project-zot/golang:1.23
   binds:
     - ../. -> /zotcopy
   run: |

--- a/build/stacker-zxp.yaml
+++ b/build/stacker-zxp.yaml
@@ -1,7 +1,7 @@
 build:
   from:
     type: docker
-    url: docker://ghcr.io/project-zot/golang:1.22
+    url: docker://ghcr.io/project-zot/golang:1.23
   binds:
     - ../. -> /zotcopy
   run: |

--- a/build/stacker.yaml
+++ b/build/stacker.yaml
@@ -1,7 +1,7 @@
 build:
   from:
     type: docker
-    url: docker://ghcr.io/project-zot/golang:1.22
+    url: docker://ghcr.io/project-zot/golang:1.23
   binds:
     - ../. -> /zotcopy
   run: |

--- a/test/blackbox/restore_s3_blobs.bats
+++ b/test/blackbox/restore_s3_blobs.bats
@@ -131,7 +131,7 @@ function teardown_file() {
 
     start=`date +%s`
     echo "waiting for restoring blobs task to finish" >&3
-    run wait_for_string "no digests left, finished" ${ZOT_LOG_FILE} "5m"
+    run wait_for_string "no digests left, finished" ${ZOT_LOG_FILE} "6m"
     [ "$status" -eq 0 ]
 
     end=`date +%s`


### PR DESCRIPTION
There is also this issue with the dedupe tests which should not have failed according to the logs:

```
# {"level":"info","component":"dedupe","goroutine":66,"caller":"zotregistry.dev/zot/pkg/storage/common/common.go:929","time":"2024-11-08T19:03:24.784121491Z","message":"no digests left, finished"}
# {"level":"debug","component":"scheduler","generator":"DedupeTaskGenerator","goroutine":66,"caller":"zotregistry.dev/zot/pkg/scheduler/scheduler.go:481","time":"2024-11-08T19:03:24.784144645Z","message":"generator is done"}
# {"level":"info","digest":"sha256:f56be85fc22e46face30e2c3de3f7fe7c15f8fd7c4e5add29d7f64b87abdaa09","component":"dedupe","goroutine":57,"caller":"zotregistry.dev/zot/pkg/storage/imagestore/imagestore.go:1990","time":"2024-11-08T19:03:24.784176314Z","message":"restoring deduped blobs for digest"}
# {"level":"warn","component":"dedupe","goroutine":57,"caller":"zotregistry.dev/zot/pkg/storage/imagestore/imagestore.go:1896","time":"2024-11-08T19:03:24.784230305Z","message":"failed to find blob in cache, searching it in storage..."}
# {"level":"info","originalBlob":"/zot/alpine1/blobs/sha256/f56be85fc22e46face30e2c3de3f7fe7c15f8fd7c4e5add29d7f64b87abdaa09","component":"dedupe","goroutine":57,"caller":"zotregistry.dev/zot/pkg/storage/imagestore/imagestore.go:1906","time":"2024-11-08T19:03:24.785769422Z","message":"found original blob"}
# {"level":"info","digest":"sha256:f56be85fc22e46face30e2c3de3f7fe7c15f8fd7c4e5add29d7f64b87abdaa09","component":"dedupe","goroutine":57,"caller":"zotregistry.dev/zot/pkg/storage/imagestore/imagestore.go:2031","time":"2024-11-08T19:03:27.130968035Z","message":"restoring deduped blobs for digest finished successfully"}
# {"level":"debug","component":"scheduler","worker":2,"task":"{Name: DedupeTask, digest: sha256:f56be85fc22e46face30e2c3de3f7fe7c15f8fd7c4e5add29d7f64b87abdaa09, dedupe: false}","goroutine":57,"caller":"zotregistry.dev/zot/pkg/scheduler/scheduler.go:157","time":"2024-11-08T19:03:27.131015424Z","message":"finished task"}
# Last output:
# timeout of 5m reached. unable to find 'no digests left, finished' in '/tmp/bats-run-zXthH1/file/0/zot-log-nodedupe.json'
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
