### PR TITLE
minor metadb fixes for dynamo and bolt

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -129,6 +129,7 @@ var (
 	ErrMissingAuthHeader              = errors.New("required authorization header is missing")
 	ErrUserAPIKeyNotFound             = errors.New("user info for given API key hash not found")
 	ErrUserSessionNotFound            = errors.New("user session for given ID not found")
+	ErrInvalidMetaDBVersion           = errors.New("unrecognized version meta")
 	ErrBucketDoesNotExist             = errors.New("bucket does not exist")
 	ErrOpenIDProviderDoesNotExist     = errors.New("openid provider does not exist in given config")
 	ErrHashKeyNotCreated              = errors.New("cookiestore generated random hash key is nil, aborting")

--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -1569,7 +1569,7 @@ func (bdw *BoltDB) PatchDB() error {
 	}
 
 	if version.GetVersionIndex(DBVersion) == -1 {
-		return fmt.Errorf("DB has broken format, no version found %w", err)
+		return fmt.Errorf("%w: %s could not identify patches", zerr.ErrInvalidMetaDBVersion, DBVersion)
 	}
 
 	for patchIndex, patch := range bdw.Patches {

--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -2055,7 +2055,7 @@ func (dwr *DynamoDB) PatchDB() error {
 	}
 
 	if version.GetVersionIndex(DBVersion) == -1 {
-		return fmt.Errorf("DB has broken format, no version found %w", err)
+		return fmt.Errorf("%w: %s could not identify patches", zerr.ErrInvalidMetaDBVersion, DBVersion)
 	}
 
 	for patchIndex, patch := range dwr.Patches {


### PR DESCRIPTION
1. dynamodb: refactor multiple apikey metadb calls into a single one
2. dynamodb/boltdb: fix an error message related to getting the patches to update the db (as a note this is not used atm in production)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
