### PR TITLE
[Feat]: Support for AWS ECR Authentication with Temporary Tokens

### DIFF
--- a/examples/config-sync-ecr-credential-helper.json
+++ b/examples/config-sync-ecr-credential-helper.json
@@ -1,0 +1,39 @@
+{
+    "distSpecVersion": "1.1.0",
+    "storage": {
+        "rootDirectory": "/tmp/zot",
+        "dedupe": false,
+        "storageDriver": {
+            "name": "s3",
+            "region": "REGION_NAME",
+            "bucket": "BUGKET_NAME",
+            "rootdirectory": "/ROOTDIR",
+            "secure": true,
+            "skipverify": false
+        }
+    },
+    "http": {
+        "address": "0.0.0.0",
+        "port": "8080"
+    },
+    "log": {
+        "level": "debug"
+    },
+    "extensions": {
+        "sync": {
+            "credentialsFile": "",
+            "DownloadDir": "/tmp/zot",
+            "registries": [
+                {
+                    "urls": [
+                        "https://ACCOUNTID.dkr.ecr.REGION.amazonaws.com"
+                    ],
+                    "onDemand": true,
+                    "maxRetries": 5,
+                    "retryDelay": "2m",
+                    "credentialHelper": "ecr"
+                }
+            ]
+        }
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.29.1
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.15.25
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.39.5
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.36.6
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.13
 	github.com/aws/aws-secretsmanager-caching-go v1.2.0
 	github.com/aws/smithy-go v1.22.1
@@ -158,7 +159,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.24.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ebs v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.193.0 // indirect
-	github.com/aws/aws-sdk-go-v2/service/ecr v1.36.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.25.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.10.9 // indirect

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -23,15 +23,16 @@ type Config struct {
 }
 
 type RegistryConfig struct {
-	URLs         []string
-	PollInterval time.Duration
-	Content      []Content
-	TLSVerify    *bool
-	OnDemand     bool
-	CertDir      string
-	MaxRetries   *int
-	RetryDelay   *time.Duration
-	OnlySigned   *bool
+	URLs             []string
+	PollInterval     time.Duration
+	Content          []Content
+	TLSVerify        *bool
+	OnDemand         bool
+	CertDir          string
+	MaxRetries       *int
+	RetryDelay       *time.Duration
+	OnlySigned       *bool
+	CredentialHelper string
 }
 
 type Content struct {

--- a/pkg/extensions/sync/ecr_credential_helper.go
+++ b/pkg/extensions/sync/ecr_credential_helper.go
@@ -1,0 +1,195 @@
+//go:build sync
+// +build sync
+
+package sync
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+
+	syncconf "zotregistry.dev/zot/pkg/extensions/config/sync"
+	"zotregistry.dev/zot/pkg/log"
+)
+
+// ECR tokens are valid for 12 hours. The expiryWindow variable is set to 1 hour,
+// meaning if the remaining validity of the token is less than 1 hour, it will be considered expired.
+const (
+	expiryWindow          int = 1
+	ecrURLSplitPartsCount int = 6
+	mockExpiryDuration    int = 12
+	usernameTokenParts    int = 2
+)
+
+var (
+	errInvalidURLFormat          = errors.New("invalid ECR URL is received")
+	errInvalidTokenFormat        = errors.New("invalid token format received from ECR")
+	errUnableToLoadAWSConfig     = errors.New("unable to load AWS config for region")
+	errUnableToGetECRAuthToken   = errors.New("unable to get ECR authorization token for account")
+	errUnableToDecodeECRToken    = errors.New("unable to decode ECR token")
+	errFailedToGetECRCredentials = errors.New("failed to get ECR credentials")
+)
+
+type ecrCredential struct {
+	username string
+	password string
+	expiry   time.Time
+	account  string
+	region   string
+}
+
+type ecrCredentialsHelper struct {
+	credentials        map[string]ecrCredential
+	log                log.Logger
+	getCredentialsFunc func(string) (ecrCredential, error)
+}
+
+func NewECRCredentialHelper(log log.Logger, getCredentialsFunc func(string) (ecrCredential, error)) CredentialHelper {
+	return &ecrCredentialsHelper{
+		credentials:        make(map[string]ecrCredential),
+		log:                log,
+		getCredentialsFunc: getCredentialsFunc,
+	}
+}
+
+// extractAccountAndRegion extracts the account ID and region from the given ECR URL.
+// Example URL format: account.dkr.ecr.region.amazonaws.com.
+func extractAccountAndRegion(url string) (string, string, error) {
+	parts := strings.Split(url, ".")
+	if len(parts) < ecrURLSplitPartsCount {
+		return "", "", fmt.Errorf("%w: %s", errInvalidURLFormat, url)
+	}
+
+	accountID := parts[0] // First part is the account ID
+
+	region := parts[3] // Fourth part is the region
+
+	return accountID, region, nil
+}
+
+// getMockECRCredentials provides mock credentials for testing purposes.
+func GetMockECRCredentials(remoteAddress string) (ecrCredential, error) {
+	// Extract account ID and region from the URL.
+	accountID, region, err := extractAccountAndRegion(remoteAddress)
+	if err != nil {
+		return ecrCredential{}, fmt.Errorf("%w %s: %w", errInvalidTokenFormat, remoteAddress, err)
+	}
+	expiry := time.Now().Add(time.Duration(mockExpiryDuration) * time.Hour)
+
+	return ecrCredential{
+		username: "mockUsername",
+		password: "mockPassword",
+		expiry:   expiry,
+		account:  accountID,
+		region:   region,
+	}, nil
+}
+
+// getECRCredentials retrieves actual ECR credentials using AWS SDK.
+func GetECRCredentials(remoteAddress string) (ecrCredential, error) {
+	// Extract account ID and region from the URL.
+	accountID, region, err := extractAccountAndRegion(remoteAddress)
+	if err != nil {
+		return ecrCredential{}, fmt.Errorf("%w %s: %w", errInvalidTokenFormat, remoteAddress, err)
+	}
+
+	// Load the AWS config for the specific region.
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
+	if err != nil {
+		return ecrCredential{}, fmt.Errorf("%w %s: %w", errUnableToLoadAWSConfig, region, err)
+	}
+
+	// Create an ECR client
+	ecrClient := ecr.NewFromConfig(cfg)
+
+	// Fetch the ECR authorization token.
+	ecrAuth, err := ecrClient.GetAuthorizationToken(context.TODO(), &ecr.GetAuthorizationTokenInput{
+		RegistryIds: []string{accountID}, // Filter by the account ID.
+	})
+	if err != nil {
+		return ecrCredential{}, fmt.Errorf("%w %s: %w", errUnableToGetECRAuthToken, accountID, err)
+	}
+
+	// Decode the base64-encoded ECR token.
+	authToken := *ecrAuth.AuthorizationData[0].AuthorizationToken
+
+	decodedToken, err := base64.StdEncoding.DecodeString(authToken)
+	if err != nil {
+		return ecrCredential{}, fmt.Errorf("%w: %w", errUnableToDecodeECRToken, err)
+	}
+
+	// Split the decoded token into username and password (username is "AWS").
+	tokenParts := strings.Split(string(decodedToken), ":")
+	if len(tokenParts) != usernameTokenParts {
+		return ecrCredential{}, fmt.Errorf("%w", errInvalidTokenFormat)
+	}
+
+	expiry := *ecrAuth.AuthorizationData[0].ExpiresAt
+	username := tokenParts[0]
+	password := tokenParts[1]
+
+	return ecrCredential{username: username, password: password, expiry: expiry, account: accountID, region: region}, nil
+}
+
+// GetECRCredentials retrieves the ECR credentials (username and password) from AWS ECR.
+func (credHelper *ecrCredentialsHelper) GetCredentials(urls []string) (syncconf.CredentialsFile, error) {
+	ecrCredentials := make(syncconf.CredentialsFile)
+
+	for _, url := range urls {
+		remoteAddress := StripRegistryTransport(url)
+
+		// Use the injected credential retrieval function.
+		ecrCred, err := credHelper.getCredentialsFunc(remoteAddress)
+		if err != nil {
+			return syncconf.CredentialsFile{}, fmt.Errorf("%w %s: %w", errFailedToGetECRCredentials, url, err)
+		}
+		// Store the credentials in the map using the base URL as the key.
+		ecrCredentials[remoteAddress] = syncconf.Credentials{
+			Username: ecrCred.username,
+			Password: ecrCred.password,
+		}
+		credHelper.credentials[remoteAddress] = ecrCred
+	}
+
+	return ecrCredentials, nil
+}
+
+// AreCredentialsValid checks if the credentials for a given remote address are still valid.
+func (credHelper *ecrCredentialsHelper) AreCredentialsValid(remoteAddress string) bool {
+	expiry := credHelper.credentials[remoteAddress].expiry
+	expiryDuration := time.Duration(expiryWindow) * time.Hour
+
+	if time.Until(expiry) <= expiryDuration {
+		credHelper.log.Info().
+			Str("url", remoteAddress).
+			Msg("the credentials are close to expiring")
+
+		return false
+	}
+
+	credHelper.log.Info().
+		Str("url", remoteAddress).
+		Msg("the credentials are valid")
+
+	return true
+}
+
+// RefreshCredentials refreshes the ECR credentials for the given remote address.
+func (credHelper *ecrCredentialsHelper) RefreshCredentials(
+	remoteAddress string,
+) (syncconf.Credentials, error) {
+	credHelper.log.Info().Str("url", remoteAddress).Msg("refreshing the ECR credentials")
+
+	ecrCred, err := credHelper.getCredentialsFunc(remoteAddress)
+	if err != nil {
+		return syncconf.Credentials{}, fmt.Errorf("%w %s: %w", errFailedToGetECRCredentials, remoteAddress, err)
+	}
+
+	return syncconf.Credentials{Username: ecrCred.username, Password: ecrCred.password}, nil
+}

--- a/pkg/extensions/sync/remote.go
+++ b/pkg/extensions/sync/remote.go
@@ -44,6 +44,13 @@ func NewRemoteRegistry(client *client.Client, logger log.Logger) Remote {
 	return registry
 }
 
+func (registry *RemoteRegistry) SetUpstreamAuthConfig(username, password string) {
+	registry.context.DockerAuthConfig = &types.DockerAuthConfig{
+		Username: username,
+		Password: password,
+	}
+}
+
 func (registry *RemoteRegistry) GetContext() *types.SystemContext {
 	return registry.context
 }

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -7045,6 +7045,29 @@ func TestSyncImageIndex(t *testing.T) {
 	})
 }
 
+func TestECRCredentialsHelper(t *testing.T) {
+	Convey("Test ECR Credentials Helper", t, func() {
+		// use getMockECRCredentials for testing purposes
+		credentialHelper := sync.NewECRCredentialHelper(log.NewLogger("debug", ""), sync.GetMockECRCredentials)
+		url := "https://mockAccount.dkr.ecr.mockRegion.amazonaws.com"
+		remoteAddress := sync.StripRegistryTransport(url)
+
+		Convey("Test Credentials Retrieval & Validity", func() {
+			creds, err := credentialHelper.GetCredentials([]string{url})
+			So(err, ShouldBeNil)
+			So(creds, ShouldNotBeNil)
+			So(creds[remoteAddress].Username, ShouldEqual, "mockUsername")
+			So(creds[remoteAddress].Password, ShouldEqual, "mockPassword")
+			So(credentialHelper.AreCredentialsValid(remoteAddress), ShouldBeTrue)
+		})
+
+		Convey("Test Credentials Refresh", func() {
+			_, err := credentialHelper.RefreshCredentials(remoteAddress)
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
 func generateKeyPairs(tdir string) {
 	// generate a keypair
 	os.Setenv("COSIGN_PASSWORD", "")

--- a/pkg/test/mocks/sync_remote_mock.go
+++ b/pkg/test/mocks/sync_remote_mock.go
@@ -75,3 +75,6 @@ func (remote SyncRemote) GetManifestContent(imageReference types.ImageReference)
 
 	return nil, "", "", nil
 }
+
+func (remote SyncRemote) SetUpstreamAuthConfig(username, password string) {
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes. - yes 
2. Ensure you have included output of manual testing done in the Testing section. 
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature
**Which issue does this PR fix**:
https://github.com/project-zot/zot/issues/2650

**What does this PR do / Why do we need it**:
This PR adds support for temporary credentials for upstream registries, specifically focusing on AWS ECR. Since ECR credentials are not permanent and need to be rotated periodically, this enhancement enables Zot to dynamically obtain and refresh valid usernames and passwords when the CredentialHelper is configured for the registry

**If an issue # is not available please add repro steps and logs showing the issue**:
N/A

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
During initialization, the logs confirm that ECR credentials have been updated:
```
{"level":"info","goroutine":1,"caller":"zotregistry.dev/zot/pkg/extensions/sync/service.go:77","time":"2024-10-18T23:15:48.269973286+05:30","message":"Using credentials helper, because CredentialHelper is set to ecr"}
{"level":"info","goroutine":1,"caller":"zotregistry.dev/zot/pkg/extensions/sync/service.go:81","time":"2024-10-18T23:15:48.269998807+05:30","message":"Fetch the credentials using AWS ECR Auth Token."}
```
During credential expiry, the following log entries are generated:
```
{"level":"info","url":"accountid.dkr.ecr.us-east-1.amazonaws.com","goroutine":593,"caller":"zotregistry.dev/zot/pkg/extensions/sync/ecr_credential_helper.go:126","time":"2024-10-19T00:43:06.320476296+05:30","message":"The credentials are close to expiring"}
{"level":"info","url":"accountid.dkr.ecr.us-east-1.amazonaws.com","goroutine":593,"caller":"zotregistry.dev/zot/pkg/extensions/sync/ecr_credential_helper.go:135","time":"2024-10-19T00:43:06.320498388+05:30","message":"Refreshing the ECR credentials"}
{"level":"info","url":"accountid.dkr.ecr.us-east-1.amazonaws.com","goroutine":593,"caller":"zotregistry.dev/zot/pkg/extensions/sync/service.go:162","time":"2024-10-19T00:43:07.009198386+05:30","message":"Refreshing the upstream remote registry credentials"}
```
These logs verify that the credentials are nearing the expiry window of one hour and have been successfully refreshed.
**Automation added to e2e**:
Added TestECRCredentialsHelper in sync_internal_test

**Will this break upgrades or downgrades?**
No 

**Does this PR introduce any user-facing change?**:
No

**release-note**
With this PR, users can configure AWS ECR as an upstream registry for on-demand or periodic sync by setting `CredentialHelper: ecr` in the extension sync configuration. This change eliminates the need for users to manually add usernames and passwords in the `credentialsFile`; instead, credentials will be stored in memory and automatically rotated as they approach expiry. An example configuration is available in `examples/config-sync-ecr-credential-helper.json`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
