### PR TITLE
MetaDB fixes related to Docker media types

### DIFF
--- a/pkg/compat/compat.go
+++ b/pkg/compat/compat.go
@@ -45,6 +45,20 @@ func IsCompatibleManifestListMediaType(mediatype string) bool {
 	return false
 }
 
+func CompatibleConfigMediaTypes() []string {
+	return []string{docker.MediaTypeImageConfig}
+}
+
+func IsCompatibleConfigMediaType(mediatype string) bool {
+	for _, mt := range CompatibleConfigMediaTypes() {
+		if mt == mediatype {
+			return true
+		}
+	}
+
+	return false
+}
+
 func Validate(body []byte, mediaType string) ([]v1.Descriptor, error) {
 	switch mediaType {
 	case docker.MediaTypeManifest:

--- a/pkg/extensions/search/cve/cve.go
+++ b/pkg/extensions/search/cve/cve.go
@@ -331,7 +331,8 @@ func getConfigAndDigest(metaDB mTypes.MetaDB, manifestDigestStr string) (ispec.I
 	}
 
 	// we'll fail the execution if the config is not compatible with ispec.Image because we can't scan this type of images.
-	if manifestData.Manifests[0].Manifest.Config.MediaType != ispec.MediaTypeImageConfig {
+	configMediaType := manifestData.Manifests[0].Manifest.Config.MediaType
+	if configMediaType != ispec.MediaTypeImageConfig && !compat.IsCompatibleConfigMediaType(configMediaType) {
 		return ispec.Image{}, "", zerr.ErrUnexpectedMediaType
 	}
 

--- a/pkg/meta/hooks.go
+++ b/pkg/meta/hooks.go
@@ -7,6 +7,7 @@ import (
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	zcommon "zotregistry.dev/zot/pkg/common"
+	"zotregistry.dev/zot/pkg/compat"
 	"zotregistry.dev/zot/pkg/log"
 	mTypes "zotregistry.dev/zot/pkg/meta/types"
 	"zotregistry.dev/zot/pkg/storage"
@@ -117,7 +118,8 @@ func OnGetManifest(name, reference, mediaType string, body []byte,
 		return nil
 	}
 
-	if !(mediaType == v1.MediaTypeImageManifest || mediaType == v1.MediaTypeImageIndex) {
+	if !(mediaType == v1.MediaTypeImageManifest || mediaType == v1.MediaTypeImageIndex ||
+		compat.IsCompatibleManifestMediaType(mediaType) || compat.IsCompatibleManifestListMediaType(mediaType)) {
 		return nil
 	}
 

--- a/pkg/meta/parse.go
+++ b/pkg/meta/parse.go
@@ -321,7 +321,8 @@ func SetImageMetaFromInput(ctx context.Context, repo, reference, mediaType strin
 			return err
 		}
 
-		if manifestContent.Config.MediaType == ispec.MediaTypeImageConfig {
+		if manifestContent.Config.MediaType == ispec.MediaTypeImageConfig ||
+			compat.IsCompatibleConfigMediaType(manifestContent.Config.MediaType) {
 			configBlob, err := imageStore.GetBlobContent(repo, manifestContent.Config.Digest)
 			if err != nil {
 				return err


### PR DESCRIPTION
- update download counters for docker media types - closes #2929
- handle docker config media type in MetaDB - The OS/Arch/Layer History information was not written to MetaDB

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
