### PR TITLE
feat: redirect to download urls of blobs

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -60,6 +60,7 @@ var (
 	ErrBadBlob                        = errors.New("bad blob")
 	ErrBadBlobDigest                  = errors.New("bad blob digest")
 	ErrBlobReferenced                 = errors.New("blob referenced by manifest")
+	ErrBlobRedirectURLNotSupported    = errors.New("blob redirect url not supported")
 	ErrManifestReferenced             = errors.New("manifest referenced by index image")
 	ErrUnknownCode                    = errors.New("unknown error code")
 	ErrBadCACert                      = errors.New("invalid tls ca cert")

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -34,6 +34,7 @@ type StorageConfig struct {
 	Retention     ImageRetention
 	StorageDriver map[string]interface{} `mapstructure:",omitempty"`
 	CacheDriver   map[string]interface{} `mapstructure:",omitempty"`
+	Redirect      bool
 }
 
 type ImageRetention struct {

--- a/pkg/storage/local/driver.go
+++ b/pkg/storage/local/driver.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"sort"
@@ -56,6 +57,10 @@ func (driver *Driver) DirExists(path string) bool {
 	}
 
 	return true
+}
+
+func (driver *Driver) URLFor(_ *http.Request, _ string) (string, error) {
+	return "", zerr.ErrBlobRedirectURLNotSupported
 }
 
 func (driver *Driver) Reader(path string, offset int64) (io.ReadCloser, error) {

--- a/pkg/storage/s3/driver.go
+++ b/pkg/storage/s3/driver.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	"io"
+	"net/http"
 
 	// Add s3 support.
 	"github.com/distribution/distribution/v3/registry/storage/driver"
@@ -33,6 +34,10 @@ func (driver *Driver) DirExists(path string) bool {
 	}
 
 	return false
+}
+
+func (driver *Driver) URLFor(r *http.Request, path string) (string, error) {
+	return driver.store.RedirectURL(r, path)
 }
 
 func (driver *Driver) Reader(path string, offset int64) (io.ReadCloser, error) {

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"io"
+	"net/http"
 	"time"
 
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
@@ -53,6 +54,7 @@ type ImageStore interface { //nolint:interfacebloat
 	CheckBlob(repo string, digest godigest.Digest) (bool, int64, error)
 	StatBlob(repo string, digest godigest.Digest) (bool, int64, time.Time, error)
 	GetBlob(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error)
+	GetBlobURL(r *http.Request, repo string, digest godigest.Digest, mediaType string) (string, error)
 	GetBlobPartial(repo string, digest godigest.Digest, mediaType string, from, to int64,
 	) (io.ReadCloser, int64, int64, error)
 	DeleteBlob(repo string, digest godigest.Digest) error
@@ -75,6 +77,7 @@ type Driver interface { //nolint:interfacebloat
 	Name() string
 	EnsureDir(path string) error
 	DirExists(path string) bool
+	URLFor(request *http.Request, path string) (string, error)
 	Reader(path string, offset int64) (io.ReadCloser, error)
 	ReadFile(path string) ([]byte, error)
 	Delete(path string) error

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"context"
 	"io"
+	"net/http"
 	"time"
 
 	godigest "github.com/opencontainers/go-digest"
@@ -44,6 +45,7 @@ type MockedImageStore struct {
 	GetBlobPartialFn       func(repo string, digest godigest.Digest, mediaType string, from, to int64,
 	) (io.ReadCloser, int64, int64, error)
 	GetBlobFn            func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error)
+	GetBlobURLFn         func(request *http.Request, repo string, digest godigest.Digest, mediaType string) (string, error)
 	DeleteBlobFn         func(repo string, digest godigest.Digest) error
 	GetIndexContentFn    func(repo string) ([]byte, error)
 	GetBlobContentFn     func(repo string, digest godigest.Digest) ([]byte, error)
@@ -337,6 +339,15 @@ func (is MockedImageStore) GetBlob(repo string, digest godigest.Digest, mediaTyp
 	}
 
 	return io.NopCloser(&io.LimitedReader{}), 0, nil
+}
+
+func (is MockedImageStore) GetBlobURL(request *http.Request, repo string, digest godigest.Digest, mediaType string,
+) (string, error) {
+	if is.GetBlobURLFn != nil {
+		return is.GetBlobURLFn(request, repo, digest, mediaType)
+	}
+
+	return "", nil
 }
 
 func (is MockedImageStore) DeleteBlobUpload(repo string, uuid string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#2752 

**What does this PR do / Why do we need it**:
redirects clients to a presigned urls for blob downloads, which significantly reduces load of the zot server, since the blobs no longer need to go through the server.

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
redirect clients to S3 URLs when fetching blobs
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
