### PR TITLE
feat(storage): enable parallel writes by using per-repo and per-digest locking

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,8 +1,11 @@
 name: 'Nightly jobs'
 on:
-  schedule:
-    - cron: '30 1 * * *'
+  # schedule:
+  #   - cron: '30 1 * * *'
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
 
 permissions: read-all
 

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -956,12 +956,12 @@ func (rh *RouteHandler) CheckBlob(response http.ResponseWriter, request *http.Re
 	if userCanMount {
 		ok, blen, err = imgStore.CheckBlob(name, digest)
 	} else {
-		var lockLatency time.Time
+		err = imgStore.WithRepoReadLock(name, func() error {
+			var err error
+			ok, blen, _, err = imgStore.StatBlob(name, digest)
 
-		imgStore.RLock(&lockLatency)
-		defer imgStore.RUnlock(&lockLatency)
-
-		ok, blen, _, err = imgStore.StatBlob(name, digest)
+			return err
+		})
 	}
 
 	if err != nil {

--- a/pkg/storage/imagestore/lock.go
+++ b/pkg/storage/imagestore/lock.go
@@ -1,0 +1,74 @@
+package imagestore
+
+import (
+	"sync"
+	"time"
+
+	godigest "github.com/opencontainers/go-digest"
+
+	storageConstants "zotregistry.dev/zot/pkg/storage/constants"
+	storageTypes "zotregistry.dev/zot/pkg/storage/types"
+)
+
+type ImageStoreLock struct {
+	// locks per repository paths
+	repoLocks   sync.Map
+	digestLocks sync.Map
+	imgStore    storageTypes.ImageStore
+}
+
+func NewImageStoreLock(imgStore storageTypes.ImageStore) *ImageStoreLock {
+	return &ImageStoreLock{
+		repoLocks:   sync.Map{},
+		digestLocks: sync.Map{},
+		imgStore:    imgStore,
+	}
+}
+
+func (sl *ImageStoreLock) WithRepoLock(repo string, wrappedFunc func() error) error {
+	val, _ := sl.repoLocks.LoadOrStore(repo, &sync.RWMutex{})
+	repoLock, _ := val.(*sync.RWMutex)
+
+	lockStart := time.Now()
+
+	// write-lock individual repo
+	repoLock.Lock()
+
+	defer func() {
+		repoLock.Unlock()
+		latency := time.Since(lockStart)
+
+		sl.imgStore.ObserveLockLatency(latency, storageConstants.RWLOCK) // histogram
+	}()
+
+	return wrappedFunc()
+}
+
+func (sl *ImageStoreLock) WithRepoReadLock(repo string, wrappedFunc func() error) error {
+	val, _ := sl.repoLocks.LoadOrStore(repo, &sync.RWMutex{})
+	repoLock, _ := val.(*sync.RWMutex)
+
+	lockStart := time.Now()
+
+	// read-lock individual repo
+	repoLock.RLock()
+
+	defer func() {
+		repoLock.RUnlock()
+		latency := time.Since(lockStart)
+
+		sl.imgStore.ObserveLockLatency(latency, storageConstants.RLOCK) // histogram
+	}()
+
+	return wrappedFunc()
+}
+
+func (sl *ImageStoreLock) WithDigestLock(digest godigest.Digest, wrappedFunc func() error) error {
+	val, _ := sl.repoLocks.LoadOrStore(digest.String(), &sync.Mutex{})
+	digestLock, _ := val.(*sync.Mutex)
+	digestLock.Lock()
+
+	defer digestLock.Unlock()
+
+	return wrappedFunc()
+}

--- a/pkg/storage/imagestore/lock_test.go
+++ b/pkg/storage/imagestore/lock_test.go
@@ -1,0 +1,70 @@
+package imagestore_test
+
+import (
+	_ "crypto/sha256"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/rs/zerolog"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/pkg/extensions/monitoring"
+	zlog "zotregistry.dev/zot/pkg/log"
+	"zotregistry.dev/zot/pkg/storage"
+	"zotregistry.dev/zot/pkg/storage/cache"
+	"zotregistry.dev/zot/pkg/storage/local"
+)
+
+func TestStorageLocks(t *testing.T) {
+	dir := t.TempDir()
+
+	log := zlog.Logger{Logger: zerolog.New(os.Stdout)}
+	metrics := monitoring.NewMetricsServer(false, log)
+	cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
+		RootDir:     dir,
+		Name:        "cache",
+		UseRelPaths: true,
+	}, log)
+
+	imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil)
+
+	Convey("Locks", t, func() {
+		// in parallel, a mix of read and write locks - mainly for coverage
+		var wg sync.WaitGroup
+
+		for i := 0; i < 1000; i++ {
+			repo := "repo" + strconv.Itoa(i%10)
+
+			wg.Add(2)
+
+			go func() {
+				defer wg.Done()
+
+				t.Logf("Repo %s will be write-locked in loop %d", repo, i)
+				_ = imgStore.WithRepoLock(repo, func() error {
+					t.Logf("Execute while repo %s is write-locked in loop %d", repo, i)
+
+					return nil
+				})
+
+				t.Logf("Repo %s is write-unlocked in loop %d", repo, i)
+			}()
+			go func() {
+				defer wg.Done()
+
+				t.Logf("Repo %s will be read-locked in loop %d", repo, i)
+				_ = imgStore.WithRepoReadLock(repo, func() error {
+					t.Logf("Execute while repo %s is read-locked in loop %d", repo, i)
+
+					return nil
+				})
+
+				t.Logf("Repo %s is read-unlocked in loop %d", repo, i)
+			}()
+		}
+
+		wg.Wait()
+	})
+}

--- a/pkg/storage/local/driver.go
+++ b/pkg/storage/local/driver.go
@@ -189,7 +189,13 @@ func (driver *Driver) WriteFile(filepath string, content []byte) (int, error) {
 func (driver *Driver) Walk(path string, walkFn storagedriver.WalkFn) error {
 	children, err := driver.List(path)
 	if err != nil {
-		return err
+		switch errors.As(err, &storagedriver.PathNotFoundError{}) {
+		case true:
+			// repository was removed in between listing and enumeration. Ignore it.
+			return nil
+		default:
+			return err
+		}
 	}
 
 	sort.Stable(sort.StringSlice(children))

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -24,10 +24,9 @@ type ImageStore interface { //nolint:interfacebloat
 	Name() string
 	DirExists(d string) bool
 	RootDir() string
-	RLock(*time.Time)
-	RUnlock(*time.Time)
-	Lock(*time.Time)
-	Unlock(*time.Time)
+	WithRepoReadLock(repo string, wrappedFunc func() error) error
+	WithRepoLock(repo string, wrappedFunc func() error) error
+	ObserveLockLatency(latency time.Duration, lockType string)
 	InitRepo(name string) error
 	ValidateRepo(name string) (bool, error)
 	GetRepositories() ([]string, error)

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -72,16 +72,15 @@ func (is MockedImageStore) StatIndex(repo string) (bool, int64, time.Time, error
 	return true, 0, time.Time{}, nil
 }
 
-func (is MockedImageStore) Lock(t *time.Time) {
+func (is MockedImageStore) WithRepoReadLock(repo string, wrappedFunc func() error) error {
+	return wrappedFunc()
 }
 
-func (is MockedImageStore) Unlock(t *time.Time) {
+func (is MockedImageStore) WithRepoLock(repo string, wrappedFunc func() error) error {
+	return wrappedFunc()
 }
 
-func (is MockedImageStore) RUnlock(t *time.Time) {
-}
-
-func (is MockedImageStore) RLock(t *time.Time) {
+func (is MockedImageStore) ObserveLockLatency(latency time.Duration, lockType string) {
 }
 
 func (is MockedImageStore) Name() string {

--- a/test/scale-out/cloud_scale_out_redis.bats
+++ b/test/scale-out/cloud_scale_out_redis.bats
@@ -32,6 +32,7 @@ function launch_zot_server() {
     local zot_log_file="${ZOT_LOG_DIR}/zot-${zot_server_address}-${zot_server_port}.log"
 
     create_zot_cloud_redis_config_file ${zot_server_address} ${zot_server_port} ${zot_root_dir} ${zot_config_file} ${zot_log_file} ${redis_url}
+    update_zot_cluster_member_list_in_config_file ${zot_config_file} ${ZOT_CLUSTER_MEMBERS_PATCH_FILE}
     
     echo "launching zot server ${zot_server_address}:${zot_server_port}" >&3
     echo "config file: ${zot_config_file}" >&3
@@ -54,6 +55,7 @@ function setup() {
     
     # setup S3 bucket and DynamoDB tables
     setup_cloud_services
+    generate_zot_cluster_member_list ${NUM_ZOT_INSTANCES} ${ZOT_CLUSTER_MEMBERS_PATCH_FILE}
 
     for ((i=0;i<${NUM_ZOT_INSTANCES};i++)); do
         launch_zot_server 127.0.0.1 $(( 10000 + $i )) ${redis_url}

--- a/test/scale-out/cloud_scale_out_redis_scale.bats
+++ b/test/scale-out/cloud_scale_out_redis_scale.bats
@@ -32,6 +32,7 @@ function launch_zot_server() {
     local zot_log_file="${ZOT_LOG_DIR}/zot-${zot_server_address}-${zot_server_port}.log"
 
     create_zot_cloud_redis_config_file ${zot_server_address} ${zot_server_port} ${zot_root_dir} ${zot_config_file} ${zot_log_file} ${redis_url}
+    update_zot_cluster_member_list_in_config_file ${zot_config_file} ${ZOT_CLUSTER_MEMBERS_PATCH_FILE}
     
     echo "launching zot server ${zot_server_address}:${zot_server_port}" >&3
     echo "config file: ${zot_config_file}" >&3
@@ -54,6 +55,7 @@ function setup() {
     
     # setup S3 bucket and DynamoDB tables
     setup_cloud_services
+    generate_zot_cluster_member_list ${NUM_ZOT_INSTANCES} ${ZOT_CLUSTER_MEMBERS_PATCH_FILE}
 
     for ((i=0;i<${NUM_ZOT_INSTANCES};i++)); do
         launch_zot_server 127.0.0.1 $(( 10000 + $i )) ${redis_url}

--- a/test/scale-out/helpers_zot.bash
+++ b/test/scale-out/helpers_zot.bash
@@ -272,6 +272,10 @@ function create_zot_cloud_redis_config_file() {
         "address": "${zot_server_address}",
         "port": "${zot_server_port}"
     },
+    "cluster": {
+      "members": [],
+      "hashKey": "loremipsumdolors"
+    },
     "log": {
         "level": "debug",
         "output": "${zot_log_file}"


### PR DESCRIPTION
Should fix issues such as https://github.com/project-zot/zot/issues/2964

- lock per repo on pushes/pulls/retention, in short index operations
- lock per digest when using multiple operations affecting the cachedb and storage
(blob writes/deletes/moves/links in storage which need to be in accordance with cachedb content)

Do not lock multiple repos at the same time in the same goroutine! It will cause deadlocks.
Same applies to digests.

In separate commits:
- show more error information in zb output
- gc stress tests to save logs as artifacts

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.