### PR TITLE
[feat]: add support for EC/ED25519 public keys for token authentication

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -175,6 +175,8 @@ var (
 	ErrImageNotFound                  = errors.New("image not found")
 	ErrAmbiguousInput                 = errors.New("input is not specific enough")
 	ErrReceivedUnexpectedAuthHeader   = errors.New("received unexpected www-authenticate header")
+	ErrNoBearerToken                  = errors.New("no bearer token given")
 	ErrInvalidBearerToken             = errors.New("invalid bearer token given")
+	ErrInsufficientScope              = errors.New("bearer token does not have sufficient scope")
 	ErrCouldNotLoadCertificate        = errors.New("failed to load certificate")
 )

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -176,5 +176,5 @@ var (
 	ErrAmbiguousInput                 = errors.New("input is not specific enough")
 	ErrReceivedUnexpectedAuthHeader   = errors.New("received unexpected www-authenticate header")
 	ErrInvalidBearerToken             = errors.New("invalid bearer token given")
-	ErrCouldNotLoadPublicKey          = errors.New("failed to load public key")
+	ErrCouldNotLoadCertificate        = errors.New("failed to load certificate")
 )

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -175,4 +175,6 @@ var (
 	ErrImageNotFound                  = errors.New("image not found")
 	ErrAmbiguousInput                 = errors.New("input is not specific enough")
 	ErrReceivedUnexpectedAuthHeader   = errors.New("received unexpected www-authenticate header")
+	ErrInvalidBearerToken             = errors.New("invalid bearer token given")
+	ErrCouldNotLoadPublicKey          = errors.New("failed to load public key")
 )

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/go-redsync/redsync/v4 v4.13.0
 	github.com/gofrs/uuid v4.4.0+incompatible
+	github.com/golang-jwt/jwt/v5 v5.2.1
 	github.com/google/go-containerregistry v0.20.3
 	github.com/google/go-github/v62 v62.0.0
 	github.com/google/uuid v1.6.0
@@ -273,7 +274,6 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
-	github.com/golang-jwt/jwt/v5 v5.2.1 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -454,7 +454,7 @@ func bearerAuthHandler(ctlr *Controller) mux.MiddlewareFunc {
 				}
 			}
 
-			err = authorizer.Authorize(header, requestedAccess)
+			err := authorizer.Authorize(header, requestedAccess)
 			if err != nil {
 				var challenge *authChallenge
 				if errors.As(err, &challenge) {

--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -407,7 +407,7 @@ func bearerAuthHandler(ctlr *Controller) mux.MiddlewareFunc {
 		ctlr.Log.Panic().Err(err).Msg("failed to load certificate for bearer authentication")
 	}
 
-	authorizer := newBearerAuthorizer(
+	authorizer := NewBearerAuthorizer(
 		ctlr.Config.HTTP.Auth.Bearer.Realm,
 		ctlr.Config.HTTP.Auth.Bearer.Service,
 		certificate.PublicKey,
@@ -435,7 +435,7 @@ func bearerAuthHandler(ctlr *Controller) mux.MiddlewareFunc {
 				return
 			}
 
-			var requestedAccess *resourceAction
+			var requestedAccess *ResourceAction
 
 			if request.RequestURI != "/v2/" {
 				// if this is not the base route, the requested repository/action must be authorized
@@ -447,7 +447,7 @@ func bearerAuthHandler(ctlr *Controller) mux.MiddlewareFunc {
 					action = "push"
 				}
 
-				requestedAccess = &resourceAction{
+				requestedAccess = &ResourceAction{
 					Type:   "repository",
 					Name:   name,
 					Action: action,
@@ -456,9 +456,9 @@ func bearerAuthHandler(ctlr *Controller) mux.MiddlewareFunc {
 
 			err := authorizer.Authorize(header, requestedAccess)
 			if err != nil {
-				var challenge *authChallengeError
+				var challenge *AuthChallengeError
 				if errors.As(err, &challenge) {
-					ctlr.Log.Debug().Err(challenge.err).Msg("bearer token authorization failed")
+					ctlr.Log.Debug().Err(challenge).Msg("bearer token authorization failed")
 					response.Header().Set("Content-Type", "application/json")
 					response.Header().Set("WWW-Authenticate", challenge.Header())
 					zcommon.WriteJSON(response, http.StatusUnauthorized, apiErr.NewError(apiErr.UNAUTHORIZED))

--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -2,21 +2,21 @@ package api
 
 import (
 	"context"
+	"crypto"
 	"crypto/sha256"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/golang-jwt/jwt/v5"
 	"net"
 	"net/http"
 	"os"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
-	"github.com/chartmuseum/auth"
 	guuid "github.com/gofrs/uuid"
 	"github.com/google/go-github/v62/github"
 	"github.com/google/uuid"
@@ -39,9 +39,8 @@ import (
 )
 
 const (
-	bearerAuthDefaultAccessEntryType = "repository"
-	issuedAtOffset                   = 5 * time.Second
-	relyingPartyCookieMaxAge         = 120
+	issuedAtOffset           = 5 * time.Second
+	relyingPartyCookieMaxAge = 120
 )
 
 type AuthnMiddleware struct {
@@ -404,16 +403,16 @@ func (amw *AuthnMiddleware) tryAuthnHandlers(ctlr *Controller) mux.MiddlewareFun
 }
 
 func bearerAuthHandler(ctlr *Controller) mux.MiddlewareFunc {
-	authorizer, err := auth.NewAuthorizer(&auth.AuthorizerOptions{
-		Realm:                 ctlr.Config.HTTP.Auth.Bearer.Realm,
-		Service:               ctlr.Config.HTTP.Auth.Bearer.Service,
-		PublicKeyPath:         ctlr.Config.HTTP.Auth.Bearer.Cert,
-		AccessEntryType:       bearerAuthDefaultAccessEntryType,
-		EmptyDefaultNamespace: true,
-	})
+	pubKey, err := loadPublicKeyFromFile(ctlr.Config.HTTP.Auth.Bearer.Cert)
 	if err != nil {
-		ctlr.Log.Panic().Err(err).Msg("failed to create bearer authorizer")
+		ctlr.Log.Panic().Err(err).Msg("failed to load signing key for bearer authentication")
 	}
+
+	authorizer := newBearerAuthorizer(
+		ctlr.Config.HTTP.Auth.Bearer.Realm,
+		ctlr.Config.HTTP.Auth.Bearer.Service,
+		pubKey,
+	)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
@@ -425,8 +424,6 @@ func bearerAuthHandler(ctlr *Controller) mux.MiddlewareFunc {
 			}
 
 			acCtrlr := NewAccessController(ctlr.Config)
-			vars := mux.Vars(request)
-			name := vars["name"]
 
 			// we want to bypass auth for mgmt route
 			isMgmtRequested := request.RequestURI == constants.FullMgmt
@@ -439,67 +436,39 @@ func bearerAuthHandler(ctlr *Controller) mux.MiddlewareFunc {
 				return
 			}
 
-			action := auth.PullAction
-			if m := request.Method; m != http.MethodGet && m != http.MethodHead {
-				action = auth.PushAction
+			var requestedAccess *resourceAction
+			if request.RequestURI != "/v2/" {
+				// if this is not the base route, the requested repository/action must be authorized
+				vars := mux.Vars(request)
+				name := vars["name"]
+
+				action := "pull"
+				if m := request.Method; m != http.MethodGet && m != http.MethodHead {
+					action = "push"
+				}
+
+				requestedAccess = &resourceAction{
+					Type:   "repository",
+					Name:   name,
+					Action: action,
+				}
 			}
 
-			var permissions *auth.Permission
-
-			// Empty scope should be allowed according to the distribution auth spec
-			// This is only necessary for the bearer auth type
-			if request.RequestURI == "/v2/" && authorizer.Type == auth.BearerAuthAuthorizerType {
-				if header == "" {
-					// first request that clients make (without any header)
-					WWWAuthenticateHeader := fmt.Sprintf("Bearer realm=\"%s\",service=\"%s\",scope=\"\"",
-						authorizer.Realm, authorizer.Service)
-
-					permissions = &auth.Permission{
-						// challenge for the client to use to authenticate to /v2/
-						WWWAuthenticateHeader: WWWAuthenticateHeader,
-						Allowed:               false,
-					}
-				} else {
-					// subsequent requests with token on /v2/
-					bearerTokenMatch := regexp.MustCompile("(?i)bearer (.*)")
-
-					signedString := bearerTokenMatch.ReplaceAllString(header, "$1")
-
-					// If the token is valid, our job is done
-					// Since this is the /v2 base path and we didn't pass a scope to the auth header in the previous step
-					// there is no access check to enforce
-					_, err := authorizer.TokenDecoder.DecodeToken(signedString)
-					if err != nil {
-						ctlr.Log.Error().Err(err).Msg("failed to parse Authorization header")
-						response.Header().Set("Content-Type", "application/json")
-						zcommon.WriteJSON(response, http.StatusUnauthorized, apiErr.NewError(apiErr.UNSUPPORTED))
-
-						return
-					}
-
-					permissions = &auth.Permission{
-						Allowed: true,
-					}
-				}
-			} else {
-				var err error
-
-				// subsequent requests with token on /v2/<resource>/
-				permissions, err = authorizer.Authorize(header, action, name)
-				if err != nil {
-					ctlr.Log.Error().Err(err).Msg("failed to parse Authorization header")
+			err = authorizer.Authorize(header, requestedAccess)
+			if err != nil {
+				var challenge *authChallenge
+				if errors.As(err, &challenge) {
+					ctlr.Log.Debug().Err(challenge.err).Msg("bearer token authorization failed")
 					response.Header().Set("Content-Type", "application/json")
-					zcommon.WriteJSON(response, http.StatusInternalServerError, apiErr.NewError(apiErr.UNSUPPORTED))
+					response.Header().Set("WWW-Authenticate", challenge.Header())
+					zcommon.WriteJSON(response, http.StatusUnauthorized, apiErr.NewError(apiErr.UNAUTHORIZED))
 
 					return
 				}
-			}
 
-			if !permissions.Allowed {
+				ctlr.Log.Error().Err(err).Msg("failed to parse Authorization header")
 				response.Header().Set("Content-Type", "application/json")
-				response.Header().Set("WWW-Authenticate", permissions.WWWAuthenticateHeader)
-
-				zcommon.WriteJSON(response, http.StatusUnauthorized, apiErr.NewError(apiErr.UNAUTHORIZED))
+				zcommon.WriteJSON(response, http.StatusUnauthorized, apiErr.NewError(apiErr.UNSUPPORTED))
 
 				return
 			}
@@ -931,4 +900,37 @@ func GenerateAPIKey(uuidGenerator guuid.Generator, log log.Logger,
 	}
 
 	return apiKey, apiKeyID.String(), err
+}
+
+func loadPublicKeyFromFile(path string) (crypto.PublicKey, error) {
+	d, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read certificate file %s: %w", path, err)
+	}
+
+	rsaKey, err := jwt.ParseRSAPublicKeyFromPEM(d)
+	if err == nil {
+		return rsaKey, nil
+	}
+	if !errors.Is(err, jwt.ErrNotRSAPublicKey) {
+		return nil, err
+	}
+
+	ecKey, err := jwt.ParseECPublicKeyFromPEM(d)
+	if err == nil {
+		return ecKey, nil
+	}
+	if !errors.Is(err, jwt.ErrNotECPublicKey) {
+		return nil, err
+	}
+
+	edKey, err := jwt.ParseEdPublicKeyFromPEM(d)
+	if err == nil {
+		return edKey, nil
+	}
+	if !errors.Is(err, jwt.ErrNotEdPublicKey) {
+		return nil, err
+	}
+
+	return nil, errors.New("invalid public key given")
 }

--- a/pkg/api/bearer.go
+++ b/pkg/api/bearer.go
@@ -93,7 +93,7 @@ func (a *BearerAuthorizer) Authorize(header string, requested *ResourceAction) e
 
 	token, err := jwt.ParseWithClaims(signedString, &ClaimsWithAccess{}, func(token *jwt.Token) (interface{}, error) {
 		return a.key, nil
-	}, jwt.WithValidMethods(a.allowedSigningAlgorithms()))
+	}, jwt.WithValidMethods(a.allowedSigningAlgorithms()), jwt.WithIssuedAt())
 	if err != nil {
 		return fmt.Errorf("%w: %w", zerr.ErrInvalidBearerToken, err)
 	}

--- a/pkg/api/bearer.go
+++ b/pkg/api/bearer.go
@@ -13,6 +13,19 @@ import (
 
 var bearerTokenMatch = regexp.MustCompile("(?i)bearer (.*)")
 
+var allowedSigningAlgorithms = []string{
+	"EdDSA",
+	"RS256",
+	"RS384",
+	"RS512",
+	"ES256",
+	"ES384",
+	"ES512",
+	"PS256",
+	"PS384",
+	"PS512",
+}
+
 // ResourceAccess is a single entry in the private 'access' claim specified by the distribution token authentication
 // specification.
 type ResourceAccess struct {
@@ -91,7 +104,7 @@ func (a *bearerAuthorizer) Authorize(header string, requested *resourceAction) e
 
 	token, err := jwt.ParseWithClaims(signedString, &ClaimsWithAccess{}, func(token *jwt.Token) (interface{}, error) {
 		return a.key, nil
-	})
+	}, jwt.WithValidMethods(allowedSigningAlgorithms))
 	if err != nil {
 		return fmt.Errorf("%w: %w", zerr.ErrInvalidBearerToken, err)
 	}

--- a/pkg/api/bearer.go
+++ b/pkg/api/bearer.go
@@ -13,9 +13,9 @@ import (
 
 var bearerTokenMatch = regexp.MustCompile("(?i)bearer (.*)")
 
-// resourceAccess is a single entry in the private 'access' claim specified by the distribution token authentication
+// ResourceAccess is a single entry in the private 'access' claim specified by the distribution token authentication
 // specification.
-type resourceAccess struct {
+type ResourceAccess struct {
 	Type    string   `json:"type"`
 	Name    string   `json:"name"`
 	Actions []string `json:"actions"`
@@ -27,11 +27,11 @@ type resourceAction struct {
 	Action string `json:"action"`
 }
 
-// claimsWithAccess is a claim set containing the private 'access' claim specified by the distribution token
+// ClaimsWithAccess is a claim set containing the private 'access' claim specified by the distribution token
 // authentication specification, in addition to the standard registered claims.
 // https://distribution.github.io/distribution/spec/auth/jwt/
-type claimsWithAccess struct {
-	Access []resourceAccess `json:"access"`
+type ClaimsWithAccess struct {
+	Access []ResourceAccess `json:"access"`
 	jwt.RegisteredClaims
 }
 
@@ -89,7 +89,7 @@ func (a *bearerAuthorizer) Authorize(header string, requested *resourceAction) e
 
 	signedString := bearerTokenMatch.ReplaceAllString(header, "$1")
 
-	token, err := jwt.ParseWithClaims(signedString, &claimsWithAccess{}, func(token *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(signedString, &ClaimsWithAccess{}, func(token *jwt.Token) (interface{}, error) {
 		return a.key, nil
 	})
 	if err != nil {
@@ -101,7 +101,7 @@ func (a *bearerAuthorizer) Authorize(header string, requested *resourceAction) e
 		return nil
 	}
 
-	claims, ok := token.Claims.(*claimsWithAccess)
+	claims, ok := token.Claims.(*ClaimsWithAccess)
 	if !ok {
 		return fmt.Errorf("%w: invalid claims type", zerr.ErrInvalidBearerToken)
 	}

--- a/pkg/api/bearer.go
+++ b/pkg/api/bearer.go
@@ -1,0 +1,114 @@
+package api
+
+import (
+	"crypto"
+	"errors"
+	"fmt"
+	"github.com/golang-jwt/jwt/v5"
+	"regexp"
+	"slices"
+)
+
+var bearerTokenMatch = regexp.MustCompile("(?i)bearer (.*)")
+
+// resourceAccess is a single entry in the private 'access' claim specified by the distribution token authentication
+// specification.
+type resourceAccess struct {
+	Type    string   `json:"type"`
+	Name    string   `json:"name"`
+	Actions []string `json:"actions"`
+}
+
+type resourceAction struct {
+	Type   string `json:"type"`
+	Name   string `json:"name"`
+	Action string `json:"action"`
+}
+
+// claimsWithAccess is a claim set containing the private 'access' claim specified by the distribution token
+// authentication specification, in addition to the standard registered claims.
+// https://distribution.github.io/distribution/spec/auth/jwt/
+type claimsWithAccess struct {
+	Access []resourceAccess `json:"access"`
+	jwt.RegisteredClaims
+}
+
+type authChallenge struct {
+	err            error
+	realm          string
+	service        string
+	resourceAction *resourceAction
+}
+
+func (c authChallenge) Error() string {
+	return c.err.Error()
+}
+
+// Header constructs an appropriate value for the WWW-Authenticate header to be returned to the client.
+func (c authChallenge) Header() string {
+	if c.resourceAction == nil {
+		// no access was requested, so return an empty scope
+		return fmt.Sprintf("Bearer realm=\"%s\",service=\"%s\",scope=\"\"",
+			c.realm, c.service)
+	}
+
+	return fmt.Sprintf("Bearer realm=\"%s\",service=\"%s\",scope=\"%s:%s:%s\"",
+		c.realm, c.service, c.resourceAction.Type, c.resourceAction.Name, c.resourceAction.Action)
+}
+
+type bearerAuthorizer struct {
+	realm   string
+	service string
+	key     crypto.PublicKey
+}
+
+func newBearerAuthorizer(realm string, service string, key crypto.PublicKey) bearerAuthorizer {
+	return bearerAuthorizer{
+		realm:   realm,
+		service: service,
+		key:     key,
+	}
+}
+
+// Authorize verifies whether the bearer token in the given Authorization header is valid, and whether it has sufficient
+// scope for the requested resource action. If an authorization error occurs (e.g. no token is given or the token has
+// insufficient scope), an authChallenge is returned as the error.
+func (a *bearerAuthorizer) Authorize(header string, requested *resourceAction) error {
+	challenge := &authChallenge{
+		realm:          a.realm,
+		service:        a.service,
+		resourceAction: requested,
+	}
+
+	if header == "" {
+		// if no bearer token is set in the authorization header, return the authentication challenge
+		return challenge
+	}
+
+	signedString := bearerTokenMatch.ReplaceAllString(header, "$1")
+	token, err := jwt.ParseWithClaims(signedString, &claimsWithAccess{}, func(token *jwt.Token) (interface{}, error) {
+		return a.key, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if requested == nil {
+		// the token is valid and no access is requested, so we do not have to validate the access claim
+		return nil
+	}
+
+	claims, ok := token.Claims.(*claimsWithAccess)
+	if !ok {
+		return errors.New("invalid claims type in token")
+	}
+
+	// check whether the requested access is allowed by the scope of the token
+	for _, allowed := range claims.Access {
+		if allowed.Type == requested.Type && allowed.Name == requested.Name && slices.Contains(allowed.Actions, requested.Action) {
+			return nil
+		}
+	}
+
+	return challenge
+}

--- a/pkg/api/bearer_test.go
+++ b/pkg/api/bearer_test.go
@@ -3,13 +3,14 @@ package api_test
 import (
 	"crypto/rand"
 	"crypto/rsa"
-	"github.com/golang-jwt/jwt/v5"
 	"testing"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	. "github.com/smartystreets/goconvey/convey"
+
 	zerr "zotregistry.dev/zot/errors"
 	"zotregistry.dev/zot/pkg/api"
-
-	. "github.com/smartystreets/goconvey/convey"
 )
 
 func TestBearerAuthorizer(t *testing.T) {
@@ -58,49 +59,49 @@ func TestBearerAuthorizer(t *testing.T) {
 			authHeader := "Bearer " + token
 
 			Convey("Unauthorized type", func() {
-				r := &api.ResourceAction{
+				requested := &api.ResourceAction{
 					Type:   "registry",
 					Name:   "catalog",
 					Action: "*",
 				}
 
-				err := authorizer.Authorize(authHeader, r)
+				err := authorizer.Authorize(authHeader, requested)
 				So(err, ShouldHaveSameTypeAs, &api.AuthChallengeError{})
 				So(err, ShouldBeError, zerr.ErrInsufficientScope)
 			})
 
 			Convey("Unauthorized name", func() {
-				r := &api.ResourceAction{
+				requested := &api.ResourceAction{
 					Type:   "repository",
 					Name:   "unauthorized-repository",
 					Action: "pull",
 				}
 
-				err := authorizer.Authorize(authHeader, r)
+				err := authorizer.Authorize(authHeader, requested)
 				So(err, ShouldHaveSameTypeAs, &api.AuthChallengeError{})
 				So(err, ShouldBeError, zerr.ErrInsufficientScope)
 			})
 
 			Convey("Unauthorized action", func() {
-				r := &api.ResourceAction{
+				requested := &api.ResourceAction{
 					Type:   "repository",
 					Name:   "authorized-repository",
 					Action: "push",
 				}
 
-				err := authorizer.Authorize(authHeader, r)
+				err := authorizer.Authorize(authHeader, requested)
 				So(err, ShouldHaveSameTypeAs, &api.AuthChallengeError{})
 				So(err, ShouldBeError, zerr.ErrInsufficientScope)
 			})
 
 			Convey("Successful authorization with requested access", func() {
-				r := &api.ResourceAction{
+				requested := &api.ResourceAction{
 					Type:   "repository",
 					Name:   "authorized-repository",
 					Action: "pull",
 				}
 
-				err := authorizer.Authorize(authHeader, r)
+				err := authorizer.Authorize(authHeader, requested)
 				So(err, ShouldBeNil)
 			})
 

--- a/pkg/api/bearer_test.go
+++ b/pkg/api/bearer_test.go
@@ -1,0 +1,120 @@
+package api_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"github.com/golang-jwt/jwt/v5"
+	"testing"
+	"time"
+	zerr "zotregistry.dev/zot/errors"
+	"zotregistry.dev/zot/pkg/api"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestBearerAuthorizer(t *testing.T) {
+	Convey("Test bearer token authorization", t, func() {
+		signingMethod := jwt.SigningMethodRS256
+
+		privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		if err != nil {
+			panic(err)
+		}
+
+		pubKey := privKey.Public()
+
+		authorizer := api.NewBearerAuthorizer("realm", "service", pubKey)
+
+		Convey("Empty authorization header given", func() {
+			err := authorizer.Authorize("", nil)
+			So(err, ShouldBeError, zerr.ErrNoBearerToken)
+		})
+
+		Convey("Valid token", func() {
+			access := []api.ResourceAccess{
+				{
+					Name:    "authorized-repository",
+					Type:    "repository",
+					Actions: []string{"pull"},
+				},
+			}
+
+			now := time.Now()
+			claims := api.ClaimsWithAccess{
+				Access: access,
+				RegisteredClaims: jwt.RegisteredClaims{
+					ExpiresAt: jwt.NewNumericDate(now.Add(time.Minute * 1)),
+					IssuedAt:  jwt.NewNumericDate(now),
+					Issuer:    "Zot",
+					Audience:  []string{"Zot Registry"},
+				},
+			}
+
+			token, err := jwt.NewWithClaims(signingMethod, claims).SignedString(privKey)
+			if err != nil {
+				panic(err)
+			}
+
+			authHeader := "Bearer " + token
+
+			Convey("Unauthorized type", func() {
+				r := &api.ResourceAction{
+					Type:   "registry",
+					Name:   "catalog",
+					Action: "*",
+				}
+
+				err := authorizer.Authorize(authHeader, r)
+				So(err, ShouldHaveSameTypeAs, &api.AuthChallengeError{})
+				So(err, ShouldBeError, zerr.ErrInsufficientScope)
+			})
+
+			Convey("Unauthorized name", func() {
+				r := &api.ResourceAction{
+					Type:   "repository",
+					Name:   "unauthorized-repository",
+					Action: "pull",
+				}
+
+				err := authorizer.Authorize(authHeader, r)
+				So(err, ShouldHaveSameTypeAs, &api.AuthChallengeError{})
+				So(err, ShouldBeError, zerr.ErrInsufficientScope)
+			})
+
+			Convey("Unauthorized action", func() {
+				r := &api.ResourceAction{
+					Type:   "repository",
+					Name:   "authorized-repository",
+					Action: "push",
+				}
+
+				err := authorizer.Authorize(authHeader, r)
+				So(err, ShouldHaveSameTypeAs, &api.AuthChallengeError{})
+				So(err, ShouldBeError, zerr.ErrInsufficientScope)
+			})
+
+			Convey("Successful authorization with requested access", func() {
+				r := &api.ResourceAction{
+					Type:   "repository",
+					Name:   "authorized-repository",
+					Action: "pull",
+				}
+
+				err := authorizer.Authorize(authHeader, r)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Successful authorization without requested access", func() {
+				err := authorizer.Authorize(authHeader, nil)
+				So(err, ShouldBeNil)
+			})
+		})
+
+		Convey("Invalid token", func() {
+			authHeader := "invalid"
+
+			err := authorizer.Authorize(authHeader, nil)
+			So(err, ShouldWrap, zerr.ErrInvalidBearerToken)
+		})
+	})
+}

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2314,6 +2314,11 @@ func TestAuthnErrors(t *testing.T) {
 		err := os.WriteFile(tmpFile, []byte("test"), 0o000)
 		So(err, ShouldBeNil)
 
+		defer func() {
+			err := os.Chmod(tmpFile, 0o644)
+			So(err, ShouldBeNil)
+		}()
+
 		conf.HTTP.Auth.LDAP = (&config.LDAPConfig{
 			Insecure:      true,
 			Address:       LDAPAddress,
@@ -2328,9 +2333,6 @@ func TestAuthnErrors(t *testing.T) {
 		So(func() {
 			api.AuthHandler(ctlr)
 		}, ShouldPanic)
-
-		err = os.Chmod(tmpFile, 0o644)
-		So(err, ShouldBeNil)
 	})
 
 	Convey("ldap CA certs is empty", t, func() {
@@ -2391,6 +2393,11 @@ func TestAuthnErrors(t *testing.T) {
 		err := os.WriteFile(tmpFile, []byte("test"), 0o000)
 		So(err, ShouldBeNil)
 
+		defer func() {
+			err := os.Chmod(tmpFile, 0o644)
+			So(err, ShouldBeNil)
+		}()
+
 		conf.HTTP.Auth.HTPasswd = config.AuthHTPasswd{
 			Path: tmpFile,
 		}
@@ -2400,9 +2407,6 @@ func TestAuthnErrors(t *testing.T) {
 		So(func() {
 			api.AuthHandler(ctlr)
 		}, ShouldPanic)
-
-		err = os.Chmod(tmpFile, 0o644)
-		So(err, ShouldBeNil)
 	})
 
 	Convey("Bearer auth invalid PEM data", t, func() {
@@ -2415,6 +2419,11 @@ func TestAuthnErrors(t *testing.T) {
 		err := os.WriteFile(tmpFile, []byte("invalid"), 0o000)
 		So(err, ShouldBeNil)
 
+		defer func() {
+			err := os.Chmod(tmpFile, 0o644)
+			So(err, ShouldBeNil)
+		}()
+
 		conf.HTTP.Auth.Bearer = &config.BearerConfig{
 			Realm:   "realm",
 			Service: "service",
@@ -2426,9 +2435,6 @@ func TestAuthnErrors(t *testing.T) {
 		So(func() {
 			api.AuthHandler(ctlr)
 		}, ShouldPanic)
-
-		err = os.Chmod(tmpFile, 0o644)
-		So(err, ShouldBeNil)
 	})
 
 	Convey("Bearer auth invalid certificate", t, func() {
@@ -2442,6 +2448,11 @@ func TestAuthnErrors(t *testing.T) {
 		err := os.WriteFile(tmpFile, []byte("-----BEGIN CERTIFICATE-----\naW52YWxpZA==\n-----END CERTIFICATE-----"), 0o000)
 		So(err, ShouldBeNil)
 
+		defer func() {
+			err := os.Chmod(tmpFile, 0o644)
+			So(err, ShouldBeNil)
+		}()
+
 		conf.HTTP.Auth.Bearer = &config.BearerConfig{
 			Realm:   "realm",
 			Service: "service",
@@ -2453,9 +2464,6 @@ func TestAuthnErrors(t *testing.T) {
 		So(func() {
 			api.AuthHandler(ctlr)
 		}, ShouldPanic)
-
-		err = os.Chmod(tmpFile, 0o644)
-		So(err, ShouldBeNil)
 	})
 
 	Convey("NewRelyingPartyGithub fail", t, func() {
@@ -2468,6 +2476,11 @@ func TestAuthnErrors(t *testing.T) {
 		err := os.WriteFile(tmpFile, []byte("test"), 0o000)
 		So(err, ShouldBeNil)
 
+		defer func() {
+			err := os.Chmod(tmpFile, 0o644)
+			So(err, ShouldBeNil)
+		}()
+
 		conf.HTTP.Auth.HTPasswd = config.AuthHTPasswd{
 			Path: tmpFile,
 		}
@@ -2475,9 +2488,6 @@ func TestAuthnErrors(t *testing.T) {
 		So(func() {
 			api.NewRelyingPartyGithub(conf, "prov", nil, nil, log.NewLogger("debug", ""))
 		}, ShouldPanic)
-
-		err = os.Chmod(tmpFile, 0o644)
-		So(err, ShouldBeNil)
 	})
 }
 

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path"
@@ -2553,124 +2554,301 @@ func TestTLS(t *testing.T) {
 }
 
 func TestBearerAuth(t *testing.T) {
-	Convey("Verify periodically sync bearer auth", t, func() {
-		updateDuration, _ := time.ParseDuration("1h")
-		// a repo for which clients do not have access, sync shouldn't be able to sync it
-		unauthorizedNamespace := testCveImage
+	testCases := []struct {
+		name                    string
+		useLegacyAuthTestServer bool
+	}{
+		{
+			name:                    "new authentication test server",
+			useLegacyAuthTestServer: false,
+		},
+		{
+			name:                    "legacy authentication test server",
+			useLegacyAuthTestServer: true,
+		},
+	}
 
-		authTestServer := authutils.MakeAuthTestServer(ServerKey, unauthorizedNamespace)
-		defer authTestServer.Close()
+	for _, testCase := range testCases {
+		Convey("Verify periodically sync bearer auth with "+testCase.name, t, func() {
+			updateDuration, _ := time.ParseDuration("1h")
+			// a repo for which clients do not have access, sync shouldn't be able to sync it
+			unauthorizedNamespace := testCveImage
 
-		sctlr, srcBaseURL, _, _, srcClient := makeUpstreamServer(t, false, false)
+			var authTestServer *httptest.Server
+			if testCase.useLegacyAuthTestServer {
+				authTestServer = authutils.MakeAuthTestServerLegacy(ServerKey, unauthorizedNamespace)
+			} else {
+				authTestServer = authutils.MakeAuthTestServer(ServerKey, "RS256", unauthorizedNamespace)
+			}
+			defer authTestServer.Close()
 
-		aurl, err := url.Parse(authTestServer.URL)
-		So(err, ShouldBeNil)
+			sctlr, srcBaseURL, _, _, srcClient := makeUpstreamServer(t, false, false)
 
-		sctlr.Config.HTTP.Auth = &config.AuthConfig{
-			Bearer: &config.BearerConfig{
-				Cert:    ServerCert,
-				Realm:   authTestServer.URL + "/auth/token",
-				Service: aurl.Host,
-			},
-		}
+			aurl, err := url.Parse(authTestServer.URL)
+			So(err, ShouldBeNil)
 
-		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
-
-		defer scm.StopServer()
-
-		registryName := sync.StripRegistryTransport(srcBaseURL)
-		credentialsFile := makeCredentialsFile(fmt.Sprintf(`{"%s":{"username": "%s", "password": "%s"}}`,
-			registryName, username, password))
-
-		var tlsVerify bool
-
-		syncRegistryConfig := syncconf.RegistryConfig{
-			Content: []syncconf.Content{
-				{
-					Prefix: "**", // sync everything
+			sctlr.Config.HTTP.Auth = &config.AuthConfig{
+				Bearer: &config.BearerConfig{
+					Cert:    ServerCert,
+					Realm:   authTestServer.URL + "/auth/token",
+					Service: aurl.Host,
 				},
-			},
-			URLs:         []string{srcBaseURL},
-			PollInterval: updateDuration,
-			TLSVerify:    &tlsVerify,
-			CertDir:      "",
-		}
+			}
 
-		defaultVal := true
-		syncConfig := &syncconf.Config{
-			Enable:          &defaultVal,
-			CredentialsFile: credentialsFile,
-			Registries:      []syncconf.RegistryConfig{syncRegistryConfig},
-		}
+			scm := test.NewControllerManager(sctlr)
+			scm.StartAndWait(sctlr.Config.HTTP.Port)
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+			defer scm.StopServer()
 
-		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			registryName := sync.StripRegistryTransport(srcBaseURL)
+			credentialsFile := makeCredentialsFile(fmt.Sprintf(`{"%s":{"username": "%s", "password": "%s"}}`,
+				registryName, username, password))
 
-		defer dcm.StopServer()
+			var tlsVerify bool
 
-		var (
-			srcTagsList  TagsList
-			destTagsList TagsList
-		)
+			syncRegistryConfig := syncconf.RegistryConfig{
+				Content: []syncconf.Content{
+					{
+						Prefix: "**", // sync everything
+					},
+				},
+				URLs:         []string{srcBaseURL},
+				PollInterval: updateDuration,
+				TLSVerify:    &tlsVerify,
+				CertDir:      "",
+			}
 
-		resp, err := srcClient.R().Get(srcBaseURL + "/v2/")
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+			defaultVal := true
+			syncConfig := &syncconf.Config{
+				Enable:          &defaultVal,
+				CredentialsFile: credentialsFile,
+				Registries:      []syncconf.RegistryConfig{syncRegistryConfig},
+			}
 
-		authorizationHeader := authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
-		resp, err = resty.R().
-			SetQueryParam("service", authorizationHeader.Service).
-			Get(authorizationHeader.Realm)
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
-		var goodToken authutils.AccessTokenResponse
+			dcm := test.NewControllerManager(dctlr)
+			dcm.StartAndWait(dctlr.Config.HTTP.Port)
 
-		err = json.Unmarshal(resp.Body(), &goodToken)
-		So(err, ShouldBeNil)
+			defer dcm.StopServer()
 
-		resp, err = srcClient.R().
-			SetHeader("Authorization", "Bearer "+goodToken.AccessToken).
-			Get(srcBaseURL + "/v2/")
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			var (
+				srcTagsList  TagsList
+				destTagsList TagsList
+			)
 
-		resp, err = srcClient.R().Get(srcBaseURL + "/v2/" + testImage + "/tags/list")
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+			resp, err := srcClient.R().Get(srcBaseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
 
-		authorizationHeader = authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
-		resp, err = resty.R().
-			SetQueryParam("service", authorizationHeader.Service).
-			SetQueryParam("scope", authorizationHeader.Scope).
-			Get(authorizationHeader.Realm)
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			authorizationHeader := authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
+			resp, err = resty.R().
+				SetQueryParam("service", authorizationHeader.Service).
+				Get(authorizationHeader.Realm)
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 
-		goodToken = authutils.AccessTokenResponse{}
-		err = json.Unmarshal(resp.Body(), &goodToken)
-		So(err, ShouldBeNil)
+			var goodToken authutils.AccessTokenResponse
 
-		resp, err = srcClient.R().SetHeader("Authorization", "Bearer "+goodToken.AccessToken).
-			Get(srcBaseURL + "/v2/" + testImage + "/tags/list")
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			err = json.Unmarshal(resp.Body(), &goodToken)
+			So(err, ShouldBeNil)
 
-		err = json.Unmarshal(resp.Body(), &srcTagsList)
-		if err != nil {
-			panic(err)
-		}
+			resp, err = srcClient.R().
+				SetHeader("Authorization", "Bearer "+goodToken.AccessToken).
+				Get(srcBaseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 
-		for {
+			resp, err = srcClient.R().Get(srcBaseURL + "/v2/" + testImage + "/tags/list")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+
+			authorizationHeader = authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
+			resp, err = resty.R().
+				SetQueryParam("service", authorizationHeader.Service).
+				SetQueryParam("scope", authorizationHeader.Scope).
+				Get(authorizationHeader.Realm)
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			goodToken = authutils.AccessTokenResponse{}
+			err = json.Unmarshal(resp.Body(), &goodToken)
+			So(err, ShouldBeNil)
+
+			resp, err = srcClient.R().SetHeader("Authorization", "Bearer "+goodToken.AccessToken).
+				Get(srcBaseURL + "/v2/" + testImage + "/tags/list")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			err = json.Unmarshal(resp.Body(), &srcTagsList)
+			if err != nil {
+				panic(err)
+			}
+
+			for {
+				resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/tags/list")
+				if err != nil {
+					panic(err)
+				}
+
+				err = json.Unmarshal(resp.Body(), &destTagsList)
+				if err != nil {
+					panic(err)
+				}
+
+				if len(destTagsList.Tags) > 0 {
+					break
+				}
+
+				time.Sleep(500 * time.Millisecond)
+			}
+
+			So(destTagsList, ShouldResemble, srcTagsList)
+
+			waitSyncFinish(dctlr.Config.Log.Output)
+
+			resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			// unauthorized namespace
+			resp, err = destClient.R().Get(destBaseURL + "/v2/" + testCveImage + "/manifests/" + testImageTag)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+		})
+
+		Convey("Verify ondemand sync bearer auth", t, func() {
+			// a repo for which clients do not have access, sync shouldn't be able to sync it
+			unauthorizedNamespace := testCveImage
+
+			var authTestServer *httptest.Server
+			if testCase.useLegacyAuthTestServer {
+				authTestServer = authutils.MakeAuthTestServerLegacy(ServerKey, unauthorizedNamespace)
+			} else {
+				authTestServer = authutils.MakeAuthTestServer(ServerKey, "RS256", unauthorizedNamespace)
+			}
+			defer authTestServer.Close()
+
+			sctlr, srcBaseURL, _, _, srcClient := makeUpstreamServer(t, false, false)
+
+			aurl, err := url.Parse(authTestServer.URL)
+			So(err, ShouldBeNil)
+
+			sctlr.Config.HTTP.Auth = &config.AuthConfig{
+				Bearer: &config.BearerConfig{
+					Cert:    ServerCert,
+					Realm:   authTestServer.URL + "/auth/token",
+					Service: aurl.Host,
+				},
+			}
+
+			scm := test.NewControllerManager(sctlr)
+			scm.StartAndWait(sctlr.Config.HTTP.Port)
+
+			defer scm.StopServer()
+
+			registryName := sync.StripRegistryTransport(srcBaseURL)
+			credentialsFile := makeCredentialsFile(fmt.Sprintf(`{"%s":{"username": "%s", "password": "%s"}}`,
+				registryName, username, password))
+
+			var tlsVerify bool
+
+			syncRegistryConfig := syncconf.RegistryConfig{
+				Content: []syncconf.Content{
+					{
+						Prefix: "**", // sync everything
+					},
+				},
+				URLs:      []string{srcBaseURL},
+				TLSVerify: &tlsVerify,
+				OnDemand:  true,
+				CertDir:   "",
+			}
+
+			defaultVal := true
+			syncConfig := &syncconf.Config{
+				Enable:          &defaultVal,
+				CredentialsFile: credentialsFile,
+				Registries:      []syncconf.RegistryConfig{syncRegistryConfig},
+			}
+
+			dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+
+			dcm := test.NewControllerManager(dctlr)
+			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+
+			defer dcm.StopServer()
+
+			var (
+				srcTagsList  TagsList
+				destTagsList TagsList
+			)
+
+			resp, err := srcClient.R().Get(srcBaseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+
+			authorizationHeader := authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
+			resp, err = resty.R().
+				SetQueryParam("service", authorizationHeader.Service).
+				Get(authorizationHeader.Realm)
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			var goodToken authutils.AccessTokenResponse
+
+			err = json.Unmarshal(resp.Body(), &goodToken)
+			So(err, ShouldBeNil)
+
+			resp, err = srcClient.R().
+				SetHeader("Authorization", "Bearer "+goodToken.AccessToken).
+				Get(srcBaseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			resp, err = srcClient.R().Get(srcBaseURL + "/v2/" + testImage + "/tags/list")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+
+			authorizationHeader = authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
+			resp, err = resty.R().
+				SetQueryParam("service", authorizationHeader.Service).
+				SetQueryParam("scope", authorizationHeader.Scope).
+				Get(authorizationHeader.Realm)
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			goodToken = authutils.AccessTokenResponse{}
+			err = json.Unmarshal(resp.Body(), &goodToken)
+			So(err, ShouldBeNil)
+
+			resp, err = srcClient.R().SetHeader("Authorization", "Bearer "+goodToken.AccessToken).
+				Get(srcBaseURL + "/v2/" + testImage + "/tags/list")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			err = json.Unmarshal(resp.Body(), &srcTagsList)
+			if err != nil {
+				panic(err)
+			}
+
+			// sync on demand
+			resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
 			resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/tags/list")
 			if err != nil {
 				panic(err)
@@ -2681,165 +2859,14 @@ func TestBearerAuth(t *testing.T) {
 				panic(err)
 			}
 
-			if len(destTagsList.Tags) > 0 {
-				break
-			}
+			So(destTagsList, ShouldResemble, srcTagsList)
 
-			time.Sleep(500 * time.Millisecond)
-		}
-
-		So(destTagsList, ShouldResemble, srcTagsList)
-
-		waitSyncFinish(dctlr.Config.Log.Output)
-
-		resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
-		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
-
-		// unauthorized namespace
-		resp, err = destClient.R().Get(destBaseURL + "/v2/" + testCveImage + "/manifests/" + testImageTag)
-		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
-	})
-
-	Convey("Verify ondemand sync bearer auth", t, func() {
-		// a repo for which clients do not have access, sync shouldn't be able to sync it
-		unauthorizedNamespace := testCveImage
-
-		authTestServer := authutils.MakeAuthTestServer(ServerKey, unauthorizedNamespace)
-		defer authTestServer.Close()
-
-		sctlr, srcBaseURL, _, _, srcClient := makeUpstreamServer(t, false, false)
-
-		aurl, err := url.Parse(authTestServer.URL)
-		So(err, ShouldBeNil)
-
-		sctlr.Config.HTTP.Auth = &config.AuthConfig{
-			Bearer: &config.BearerConfig{
-				Cert:    ServerCert,
-				Realm:   authTestServer.URL + "/auth/token",
-				Service: aurl.Host,
-			},
-		}
-
-		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
-
-		defer scm.StopServer()
-
-		registryName := sync.StripRegistryTransport(srcBaseURL)
-		credentialsFile := makeCredentialsFile(fmt.Sprintf(`{"%s":{"username": "%s", "password": "%s"}}`,
-			registryName, username, password))
-
-		var tlsVerify bool
-
-		syncRegistryConfig := syncconf.RegistryConfig{
-			Content: []syncconf.Content{
-				{
-					Prefix: "**", // sync everything
-				},
-			},
-			URLs:      []string{srcBaseURL},
-			TLSVerify: &tlsVerify,
-			OnDemand:  true,
-			CertDir:   "",
-		}
-
-		defaultVal := true
-		syncConfig := &syncconf.Config{
-			Enable:          &defaultVal,
-			CredentialsFile: credentialsFile,
-			Registries:      []syncconf.RegistryConfig{syncRegistryConfig},
-		}
-
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
-
-		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
-
-		defer dcm.StopServer()
-
-		var (
-			srcTagsList  TagsList
-			destTagsList TagsList
-		)
-
-		resp, err := srcClient.R().Get(srcBaseURL + "/v2/")
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
-
-		authorizationHeader := authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
-		resp, err = resty.R().
-			SetQueryParam("service", authorizationHeader.Service).
-			Get(authorizationHeader.Realm)
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
-
-		var goodToken authutils.AccessTokenResponse
-
-		err = json.Unmarshal(resp.Body(), &goodToken)
-		So(err, ShouldBeNil)
-
-		resp, err = srcClient.R().
-			SetHeader("Authorization", "Bearer "+goodToken.AccessToken).
-			Get(srcBaseURL + "/v2/")
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
-
-		resp, err = srcClient.R().Get(srcBaseURL + "/v2/" + testImage + "/tags/list")
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
-
-		authorizationHeader = authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
-		resp, err = resty.R().
-			SetQueryParam("service", authorizationHeader.Service).
-			SetQueryParam("scope", authorizationHeader.Scope).
-			Get(authorizationHeader.Realm)
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
-
-		goodToken = authutils.AccessTokenResponse{}
-		err = json.Unmarshal(resp.Body(), &goodToken)
-		So(err, ShouldBeNil)
-
-		resp, err = srcClient.R().SetHeader("Authorization", "Bearer "+goodToken.AccessToken).
-			Get(srcBaseURL + "/v2/" + testImage + "/tags/list")
-		So(err, ShouldBeNil)
-		So(resp, ShouldNotBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
-
-		err = json.Unmarshal(resp.Body(), &srcTagsList)
-		if err != nil {
-			panic(err)
-		}
-
-		// sync on demand
-		resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
-		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
-
-		resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/tags/list")
-		if err != nil {
-			panic(err)
-		}
-
-		err = json.Unmarshal(resp.Body(), &destTagsList)
-		if err != nil {
-			panic(err)
-		}
-
-		So(destTagsList, ShouldResemble, srcTagsList)
-
-		// unauthorized namespace
-		resp, err = destClient.R().Get(destBaseURL + "/v2/" + testCveImage + "/manifests/" + testImageTag)
-		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
-	})
+			// unauthorized namespace
+			resp, err = destClient.R().Get(destBaseURL + "/v2/" + testCveImage + "/manifests/" + testImageTag)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+		})
+	}
 }
 
 func TestBasicAuth(t *testing.T) {

--- a/pkg/test/auth/bearer_test.go
+++ b/pkg/test/auth/bearer_test.go
@@ -10,6 +10,12 @@ import (
 
 func TestBearerServer(t *testing.T) {
 	Convey("test MakeAuthTestServer() no serve key", t, func() {
-		So(func() { auth.MakeAuthTestServer("", "") }, ShouldPanic)
+		So(func() { auth.MakeAuthTestServer("", "", "") }, ShouldPanic)
+	})
+}
+
+func TestBearerServerLegacy(t *testing.T) {
+	Convey("test MakeAuthTestServerLegacy() no serve key", t, func() {
+		So(func() { auth.MakeAuthTestServerLegacy("", "") }, ShouldPanic)
 	})
 }

--- a/test/scripts/gen_certs.sh
+++ b/test/scripts/gen_certs.sh
@@ -2,6 +2,7 @@
 
 set -xe
 
+# RSA
 openssl req \
     -newkey rsa:2048 \
     -nodes \
@@ -45,3 +46,78 @@ openssl x509 \
     -CAkey ca.key \
     -CAcreateserial \
     -out client.cert
+
+# ECDSA
+openssl ecparam \
+    -name prime256v1 \
+    -genkey \
+    -noout \
+    -out ca-ecdsa.key
+
+openssl req \
+    -new \
+    -key ca-ecdsa.key \
+    -nodes \
+    -days 3650 \
+    -x509 \
+    -out ca-ecdsa.crt \
+    -subj "/CN=*"
+
+openssl ecparam \
+    -name prime256v1 \
+    -genkey \
+    -noout \
+    -out server-ecdsa.key
+
+openssl req \
+    -new \
+    -key server-ecdsa.key \
+    -nodes \
+    -out server-ecdsa.csr \
+    -subj "/OU=TestServer/CN=*"
+
+openssl x509 \
+    -req \
+    -days 3650 \
+    -sha256 \
+    -in server-ecdsa.csr \
+    -CA ca-ecdsa.crt \
+    -CAkey ca-ecdsa.key \
+    -CAcreateserial \
+    -out server-ecdsa.cert \
+    -extfile <(echo subjectAltName = IP:127.0.0.1)
+
+# ED25519
+openssl genpkey \
+    -algorithm ed25519 \
+    -out ca-ed25519.key
+
+openssl req \
+    -new \
+    -key ca-ed25519.key \
+    -nodes \
+    -days 3650 \
+    -x509 \
+    -out ca-ed25519.crt \
+    -subj "/CN=*"
+
+openssl genpkey \
+    -algorithm ed25519 \
+    -out server-ed25519.key
+
+openssl req \
+    -new \
+    -key server-ed25519.key \
+    -nodes \
+    -out server-ed25519.csr \
+    -subj "/OU=TestServer/CN=*"
+
+openssl x509 \
+    -req \
+    -days 3650 \
+    -in server-ed25519.csr \
+    -CA ca-ed25519.crt \
+    -CAkey ca-ed25519.key \
+    -CAcreateserial \
+    -out server-ed25519.cert \
+    -extfile <(echo subjectAltName = IP:127.0.0.1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature

**Which issue does this PR fix**:
https://github.com/project-zot/zot/issues/2587

**What does this PR do / Why do we need it**:
Currently the `github.com/chartmuseum/auth` package is used for token authentication, which [only supports RSA keys](https://github.com/chartmuseum/auth/blob/2d81aa85f9fbc574ca7849526c7b6818880e269b/token.go#L93-L94). It also doesn't seem to be updated anymore, and uses a pretty [old version of the `golang-jwt` package](https://github.com/chartmuseum/auth/blob/2d81aa85f9fbc574ca7849526c7b6818880e269b/go.mod#L6) which could use a bump.
I have ripped out the important bits and re-implemented the token handling directly using `golang-jwt`, which allows it to support EC/ED25519 keys as well as RSA keys.

**Testing done on this change**:
In addition to the added automated tests, I have done some manual testing by spinning up a local Zot instance + authorization server. I tested using an RSA (RS256), ECDSA (ES256) and ED25519 key/certificate, did some API calls with tokens signed using these keys and some logins/pushes/pulls using the Docker CLI. This all seemed to work just fine.

**Automation added to e2e**:

**Will this break upgrades or downgrades?**
It shouldn't, I've tried to keep the behavior as close to what it was before as possible, but I can't guarantee it (there are some more improvements I could think of, but I don't want to break backward compatibility completely).

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
