### PR TITLE
fix: allow changing media-type when pushing an image tag

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -10835,13 +10835,13 @@ func TestManifestImageIndex(t *testing.T) {
 					resp, err = resty.R().SetHeader("Content-Type", ispec.MediaTypeImageIndex).
 						SetBody(content).Put(baseURL + "/v2/index/manifests/test:1.0")
 					So(err, ShouldBeNil)
-					So(resp.StatusCode(), ShouldEqual, http.StatusBadRequest)
+					So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
 
 					// previously an image index, try writing a manifest
 					resp, err = resty.R().SetHeader("Content-Type", ispec.MediaTypeImageManifest).
 						SetBody(m1content).Put(baseURL + "/v2/index/manifests/test:index1")
 					So(err, ShouldBeNil)
-					So(resp.StatusCode(), ShouldEqual, http.StatusBadRequest)
+					So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
 				})
 			})
 		})

--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -250,15 +250,9 @@ func CheckIfIndexNeedsUpdate(index *ispec.Index, desc *ispec.Descriptor,
 
 			// changing media-type is disallowed!
 			if manifest.MediaType != desc.MediaType {
-				err := zerr.ErrBadManifest
-				log.Error().Err(err).
+				log.Info().
 					Str("old mediaType", manifest.MediaType).
-					Str("new mediaType", desc.MediaType).Msg("cannot change media-type")
-
-				reason := fmt.Sprintf("changing manifest media-type from \"%s\" to \"%s\" is disallowed",
-					manifest.MediaType, desc.MediaType)
-
-				return false, "", zerr.NewError(err).AddDetail("reason", reason)
+					Str("new mediaType", desc.MediaType).Msg("media-type changed")
 			}
 
 			oldDesc := *desc

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -3410,11 +3410,11 @@ func TestS3ManifestImageIndex(t *testing.T) {
 					So(digest, ShouldNotBeNil)
 
 					_, _, err = imgStore.PutImageManifest("index", "test:1.0", ispec.MediaTypeImageIndex, content)
-					So(err, ShouldNotBeNil)
+					So(err, ShouldBeNil)
 
 					// previously an image index, try writing a manifest
 					_, _, err = imgStore.PutImageManifest("index", "test:index1", ispec.MediaTypeImageManifest, m1content)
-					So(err, ShouldNotBeNil)
+					So(err, ShouldBeNil)
 				})
 			})
 		})


### PR DESCRIPTION
Fixes #3005

Previously, changing a image's media-type was disallowed. However, "docker buildx" appears to first push an image manifest and then an image index for the same image tag. So, allow this.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
