### PR TITLE
chore: Remove `VOLUME` instruction from image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -36,5 +36,4 @@ COPY --from=builder /go/src/github.com/project-zot/zot/bin/zot-$TARGETOS-$TARGET
 COPY --from=builder /go/src/github.com/project-zot/zot/config.json /etc/zot/config.json
 ENTRYPOINT ["/usr/bin/zot"]
 EXPOSE 5000
-VOLUME ["/var/lib/registry"]
 CMD ["serve", "/etc/zot/config.json"]

--- a/build/Dockerfile-conformance
+++ b/build/Dockerfile-conformance
@@ -32,5 +32,4 @@ COPY --from=builder /go/src/github.com/project-zot/zot/bin/zot-$TARGETOS-$TARGET
 COPY --from=builder /go/src/github.com/project-zot/zot/config.json /etc/zot/config.json
 ENTRYPOINT ["/usr/bin/zot"]
 EXPOSE 5000
-VOLUME ["/var/lib/registry"]
 CMD ["serve", "/etc/zot/config.yaml"]

--- a/build/Dockerfile-minimal
+++ b/build/Dockerfile-minimal
@@ -35,5 +35,4 @@ COPY --from=builder /go/src/github.com/project-zot/zot/bin/zot-$TARGETOS-$TARGET
 COPY --from=builder /go/src/github.com/project-zot/zot/config.json /etc/zot/config.json
 ENTRYPOINT ["/usr/bin/zot"]
 EXPOSE 5000
-VOLUME ["/var/lib/registry"]
 CMD ["serve", "/etc/zot/config.json"]

--- a/build/stacker-conformance.yaml
+++ b/build/stacker-conformance.yaml
@@ -58,8 +58,6 @@ build:
       dest: /etc/zot
   entrypoint:
     - /usr/bin/zot-linux-amd64
-  volumes:
-    - /var/lib/registry
   cmd:
     - serve
     - /etc/zot/config.json

--- a/build/stacker-minimal.yaml
+++ b/build/stacker-minimal.yaml
@@ -57,8 +57,6 @@ build:
       dest: /etc/zot
   entrypoint:
     - /usr/local/bin/zot-${{OS}}-${{ARCH}}${{EXT:}}
-  volumes:
-    - /var/lib/registry
   cmd:
     - serve
     - /etc/zot/config.json

--- a/build/stacker.yaml
+++ b/build/stacker.yaml
@@ -72,8 +72,6 @@ build:
       dest: /etc/zot
   entrypoint:
     - /usr/local/bin/zot-${{OS}}-${{ARCH}}
-  volumes:
-    - /var/lib/registry
   cmd:
     - serve
     - /etc/zot/config.json


### PR DESCRIPTION
**What type of PR is this?**

cleanup

**Which issue does this PR fix**:

PR was requested: https://github.com/project-zot/zot/discussions/3020#discussioncomment-12492398

Context for prior PRs that introduced `VOLUME`:
- `Dockerfile` originally introduced `VOLUME` in 2020: https://github.com/project-zot/zot/pull/64
- `stacker.yaml` originally introduced `volume` in 2022: https://github.com/project-zot/zot/pull/499

**What does this PR do / Why do we need it**:

`VOLUME` is an old instruction that creates an implicit anonymous volume when starting a container.
- Today this implicit volume often has minimal benefits to improving performance and can be prone to causing more problems than good.
- When `VOLUME` was introduced into images for `zot`, there was no demand requesting it, nor any issue resolved identified from it's inclusion. It is assumed to have been added either for more clearly communicating the path to persist explicitly, or following outdated advice from the official Docker "Best Practice" advice for building images (_which has not updated the section on `VOLUME` since 2014, yet we now have explicit named volumes and bind mounts supported since then_).

As a container should be treated as ephemeral with it's state unless explicit volumes are used for persisting data, `VOLUME` is removed from the image to ensure broader consistency across container engines and tooling. Notably Docker Compose implements a feature to associate the anonymous volume to the Compose service rather than the image itself.

Additional references:
- https://github.com/project-zot/zot/discussions/3020#discussioncomment-12493994
- https://github.com/moby/moby/issues/49482#issuecomment-2664694404
- https://github.com/docker-library/postgres/issues/1319#issuecomment-2695719952
- https://github.com/kanidm/kanidm/pull/2948
- https://github.com/rspamd/rspamd/issues/4400#issuecomment-1745881053

**Testing done on this change**:

 N/A

**Automation added to e2e**:

N/A

**Will this break upgrades or downgrades?**

Potentially.
- Containers should persist the same data across restarts of the same container instance in it's own internal filesystem layer. Typically upgrading an image would lose that anonymous volume.
- Docker Compose has additional logic to associate the volume to the service rather than the image, hence retaining the volume across image upgrades. Any users relying on this feature instead of using an explicit volume to persist data they care about would be affected.

For Docker Compose, the volume will still remain on disk. The user can roll-back to the previous image or explicitly assign an anonymous volume to the `/var/lib/registry` path and it will restore the data. However if the volume was pruned/destroyed (_manually or via automated schedule_) prior to doing this, then the data would be lost.

Generally, users should know better to use explicit volume mounts for data they care about. Documentation encourages awareness of persisting `/var/lib/registry` with explicit volumes, and without any known demand for this implicit volume it is unclear if any existing deployment is reliant upon it. The risk of impact is considered low.

Should a user rely on this Docker Compose feature with the implicit anonymous volume, they can retain their data by adding an explicit anonymous volume to their `compose.yaml` for the service running `zot`. Compose will then attach the same anonymous volume for that path associated to the compose service name.

```yaml
services:
  zot:
    volumes:
      - /var/lib/registry
```

**Does this PR introduce any user-facing change?**:

```release-note
Container images are no longer built with the `VOLUME` instruction.

action required: If relying on `/var/lib/registry` to be persisted via an implicit anonymous volume, you must now define an explicit anonymous volume to retain the volume across the image upgrade.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
