### PR TITLE
fix: get groups claim from idtokenclaims

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -17,6 +17,7 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1992,12 +1993,23 @@ func (rh *RouteHandler) OpenIDCodeExchangeCallback() rp.CodeExchangeUserinfoCall
 
 		val, ok := info.Claims["groups"].([]interface{})
 		if !ok {
-			rh.c.Log.Info().Msgf("failed to find any 'groups' claim for user %s", email)
+			rh.c.Log.Info().Msgf("failed to find any 'groups' claim for user %s in UserInfo", email)
 		}
 
 		for _, group := range val {
 			groups = append(groups, fmt.Sprint(group))
 		}
+
+		val, ok = tokens.IDTokenClaims.Claims["groups"].([]interface{})
+		if !ok {
+			rh.c.Log.Info().Msgf("failed to find any 'groups' claim for user %s in IDTokenClaimsToken", email)
+		}
+		for _, group := range val {
+			groups = append(groups, fmt.Sprint(group))
+		}
+
+		slices.Sort(groups)
+		groups = slices.Compact(groups)
 
 		callbackUI, err := OAuth2Callback(rh.c, w, r, state, email, groups)
 		if err != nil {

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -2004,6 +2004,7 @@ func (rh *RouteHandler) OpenIDCodeExchangeCallback() rp.CodeExchangeUserinfoCall
 		if !ok {
 			rh.c.Log.Info().Msgf("failed to find any 'groups' claim for user %s in IDTokenClaimsToken", email)
 		}
+
 		for _, group := range val {
 			groups = append(groups, fmt.Sprint(group))
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
bug
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
I tried to integrate Microsoft Entra as an OIDC provider. Entra is not returning the groups claim in the userinfo endpoint (see https://learn.microsoft.com/en-us/entra/identity-platform/userinfo).

**What does this PR do / Why do we need it**:
This PR makes the OpenIDCodeExchangeCallback groups claim extraction compatible with Microsoft Entra. The groups claim from the IDTokenClaims is extracted and merged with the groups claim of the userinfo endpoint response.

**If an issue # is not available please add repro steps and logs showing the issue**:
Configure an Entra application as OIDC Provider. Zot is not able to find the groups claim.
```
{"level":"info","goroutine":881,"caller":"zotregistry.dev/zot/pkg/api/routes.go:1996","time":"2025-04-14T18:50:57.577074951Z","message":"failed to find any 'groups' claim for user test@test.com"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
