### PR TITLE
feat(authz): Audit failed operations

### DIFF
--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -116,7 +116,7 @@ func (amw *AuthnMiddleware) basicAuthn(ctlr *Controller, userAc *reqCtx.UserAcce
 		var groups []string
 
 		if ctlr.Config.HTTP.AccessControl != nil {
-			ac := NewAccessController(ctlr.Config)
+			ac := NewAccessController(ctlr.Config, ctlr.Audit)
 			groups = ac.getUserGroups(identity)
 		}
 
@@ -151,7 +151,7 @@ func (amw *AuthnMiddleware) basicAuthn(ctlr *Controller, userAc *reqCtx.UserAcce
 			var groups []string
 
 			if ctlr.Config.HTTP.AccessControl != nil {
-				ac := NewAccessController(ctlr.Config)
+				ac := NewAccessController(ctlr.Config, ctlr.Audit)
 				groups = ac.getUserGroups(identity)
 			}
 
@@ -422,7 +422,7 @@ func bearerAuthHandler(ctlr *Controller) mux.MiddlewareFunc {
 				return
 			}
 
-			acCtrlr := NewAccessController(ctlr.Config)
+			acCtrlr := NewAccessController(ctlr.Config, ctlr.Audit)
 
 			// we want to bypass auth for mgmt route
 			isMgmtRequested := request.RequestURI == constants.FullMgmt

--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -129,6 +129,10 @@ func (ac *AccessController) can(userAc *reqCtx.UserAccessControl, action, reposi
 		}
 	}
 
+	if !can {
+		ac.Log.Info().Str("repo", repository).Str("user", username).Str("action", action).Msg("AUDIT: Permission denied")
+	}
+
 	return can
 }
 


### PR DESCRIPTION
It's generally good practice to keep track of authorization failures, this PR adds a log message whenever access is denied.