### PR TITLE
fix: parse public key as fallback for certificate for bearer authentication

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -179,7 +179,7 @@ var (
 	ErrNoBearerToken                    = errors.New("no bearer token given")
 	ErrInvalidBearerToken               = errors.New("invalid bearer token given")
 	ErrInsufficientScope                = errors.New("bearer token does not have sufficient scope")
-	ErrCouldNotLoadCertificate          = errors.New("failed to load certificate")
+	ErrCouldNotLoadPublicKey            = errors.New("failed to load certificate")
 	ErrEventTypeEmpty                   = errors.New("event type empty")
 	ErrEventSinkIsNil                   = errors.New("event sink is nil")
 	ErrUnsupportedEventSink             = errors.New("event sink is not supported")

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -179,7 +179,7 @@ var (
 	ErrNoBearerToken                    = errors.New("no bearer token given")
 	ErrInvalidBearerToken               = errors.New("invalid bearer token given")
 	ErrInsufficientScope                = errors.New("bearer token does not have sufficient scope")
-	ErrCouldNotLoadPublicKey            = errors.New("failed to load certificate")
+	ErrCouldNotLoadPublicKey            = errors.New("failed to load public key")
 	ErrEventTypeEmpty                   = errors.New("event type empty")
 	ErrEventSinkIsNil                   = errors.New("event sink is nil")
 	ErrUnsupportedEventSink             = errors.New("event sink is not supported")

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -77,11 +77,15 @@ import (
 const (
 	ServerCert             = "../../test/data/server.cert"
 	ServerKey              = "../../test/data/server.key"
+	ServerPublicKey        = "../../test/data/server-public.key"
+	ServerPublicKeyPKCS1   = "../../test/data/server-public-pkcs1.key"
 	CACert                 = "../../test/data/ca.crt"
 	ServerCertECDSA        = "../../test/data/server-ecdsa.cert"
 	ServerKeyECDSA         = "../../test/data/server-ecdsa.key"
+	ServerPublicKeyECDSA   = "../../test/data/server-public-ecdsa.key"
 	ServerCertED25519      = "../../test/data/server-ed25519.cert"
 	ServerKeyED25519       = "../../test/data/server-ed25519.key"
+	ServerPublicKeyED25519 = "../../test/data/server-public-ed25519.key"
 	UnauthorizedNamespace  = "fortknox/notallowed"
 	AuthorizationNamespace = "authz/image"
 	LDAPAddress            = "127.0.0.1"
@@ -3921,21 +3925,45 @@ func TestBearerAuthMultipleAlgorithms(t *testing.T) {
 		alg  string
 	}{
 		{
-			"RSA signing key",
+			"RSA signing key using certificate",
 			ServerKey,
 			ServerCert,
 			"RS256",
 		},
 		{
-			"ECDSA signing key",
+			"RSA signing key using public key",
+			ServerKey,
+			ServerPublicKey,
+			"RS256",
+		},
+		{
+			"RSA signing key using public key in PKCS1 format",
+			ServerKey,
+			ServerPublicKeyPKCS1,
+			"RS256",
+		},
+		{
+			"ECDSA signing key using certificate",
 			ServerKeyECDSA,
 			ServerCertECDSA,
 			"ES256",
 		},
 		{
-			"ED25519 signing key",
+			"ECDSA signing key using public key",
+			ServerKeyECDSA,
+			ServerPublicKeyECDSA,
+			"ES256",
+		},
+		{
+			"ED25519 signing key using certificate",
 			ServerKeyED25519,
 			ServerCertED25519,
+			"EdDSA",
+		},
+		{
+			"ED25519 signing key using public key",
+			ServerKeyED25519,
+			ServerPublicKeyED25519,
 			"EdDSA",
 		},
 	}

--- a/test/scripts/gen_certs.sh
+++ b/test/scripts/gen_certs.sh
@@ -19,6 +19,16 @@ openssl req \
     -out server.csr \
     -subj "/OU=TestServer/CN=*"
 
+openssl rsa \
+    -in server.key \
+    -pubout \
+    -out server-public.key
+
+openssl rsa \
+    -in server.key \
+    -RSAPublicKey_out \
+    -out server-public-pkcs1.key
+
 openssl x509 \
     -req \
     -days 3650 \
@@ -76,6 +86,11 @@ openssl req \
     -out server-ecdsa.csr \
     -subj "/OU=TestServer/CN=*"
 
+openssl ec \
+    -in server-ecdsa.key \
+    -pubout \
+    -out server-public-ecdsa.key
+
 openssl x509 \
     -req \
     -days 3650 \
@@ -111,6 +126,11 @@ openssl req \
     -nodes \
     -out server-ed25519.csr \
     -subj "/OU=TestServer/CN=*"
+
+openssl pkey \
+    -in server-ed25519.key \
+    -pubout \
+    -out server-public-ed25519.key
 
 openssl x509 \
     -req \


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
https://github.com/project-zot/zot/issues/3173

**Testing done on this change**:
Added automated test cases to check whether supplying RSA/ED/EC public keys instead of certificates works as expected.
Additionally, I spun up a local Zot instance and handed it an RSA public key (not a certificate), and verified that bearer authentication works as expected.
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**
Nope.

**Does this PR introduce any user-facing change?**:

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
