### PR TITLE
fix: image retention policy to handle patterns even if metadb is not instantiated

### DIFF
--- a/pkg/retention/candidate.go
+++ b/pkg/retention/candidate.go
@@ -1,6 +1,8 @@
 package retention
 
 import (
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+
 	mTypes "zotregistry.dev/zot/pkg/meta/types"
 	"zotregistry.dev/zot/pkg/retention/types"
 )
@@ -23,6 +25,28 @@ func GetCandidates(repoMeta mTypes.RepoMeta) []*types.Candidate {
 				candidates = append(candidates, candidate)
 			}
 		}
+	}
+
+	return candidates
+}
+
+func GetCandidatesFromIndex(index ispec.Index) []*types.Candidate {
+	candidates := make([]*types.Candidate, 0)
+
+	// collect all manifests in the repo
+	for _, manifest := range index.Manifests {
+		tag, ok := manifest.Annotations[ispec.AnnotationRefName]
+		if !ok {
+			continue
+		}
+
+		candidate := &types.Candidate{
+			MediaType: manifest.MediaType,
+			DigestStr: string(manifest.Digest),
+			Tag:       tag,
+		}
+
+		candidates = append(candidates, candidate)
 	}
 
 	return candidates

--- a/pkg/retention/types/types.go
+++ b/pkg/retention/types/types.go
@@ -22,7 +22,8 @@ type PolicyManager interface {
 	HasDeleteReferrer(repo string) bool
 	HasDeleteUntagged(repo string) bool
 	HasTagRetention(repo string) bool
-	GetRetainedTags(ctx context.Context, repoMeta mTypes.RepoMeta, index ispec.Index) []string
+	GetRetainedTagsFromIndex(ctx context.Context, repo string, index ispec.Index) []string
+	GetRetainedTagsFromMetaDB(ctx context.Context, repoMeta mTypes.RepoMeta, index ispec.Index) []string
 }
 
 type Rule interface {


### PR DESCRIPTION
It is to fix #3185.
This fixes the case where MetaDB is not instantiated (none of the conditions match), and we want to retain tags only by pattern (which should not need to use MetaBD).

Without this fix you could only use retention to delete untagged manifests. If you specified only the key "patterns" under "keepTags", zot would crash. It was possible to not specify "keepTags" all, which would retain all tags, but it was not possible to retains specific tags.

Basically the case quoted below, from the documentation, was broken:: https://zotregistry.dev/v2.1.4/articles/retention/#configuration-example

```
When you specify a regex pattern with no rules other than the default, all tags matching the pattern are retained.
```

This would only work if MetaDb was instantiated by an unrelated configured feature.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
