### PR TITLE
fix: GetNextRepository in case previous repo is no longer present start over

### DIFF
--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -422,6 +422,11 @@ func (is *ImageStore) GetNextRepository(repo string) (string, error) {
 		return "", err
 	}
 
+	ok, err := is.ValidateRepo(repo)
+	if !ok || err != nil {
+		repo = "" // the last repo may have been deleted in the meantime
+	}
+
 	found := false
 	store := ""
 	err = is.storeDriver.Walk(dir, func(fileInfo driver.FileInfo) error {

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -2929,6 +2929,7 @@ func TestGetNextRepository(t *testing.T) {
 	imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 	firstRepoName := "repo1"
 	secondRepoName := "repo2"
+	missingRepoName := "repo3"
 
 	srcStorageCtlr := storage.StoreController{DefaultStore: imgStore}
 	image := CreateDefaultImage()
@@ -2954,6 +2955,12 @@ func TestGetNextRepository(t *testing.T) {
 	Convey("Return second repository", t, func() {
 		secondRepo, err := imgStore.GetNextRepository(firstRepoName)
 		So(secondRepo, ShouldEqual, secondRepoName)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Return first repository last repo is non-existent", t, func() {
+		secondRepo, err := imgStore.GetNextRepository(missingRepoName)
+		So(secondRepo, ShouldEqual, firstRepoName)
 		So(err, ShouldBeNil)
 	})
 


### PR DESCRIPTION
Right now `GetNextRepository("deletedRepo")` returns `""`, causing the generator to be marked completed at https://github.com/project-zot/zot/blob/main/pkg/storage/gc/gc.go#L833.
This stops the generator, and the user needs to wait for the generator to be scheduled again before gc is resumed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
