### PR TITLE
fix: GetNextRepository to use a list already scanned repositories as input

### DIFF
--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -467,12 +467,13 @@ func TestPopulateStorageMetrics(t *testing.T) {
 		sch := scheduler.NewScheduler(conf, metrics, ctlr.Log)
 		sch.RunScheduler()
 
-		generator := &common.StorageMetricsInitGenerator{
-			ImgStore: ctlr.StoreController.DefaultStore,
-			Metrics:  ctlr.Metrics,
-			Log:      ctlr.Log,
-			MaxDelay: 1, // maximum delay between jobs (each job computes repo's storage size)
-		}
+		generator := common.NewStorageMetricsInitGenerator(
+			ctlr.StoreController.DefaultStore,
+			ctlr.Metrics,
+			ctlr.Log,
+		)
+
+		generator.MaxDelay = 1 // maximum delay between jobs (each job computes repo's storage size)
 
 		sch.SubmitGenerator(generator, time.Duration(0), scheduler.LowPriority)
 

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -2245,7 +2245,9 @@ func TestNextRepositoryMockStoreDriver(t *testing.T) {
 			},
 		})
 
-		nextRepository, err := imgStore.GetNextRepository("testRepo")
+		processedRepos := make(map[string]struct{}, 0)
+		processedRepos["testRepo"] = struct{}{}
+		nextRepository, err := imgStore.GetNextRepository(processedRepos)
 		So(err, ShouldBeNil)
 		So(nextRepository, ShouldEqual, "")
 	})

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -31,7 +31,7 @@ type ImageStore interface { //nolint:interfacebloat
 	InitRepo(name string) error
 	ValidateRepo(name string) (bool, error)
 	GetRepositories() ([]string, error)
-	GetNextRepository(repo string) (string, error)
+	GetNextRepository(processedRepos map[string]struct{}) (string, error)
 	GetNextRepositories(repo string, maxEntries int, fn FilterRepoFunc) ([]string, bool, error)
 	GetImageTags(repo string) ([]string, error)
 	GetImageManifest(repo, reference string) ([]byte, godigest.Digest, string, error)

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -19,7 +19,7 @@ type MockedImageStore struct {
 	InitRepoFn            func(name string) error
 	ValidateRepoFn        func(name string) (bool, error)
 	GetRepositoriesFn     func() ([]string, error)
-	GetNextRepositoryFn   func(repo string) (string, error)
+	GetNextRepositoryFn   func(processedRepos map[string]struct{}) (string, error)
 	GetNextRepositoriesFn func(lastRepo string, maxEntries int, fn storageTypes.FilterRepoFunc) ([]string, bool, error)
 	GetImageTagsFn        func(repo string) ([]string, error)
 	GetImageManifestFn    func(repo string, reference string) ([]byte, godigest.Digest, string, error)
@@ -132,9 +132,9 @@ func (is MockedImageStore) GetRepositories() ([]string, error) {
 	return []string{}, nil
 }
 
-func (is MockedImageStore) GetNextRepository(repo string) (string, error) {
+func (is MockedImageStore) GetNextRepository(processedRepos map[string]struct{}) (string, error) {
 	if is.GetNextRepositoryFn != nil {
-		return is.GetNextRepositoryFn(repo)
+		return is.GetNextRepositoryFn(processedRepos)
 	}
 
 	return "", nil


### PR DESCRIPTION
Using just the last repository is not enough as in the case when it is deleted (either by GC or some other way), GetNextRepository returns empty string causing the generator to be marked completed without any errors.

An alternative would have been to start over from the first repository, but this can take hours if multiple repositories need to be deleted, not to mention the processing power and I/O and S3 load this could take.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
