### PR TITLE
Fix building zot natively on FreeBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ build-metadata: $(if $(findstring ui,$(BUILD_LABELS)), ui)
 	go list $(GO_CMD_TAGS) -f '{{ join .GoFiles "\n" }}' ./... | sort -u
 
 .PHONY: gen-protobuf
-gen-protobuf: check-not-freebds $(PROTOC)
+gen-protobuf: $(PROTOC)
 	$(PROTOC) --experimental_allow_proto3_optional \
 		--proto_path=$(TOP_LEVEL)/pkg/meta/proto \
 		--go_out=$(TOP_LEVEL)/pkg/meta/proto \
@@ -610,12 +610,6 @@ ui:
 check-linux:
 ifneq ($(shell go env GOOS),linux)
 	$(error makefile target can be run only on linux)
-endif
-
-.PHONY: check-not-freebds
-check-not-freebds:
-ifeq ($(shell go env GOOS),freebsd)
-  $(error makefile target can't be run on freebsd)
 endif
 
 .PHONY: check-compatibility

--- a/pkg/api/runtime.go
+++ b/pkg/api/runtime.go
@@ -20,7 +20,7 @@ func DumpRuntimeParams(log log.Logger) {
 
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 	if err == nil {
-		evt = evt.Uint64("max. open files", uint64(rLimit.Cur)) //nolint: unconvert // required for *BSD
+		evt = evt.Uint64("max. open files", uint64(rLimit.Cur)) //nolint: unconvert,gosec // required for *BSD
 	}
 
 	if content, err := os.ReadFile("/proc/sys/net/core/somaxconn"); err == nil {

--- a/pkg/cli/server/stress_test.go
+++ b/pkg/cli/server/stress_test.go
@@ -193,7 +193,7 @@ func worker(id int, zotPort, rootDir string) {
 	}
 }
 
-func setMaxOpenFilesLimit(limit uint64) (uint64, error) {
+func setMaxOpenFilesLimit(limit test.RlimT) (test.RlimT, error) {
 	var rLimit syscall.Rlimit
 
 	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rLimit)

--- a/pkg/test/common/rlimit_freebsd.go
+++ b/pkg/test/common/rlimit_freebsd.go
@@ -1,0 +1,3 @@
+package common
+
+type RlimT = int64

--- a/pkg/test/common/rlimit_linux.go
+++ b/pkg/test/common/rlimit_linux.go
@@ -1,0 +1,3 @@
+package common
+
+type RlimT = uint64


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

cleanup

**Which issue does this PR fix**:

#3246 

**What does this PR do / Why do we need it**:

Allows building zot on a FreeBSD host. Not strictly needed since FreeBSD binaries can be cross-built on a Linux host but it is convenient for developers who prefer to use FreeBSD where possible.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:

Run 'gmake' on a host running FreeBSD-14.3.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
