### PR TITLE
fix: return the entire blob size in patch upload response

### DIFF
--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -943,7 +943,9 @@ func (is *ImageStore) PutBlobChunk(repo, uuid string, from, to int64,
 
 	defer file.Close()
 
-	if from != file.Size() {
+	fsize := file.Size()
+
+	if from != fsize {
 		is.log.Error().Int64("expected", from).Int64("actual", file.Size()).
 			Msg("invalid range start for blob upload")
 
@@ -952,7 +954,7 @@ func (is *ImageStore) PutBlobChunk(repo, uuid string, from, to int64,
 
 	n, err := io.Copy(file, body)
 
-	return n, err
+	return n + fsize, err
 }
 
 // BlobUploadInfo returns the current blob size in bytes.

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -493,7 +493,7 @@ func TestStorageAPIs(t *testing.T) {
 
 						bupload, err = imgStore.PutBlobChunk("test", upload, int64(firstChunkLen), int64(buflen), secondChunkBuf)
 						So(err, ShouldBeNil)
-						So(bupload, ShouldEqual, secondChunkLen)
+						So(bupload, ShouldEqual, int64(firstChunkLen+secondChunkLen))
 
 						err = imgStore.FinishBlobUpload("test", upload, buf, digest)
 						So(err, ShouldBeNil)


### PR DESCRIPTION
https://github.com/regclient/regclient/issues/961
https://github.com/opencontainers/distribution-spec/pull/581

Previously, zot returned the size of the currently uploaded chunk. Other registries the size of the entire blob.

Align with the latter behavior.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
