### PR TITLE
chore(ci): update github runners to oci gh arc runners

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   benchmark:
     name: Performance regression check
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   client-tools:
     name: Check client tools
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/gc-stress-test.yaml
+++ b/.github/workflows/gc-stress-test.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   gc-referrers-stress-local:
     name: GC(with referrers) on filesystem with short interval
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -53,7 +53,7 @@ jobs:
 
   gc-stress-local:
     name: GC(without referrers) on filesystem with short interval
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -92,7 +92,7 @@ jobs:
 
   gc-referrers-stress-s3:
     name: GC(with referrers) on S3(minio) with short interval
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -176,7 +176,7 @@ jobs:
 
   gc-stress-s3:
     name: GC(without referrers) on S3(minio) with short interval
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -84,7 +84,7 @@ jobs:
 
   gc-referrers-stress-s3:
     name: GC(with referrers) on S3(localstack) with short interval
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -121,7 +121,7 @@ jobs:
 
   gc-stress-s3:
     name: GC(without referrers) on S3(localstack) with short interval
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -170,7 +170,7 @@ jobs:
 
   kind-setup:
     name: Prometheus setup
-    runs-on: ubuntu-latest-8-cores
+    runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -201,7 +201,7 @@ jobs:
 
   cloud-scale-out:
     name: s3+dynamodb scale-out
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -287,7 +287,7 @@ jobs:
 
   cloud-scale-out-redis:
     name: s3+redis scale-out
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -54,7 +54,7 @@ jobs:
       - uses: ./.github/actions/teardown-localstack
   test-run-extensions:
     name: Run zot with extensions tests
-    runs-on: ubuntu-latest-16-cores
+    runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
**What type of PR is this?**
chore

**Which issue does this PR fix?**:
N/A

**What does this PR do / Why do we need it**:
CNCF has hosted ephemeral GitHub runners on Oracle that we want projects to use instead of the GitHub-hosted ones, which now incur a cost to use.

Please direct any questions to me, @jeefy, @krook, and @RobertKielty. You can also join `#cncf-ci-infra` channel on CNCF Slack.

**If an issue # is not available, please add repro steps and logs showing the issue**:
N/A

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
No


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
