### PR TITLE
feat(sessions): add support for remote redis session store

### DIFF
--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -27,7 +27,7 @@ jobs:
           go install github.com/swaggo/swag/cmd/swag@v1.16.2
           go mod download
           sudo apt-get update
-          sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap haproxy jq
+          sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap haproxy jq valkey-tools
           # install skopeo
           git clone -b v1.12.0 https://github.com/containers/skopeo.git
           cd skopeo

--- a/examples/README.md
+++ b/examples/README.md
@@ -370,6 +370,45 @@ Using that cookie on subsequent calls will authenticate them, asumming the cooki
 In case of using filesystem storage sessions are saved in zot's root directory.
 In case of using cloud storage sessions are saved in memory.
 
+Note: By default, the session driver config would be local for file system or in-memory. The session driver name for this is `local`. An example config is shown below, but the config can be omitted as it is a default.
+
+```
+    "auth": {
+      "htpasswd": {
+        "path": "test/data/htpasswd"
+      },
+      "sessionDriver": {
+        "name": "local"
+      }
+    }
+```
+
+Note: This `sessionDriver` config is optional if a local session storage is desired.
+
+#### Remote Session Storage Driver
+
+Redis and Redis-compatible storage drivers can also be used for cases where session storage is required to be kept separately from zot or multiple zot instances need to share the session information.
+
+This can be configured in the `auth` section of the configuration as shown below:
+
+`sessionDriver`
+
+```
+    "auth": {
+      "htpasswd": {
+        "path": "test/data/htpasswd"
+      },
+      "sessionDriver": {
+        "name": "redis",
+        "url": "redis://localhost:6379",
+        "keyprefix": "zotsession"
+      }
+    }
+```
+
+The `redis` driver configuration options are the same as those in the [Redis Cache Driver](#redis) section. If the `redis` session driver is being used along with a `redis` cache driver and both configurations point to the same Redis instance, there will be two independent connections used.
+
+Note: The `redis` session driver cannot be specified along with configuration for the SessionKeysFile.
 
 ### Securing session based login
 

--- a/examples/config-remote-session-store-redis.json
+++ b/examples/config-remote-session-store-redis.json
@@ -1,0 +1,34 @@
+{
+  "distSpecVersion": "1.1.1",
+  "storage": {
+    "rootDirectory": "/tmp/zot"
+  },
+  "http": {
+    "address": "127.0.0.1",
+    "port": "8080",
+    "realm": "zot",
+    "auth": {
+      "htpasswd": {
+        "path": "/tmp/zotpasswd"
+      },
+      "sessionDriver": {
+        "name": "redis",
+        "url": "redis://localhost:6379",
+        "keyprefix": "zotsession"
+      }
+    }
+  },
+  "log": {
+    "level": "debug"
+  },
+  "extensions": {
+    "search": {
+      "cve": {
+        "updateInterval": "2h"
+      }
+    },
+    "ui": {
+      "enable": true
+    }
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/project-zot/mockoidc v0.0.0-20240610203808-d69d9e02020a
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
+	github.com/rbcervilla/redisstore/v9 v9.0.0
 	github.com/redis/go-redis/v9 v9.14.0
 	github.com/regclient/regclient v0.9.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -1873,6 +1873,8 @@ github.com/prometheus/procfs v0.16.1 h1:hZ15bTNuirocR6u0JZ6BAHHmwS1p8B4P6MRqxtzM
 github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlTmWl8x/U+Is=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20241112170944-20d2c9ebc01d h1:HWfigq7lB31IeJL8iy7jkUmU/PG1Sr8jVGhS749dbUA=
 github.com/protocolbuffers/txtpbfmt v0.0.0-20241112170944-20d2c9ebc01d/go.mod h1:jgxiZysxFPM+iWKwQwPR+y+Jvo54ARd4EisXxKYpB5c=
+github.com/rbcervilla/redisstore/v9 v9.0.0 h1:wOPbBaydbdxzi1gTafDftCI/Z7vnsXw0QDPCuhiMG0g=
+github.com/rbcervilla/redisstore/v9 v9.0.0/go.mod h1:q/acLpoKkTZzIsBYt0R4THDnf8W/BH6GjQYvxDSSfdI=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:N/ElC8H3+5XpJzTSTfLsJV/mx9Q9g7kxmchpfZyxgzM=
 github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.0.5 h1:EaDatTxkdHG+U3Bk4EUr+DZ7fOGwTfezUiUJMaIcaho=

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -75,8 +75,9 @@ type AuthConfig struct {
 	OpenID            *OpenIDConfig
 	APIKey            bool
 	SessionKeysFile   string
-	SessionHashKey    []byte `json:"-"`
-	SessionEncryptKey []byte `json:"-"`
+	SessionHashKey    []byte         `json:"-"`
+	SessionEncryptKey []byte         `json:"-"`
+	SessionDriver     map[string]any `mapstructure:",omitempty"`
 }
 
 type BearerConfig struct {

--- a/pkg/api/config/redis/redis.go
+++ b/pkg/api/config/redis/redis.go
@@ -81,7 +81,7 @@ func ParseRedisUniversalOptions(redisConfig map[string]interface{}, //nolint: go
 		opts.Addrs = val
 	}
 
-	if val, ok := getString(redisConfig, "client_name", false, log); ok {
+	if val, ok := GetString(redisConfig, "client_name", false, log); ok {
 		opts.ClientName = val
 	}
 
@@ -93,19 +93,19 @@ func ParseRedisUniversalOptions(redisConfig map[string]interface{}, //nolint: go
 		opts.Protocol = val
 	}
 
-	if val, ok := getString(redisConfig, "username", false, log); ok {
+	if val, ok := GetString(redisConfig, "username", false, log); ok {
 		opts.Username = val
 	}
 
-	if val, ok := getString(redisConfig, "password", true, log); ok {
+	if val, ok := GetString(redisConfig, "password", true, log); ok {
 		opts.Password = val
 	}
 
-	if val, ok := getString(redisConfig, "sentinel_username", false, log); ok {
+	if val, ok := GetString(redisConfig, "sentinel_username", false, log); ok {
 		opts.SentinelUsername = val
 	}
 
-	if val, ok := getString(redisConfig, "sentinel_password", true, log); ok {
+	if val, ok := GetString(redisConfig, "sentinel_password", true, log); ok {
 		opts.SentinelPassword = val
 	}
 
@@ -185,7 +185,7 @@ func ParseRedisUniversalOptions(redisConfig map[string]interface{}, //nolint: go
 		opts.RouteRandomly = val
 	}
 
-	if val, ok := getString(redisConfig, "master_name", false, log); ok {
+	if val, ok := GetString(redisConfig, "master_name", false, log); ok {
 		opts.MasterName = val
 	}
 
@@ -193,7 +193,7 @@ func ParseRedisUniversalOptions(redisConfig map[string]interface{}, //nolint: go
 		opts.DisableIdentity = val
 	}
 
-	if val, ok := getString(redisConfig, "identity_suffix", false, log); ok {
+	if val, ok := GetString(redisConfig, "identity_suffix", false, log); ok {
 		opts.IdentitySuffix = val
 	}
 
@@ -246,7 +246,7 @@ func getInt(dict map[string]interface{}, key string, log log.Logger) (int, bool)
 	return ret, true
 }
 
-func getString(dict map[string]interface{}, key string, hideValue bool, log log.Logger) (string, bool) {
+func GetString(dict map[string]interface{}, key string, hideValue bool, log log.Logger) (string, bool) {
 	value, ok := dict[key]
 	if !ok {
 		return "", false

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -324,8 +324,7 @@ func (c *Controller) initCookieStore() error {
 			c.Config.HTTP.Auth.SessionHashKey = securecookie.GenerateRandomKey(64) //nolint: gomnd
 		}
 
-		cookieStore, err := NewCookieStore(c.StoreController, c.Config.HTTP.Auth.SessionHashKey,
-			c.Config.HTTP.Auth.SessionEncryptKey)
+		cookieStore, err := NewCookieStore(c.Config.HTTP.Auth, c.StoreController, c.Log)
 		if err != nil {
 			return err
 		}

--- a/test/blackbox/ci.sh
+++ b/test/blackbox/ci.sh
@@ -9,7 +9,7 @@ PATH=$PATH:${SCRIPTPATH}/../../hack/tools/bin
 
 tests=("pushpull" "pushpull_authn" "delete_images" "referrers" "metadata" "anonymous_policy"
       "annotations" "detect_manifest_collision" "cve" "sync" "sync_docker" "sync_replica_cluster"
-      "scrub" "garbage_collect" "metrics" "metrics_minimal" "multiarch_index" "docker_compat" "redis_local"
+      "scrub" "garbage_collect" "metrics" "metrics_minimal" "multiarch_index" "docker_compat" "redis_local" "redis_session_store"
       "events_nats" "events_http" "events_nats_lint_failure" "events_http_lint_failure" "events_sink_failure" "events_config_decoding")
 
 for test in ${tests[*]}; do

--- a/test/blackbox/redis_session_store.bats
+++ b/test/blackbox/redis_session_store.bats
@@ -1,0 +1,253 @@
+# Note: Intended to be run as "make run-blackbox-tests" or "make run-blackbox-ci"
+#       Makefile target installs & checks all necessary tooling
+#       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
+
+load helpers_zot
+load helpers_redis
+load ../port_helper
+
+function verify_prerequisites() {
+    if [ ! $(command -v curl) ]; then
+        echo "you need to install curl as a prerequisite to running the tests" >&3
+        return 1
+    fi
+
+    if [ ! $(command -v docker) ]; then
+        echo "you need to install docker as a prerequisite to running the tests" >&3
+        return 1
+    fi
+
+    if [ ! $(command -v valkey-cli) ]; then
+        echo "you need to install valkey-cli as a prerequisite to running the tests" >&3
+        return 1
+    fi
+
+    return 0
+}
+
+HTPASSWD_PATH=/tmp/zotpasswd
+CURL_COOKIES_DIR=/tmp/zotcookies
+REDIS_TEST_CONTAINER_NAME="redis_sessions_server_local"
+
+function setup_file() {
+    # Verify prerequisites are available
+    if ! $(verify_prerequisites); then
+        exit 1
+    fi
+
+    mkdir -p ${CURL_COOKIES_DIR}
+
+    # Create htpasswd file for basic auth
+    htpasswd -bBn test test123 > ${HTPASSWD_PATH}
+
+    # Setup redis server
+    redis_port=$(get_free_port_for_service "redis")
+    redis_start ${REDIS_TEST_CONTAINER_NAME} ${redis_port}
+
+    # Setup zot server
+    local zot_root_dir=${BATS_FILE_TMPDIR}/zot
+    local zot_redis_session_config_file=${BATS_FILE_TMPDIR}/zot_redis_session_config.json
+    zot_port=$(get_free_port_for_service "zot")
+    echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
+    echo ${redis_port} > ${BATS_FILE_TMPDIR}/redis.port
+
+    mkdir -p ${zot_root_dir}
+
+    cat >${zot_redis_session_config_file} <<EOF
+{
+    "distSpecVersion": "1.1.1",
+    "storage": {
+        "rootDirectory": "${zot_root_dir}"
+    },
+    "http": {
+        "address": "127.0.0.1",
+        "port": "${zot_port}",
+        "auth": {
+            "htpasswd": {
+                "path": "${HTPASSWD_PATH}"
+            },
+            "sessionDriver": {
+                "name": "redis",
+                "url": "redis://localhost:${redis_port}",
+                "keyprefix": "zotsession"
+            }
+        }
+    },
+    "log": {
+        "level": "debug",
+        "output": "/tmp/blackbox.log"
+    },
+    "extensions": {
+      "ui": {
+        "enable": true
+      },
+      "search": {
+        "enable": true
+      }
+    }
+}
+EOF
+
+    zot_serve ${ZOT_PATH} ${zot_redis_session_config_file}
+    wait_zot_reachable ${zot_port}
+}
+
+function get_zot_port() {
+    cat ${BATS_FILE_TMPDIR}/zot.port
+}
+
+function get_redis_port() {
+    cat ${BATS_FILE_TMPDIR}/redis.port
+}
+
+function get_session_count() {
+    port=$(get_redis_port)
+    valkey-cli -u "redis://localhost:${port}" --scan --pattern 'zotsession:*' | wc -l
+}
+
+function perform_login() {
+    zot_port=$(get_zot_port)
+    user_num=$1
+
+    # The authorization header carries a base 64 encode of test:test123
+    curl -s -o /dev/null -w '%{http_code}' --cookie-jar "${CURL_COOKIES_DIR}/zot-cookie-${user_num}" \
+    "http://localhost:${zot_port}/v2/" \
+    -H 'Accept: application/json, text/plain, */*' \
+    -H 'Accept-Language: en-US,en;q=0.5' \
+    -H 'Accept-Encoding: gzip, deflate, br, zstd' \
+    -H 'Authorization: Basic dGVzdDp0ZXN0MTIz' \
+    -H 'X-ZOT-API-CLIENT: zot-ui' \
+    -H 'Connection: keep-alive' \
+    -H "Referer: http://localhost:${zot_port}/login" \
+    -H 'Sec-Fetch-Dest: empty' \
+    -H 'Sec-Fetch-Mode: cors' \
+    -H 'Sec-Fetch-Site: same-origin' \
+    -H 'Priority: u=0' \
+    -H 'Pragma: no-cache' \
+    -H 'Cache-Control: no-cache'
+}
+
+function perform_logout() {
+    zot_port=$(get_zot_port)
+    user_num=$1
+
+    curl -s -o /dev/null -w '%{http_code}' --cookie "${CURL_COOKIES_DIR}/zot-cookie-${user_num}" \
+    -X POST \
+    "http://localhost:${zot_port}/zot/auth/logout" \
+    -H 'Accept: application/json, text/plain, */*' \
+    -H 'Accept-Language: en-US,en;q=0.5' \
+    -H 'Accept-Encoding: gzip, deflate, br, zstd' \
+    -H "Origin: http://localhost:${zot_port}/login" \
+    -H 'X-ZOT-API-CLIENT: zot-ui' \
+    -H 'Connection: keep-alive' \
+    -H "Referer: http://localhost:${zot_port}/home" \
+    -H 'Sec-Fetch-Dest: empty' \
+    -H 'Sec-Fetch-Mode: cors' \
+    -H 'Sec-Fetch-Site: same-origin' \
+    -H 'Priority: u=0' \
+    -H 'Pragma: no-cache' \
+    -H 'Cache-Control: no-cache' \
+    -H 'Content-Length: 0'
+}
+
+function perform_authenticated_globalsearch() {
+    zot_port=$(get_zot_port)
+    user_num=$1
+
+    url="http://localhost:${zot_port}"
+    url+='/v2/_zot/ext/search?query={GlobalSearch(query:%22%22,%20requestedPage:%20{limit:3%20offset:0%20sortBy:%20DOWNLOADS}%20)%20{Page%20{TotalCount%20ItemCount}%20Repos%20{Name%20LastUpdated%20Size%20Platforms%20{%20Os%20Arch%20}%20IsStarred%20IsBookmarked%20NewestImage%20{%20Tag%20Vulnerabilities%20{MaxSeverity%20Count}%20Description%20IsSigned%20SignatureInfo%20{%20Tool%20IsTrusted%20Author%20}%20Licenses%20Vendor%20Labels%20}%20StarCount%20DownloadCount}}}'
+
+    curl -g -s -o /dev/null -w '%{http_code}' --cookie "${CURL_COOKIES_DIR}/zot-cookie-${user_num}" \
+     "${url}" \
+    -H 'Accept: application/json' \
+    -H 'Accept-Language: en-US,en;q=0.5' \
+    -H 'Accept-Encoding: gzip, deflate, br, zstd' \
+    -H 'X-ZOT-API-CLIENT: zot-ui' \
+    -H 'Connection: keep-alive' \
+    -H "Referer: http://localhost:${zot_port}/home" \
+    -H 'Sec-Fetch-Dest: empty' \
+    -H 'Sec-Fetch-Mode: cors' \
+    -H 'Sec-Fetch-Site: same-origin' \
+    -H 'Pragma: no-cache' \
+    -H 'Cache-Control: no-cache'
+}
+
+@test "verify bulk user authentication cycle" {
+    num_users=20
+
+    # Note: queries are forked and run concurrently for load
+
+    for i in $(seq 1 ${num_users}); do
+        (
+            # User tries to access the global search URL without login
+            echo "user $i unauthenticated URL check"
+            status=$(perform_authenticated_globalsearch $i)
+            [ 401 -eq "${status}" ]
+
+            # User login
+            echo "user $i login"
+            status=$(perform_login $i)
+            [ 200 -eq "${status}" ]
+        ) &
+    done
+
+    # wait for background processes to complete
+    sleep 0.1
+    echo "waiting for background process completion"
+    wait $(jobs -p)
+
+    for i in $(seq 1 ${num_users}); do
+        # Retry authenticated global search URL
+        (
+            echo "user $i authenticated URL check"
+            status=$(perform_authenticated_globalsearch $i)
+            [ 200 -eq "${status}" ]
+        ) &
+    done
+
+    # wait for background processes to complete
+    sleep 0.1
+    echo "waiting for background process completion"
+    wait $(jobs -p)
+
+    cookies_count=$(get_session_count)
+    echo "total cookies ${cookies_count}"
+    [ "${cookies_count}" -eq "${num_users}" ]
+
+    for i in $(seq 1 ${num_users}); do
+        # All users logout
+        (
+            status=$(perform_logout $i)
+            [ 200 -eq "${status}" ]
+        ) &
+    done
+
+    # wait for background processes to complete
+    sleep 0.1
+    echo "waiting for background process completion"
+    wait $(jobs -p)
+
+    for i in $(seq 1 ${num_users}); do
+        # All users verify no access to URL
+        (
+            status=$(perform_authenticated_globalsearch $i)
+            [ 401 -eq "${status}" ]
+        ) &
+    done
+
+    # wait for background processes to complete
+    sleep 0.1
+    echo "waiting for background process completion"
+    wait $(jobs -p)
+
+    cookies_count=$(get_session_count)
+    echo "total cookies ${cookies_count}"
+    [ 0 -eq "${cookies_count}" ]
+}
+
+function teardown_file() {
+    zot_stop_all
+    redis_stop ${REDIS_TEST_CONTAINER_NAME}
+    rm ${HTPASSWD_PATH}
+    rm -r ${CURL_COOKIES_DIR}
+}

--- a/test/ports.json
+++ b/test/ports.json
@@ -392,5 +392,15 @@
       "begin": 8700,
       "end": 8750
     }
+  },
+  "blackbox/redis_session_store.bats": {
+    "redis": {
+      "begin": 11400,
+      "end": 11409
+    },
+    "zot": {
+      "begin": 11420,
+      "end": 11429
+    }
   }
 }


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Towards #3333 

**What does this PR do / Why do we need it**:
- Adds support for Redis to be used as a remote storage for session information.
- Sessions are stored in Redis and get invalidated when the user logs out on the browser or after expiry.
- Allows session information to persist outside of the Zot instance for use cases where Zot is fully stateless or there are multiple Zot instances running.

**Testing done on this change**:
A local redis 8 container is used for this testing. The container has been started and `valkey-cli` is used to access and read the entries to verify behavior.

The test config for zot is the file `examples/config-remote-session-store-redis.json`

A login is initiated through ZUI on browser. A cookie is successfully created and saved.
<img width="1912" height="421" alt="Screenshot from 2025-08-30 11-08-22" src="https://github.com/user-attachments/assets/e4ecb584-bde3-449c-8c61-f77bcc2fea33" />

Inspecting on Redis indicates that it was originally empty, but later a single entry was created for the new cookie.
<img width="235" height="124" alt="Screenshot from 2025-08-30 11-09-25" src="https://github.com/user-attachments/assets/ad381069-a6fb-4d85-8d40-b417b13a4b75" />

Post this, a logout operation was initiated from the browser and Redis was inspected again:
<img width="234" height="147" alt="Screenshot from 2025-08-30 11-11-16" src="https://github.com/user-attachments/assets/06a541d2-b88e-4208-81a9-dab8c6bafcaf" />

Additional testing after addressing review comments:
<img width="237" height="373" alt="Screenshot from 2025-09-07 23-28-18" src="https://github.com/user-attachments/assets/05e9eb01-acb1-40af-8791-2cb616a2c35b" />

This shows that the session was successfully deleted from the Redis storage.

**Automation added to e2e**:
A new BATS test has been added for the feature.

**Will this break upgrades or downgrades?**
No. Additional configuration is needed to enable it. Otherwise, the existing behavior will continue as-is.

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Zot now supports configuring a remote Redis compatible session store. Refer to examples/config-remote-session-store-redis.json for an example on how to enable it.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
