### PR TITLE
fix: gc for untagged docker manifests

### DIFF
--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -485,7 +485,8 @@ func (gc GarbageCollect) removeUntaggedManifests(repo string, index *ispec.Index
 		}
 
 		// remove untagged images
-		if desc.MediaType == ispec.MediaTypeImageManifest || desc.MediaType == ispec.MediaTypeImageIndex {
+		if desc.MediaType == ispec.MediaTypeImageManifest || compat.IsCompatibleManifestMediaType(desc.MediaType) ||
+			desc.MediaType == ispec.MediaTypeImageIndex || compat.IsCompatibleManifestListMediaType(desc.MediaType) {
 			_, ok := getDescriptorTag(desc)
 			if !ok {
 				gced, err = gc.gcManifest(repo, index, desc, "", "", gc.opts.ImageRetention.Delay)

--- a/pkg/test/image-utils/images_test.go
+++ b/pkg/test/image-utils/images_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	docker "github.com/distribution/distribution/v3/manifest/schema2"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
@@ -194,6 +195,22 @@ func TestImageMethods(t *testing.T) {
 			So(manifestDigest, ShouldResemble, descriptor.Digest)
 			So(manifestSize, ShouldEqual, descriptor.Size)
 			So(ispec.MediaTypeImageManifest, ShouldResemble, descriptor.MediaType)
+		})
+	})
+}
+
+func TestConvertImageToDocker(t *testing.T) {
+	Convey("AsDockerImage", t, func() {
+		Convey("DefaultImage", func() {
+			img := CreateDefaultImage()
+			dockerImage := img.AsDockerImage()
+
+			So(dockerImage.Manifest.MediaType, ShouldEqual, docker.MediaTypeManifest)
+			So(dockerImage.ConfigDescriptor.MediaType, ShouldEqual, docker.MediaTypeImageConfig)
+
+			for _, layer := range dockerImage.Manifest.Layers {
+				So(layer.MediaType, ShouldEqual, docker.MediaTypeLayer)
+			}
 		})
 	})
 }

--- a/pkg/test/image-utils/write.go
+++ b/pkg/test/image-utils/write.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 
 	godigest "github.com/opencontainers/go-digest"
-	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	stypes "zotregistry.dev/zot/pkg/storage/types"
 )
@@ -52,7 +51,7 @@ func WriteImageToFileSystem(image Image, repoName, ref string, storeController s
 		return err
 	}
 
-	_, _, err = store.PutImageManifest(repoName, ref, ispec.MediaTypeImageManifest, manifestBlob)
+	_, _, err = store.PutImageManifest(repoName, ref, image.Manifest.MediaType, manifestBlob)
 	if err != nil {
 		return err
 	}
@@ -82,7 +81,7 @@ func WriteMultiArchImageToFileSystem(multiarchImage MultiarchImage, repoName, re
 		return err
 	}
 
-	_, _, err = store.PutImageManifest(repoName, ref, ispec.MediaTypeImageIndex,
+	_, _, err = store.PutImageManifest(repoName, ref, multiarchImage.Index.MediaType,
 		indexBlob)
 
 	return err


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:
- fixes #3347: removeUntaggedManifests() did not consider compatible manifest types

**What does this PR do / Why do we need it**:
- check for compatible manifest types in removeUntaggedManifests()

**If an issue # is not available please add repro steps and logs showing the issue**:
see #3347 

**Testing done on this change**:
- extend TestGarbageCollectAndRetentionMetaDB to test docker image and multiarch image
- add AsDockerImage() to Image and MultiarchImage for testing

**Automation added to e2e**:
n/a

**Will this break upgrades or downgrades?**
no

**Does this PR introduce any user-facing change?**:
yes

```release-note
Image GC now considers images using docker manifests.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
