### PR TITLE
chore: update zui version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ CRICTL_VERSION := v1.26.1
 ACTION_VALIDATOR := $(TOOLSDIR)/bin/action-validator
 ACTION_VALIDATOR_VERSION := v0.5.3
 ZUI_BUILD_PATH := ""
-ZUI_VERSION := commit-d25abda
+ZUI_VERSION := commit-731b639
 ZUI_REPO_OWNER := project-zot
 ZUI_REPO_NAME := zui
 SWAGGER_VERSION := v1.16.2
@@ -321,7 +321,7 @@ $(GOLINTER):
 	$(GOLINTER) version
 
 .PHONY: check-logs
-check-logs: 
+check-logs:
 	@./scripts/check_logs.sh
 
 .PHONY: check


### PR DESCRIPTION
- upgrade axios to v1.12.2 for cve fixes
- update mui libraries to 6.5.0 for cve fixes
- other updates for fixes
- react-scripts@5.0.1 is outdated and only supports TypeScript 4.9.5, so downgrade to 4.9.5 (note this was alreays done on npm install even in the previous commit)

Should fix https://github.com/project-zot/zot/actions/runs/18036432234/job/51324327982

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
