### PR TITLE
fix(ci): use fixed ranges for BATS server ports

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,30 @@
+# BATS Port Allocations
+
+The `ports.json` file in this directory tracks the port ranges provided for each BATS test that runs concurrently to avoid overlaps.
+IANA registered ports range - 1024 to 49151
+
+## Adding a new BATS Test file
+
+For the range, use a gap of 10 ports (e.g. 9000 to 9009) and leave a gap of 10 ports between the new range and the last range.
+
+Avoid ranges in the 4000, 8000, and 10000 series as these may overlap with other services such as localstack, fixed port zot, and clustered zot.
+
+For a new BATS test file, add a new entry to `ports.json` as follows:
+
+replace `TEST_DIR` with just the directory name of the directory containing your test file.
+replace `FILENAME` with the name of the test file along with its extension e.g. `new_test.bats`
+
+```json
+"TEST_DIR/FILENAME": {
+  "svc1": {
+    "begin": 20020,
+    "end": 20029
+  },
+  "svc2": {
+    "begin": 20040,
+    "end": 20049
+  }
+}
+```
+
+A test file may have multiple services defined by a unique key. You can use any key for the service identifier, however, ensure that the same key is used in the BATS test file as an argument to the `get_free_port_for_service` function.

--- a/test/blackbox/annotations.bats
+++ b/test/blackbox/annotations.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites {
     if [ ! $(command -v curl) ]; then
@@ -35,7 +36,8 @@ function setup_file() {
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
     mkdir -p ${zot_root_dir}
-    zot_port=$(get_free_port)
+
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat > ${zot_config_file}<<EOF
 {

--- a/test/blackbox/anonymous_policy.bats
+++ b/test/blackbox/anonymous_policy.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites {
     if [ ! $(command -v htpasswd) ]; then
@@ -28,7 +29,7 @@ function setup_file() {
     local zot_htpasswd_file=${BATS_FILE_TMPDIR}/htpasswd
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     htpasswd -Bbn ${AUTH_USER} ${AUTH_PASS} >> ${zot_htpasswd_file}
     cat > ${zot_config_file}<<EOF

--- a/test/blackbox/cve.bats
+++ b/test/blackbox/cve.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites {
     if [ ! $(command -v curl) ]; then
@@ -31,7 +32,7 @@ function setup_file() {
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
     mkdir -p ${zot_root_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat >${zot_config_file} <<EOF
 {

--- a/test/blackbox/delete_images.bats
+++ b/test/blackbox/delete_images.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites {
     if [ ! command -v curl ] &>/dev/null; then
@@ -32,7 +33,7 @@ function setup_file() {
     local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
     mkdir -p ${ZOT_ROOT_DIR}
     touch ${zot_log_file}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat >${zot_config_file} <<EOF
 {

--- a/test/blackbox/detect_manifest_collision.bats
+++ b/test/blackbox/detect_manifest_collision.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites {
     if [ ! $(command -v htpasswd) ]; then
@@ -29,7 +30,7 @@ function setup_file() {
     local zot_htpasswd_file=${BATS_FILE_TMPDIR}/htpasswd
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     htpasswd -Bbn ${AUTH_USER} ${AUTH_PASS} >> ${zot_htpasswd_file}
     cat > ${zot_config_file}<<EOF

--- a/test/blackbox/docker_compat.bats
+++ b/test/blackbox/docker_compat.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites {
     if [ ! $(command -v curl) ]; then
@@ -31,7 +32,7 @@ function setup_file() {
     local oci_data_dir=${BATS_FILE_TMPDIR}/oci
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat > ${zot_config_file}<<EOF
 {

--- a/test/blackbox/events_config_decoding.bats
+++ b/test/blackbox/events_config_decoding.bats
@@ -4,6 +4,7 @@
 
 load helpers_zot
 load helpers_events
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -34,7 +35,7 @@ function setup_file() {
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
     mkdir -p ${zot_root_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot1")
     cat > ${zot_config_file}<<EOF
 {
     "distSpecVersion": "1.1.1",
@@ -86,7 +87,7 @@ EOF
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
     mkdir -p ${zot_root_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot2")
     cat > ${zot_config_file}<<EOF
 {
     "distSpecVersion": "1.1.1",

--- a/test/blackbox/events_http.bats
+++ b/test/blackbox/events_http.bats
@@ -4,6 +4,7 @@
 
 load helpers_zot
 load helpers_events
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -29,7 +30,7 @@ function setup_file() {
     fi
 
     # Setup http server
-    http_server_port=$(get_free_port)
+    http_server_port=$(get_free_port_for_service "http")
     http_event_dir="${BATS_FILE_TMPDIR}/http_events"
     http_server_start http_receiver "${http_server_port}" "${http_event_dir}"
     echo ${http_server_port} > ${BATS_FILE_TMPDIR}/http_server.port
@@ -43,7 +44,7 @@ function setup_file() {
     local oci_data_dir=${BATS_FILE_TMPDIR}/oci
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat > ${zot_config_file}<<EOF
 {

--- a/test/blackbox/events_http_lint_failure.bats
+++ b/test/blackbox/events_http_lint_failure.bats
@@ -4,6 +4,7 @@
 
 load helpers_zot
 load helpers_events
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -34,7 +35,7 @@ function setup_file() {
     fi
 
     # Setup http server
-    http_server_port=$(get_free_port)
+    http_server_port=$(get_free_port_for_service "http")
     http_event_dir="${BATS_FILE_TMPDIR}/http_events"
     http_server_start http_receiver_lint "${http_server_port}" "${http_event_dir}"
     echo ${http_server_port} > ${BATS_FILE_TMPDIR}/http_server.port
@@ -48,7 +49,7 @@ function setup_file() {
     local oci_data_dir=${BATS_FILE_TMPDIR}/oci
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat > ${zot_config_file}<<EOF
 {

--- a/test/blackbox/events_nats.bats
+++ b/test/blackbox/events_nats.bats
@@ -4,6 +4,7 @@
 
 load helpers_zot
 load helpers_events
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -29,7 +30,7 @@ function setup_file() {
     fi
 
     # Setup nats server
-    nats_server_port=$(get_free_port)
+    nats_server_port=$(get_free_port_for_service "nats")
     nats_server_start nats_server_local ${nats_server_port}
     echo ${nats_server_port} > ${BATS_FILE_TMPDIR}/nats_server.port
 
@@ -41,7 +42,7 @@ function setup_file() {
     local oci_data_dir=${BATS_FILE_TMPDIR}/oci
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat > ${zot_config_file}<<EOF
 {

--- a/test/blackbox/events_nats_lint_failure.bats
+++ b/test/blackbox/events_nats_lint_failure.bats
@@ -4,6 +4,7 @@
 
 load helpers_zot
 load helpers_events
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -34,7 +35,7 @@ function setup_file() {
     fi
 
     # Setup nats server
-    nats_server_port=$(get_free_port)
+    nats_server_port=$(get_free_port_for_service "nats")
     nats_server_start nats_server_local_lint ${nats_server_port}
     echo ${nats_server_port} > ${BATS_FILE_TMPDIR}/nats_server.port
 
@@ -46,7 +47,7 @@ function setup_file() {
     local oci_data_dir=${BATS_FILE_TMPDIR}/oci
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat > ${zot_config_file}<<EOF
 {

--- a/test/blackbox/events_sink_failure.bats
+++ b/test/blackbox/events_sink_failure.bats
@@ -4,6 +4,7 @@
 
 load helpers_zot
 load helpers_events
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -29,7 +30,7 @@ function setup_file() {
     fi
 
     # Setup http server
-    http_server_port=$(get_free_port)
+    http_server_port=$(get_free_port_for_service "http")
     http_event_dir="${BATS_FILE_TMPDIR}/http_events"
     http_server_start http_receiver_failure "${http_server_port}" "${http_event_dir}"
     wait_for_http_server $http_server_port
@@ -42,7 +43,7 @@ function setup_file() {
     local oci_data_dir=${BATS_FILE_TMPDIR}/oci
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat > ${zot_config_file}<<EOF
 {

--- a/test/blackbox/garbage_collect.bats
+++ b/test/blackbox/garbage_collect.bats
@@ -1,4 +1,5 @@
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites {
     if [ ! $(command -v curl) ]; then
@@ -26,7 +27,7 @@ function setup_file() {
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
     local oci_data_dir=${BATS_FILE_TMPDIR}/oci
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}

--- a/test/blackbox/helpers_zot.bash
+++ b/test/blackbox/helpers_zot.bash
@@ -11,20 +11,6 @@ AUTH_PASS=sup*rSecr9T
 
 mkdir -p ${TEST_DATA_DIR}
 
-function get_free_port(){
-    while true
-    do
-        random_port=$(( ((RANDOM<<15)|RANDOM) % 49152 + 10000 ))
-        status="$(nc -z 127.0.0.1 $random_port < /dev/null &>/dev/null; echo $?)"
-        if [ "${status}" != "0" ]; then
-            free_port=${random_port};
-            break;
-        fi
-    done
-
-    echo ${free_port}
-}
-
 function zot_serve() {
     local zot_path=${1}
     local config_file=${2}

--- a/test/blackbox/metadata.bats
+++ b/test/blackbox/metadata.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites {
     if [ ! $(command -v curl) ]; then
@@ -39,7 +40,7 @@ function setup_file() {
     local zot_htpasswd_file=${BATS_FILE_TMPDIR}/htpasswd
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     htpasswd -Bbn ${AUTH_USER} ${AUTH_PASS} >> ${zot_htpasswd_file}
     cat > ${zot_config_file}<<EOF

--- a/test/blackbox/metrics.bats
+++ b/test/blackbox/metrics.bats
@@ -4,6 +4,7 @@
 
 load helpers_zot
 load helpers_metrics
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -31,7 +32,7 @@ function setup_file() {
     zot_log_file=${zot_root_dir}/zot-log.json
     zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
     zot_htpasswd_file=${BATS_FILE_TMPDIR}/zot_htpasswd
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     htpasswd -Bbn ${AUTH_USER} ${AUTH_PASS} >> ${zot_htpasswd_file}
     htpasswd -Bbn ${METRICS_USER} ${METRICS_PASS} >> ${zot_htpasswd_file}

--- a/test/blackbox/metrics_minimal.bats
+++ b/test/blackbox/metrics_minimal.bats
@@ -5,6 +5,7 @@
 load helpers_zot
 load helpers_metrics
 load helpers_dist
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -32,7 +33,7 @@ function setup_file() {
     zot_log_file=${zot_root_dir}/zot-log.json
     zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
     zot_htpasswd_file=${BATS_FILE_TMPDIR}/zot_htpasswd
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     htpasswd -Bbn ${AUTH_USER} ${AUTH_PASS} >> ${zot_htpasswd_file}
     htpasswd -Bbn ${METRICS_USER} ${METRICS_PASS} >> ${zot_htpasswd_file}

--- a/test/blackbox/multiarch_index.bats
+++ b/test/blackbox/multiarch_index.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites {
     if [ ! $(command -v regctl) ]; then
@@ -24,7 +25,7 @@ function setup_file() {
     local oci_data_dir=${BATS_FILE_TMPDIR}/oci
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat > ${zot_config_file}<<EOF
 {

--- a/test/blackbox/pushpull.bats
+++ b/test/blackbox/pushpull.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites {
     if [ ! $(command -v curl) ]; then
@@ -31,7 +32,7 @@ function setup_file() {
     local oci_data_dir=${BATS_FILE_TMPDIR}/oci
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat > ${zot_config_file}<<EOF
 {

--- a/test/blackbox/pushpull_authn.bats
+++ b/test/blackbox/pushpull_authn.bats
@@ -1,4 +1,5 @@
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites {
     if [ ! $(command -v curl) ]; then
@@ -32,7 +33,7 @@ function setup_file() {
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
     local zot_htpasswd_file=${BATS_FILE_TMPDIR}/zot_htpasswd
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     htpasswd -Bbn ${AUTH_USER} ${AUTH_PASS} >> ${zot_htpasswd_file}
 

--- a/test/blackbox/redis_local.bats
+++ b/test/blackbox/redis_local.bats
@@ -4,6 +4,7 @@
 
 load helpers_zot
 load helpers_redis
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -34,13 +35,13 @@ function setup_file() {
     skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.20 oci:${TEST_DATA_DIR}/golang:1.20
 
     # Setup redis server
-    redis_port=$(get_free_port)
+    redis_port=$(get_free_port_for_service "redis")
     redis_start redis_server_local ${redis_port}
 
     # Setup zot server
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     local zot_sync_ondemand_config_file=${BATS_FILE_TMPDIR}/zot_sync_ondemand_config.json
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
 
     mkdir -p ${zot_root_dir}

--- a/test/blackbox/redis_s3.bats
+++ b/test/blackbox/redis_s3.bats
@@ -5,6 +5,7 @@
 load helpers_zot
 load helpers_redis
 load helpers_cloud
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v docker) ]; then
@@ -25,13 +26,13 @@ function setup_file() {
     skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/test-images/alpine:3.17.3 oci:${TEST_DATA_DIR}/alpine:1
 
     # Setup redis server
-    redis_port=$(get_free_port)
+    redis_port=$(get_free_port_for_service "redis")
     redis_start redis_server ${redis_port}
 
     # Setup zot server
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     local zot_sync_ondemand_config_file=${BATS_FILE_TMPDIR}/zot_sync_ondemand_config.json
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
 
     mkdir -p ${zot_root_dir}

--- a/test/blackbox/referrers.bats
+++ b/test/blackbox/referrers.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -34,7 +35,7 @@ function setup() {
     ZOT_CONFIG_FILE=${BATS_FILE_TMPDIR}/zot_config.json
     mkdir -p ${ZOT_ROOT_DIR}
     touch ${ZOT_LOG_FILE}
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     cat >${ZOT_CONFIG_FILE} <<EOF
 {

--- a/test/blackbox/scrub.bats
+++ b/test/blackbox/scrub.bats
@@ -4,6 +4,7 @@
 
 load helpers_zot
 load helpers_scrub
+load ../port_helper
 
 function verify_prerequisites() {
     return 0
@@ -24,7 +25,7 @@ function setup() {
     echo ${ZOT_ROOT_DIR}
     ZOT_LOG_FILE=${ZOT_ROOT_DIR}/zot-log.json
     ZOT_CONFIG_FILE=${BATS_FILE_TMPDIR}/zot_config.json
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     mkdir -p ${ZOT_ROOT_DIR}
     touch ${ZOT_LOG_FILE}

--- a/test/blackbox/sync.bats
+++ b/test/blackbox/sync.bats
@@ -4,7 +4,7 @@
 
 load helpers_zot
 load helpers_wait
-
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -47,11 +47,11 @@ function setup_file() {
     mkdir -p ${zot_sync_ondemand_root_dir}
     mkdir -p ${zot_minimal_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port1=$(get_free_port)
+    zot_port1=$(get_free_port_for_service "zot1")
     echo ${zot_port1} > ${BATS_FILE_TMPDIR}/zot.port1
-    zot_port2=$(get_free_port)
+    zot_port2=$(get_free_port_for_service "zot2")
     echo ${zot_port2} > ${BATS_FILE_TMPDIR}/zot.port2
-    zot_port3=$(get_free_port)
+    zot_port3=$(get_free_port_for_service "zot3")
     echo ${zot_port3} > ${BATS_FILE_TMPDIR}/zot.port3
 
     cat >${zot_sync_per_config_file} <<EOF

--- a/test/blackbox/sync_cloud.bats
+++ b/test/blackbox/sync_cloud.bats
@@ -4,7 +4,7 @@
 
 load helpers_zot
 load helpers_wait
-
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -47,11 +47,11 @@ function setup_file() {
     mkdir -p ${zot_sync_ondemand_root_dir}
     mkdir -p ${zot_minimal_root_dir}
     mkdir -p ${oci_data_dir}
-    zot_port1=$(get_free_port)
+    zot_port1=$(get_free_port_for_service "zot1")
     echo ${zot_port1} > ${BATS_FILE_TMPDIR}/zot.port1
-    zot_port2=$(get_free_port)
+    zot_port2=$(get_free_port_for_service "zot2")
     echo ${zot_port2} > ${BATS_FILE_TMPDIR}/zot.port2
-    zot_port3=$(get_free_port)
+    zot_port3=$(get_free_port_for_service "zot3")
     echo ${zot_port3} > ${BATS_FILE_TMPDIR}/zot.port3
 
     cat >${zot_sync_per_config_file} <<EOF

--- a/test/blackbox/sync_docker.bats
+++ b/test/blackbox/sync_docker.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -32,7 +33,7 @@ function setup_file() {
     # Setup zot server
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     local zot_sync_ondemand_config_file=${BATS_FILE_TMPDIR}/zot_sync_ondemand_config.json
-    zot_port=$(get_free_port)
+    zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
 
     mkdir -p ${zot_root_dir}

--- a/test/blackbox/sync_replica_cluster.bats
+++ b/test/blackbox/sync_replica_cluster.bats
@@ -3,6 +3,7 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v curl) ]; then
@@ -41,9 +42,9 @@ function setup_file() {
     mkdir -p ${zot_sync_one_root_dir}
     mkdir -p ${zot_sync_two_root_dir}
 
-    zot_port1=$(get_free_port)
+    zot_port1=$(get_free_port_for_service "zot1")
     echo ${zot_port1} > ${BATS_FILE_TMPDIR}/zot.port1
-    zot_port2=$(get_free_port)
+    zot_port2=$(get_free_port_for_service "zot2")
     echo ${zot_port2} > ${BATS_FILE_TMPDIR}/zot.port2
 
     cat >${zot_sync_one_config_file} <<EOF

--- a/test/port_helper.bash
+++ b/test/port_helper.bash
@@ -1,0 +1,51 @@
+ROOT_DIR=$(git rev-parse --show-toplevel)
+PORTS_JSON_PATH="${ROOT_DIR}/test/ports.json"
+
+# outputs an available port in the given range
+# usage: get_free_port_in_range range_start range_end
+function get_free_port_in_range(){
+    range_start=$1
+    range_end=$2
+
+    range=$(( range_end - range_start + 1 ))
+
+    while true
+    do
+        random_port=$(( range_start + (RANDOM % range) ))
+        status="$(nc -z 127.0.0.1 $random_port < /dev/null &>/dev/null; echo $?)"
+        if [ "${status}" != "0" ]; then
+            free_port=${random_port};
+            break;
+        fi
+    done
+
+    echo ${free_port}
+}
+
+# gets a free port for a service in a BATS test run
+# the output port is from an allocated range in ports.json
+# usage: get_free_port_for_service service_name
+function get_free_port_for_service() {
+    svc_name="$1"
+
+    dir_name=$(basename ${BATS_TEST_DIRNAME})
+    file_name=$(basename ${BATS_TEST_FILENAME})
+    test_file_name="${dir_name}/${file_name}"
+
+    # lookup info in ports.json
+    service_obj=$(jq ".\"${test_file_name}\".${svc_name}" ${PORTS_JSON_PATH})
+    [ "0" -eq $? ] || exit 1
+
+    range_start=$(echo "${service_obj}" | jq '.begin')
+    [ "0" -eq $? ] || exit 1
+
+    range_end=$(echo "${service_obj}" | jq '.end')
+    [ "0" -eq $? ] || exit 1
+
+    echo "# fetching free port for service ${svc_name} in ${test_file_name} range ${range_start} to ${range_end}" >&3
+
+    free_port=$(get_free_port_in_range ${range_start} ${range_end})
+    echo "# returning free port for service ${svc_name} in ${test_file_name} => ${free_port}" >&3
+
+    echo ${free_port}
+}

--- a/test/ports.json
+++ b/test/ports.json
@@ -1,0 +1,396 @@
+{
+  "blackbox/annotations.bats": {
+    "zot": {
+      "begin": 1300,
+      "end": 1309
+    }
+  },
+  "blackbox/anonymous_policy.bats": {
+    "zot": {
+      "begin": 1320,
+      "end": 1329
+    }
+  },
+  "blackbox/cve.bats": {
+    "zot": {
+      "begin": 1340,
+      "end": 1349
+    }
+  },
+  "blackbox/delete_images.bats": {
+    "zot": {
+      "begin": 1360,
+      "end": 1369
+    }
+  },
+  "blackbox/detect_manifest_collision.bats": {
+    "zot": {
+      "begin": 1380,
+      "end": 1389
+    }
+  },
+  "blackbox/docker_compat.bats": {
+    "zot": {
+      "begin": 1400,
+      "end": 1409
+    }
+  },
+  "blackbox/events_config_decoding.bats": {
+    "zot1": {
+      "begin": 1420,
+      "end": 1429
+    },
+    "zot2": {
+      "begin": 1440,
+      "end": 1449
+    }
+  },
+  "blackbox/events_http_lint_failure.bats": {
+    "http": {
+      "begin": 1460,
+      "end": 1469
+    },
+    "zot": {
+      "begin": 1480,
+      "end": 1489
+    }
+  },
+  "blackbox/events_http.bats": {
+    "http": {
+      "begin": 1500,
+      "end": 1509
+    },
+    "zot": {
+      "begin": 1520,
+      "end": 1529
+    }
+  },
+  "blackbox/events_nats_lint_failure.bats": {
+    "nats": {
+      "begin": 1540,
+      "end": 1549
+    },
+    "zot": {
+      "begin": 1560,
+      "end": 1569
+    }
+  },
+  "blackbox/events_nats.bats": {
+    "nats": {
+      "begin": 1580,
+      "end": 1589
+    },
+    "zot": {
+      "begin": 1600,
+      "end": 1609
+    }
+  },
+  "blackbox/events_sink_failure.bats": {
+    "http": {
+      "begin": 1620,
+      "end": 1629
+    },
+    "zot": {
+      "begin": 1640,
+      "end": 1649
+    }
+  },
+  "blackbox/garbage_collect.bats": {
+    "zot": {
+      "begin": 1660,
+      "end": 1669
+    }
+  },
+  "blackbox/metadata.bats": {
+    "zot": {
+      "begin": 1680,
+      "end": 1689
+    }
+  },
+  "blackbox/metrics_minimal.bats": {
+    "zot": {
+      "begin": 1700,
+      "end": 1709
+    }
+  },
+  "blackbox/metrics.bats": {
+    "zot": {
+      "begin": 1720,
+      "end": 1729
+    }
+  },
+  "blackbox/multiarch_index.bats": {
+    "zot": {
+      "begin": 1740,
+      "end": 1749
+    }
+  },
+  "blackbox/pushpull_authn.bats": {
+    "zot": {
+      "begin": 1760,
+      "end": 1769
+    }
+  },
+  "blackbox/pushpull_running_dedupe.bats": {
+    "zot": {
+      "begin": 1780,
+      "end": 1789
+    }
+  },
+  "blackbox/pushpull.bats": {
+    "zot": {
+      "begin": 1800,
+      "end": 1809
+    }
+  },
+  "blackbox/redis_local.bats": {
+    "redis": {
+      "begin": 1820,
+      "end": 1829
+    },
+    "zot": {
+      "begin": 1840,
+      "end": 1849
+    }
+  },
+  "blackbox/redis_s3.bats": {
+    "redis": {
+      "begin": 1860,
+      "end": 1869
+    },
+    "zot": {
+      "begin": 1880,
+      "end": 1889
+    }
+  },
+  "blackbox/referrers.bats": {
+    "zot": {
+      "begin": 1900,
+      "end": 1909
+    }
+  },
+  "blackbox/restore_s3_blobs.bats": {
+    "zot": {
+      "begin": 1920,
+      "end": 1929
+    }
+  },
+  "blackbox/scrub.bats": {
+    "zot": {
+      "begin": 1940,
+      "end": 1949
+    }
+  },
+  "blackbox/sync_cloud.bats": {
+    "zot1": {
+      "begin": 1960,
+      "end": 1969
+    },
+    "zot2": {
+      "begin": 1980,
+      "end": 1989
+    },
+    "zot3": {
+      "begin": 2000,
+      "end": 2009
+    }
+  },
+  "blackbox/sync_docker.bats": {
+    "zot": {
+      "begin": 2020,
+      "end": 2029
+    }
+  },
+  "blackbox/sync_harness.bats": {
+    "zot_sync": {
+      "begin": 2040,
+      "end": 2049
+    },
+    "zot_min": {
+      "begin": 2060,
+      "end": 2069
+    }
+  },
+  "blackbox/sync_replica_cluster.bats": {
+    "zot1": {
+      "begin": 2080,
+      "end": 2089
+    },
+    "zot2": {
+      "begin": 3000,
+      "end": 3009
+    }
+  },
+  "blackbox/sync.bats": {
+    "zot1": {
+      "begin": 3020,
+      "end": 3029
+    },
+    "zot2": {
+      "begin": 3040,
+      "end": 3049
+    },
+    "zot3": {
+      "begin": 3060,
+      "end": 3069
+    }
+  },
+  "scale-out/cloud_scale_out_basic_auth_tls_scale.bats": {
+    "zot0": {
+      "begin": 6000,
+      "end": 6009
+    },
+    "zot1": {
+      "begin": 6020,
+      "end": 6029
+    },
+    "zot2": {
+      "begin": 6040,
+      "end": 6049
+    },
+    "zot3": {
+      "begin": 6060,
+      "end": 6069
+    },
+    "zot4": {
+      "begin": 6080,
+      "end": 6089
+    },
+    "zot5": {
+      "begin": 7000,
+      "end": 7009
+    },
+    "haproxy": {
+      "begin": 8300,
+      "end": 8350
+    }
+  },
+  "scale-out/cloud_scale_out_basic_auth_tls.bats": {
+    "zot0": {
+      "begin": 7020,
+      "end": 7029
+    },
+    "zot1": {
+      "begin": 7040,
+      "end": 7049
+    },
+    "zot2": {
+      "begin": 7060,
+      "end": 7069
+    },
+    "zot3": {
+      "begin": 7080,
+      "end": 7089
+    },
+    "zot4": {
+      "begin": 11000,
+      "end": 11009
+    },
+    "zot5": {
+      "begin": 11020,
+      "end": 11029
+    },
+    "haproxy": {
+      "begin": 8400,
+      "end": 8450
+    }
+  },
+  "scale-out/cloud_scale_out_no_auth.bats": {
+    "zot0": {
+      "begin": 11040,
+      "end": 11049
+    },
+    "zot1": {
+      "begin": 11060,
+      "end": 11069
+    },
+    "zot2": {
+      "begin": 11080,
+      "end": 11089
+    },
+    "zot3": {
+      "begin": 11100,
+      "end": 11109
+    },
+    "zot4": {
+      "begin": 11120,
+      "end": 11129
+    },
+    "zot5": {
+      "begin": 11140,
+      "end": 11149
+    },
+    "haproxy": {
+      "begin": 8500,
+      "end": 8550
+    }
+  },
+  "scale-out/cloud_scale_out_redis_scale.bats": {
+    "redis": {
+      "begin": 20000,
+      "end": 20009
+    },
+    "zot0": {
+      "begin": 11160,
+      "end": 11169
+    },
+    "zot1": {
+      "begin": 11180,
+      "end": 11189
+    },
+    "zot2": {
+      "begin": 11200,
+      "end": 11209
+    },
+    "zot3": {
+      "begin": 11220,
+      "end": 11229
+    },
+    "zot4": {
+      "begin": 11240,
+      "end": 11249
+    },
+    "zot5": {
+      "begin": 11260,
+      "end": 11269
+    },
+    "haproxy": {
+      "begin": 8600,
+      "end": 8650
+    }
+  },
+  "scale-out/cloud_scale_out_redis.bats": {
+    "redis": {
+      "begin": 20020,
+      "end": 20029
+    },
+    "zot0": {
+      "begin": 11280,
+      "end": 11289
+    },
+    "zot1": {
+      "begin": 11300,
+      "end": 11309
+    },
+    "zot2": {
+      "begin": 11320,
+      "end": 11329
+    },
+    "zot3": {
+      "begin": 11340,
+      "end": 11349
+    },
+    "zot4": {
+      "begin": 11360,
+      "end": 11369
+    },
+    "zot5": {
+      "begin": 11380,
+      "end": 11389
+    },
+    "haproxy": {
+      "begin": 8700,
+      "end": 8750
+    }
+  }
+}

--- a/test/scale-out/cloud_scale_out_basic_auth_tls.bats
+++ b/test/scale-out/cloud_scale_out_basic_auth_tls.bats
@@ -8,6 +8,7 @@ ZOT_LOG_DIR=/tmp/zot-ft-logs/auth-tls
 load helpers_zot
 load helpers_cloud
 load helpers_haproxy
+load ../port_helper
 
 function launch_zot_server() {
     local zot_server_address=${1}
@@ -45,16 +46,26 @@ function setup() {
     # setup htpasswd for local auth
     setup_local_htpasswd
 
-    generate_zot_cluster_member_list ${NUM_ZOT_INSTANCES} ${ZOT_CLUSTER_MEMBERS_PATCH_FILE}
-
+    # generate the free ports list
+    zot_srv_ports=()
     for ((i=0;i<${NUM_ZOT_INSTANCES};i++)); do
-        launch_zot_server 127.0.0.1 $(( 10000 + $i ))
+        port=$(get_free_port_for_service "zot${i}")
+        zot_srv_ports+=("${port}")
+    done
+
+    generate_zot_cluster_member_list ${NUM_ZOT_INSTANCES} ${ZOT_CLUSTER_MEMBERS_PATCH_FILE} "${zot_srv_ports[@]}"
+
+    for inst in "${zot_srv_ports[@]}"; do
+        launch_zot_server 127.0.0.1 ${inst}
     done
 
     # list all zot processes that were started
     ps -ef | grep ".*zot.*serve.*" | grep -v grep >&3
 
-    generate_haproxy_config ${HAPROXY_CFG_FILE} "https"
+    haproxy_port=$(get_free_port_for_service "haproxy")
+    echo ${haproxy_port} > ${BATS_FILE_TMPDIR}/haproxy.port
+
+    generate_haproxy_config ${HAPROXY_CFG_FILE} "https" ${haproxy_port} "${zot_srv_ports[@]}"
     haproxy_start ${HAPROXY_CFG_FILE}
 
     # list haproxy processes that were started
@@ -70,6 +81,8 @@ function teardown() {
 }
 
 @test "Check for successful zb run on haproxy frontend" {
+    haproxy_port=`cat ${BATS_FILE_TMPDIR}/haproxy.port`
+
     # zb_run <test_name> <zot_address> <concurrency> <num_requests> <credentials (optional)>
-    zb_run "cloud-scale-out-basic-auth-tls-bats" "https://127.0.0.1:8000" 3 5 "${ZOT_AUTH_USER}:${ZOT_AUTH_PASS}"
+    zb_run "cloud-scale-out-basic-auth-tls-bats" "https://127.0.0.1:${haproxy_port}" 3 5 "${ZOT_AUTH_USER}:${ZOT_AUTH_PASS}"
 }

--- a/test/scale-out/cloud_scale_out_redis_scale.bats
+++ b/test/scale-out/cloud_scale_out_redis_scale.bats
@@ -9,6 +9,7 @@ load helpers_zot
 load helpers_cloud
 load helpers_haproxy
 load helpers_redis
+load ../port_helper
 
 function verify_prerequisites() {
     if [ ! $(command -v docker) ]; then
@@ -48,21 +49,31 @@ function setup() {
     fi
 
     # setup Redis server
-    redis_port=$(get_free_port)
+    redis_port=$(get_free_port_for_service "redis")
     redis_start redis_server ${redis_port}
     local redis_url="redis://127.0.0.1:${redis_port}"
     
     # setup S3 bucket and DynamoDB tables
     setup_cloud_services
 
+    # generate the free ports list
+    zot_srv_ports=()
     for ((i=0;i<${NUM_ZOT_INSTANCES};i++)); do
-        launch_zot_server 127.0.0.1 $(( 10000 + $i )) ${redis_url}
+        port=$(get_free_port_for_service "zot${i}")
+        zot_srv_ports+=("${port}")
+    done
+
+    for inst in "${zot_srv_ports[@]}"; do
+        launch_zot_server 127.0.0.1 ${inst} ${redis_url}
     done
 
     # list all zot processes that were started
     ps -ef | grep ".*zot.*serve.*" | grep -v grep >&3
 
-    generate_haproxy_config ${HAPROXY_CFG_FILE} "http"
+    haproxy_port=$(get_free_port_for_service "haproxy")
+    echo ${haproxy_port} > ${BATS_FILE_TMPDIR}/haproxy.port
+
+    generate_haproxy_config ${HAPROXY_CFG_FILE} "http" ${haproxy_port} "${zot_srv_ports[@]}"
     haproxy_start ${HAPROXY_CFG_FILE}
 
     # list HAproxy processes that were started
@@ -79,6 +90,8 @@ function teardown() {
 }
 
 @test "Check for successful zb run on haproxy frontend with Redis cache (high scale)" {
+    haproxy_port=`cat ${BATS_FILE_TMPDIR}/haproxy.port`
+
     # zb_run <test_name> <zot_address> <concurrency> <num_requests> <credentials (optional)>
-    zb_run "cloud-scale-out-redis-scale-bats" "http://127.0.0.1:8000" 10 100
+    zb_run "cloud-scale-out-redis-scale-bats" "http://127.0.0.1:${haproxy_port}" 10 100
 } 


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
In multiple CI runs, there is often a port overlap where `get_free_port` tests and returns a random port, but before a server can bind to it, another process binds to it and causes a test failure unrelated to the changes.

**What does this PR do / Why do we need it**:
- Replaces the get_free_port bash function in BATS tests with get_free_port_for_service that returns a random free port in a given range for a test file and service defined in a ports.json file.
- Updates all get_free_port calls to use the new function.
- A new README file for details on the ports.json file.
- Updates some tests using fixed ports to use dynamic ports.
- Adds a ports.json file with all the allocations.
- Adds a new common helper for port fetching.

**If an issue # is not available please add repro steps and logs showing the issue**:
Seen in multiple CI runs

```
docker: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint http_receiver_lint (e519fd55200c97533f0245fcca501d6621be0e89f36923775f8812d7793fe3a4): failed to bind host port for 0.0.0.0:38494:172.17.0.5:8080/tcp: address already in use
```

**Testing done on this change**:
CI run should succeed

**Will this break upgrades or downgrades?**
N/A

**Does this PR introduce any user-facing change?**:
No user facing changes. Developers adding BATS tests must note the fixed port range allocations and make changes accordingly. README in the test directory has more details.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
