### PR TITLE
ci: update stale checks

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -18,10 +18,12 @@ jobs:
           stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
           close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
-          days-before-issue-stale: 30
-          days-before-pr-stale: 45
+          days-before-issue-stale: 90
+          days-before-pr-stale: 90
           days-before-issue-close: 5
           days-before-pr-close: 10
+          operations-per-run: 60
+          ascending: true
           stale-issue-label: 'no-issue-activity'
           exempt-issue-labels: 'awaiting-approval,work-in-progress'
           stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
Since the job for triaging stale issues started running last week, it has been mainly running for recent issues.
Also 30 days of issue inactivity is too low at this moment.

Update to 90 days, and force it to start processing older issues/PRs first.
Increase the number of operations per execution, processing more issues/PRs per run.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
