### PR TITLE
feat: the default retention delay is not the GC delay

### DIFF
--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -290,9 +290,7 @@ func New() *Config {
 				GC:         true,
 				GCDelay:    storageConstants.DefaultGCDelay,
 				GCInterval: storageConstants.DefaultGCInterval,
-				Retention: ImageRetention{
-					Delay: storageConstants.DefaultRetentionDelay,
-				},
+				Retention:  ImageRetention{},
 			},
 		},
 		HTTP: HTTPConfig{Address: "127.0.0.1", Port: "8080", Auth: &AuthConfig{FailDelay: 0}},

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -724,6 +724,10 @@ func applyDefaultValues(config *config.Config, viperInstance *viper.Viper, logge
 		if viperInstance.Get("storage::gcinterval") == nil {
 			config.Storage.GCInterval = 0
 		}
+	} else if !viperInstance.IsSet("storage::retention::delay") {
+		// if GC is enabled, retentionDelay is set to gcDelay by default
+		// it could be default gcDelay or the custom value set in the config file
+		config.Storage.Retention.Delay = config.Storage.GCDelay
 	}
 
 	// apply deleteUntagged default
@@ -802,7 +806,9 @@ func applyDefaultValues(config *config.Config, viperInstance *viper.Viper, logge
 
 			// and retentionDelay is not set, it is set to default value
 			if !viperInstance.IsSet("storage::subpaths::" + name + "::retention::delay") {
-				storageConfig.Retention.Delay = storageConstants.DefaultRetentionDelay
+				// retentionDelay is set to gcDelay by default
+				// it could be default gcDelay or the custom value set in the config file
+				storageConfig.Retention.Delay = storageConfig.GCDelay
 			}
 
 			// and gcInterval is not set, it is set to default value

--- a/pkg/storage/constants/constants.go
+++ b/pkg/storage/constants/constants.go
@@ -22,7 +22,6 @@ const (
 	RedisDriverName         = "redis"
 	RedisLocksBucket        = "locks"
 	DefaultGCDelay          = 1 * time.Hour
-	DefaultRetentionDelay   = 24 * time.Hour
 	DefaultGCInterval       = 1 * time.Hour
 	S3StorageDriverName     = "s3"
 	LocalStorageDriverName  = "local"

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -52,7 +52,7 @@ func TestGarbageCollectManifestErrors(t *testing.T) {
 		gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, Options{
 			Delay: storageConstants.DefaultGCDelay,
 			ImageRetention: config.ImageRetention{
-				Delay: storageConstants.DefaultRetentionDelay,
+				Delay: storageConstants.DefaultGCDelay,
 				Policies: []config.RetentionPolicy{
 					{
 						Repositories:    []string{"**"},
@@ -176,7 +176,7 @@ func TestGarbageCollectIndexErrors(t *testing.T) {
 		gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, Options{
 			Delay: storageConstants.DefaultGCDelay,
 			ImageRetention: config.ImageRetention{
-				Delay: storageConstants.DefaultRetentionDelay,
+				Delay: storageConstants.DefaultGCDelay,
 				Policies: []config.RetentionPolicy{
 					{
 						Repositories:    []string{"**"},
@@ -291,7 +291,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 		gcOptions := Options{
 			Delay: storageConstants.DefaultGCDelay,
 			ImageRetention: config.ImageRetention{
-				Delay: storageConstants.DefaultRetentionDelay,
+				Delay: storageConstants.DefaultGCDelay,
 				Policies: []config.RetentionPolicy{
 					{
 						Repositories:    []string{"**"},
@@ -338,7 +338,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			gcOptions := Options{
 				Delay: storageConstants.DefaultGCDelay,
 				ImageRetention: config.ImageRetention{
-					Delay: storageConstants.DefaultRetentionDelay,
+					Delay: storageConstants.DefaultGCDelay,
 					Policies: []config.RetentionPolicy{
 						{
 							Repositories: []string{"**"},
@@ -366,7 +366,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			gcOptions := Options{
 				Delay: storageConstants.DefaultGCDelay,
 				ImageRetention: config.ImageRetention{
-					Delay: storageConstants.DefaultRetentionDelay,
+					Delay: storageConstants.DefaultGCDelay,
 					Policies: []config.RetentionPolicy{
 						{
 							Repositories: []string{"**"},

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -346,7 +346,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -765,7 +765,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -831,7 +831,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -894,7 +894,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -933,7 +933,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -971,7 +971,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -1009,7 +1009,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -1049,7 +1049,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -1134,7 +1134,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -1215,7 +1215,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: gcDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -1935,7 +1935,7 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -2282,7 +2282,7 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -2342,7 +2342,7 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -2397,7 +2397,7 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -2434,7 +2434,7 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},
@@ -2539,7 +2539,7 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
 						Delay: gcDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -48,7 +48,7 @@ const (
 var trueVal bool = true //nolint: gochecknoglobals
 
 var DeleteReferrers = config.ImageRetention{ //nolint: gochecknoglobals
-	Delay: storageConstants.DefaultRetentionDelay,
+	Delay: storageConstants.DefaultGCDelay,
 	Policies: []config.RetentionPolicy{
 		{
 			Repositories:    []string{"**"},

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -48,7 +48,7 @@ import (
 var trueVal bool = true //nolint: gochecknoglobals
 
 var DeleteReferrers = config.ImageRetention{ //nolint: gochecknoglobals
-	Delay: storageConstants.DefaultRetentionDelay,
+	Delay: storageConstants.DefaultGCDelay,
 	Policies: []config.RetentionPolicy{
 		{
 			Repositories:    []string{"**"},
@@ -1812,7 +1812,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					gc := gc.NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gc.Options{
 						Delay: storageConstants.DefaultGCDelay,
 						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultRetentionDelay,
+							Delay: storageConstants.DefaultGCDelay,
 							Policies: []config.RetentionPolicy{
 								{
 									Repositories:    []string{"**"},


### PR DESCRIPTION
Most users don't make the difference between retention deleting untagged manifests vs GC deleting other blobs.
This may cause confusion since the GC delay and the retention delay (used for untagged manifests and orphan referrers) have different defaults, and are set separately in the zot configuration.
Most users don't configure retention policies, and they still expect untagged manifests to be deleted at GC time.

With this change, if retention delay is not specified in the config file, the value used is the GC delay. If GC delay is also unspecified in the config file, the default GC delay is used for both.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
