### PR TITLE
ci: debugging blackbox failures

### DIFF
--- a/test/blackbox/helpers_zot.bash
+++ b/test/blackbox/helpers_zot.bash
@@ -21,7 +21,10 @@ function zot_serve() {
 
 # stops all zot instances started by the test
 function zot_stop_all() {
-    kill $(cat ${BATS_FILE_TMPDIR}/zot.pid)
+    if [ -f "${BATS_FILE_TMPDIR}/zot.pid" ]; then
+        kill $(cat ${BATS_FILE_TMPDIR}/zot.pid) 2>/dev/null || true
+        rm -f ${BATS_FILE_TMPDIR}/zot.pid
+    fi
 }
 
 function wait_zot_reachable() {


### PR DESCRIPTION
We had a failure in https://github.com/project-zot/zot/actions/runs/18458667992/job/52584890182. Let's add more debug messages and increase timeouts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
