### PR TITLE
fix: configure cookie Secure flag based on TLS configuration

### DIFF
--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -1989,6 +1989,83 @@ func TestConfig(t *testing.T) {
 			So(cfg.IsMTLSAuthEnabled(), ShouldBeTrue) // No basic auth, so mTLS enabled
 		})
 
+		Convey("Test UseSecureSession()", func() {
+			// Test with nil Config
+			var cfg *config.Config = nil
+
+			So(cfg.UseSecureSession(), ShouldBeFalse)
+
+			// Test with Config but no TLS and no Auth
+			cfg = &config.Config{
+				HTTP: config.HTTPConfig{
+					TLS:  nil,
+					Auth: nil,
+				},
+			}
+			So(cfg.UseSecureSession(), ShouldBeFalse)
+
+			// Test with TLS configured (should return true)
+			cfg = &config.Config{
+				HTTP: config.HTTPConfig{
+					TLS: &config.TLSConfig{
+						Cert: "/path/to/cert.pem",
+						Key:  "/path/to/key.pem",
+					},
+				},
+			}
+			So(cfg.UseSecureSession(), ShouldBeTrue)
+
+			// Test with no TLS but SecureSession explicitly set to true
+			secureTrue := true
+			cfg = &config.Config{
+				HTTP: config.HTTPConfig{
+					TLS: nil,
+					Auth: &config.AuthConfig{
+						SecureSession: &secureTrue,
+					},
+				},
+			}
+			So(cfg.UseSecureSession(), ShouldBeTrue)
+
+			// Test with no TLS but SecureSession explicitly set to false
+			secureFalse := false
+			cfg = &config.Config{
+				HTTP: config.HTTPConfig{
+					TLS: nil,
+					Auth: &config.AuthConfig{
+						SecureSession: &secureFalse,
+					},
+				},
+			}
+			So(cfg.UseSecureSession(), ShouldBeFalse)
+
+			// Test with no TLS and Auth but SecureSession not set
+			cfg = &config.Config{
+				HTTP: config.HTTPConfig{
+					TLS: nil,
+					Auth: &config.AuthConfig{
+						APIKey: true,
+					},
+				},
+			}
+			So(cfg.UseSecureSession(), ShouldBeFalse)
+
+			// Test with TLS configured and SecureSession set (TLS should take precedence)
+			secureTrue = true
+			cfg = &config.Config{
+				HTTP: config.HTTPConfig{
+					TLS: &config.TLSConfig{
+						Cert: "/path/to/cert.pem",
+						Key:  "/path/to/key.pem",
+					},
+					Auth: &config.AuthConfig{
+						SecureSession: &secureTrue,
+					},
+				},
+			}
+			So(cfg.UseSecureSession(), ShouldBeTrue) // TLS takes precedence
+		})
+
 		Convey("Test IsCompatEnabled()", func() {
 			// Test with nil Config
 			var cfg *config.Config = nil

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -5779,10 +5779,12 @@ func TestAuthnSessionErrors(t *testing.T) {
 			})
 
 			Convey("web request without cookies", func() {
-				client.SetCookie(&http.Cookie{})
+				// Create a new client without cookies to test unauthorized access
+				clientWithoutCookies := resty.New()
+				clientWithoutCookies.SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue)
 
-				// call endpoint with session (added to client after previous request)
-				resp, err = client.R().
+				// call endpoint without session cookies
+				resp, err = clientWithoutCookies.R().
 					SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
 					Get(baseURL + "/v2/_catalog")
 				So(err, ShouldBeNil)


### PR DESCRIPTION
Make the Secure flag for session cookies configurable based on Zot's TLS settings. This allows cookies to work properly when Zot is accessed over HTTP (without TLS).

Changes:
- Add SecureSession field to AuthConfig to allow explicit control
- Add UseSecureSession() method that returns true when TLS is configured, or uses SecureSession setting if provided
- Update saveUserLoggedSession() to accept and use secure parameter
- Add tests for UseSecureSession() in config_test.go
- Enhance authn tests to verify cookie Secure flag behavior
- Fix TestAuthnSessionErrors by creating new client without cookies

The logic is:
- If TLS is configured, cookies always have Secure=true
- If TLS is not configured but SecureSession is explicitly set, use that value
- Otherwise, default to Secure=false for HTTP-only deployments

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
