### PR TITLE
fix(log): ensure func record is correct

### DIFF
--- a/pkg/cli/server/config_reloader_test.go
+++ b/pkg/cli/server/config_reloader_test.go
@@ -494,11 +494,13 @@ func TestConfigReloader(t *testing.T) {
 		// wait for config reload
 		time.Sleep(5 * time.Second)
 
+		// Wait for the async trivy download to fail and log the error
 		found, err := test.ReadLogFileAndSearchString(logFile.Name(),
 			"failed to download trivy-db to destination dir", 30*time.Second)
 		So(err, ShouldBeNil)
 		So(found, ShouldBeTrue)
 
+		// Now read the file once and check all the expected log content
 		data, err := os.ReadFile(logFile.Name())
 		So(err, ShouldBeNil)
 		t.Logf("log file: %s", data)
@@ -508,9 +510,12 @@ func TestConfigReloader(t *testing.T) {
 		So(string(data), ShouldContainSubstring, "\"UpdateInterval\":18000000000000")
 		So(string(data), ShouldContainSubstring, "\"Scrub\":null")
 		So(string(data), ShouldContainSubstring, "\"DBRepository\":\"another/unreachable/trivy/url2\"")
-		// matching log message when it errors out, test that indeed the download will try the second url
+
+		// Just verify the new URL appears in the logs to confirm config reload worked and ignore
+		// the order of json message formatting that can change independent of this functional
+		// test.
 		found, err = test.ReadLogFileAndSearchString(logFile.Name(),
-			"\"dbRepository\":\"index.docker.io/another/unreachable/trivy/url2:2\",\"goroutine", 1*time.Minute)
+			"index.docker.io/another/unreachable/trivy/url2", 1*time.Minute)
 		So(err, ShouldBeNil)
 		So(found, ShouldBeTrue)
 	})

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -340,3 +340,85 @@ func TestNewAuditLogger(t *testing.T) {
 		}, ShouldPanic)
 	})
 }
+
+func TestCallerFunction(t *testing.T) {
+	var buf bytes.Buffer
+	logger := log.NewLoggerWithWriter("debug", &buf)
+
+	// Test case 1: Simple log without chaining
+	logger.Info().Msg("test message 1")
+	output1 := buf.String()
+
+	if !strings.Contains(output1, "test message 1") {
+		t.Errorf("Expected output to contain 'test message 1', got: %s", output1)
+	}
+
+	if !strings.Contains(output1, "TestCallerFunction") {
+		t.Errorf("Expected output to contain 'TestCallerFunction', got: %s", output1)
+	}
+
+	if strings.Contains(output1, "(*Event).Str") {
+		t.Errorf("Expected output NOT to contain '(*Event).Str', got: %s", output1)
+	}
+
+	// Reset buffer
+	buf.Reset()
+
+	// Test case 2: Log with Str() chaining (this was the problematic case)
+	logger.Info().Str("module", "test").Msg("test message 2")
+	output2 := buf.String()
+
+	if !strings.Contains(output2, "test message 2") {
+		t.Errorf("Expected output to contain 'test message 2', got: %s", output2)
+	}
+
+	if !strings.Contains(output2, "module") {
+		t.Errorf("Expected output to contain 'module', got: %s", output2)
+	}
+
+	if !strings.Contains(output2, "TestCallerFunction") {
+		t.Errorf("Expected output to contain 'TestCallerFunction', got: %s", output2)
+	}
+
+	if strings.Contains(output2, "(*Event).Str") {
+		t.Errorf("Expected output NOT to contain '(*Event).Str', got: %s", output2)
+	}
+
+	// Reset buffer
+	buf.Reset()
+
+	// Test case 3: Log with multiple chainings
+	logger.Error().Str("module", "test").Str("error", "something").Msg("test error message")
+	output3 := buf.String()
+
+	if !strings.Contains(output3, "test error message") {
+		t.Errorf("Expected output to contain 'test error message', got: %s", output3)
+	}
+
+	if !strings.Contains(output3, "TestCallerFunction") {
+		t.Errorf("Expected output to contain 'TestCallerFunction', got: %s", output3)
+	}
+
+	if strings.Contains(output3, "(*Event).Str") {
+		t.Errorf("Expected output NOT to contain '(*Event).Str', got: %s", output3)
+	}
+
+	// Reset buffer
+	buf.Reset()
+
+	// Test case 4: Debug with Int
+	logger.Debug().Int("count", 42).Msg("test debug message")
+	output4 := buf.String()
+
+	if !strings.Contains(output4, "test debug message") {
+		t.Errorf("Expected output to contain 'test debug message', got: %s", output4)
+	}
+
+	if !strings.Contains(output4, "TestCallerFunction") {
+		t.Errorf("Expected output to contain 'TestCallerFunction', got: %s", output4)
+	}
+
+	if strings.Contains(output4, "(*Event).Int") {
+		t.Errorf("Expected output NOT to contain '(*Event).Int', got: %s", output4)
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:

The "func" field in log output is incorrect in some cases and showing internal logging methods instead of the actual calling function. This is happening because the caller information is being captured statically (5 call frames) which can be different for different call patterns.

Changes:

* Move the caller capture to the event creation
* Use deterministic skip (3 frames) for event creation
* Add test cases to verify that the caller is captured correctly

Note: tests needed to written outside convey to avoid call insertion

**What does this PR do / Why do we need it**:

Fixes the logging to log the right caller function all the time.

**If an issue # is not available please add repro steps and logs showing the issue**:

```
{"time":"2025-10-29T07:48:26.089019762Z","level":"info","message":"executing gc of orphaned blobs for /data/zot/images/trinetra/observer","module":"gc","goroutine":54,"caller":"zotregistry.dev/zot/pkg/storage/gc/gc.go:89","func":"zotregistry.dev/zot/pkg/log.(*Event).Str"}
{"time":"2025-10-29T07:48:26.201378659Z","level":"debug","message":"manifests without tags","module":"gc","repository":"trinetra/observer","goroutine":54,"caller":"zotregistry.dev/zot/pkg/storage/gc/gc.go:479","func":"zotregistry.dev/zot/pkg/log.(*Event).Str"}
{"time":"2025-10-29T07:48:26.210318247Z","level":"debug","message":"cleaning orphan blobs","module":"gc","repository":"trinetra/observer","goroutine":54,"caller":"zotregistry.dev/zot/pkg/storage/gc/gc.go:613","func":"zotregistry.dev/zot/pkg/log.(*Event).Str"}
{"time":"2025-10-29T07:48:26.36994592Z","level":"error","message":"failed to run GC for /data/zot/images/trinetra/observer","error":"manifest not found","module":"gc","goroutine":54,"caller":"zotregistry.dev/zot/pkg/storage/gc/gc.go:93","func":"zotregistry.dev/zot/pkg/storage/gc.GarbageCollect.CleanRepo"}
{"time":"2025-10-29T07:48:26.369991399Z","level":"info","message":"gc unsuccessfully completed for /data/zot/images/trinetra/observer","module":"gc","goroutine":54,"caller":"zotregistry.dev/zot/pkg/storage/gc/gc.go:95","func":"zotregistry.dev/zot/pkg/log.(*Event).Str"}
```

**Testing done on this change**:

Added a test case with the PR that covers the changes.

**Automation added to e2e**:

Added a test case with the PR that covers the changes.

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
No

```release-note
improve zot logs for debuggability
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
