### PR TITLE
fix: gracefully handle manifests missing from storage (prepare for sparse indexes)

### DIFF
--- a/pkg/extensions/search/cve/scan_test.go
+++ b/pkg/extensions/search/cve/scan_test.go
@@ -384,6 +384,11 @@ func TestScanGeneratorWithMockedData(t *testing.T) { //nolint: gocyclo
 					return false, err
 				}
 
+				// If all manifests are missing (e.g., from an index), Manifests will be empty
+				if len(manifestData.Manifests) == 0 {
+					return false, nil
+				}
+
 				for _, imageLayer := range manifestData.Manifests[0].Manifest.Layers {
 					switch imageLayer.MediaType {
 					case ispec.MediaTypeImageLayerGzip, ispec.MediaTypeImageLayer, string(regTypes.DockerLayer):

--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -500,6 +500,11 @@ func getAllContainedMeta(imageBuck *bbolt.Bucket, imageIndexData *proto_go.Image
 
 		imageManifestData, err := getProtoImageMeta(imageBuck, manifest.Digest)
 		if err != nil {
+			// Skip manifests that don't have MetaDB entries (missing from storage)
+			if errors.Is(err, zerr.ErrImageMetaNotFound) {
+				continue
+			}
+
 			return imageMetaList, manifestDataList, err
 		}
 
@@ -511,6 +516,8 @@ func getAllContainedMeta(imageBuck *bbolt.Bucket, imageIndexData *proto_go.Image
 			compat.IsCompatibleManifestListMediaType(imageManifestData.MediaType) {
 			partialImageDataList, partialManifestDataList, err := getAllContainedMeta(imageBuck, imageManifestData)
 			if err != nil {
+				// getAllContainedMeta skips missing items internally, so any error returned
+				// is a real error that should be propagated
 				return imageMetaList, manifestDataList, err
 			}
 

--- a/pkg/meta/dynamodb/dynamodb_test.go
+++ b/pkg/meta/dynamodb/dynamodb_test.go
@@ -383,12 +383,15 @@ func TestWrapperErrors(t *testing.T) {
 				_, err := dynamoWrapper.GetImageMeta(testDigest)
 				So(err, ShouldNotBeNil)
 			})
-			Convey("image index, get manifest meta fails", func() {
+			Convey("image index, missing manifests are skipped gracefully", func() {
 				err := dynamoWrapper.SetRepoReference(ctx, "repo", "tag", multiarchImageMeta)
 				So(err, ShouldBeNil)
 
-				_, err = dynamoWrapper.GetImageMeta(multiarchImageMeta.Digest) //nolint: contextcheck
-				So(err, ShouldNotBeNil)
+				// Missing manifests are skipped gracefully, so GetImageMeta succeeds
+				// but returns an index with no manifests
+				imageMeta, err := dynamoWrapper.GetImageMeta(multiarchImageMeta.Digest) //nolint: contextcheck
+				So(err, ShouldBeNil)
+				So(len(imageMeta.Manifests), ShouldEqual, 0)
 			})
 		})
 		Convey("GetFullImageMeta", func() {
@@ -429,7 +432,7 @@ func TestWrapperErrors(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 
-			Convey("image is index, fail to get manifests", func() {
+			Convey("image is index, missing manifests are skipped gracefully", func() {
 				err := dynamoWrapper.SetImageMeta(multiarchImageMeta.Digest, multiarchImageMeta) //nolint: contextcheck
 				So(err, ShouldBeNil)
 
@@ -444,8 +447,11 @@ func TestWrapperErrors(t *testing.T) {
 				})
 				So(err, ShouldBeNil)
 
-				_, err = dynamoWrapper.GetFullImageMeta(ctx, "repo", "tag")
-				So(err, ShouldNotBeNil)
+				// Missing manifests are skipped gracefully, so GetFullImageMeta succeeds
+				// but returns an index with no manifests
+				fullImageMeta, err := dynamoWrapper.GetFullImageMeta(ctx, "repo", "tag")
+				So(err, ShouldBeNil)
+				So(len(fullImageMeta.Manifests), ShouldEqual, 0)
 			})
 		})
 

--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -2197,6 +2197,11 @@ func (rc *RedisDB) getAllContainedMeta(ctx context.Context, imageIndexData *prot
 
 		imageManifestData, err := rc.getProtoImageMeta(ctx, manifest.Digest)
 		if err != nil {
+			// Skip manifests that don't have MetaDB entries (missing from storage)
+			if errors.Is(err, zerr.ErrImageMetaNotFound) {
+				continue
+			}
+
 			return imageMetaList, manifestDataList, err
 		}
 
@@ -2208,6 +2213,8 @@ func (rc *RedisDB) getAllContainedMeta(ctx context.Context, imageIndexData *prot
 			compat.IsCompatibleManifestListMediaType(imageManifestData.MediaType) {
 			partialImageDataList, partialManifestDataList, err := rc.getAllContainedMeta(ctx, imageManifestData)
 			if err != nil {
+				// getAllContainedMeta skips missing items internally, so any error returned
+				// is a real error that should be propagated
 				return imageMetaList, manifestDataList, err
 			}
 

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -236,6 +236,15 @@ func (gc GarbageCollect) removeIndexReferrers(repo string, rootIndex *ispec.Inde
 		if (desc.MediaType == ispec.MediaTypeImageIndex) || compat.IsCompatibleManifestListMediaType(desc.MediaType) {
 			indexImage, err := common.GetImageIndex(gc.imgStore, repo, desc.Digest, gc.log)
 			if err != nil {
+				// Handle missing blobs (not found) gracefully
+				var pathNotFoundErr driver.PathNotFoundError
+				if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
+					gc.log.Warn().Err(err).Str("module", "gc").Str("repository", repo).Str("digest", desc.Digest.String()).
+						Msg("skipping missing image index blob, continuing GC")
+
+					continue
+				}
+
 				gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).Str("digest", desc.Digest.String()).
 					Msg("failed to read multiarch(index) image")
 
@@ -265,6 +274,15 @@ func (gc GarbageCollect) removeIndexReferrers(repo string, rootIndex *ispec.Inde
 		} else if (desc.MediaType == ispec.MediaTypeImageManifest) || compat.IsCompatibleManifestMediaType(desc.MediaType) {
 			image, err := common.GetImageManifest(gc.imgStore, repo, desc.Digest, gc.log)
 			if err != nil {
+				// Handle missing blobs (not found) gracefully
+				var pathNotFoundErr driver.PathNotFoundError
+				if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
+					gc.log.Warn().Err(err).Str("module", "gc").Str("repo", repo).Str("digest", desc.Digest.String()).
+						Msg("skipping missing image manifest blob, continuing GC")
+
+					continue
+				}
+
 				gc.log.Error().Err(err).Str("module", "gc").Str("repo", repo).Str("digest", desc.Digest.String()).
 					Msg("failed to read manifest image")
 
@@ -536,6 +554,15 @@ func (gc GarbageCollect) identifyManifestsReferencedInIndex(index ispec.Index, r
 		if (desc.MediaType == ispec.MediaTypeImageIndex) || compat.IsCompatibleManifestListMediaType(desc.MediaType) {
 			indexImage, err := common.GetImageIndex(gc.imgStore, repo, desc.Digest, gc.log)
 			if err != nil {
+				// Handle missing blobs (not found) gracefully
+				var pathNotFoundErr driver.PathNotFoundError
+				if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
+					gc.log.Warn().Err(err).Str("module", "gc").Str("repository", repo).
+						Str("digest", desc.Digest.String()).Msg("skipping missing image index blob, continuing GC")
+
+					continue
+				}
+
 				gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).
 					Str("digest", desc.Digest.String()).Msg("failed to read multiarch(index) image")
 
@@ -556,6 +583,15 @@ func (gc GarbageCollect) identifyManifestsReferencedInIndex(index ispec.Index, r
 		} else if (desc.MediaType == ispec.MediaTypeImageManifest) || compat.IsCompatibleManifestMediaType(desc.MediaType) {
 			image, err := common.GetImageManifest(gc.imgStore, repo, desc.Digest, gc.log)
 			if err != nil {
+				// Handle missing blobs (not found) gracefully
+				var pathNotFoundErr driver.PathNotFoundError
+				if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
+					gc.log.Warn().Err(err).Str("module", "gc").Str("repo", repo).
+						Str("digest", desc.Digest.String()).Msg("skipping missing image manifest blob, continuing GC")
+
+					continue
+				}
+
 				gc.log.Error().Err(err).Str("module", "gc").Str("repo", repo).
 					Str("digest", desc.Digest.String()).Msg("failed to read manifest image")
 
@@ -718,6 +754,15 @@ func (gc GarbageCollect) addImageIndexBlobsToReferences(repo string, mdigest god
 ) error {
 	index, err := common.GetImageIndex(gc.imgStore, repo, mdigest, gc.log)
 	if err != nil {
+		// Handle missing blobs (not found) gracefully
+		var pathNotFoundErr driver.PathNotFoundError
+		if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
+			gc.log.Warn().Err(err).Str("module", "gc").Str("repository", repo).Str("digest", mdigest.String()).
+				Msg("skipping missing image index blob, continuing GC")
+
+			return nil
+		}
+
 		gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).Str("digest", mdigest.String()).
 			Msg("failed to read manifest image")
 
@@ -743,6 +788,15 @@ func (gc GarbageCollect) addImageManifestBlobsToReferences(repo string, mdigest 
 ) error {
 	manifestContent, err := common.GetImageManifest(gc.imgStore, repo, mdigest, gc.log)
 	if err != nil {
+		// Handle missing blobs (not found) gracefully
+		var pathNotFoundErr driver.PathNotFoundError
+		if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
+			gc.log.Warn().Err(err).Str("module", "gc").Str("repository", repo).
+				Str("digest", mdigest.String()).Msg("skipping missing image manifest blob, continuing GC")
+
+			return nil
+		}
+
 		gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).
 			Str("digest", mdigest.String()).Msg("failed to read manifest image")
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1504,7 +1504,7 @@ func TestDeleteBlobsInUse(t *testing.T) {
 						So(err, ShouldBeNil)
 
 						ok, err := storageCommon.IsBlobReferenced(imgStore, repoName, unusedDigest, log)
-						So(err, ShouldNotBeNil)
+						So(err, ShouldBeNil)
 						So(ok, ShouldBeFalse)
 					})
 				}


### PR DESCRIPTION
GC and scrub should not stop if a manifest or index is missing from storage. Other similar changes are also included.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
