### PR TITLE
fix: deduplicate entries in referrers responses

### DIFF
--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -1187,11 +1187,18 @@ func (bdw *BoltDB) GetReferrersInfo(repo string, referredDigest godigest.Digest,
 		}
 
 		referrersInfo := protoRepoMeta.Referrers[referredDigest.String()].List
+		seenDigests := make(map[string]struct{})
 
 		for i := range referrersInfo {
 			if !common.MatchesArtifactTypes(referrersInfo[i].ArtifactType, artifactTypes) {
 				continue
 			}
+
+			if _, seen := seenDigests[referrersInfo[i].Digest]; seen {
+				continue
+			}
+
+			seenDigests[referrersInfo[i].Digest] = struct{}{}
 
 			referrersInfoResult = append(referrersInfoResult, mTypes.ReferrerInfo{
 				Digest:       referrersInfo[i].Digest,

--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -1117,11 +1117,18 @@ func (dwr *DynamoDB) GetReferrersInfo(repo string, referredDigest godigest.Diges
 	referrersInfo := repoMeta.Referrers[referredDigest.String()]
 
 	filteredResults := make([]mTypes.ReferrerInfo, 0, len(referrersInfo))
+	seenDigests := make(map[string]struct{})
 
 	for _, referrerInfo := range referrersInfo {
 		if !common.MatchesArtifactTypes(referrerInfo.ArtifactType, artifactTypes) {
 			continue
 		}
+
+		if _, seen := seenDigests[referrerInfo.Digest]; seen {
+			continue
+		}
+
+		seenDigests[referrerInfo.Digest] = struct{}{}
 
 		filteredResults = append(filteredResults, referrerInfo)
 	}

--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -1704,11 +1704,18 @@ func (rc *RedisDB) GetReferrersInfo(repo string, referredDigest godigest.Digest,
 	}
 
 	referrersInfo := protoRepoMeta.Referrers[referredDigest.String()].List
+	seenDigests := make(map[string]struct{})
 
 	for i := range referrersInfo {
 		if !common.MatchesArtifactTypes(referrersInfo[i].ArtifactType, artifactTypes) {
 			continue
 		}
+
+		if _, seen := seenDigests[referrersInfo[i].Digest]; seen {
+			continue
+		}
+
+		seenDigests[referrersInfo[i].Digest] = struct{}{}
 
 		referrersInfoResult = append(referrersInfoResult, mTypes.ReferrerInfo{
 			Digest:       referrersInfo[i].Digest,

--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -666,11 +666,20 @@ func GetReferrers(imgStore storageTypes.ImageStore, repo string, gdigest godiges
 	}
 
 	result := []ispec.Descriptor{}
+	seenDigests := make(map[godigest.Digest]struct{})
 
 	for _, descriptor := range index.Manifests {
 		if descriptor.Digest == gdigest {
 			continue
 		}
+
+		// Skip if we've already processed this digest
+		if _, seen := seenDigests[descriptor.Digest]; seen {
+			continue
+		}
+
+		// Mark as seen early to avoid processing duplicates
+		seenDigests[descriptor.Digest] = struct{}{}
 
 		buf, err := imgStore.GetBlobContent(repo, descriptor.Digest)
 		if err != nil {


### PR DESCRIPTION
See: https://github.com/project-zot/zot/issues/2506

Note we are not losing anything functionality-wise by making this change.
Initially, we considered the tags are in the annotations present in the referrers,
but the only annotations we set on referrers are the ones inside the manifests themselves,
not the ones in the manifest descriptors, so the tags were not present anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
