### PR TITLE
Fix Dockerfiles by moving the BASE_IMAGE arg  into the global scope

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,14 @@
 # ---
+# Global ARGs for FROM statements
+# This needs to be declared in the global scope otherwise the build will fail in Docker & Podman.
+# Docker:
+#   WARNING: UndefinedArgInFrom - https://docs.docker.com/go/dockerfile/rule/undefined-arg-in-from/
+#   FROM argument 'BASE_IMAGE' is not declared
+# Podman: Error: determining starting point for build: no FROM statement found
+# ---
+ARG BASE_IMAGE
+
+# ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
 FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.24 AS builder
@@ -28,7 +38,6 @@ RUN echo '{\n\
 # ---
 # Stage 2: Final image with nothing but certs, binary, and default config file
 # ---
-ARG BASE_IMAGE
 FROM $BASE_IMAGE AS final
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-conformance
+++ b/build/Dockerfile-conformance
@@ -1,4 +1,14 @@
 # ---
+# Global ARGs for FROM statements
+# This needs to be declared in the global scope otherwise the build will fail in Docker & Podman.
+# Docker:
+#   WARNING: UndefinedArgInFrom - https://docs.docker.com/go/dockerfile/rule/undefined-arg-in-from/
+#   FROM argument 'BASE_IMAGE' is not declared
+# Podman: Error: determining starting point for build: no FROM statement found
+# ---
+ARG BASE_IMAGE
+
+# ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
 FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.24 AS builder
@@ -24,7 +34,6 @@ storage:\n\
 # ---
 # Stage 2: Final image with nothing but certs, binary, and default config file
 # ---
-ARG BASE_IMAGE
 FROM $BASE_IMAGE AS final
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-minimal
+++ b/build/Dockerfile-minimal
@@ -1,4 +1,14 @@
 # ---
+# Global ARGs for FROM statements
+# This needs to be declared in the global scope otherwise the build will fail in Docker & Podman.
+# Docker:
+#   WARNING: UndefinedArgInFrom - https://docs.docker.com/go/dockerfile/rule/undefined-arg-in-from/
+#   FROM argument 'BASE_IMAGE' is not declared
+# Podman: Error: determining starting point for build: no FROM statement found
+# ---
+ARG BASE_IMAGE
+
+# ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
 FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.24 AS builder
@@ -27,7 +37,6 @@ RUN echo '{\n\
 # ---
 # Stage 2: Final image with nothing but certs, binary, and default config file
 # ---
-ARG BASE_IMAGE
 FROM $BASE_IMAGE AS final
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-zb
+++ b/build/Dockerfile-zb
@@ -1,4 +1,14 @@
 # ---
+# Global ARGs for FROM statements
+# This needs to be declared in the global scope otherwise the build will fail in Docker & Podman.
+# Docker:
+#   WARNING: UndefinedArgInFrom - https://docs.docker.com/go/dockerfile/rule/undefined-arg-in-from/
+#   FROM argument 'BASE_IMAGE' is not declared
+# Podman: Error: determining starting point for build: no FROM statement found
+# ---
+ARG BASE_IMAGE
+
+# ---
 # Stage 1: Install certs, build binary, create default config file
 # ---
 FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.24 AS builder
@@ -15,7 +25,6 @@ RUN make COMMIT=$COMMIT OS=$TARGETOS ARCH=$TARGETARCH clean bench
 # ---
 # Stage 2: Final image with nothing but certs, binary, and default config file
 # ---
-ARG BASE_IMAGE
 FROM BASE_IMAGE AS final
 ARG TARGETOS
 ARG TARGETARCH

--- a/build/Dockerfile-zxp
+++ b/build/Dockerfile-zxp
@@ -1,4 +1,14 @@
 # ---
+# Global ARGs for FROM statements
+# This needs to be declared in the global scope otherwise the build will fail in Docker & Podman.
+# Docker:
+#   WARNING: UndefinedArgInFrom - https://docs.docker.com/go/dockerfile/rule/undefined-arg-in-from/
+#   FROM argument 'BASE_IMAGE' is not declared
+# Podman: Error: determining starting point for build: no FROM statement found
+# ---
+ARG BASE_IMAGE
+
+# ---
 # Stage 1: Build binary, create default config file
 # ---
 FROM --platform=$BUILDPLATFORM ghcr.io/project-zot/golang:1.24 AS builder
@@ -28,7 +38,6 @@ RUN echo '{\n\
 # ---
 # Stage 2: Final image with nothing but binary and default config file
 # ---
-ARG BASE_IMAGE
 FROM $BASE_IMAGE AS final
 ARG TARGETOS
 ARG TARGETARCH


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

On `main` the Dockerfiles don't currently build.
Using Podman I get:

```
[1/2] STEP 10/10: ARG BASE_IMAGE
--> a11a982d6bc2
Error: determining starting point for build: no FROM statement found
make: *** [Makefile:453: binary-container] Error 125
```

Using Docker:
```
[+] Building 0.3s (1/1) FINISHED                                                                                                                                                            docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                                  0.1s
 => => transferring dockerfile: 1.22kB                                                                                                                                                                0.0s

 2 warnings found (use docker --debug to expand):
 - InvalidDefaultArgInFrom: Default value for ARG $BASE_IMAGE results in empty or invalid base image name (line 32)
 - UndefinedArgInFrom: FROM argument 'BASE_IMAGE' is not declared (line 32)
Dockerfile:32
--------------------
  30 |     # ---
  31 |     ARG BASE_IMAGE
  32 | >>> FROM $BASE_IMAGE AS final
  33 |     ARG TARGETOS
  34 |     ARG TARGETARCH
--------------------
ERROR: failed to build: failed to solve: base name ($BASE_IMAGE) should not be blank
make: *** [Makefile:453: binary-container] Error 1
```

This can be fixed by moving the `ARG` to the global scope at the top of the Dockerfile.


**If an issue # is not available please add repro steps and logs showing the issue**:

Just use `make binary-container`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
