### PR TITLE
Sync images with a background context

### DIFF
--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -663,9 +663,15 @@ func applyDefaultValues(config *config.Config, viperInstance *viper.Viper, logge
 				config.Extensions.Sync.Enable = &defaultVal
 			}
 
-			for id, regCfg := range config.Extensions.Sync.Registries {
+			defaultSyncTimeout := 3 * time.Hour
+
+			for idx, regCfg := range config.Extensions.Sync.Registries {
 				if regCfg.TLSVerify == nil {
-					config.Extensions.Sync.Registries[id].TLSVerify = &defaultVal
+					config.Extensions.Sync.Registries[idx].TLSVerify = &defaultVal
+				}
+
+				if config.Extensions.Sync.Registries[idx].SyncTimeout == 0 {
+					config.Extensions.Sync.Registries[idx].SyncTimeout = defaultSyncTimeout
 				}
 			}
 		}

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -33,7 +33,8 @@ type RegistryConfig struct {
 	RetryDelay       *time.Duration
 	OnlySigned       *bool
 	CredentialHelper string
-	PreserveDigest   bool // sync without converting
+	PreserveDigest   bool          // sync without converting
+	SyncTimeout      time.Duration // timeout for on-demand sync operations; if zero or unset, defaults to 3 hours
 }
 
 type Content struct {

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -209,6 +209,14 @@ func (service *BaseService) CanRetryOnError() bool {
 	return false
 }
 
+func (service *BaseService) GetSyncTimeout() time.Duration {
+	if service.config.SyncTimeout == 0 {
+		return 3 * time.Hour // default timeout
+	}
+
+	return service.config.SyncTimeout
+}
+
 func (service *BaseService) getNextRepoFromCatalog(lastRepo string) string {
 	var found bool
 

--- a/pkg/extensions/sync/sync.go
+++ b/pkg/extensions/sync/sync.go
@@ -35,6 +35,8 @@ type Service interface {
 	/* Returns if service has retry option set.
 	Is used by ondemand to decide if it retries pulling an image in background or not. */
 	CanRetryOnError() bool // used by sync on demand to retry in background
+	// Get the sync timeout configured for this service
+	GetSyncTimeout() time.Duration
 }
 
 // Local and remote registries must implement this interface.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

feature


**Which issue does this PR fix**:

https://github.com/project-zot/zot/issues/2505


**What does this PR do / Why do we need it**:

Images are now synced using a background context.
It is needed because the sync was tied to the incoming request that triggered the sync.
When this request was cancelled the sync is also cancelled.
In Kubernetes this caused endless loops of downloading without ever resulting in success.


**Testing done on this change**:

I added logging statements to the code to verify the behavior.
I also ran a big test on my end which used to fail 100% of the time before this patch and now succeeded immediately.
I started a new K3d cluster, started dozens of pods with multi GB images and let them download. This used to take _hours_ before until some images more or less "randomly" downloaded in time.

Now it took ~10min to settle down. I also looked at the logs and was able to confirm the behavior.


**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

None

**Will this break upgrades or downgrades?**

I don't believe so.

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Registries can now be configured with a `syncTimeout` parameter (default: 3h) after which syncs from registries will be aborted. This used to be tied to the lifetime of the incoming request which triggered the sync. This behavior caused unwanted sync aborts. This is now fixed and configurable.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
