### PR TITLE
fix (metadb): make sure metadb statistics are initialized on image download, and minor metadb fixes for Docker v2 manifest compatibility

### DIFF
--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -811,15 +811,25 @@ func (rc *RedisDB) SetRepoReference(ctx context.Context, repo string,
 			}
 		}
 
-		if _, ok := protoRepoMeta.Statistics[imageMeta.Digest.String()]; !ok {
-			protoRepoMeta.Statistics[imageMeta.Digest.String()] = &proto_go.DescriptorStatistics{
+		digestStr := imageMeta.Digest.String()
+		stats, ok := protoRepoMeta.Statistics[digestStr]
+
+		if !ok {
+			stats = &proto_go.DescriptorStatistics{
 				DownloadCount:     0,
 				LastPullTimestamp: &timestamppb.Timestamp{},
 				PushTimestamp:     timestamppb.Now(),
 				PushedBy:          userid,
 			}
-		} else if protoRepoMeta.Statistics[imageMeta.Digest.String()].PushTimestamp.AsTime().IsZero() {
-			protoRepoMeta.Statistics[imageMeta.Digest.String()].PushTimestamp = timestamppb.Now()
+			protoRepoMeta.Statistics[digestStr] = stats
+		} else {
+			if stats.PushTimestamp.AsTime().IsZero() {
+				stats.PushTimestamp = timestamppb.Now()
+			}
+
+			if userid != "" && stats.PushedBy == "" {
+				stats.PushedBy = userid
+			}
 		}
 
 		if _, ok := protoRepoMeta.Signatures[imageMeta.Digest.String()]; !ok {
@@ -1753,7 +1763,30 @@ func (rc *RedisDB) UpdateStatsOnDownload(repo string, reference string) error {
 
 		manifestStatistics, ok := protoRepoMeta.Statistics[manifestDigest]
 		if !ok {
-			return zerr.ErrImageMetaNotFound
+			// Statistics entry doesn't exist - validate digest exists in this repository before creating it
+			// Check if digest is referenced in any tag for this repository
+			digestExists := false
+
+			for _, tagDescriptor := range protoRepoMeta.Tags {
+				if tagDescriptor.Digest == manifestDigest {
+					digestExists = true
+
+					break
+				}
+			}
+
+			if !digestExists {
+				return zerr.ErrImageMetaNotFound
+			}
+
+			// Statistics entry doesn't exist - create it
+			// This can happen if SetRepoReference failed or wasn't called
+			manifestStatistics = &proto_go.DescriptorStatistics{
+				DownloadCount:     0,
+				LastPullTimestamp: &timestamppb.Timestamp{},
+				PushTimestamp:     &timestamppb.Timestamp{}, // Unknown push time
+				PushedBy:          "",                       // Unknown pusher
+			}
 		}
 
 		manifestStatistics.DownloadCount++

--- a/pkg/test/image-utils/images.go
+++ b/pkg/test/image-utils/images.go
@@ -193,7 +193,7 @@ func (img Image) AsDockerImage() Image {
 	}
 
 	img.ManifestDescriptor = ispec.Descriptor{
-		MediaType: docker.MediaTypeImageConfig,
+		MediaType: docker.MediaTypeManifest,
 		Digest:    img.digestAlgorithm.FromBytes(manifestBlob),
 		Size:      int64(len(manifestBlob)),
 		Data:      manifestBlob,

--- a/pkg/test/image-utils/upload.go
+++ b/pkg/test/image-utils/upload.go
@@ -118,8 +118,19 @@ func UploadImage(img Image, baseURL, repo, ref string) error {
 		}
 	}
 
+	// Use the media type from ManifestDescriptor, or fall back to Manifest.MediaType, or default to OCI
+	mediaType := img.ManifestDescriptor.MediaType
+
+	if mediaType == "" {
+		mediaType = img.Manifest.MediaType
+	}
+
+	if mediaType == "" {
+		mediaType = ispec.MediaTypeImageManifest
+	}
+
 	resp, err = resty.R().
-		SetHeader("Content-type", ispec.MediaTypeImageManifest).
+		SetHeader("Content-type", mediaType).
 		SetBody(manifestBlob).
 		Put(baseURL + "/v2/" + repo + "/manifests/" + ref)
 
@@ -216,9 +227,20 @@ func UploadImageWithBasicAuth(img Image, baseURL, repo, ref, user, password stri
 		return err
 	}
 
+	// Use the media type from ManifestDescriptor, or fall back to Manifest.MediaType, or default to OCI
+	mediaType := img.ManifestDescriptor.MediaType
+
+	if mediaType == "" {
+		mediaType = img.Manifest.MediaType
+	}
+
+	if mediaType == "" {
+		mediaType = ispec.MediaTypeImageManifest
+	}
+
 	_, err = resty.R().
 		SetBasicAuth(user, password).
-		SetHeader("Content-type", "application/vnd.oci.image.manifest.v1+json").
+		SetHeader("Content-type", mediaType).
 		SetBody(manifestBlob).
 		Put(baseURL + "/v2/" + repo + "/manifests/" + ref)
 
@@ -245,8 +267,19 @@ func UploadMultiarchImage(multiImage MultiarchImage, baseURL string, repo, ref s
 		}
 	}
 
+	// Use the media type from IndexDescriptor, or fall back to Index.MediaType, or default to OCI
+	mediaType := multiImage.IndexDescriptor.MediaType
+
+	if mediaType == "" {
+		mediaType = multiImage.Index.MediaType
+	}
+
+	if mediaType == "" {
+		mediaType = ispec.MediaTypeImageIndex
+	}
+
 	resp, err := resty.R().
-		SetHeader("Content-type", ispec.MediaTypeImageIndex).
+		SetHeader("Content-type", mediaType).
 		SetBody(indexBlob).
 		Put(baseURL + "/v2/" + repo + "/manifests/" + ref)
 


### PR DESCRIPTION
Looking into potential causes of https://github.com/project-zot/zot/issues/3163

1. One possible reason is the statistics were not properly initialized in the first place because of (unknown and/or unavoidable) errors on image push. To workaround this, add logic to initialize the statistics on the call to download them.

2. Some images have the download statistics while others don't, one cause could be a bug in the logic handling manifest mediatypes in the search extension. Add compatibility checks for Docker v2 manifest types in metadb convert functions, and more tests for covering the Docker mediatype use case.

Side fixes:
- Ensure PushedBy Statistics entries are properly initialized in SetRepoReference
- Fix an issue in the image upload test functions, they were uploading Docker images with OCI mediatypes in call headers

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
