### PR TITLE
fix: show relevant error messages in case of images which cannot be scanned by Trivy

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -83,7 +83,7 @@ var (
 	ErrConfigNotFound                   = errors.New("config with the given name does not exist")
 	ErrNoURLProvided                    = errors.New("no URL provided")
 	ErrIllegalConfigKey                 = errors.New("given config key is not allowed")
-	ErrScanNotSupported                 = errors.New("scanning is not supported for given image media type")
+	ErrScanNotSupported                 = errors.New("scanning is not supported for given media type")
 	ErrCLITimeout                       = errors.New("query timed out while waiting for results")
 	ErrDuplicateConfigName              = errors.New("cli config name already added")
 	ErrInvalidRoute                     = errors.New("invalid route prefix")

--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -282,7 +282,7 @@ func (scanner Scanner) isManifestScanable(digestStr string) (bool, error) {
 		case ispec.MediaTypeImageLayerGzip, ispec.MediaTypeImageLayer, string(regTypes.DockerLayer):
 			continue
 		default:
-			return false, zerr.ErrScanNotSupported
+			return false, fmt.Errorf("%w: layer media type '%s'", zerr.ErrScanNotSupported, imageLayer.MediaType)
 		}
 	}
 
@@ -299,7 +299,7 @@ func (scanner Scanner) isManifestDataScannable(manifestData mTypes.ManifestMeta)
 		case ispec.MediaTypeImageLayerGzip, ispec.MediaTypeImageLayer, string(regTypes.DockerLayer):
 			continue
 		default:
-			return false, zerr.ErrScanNotSupported
+			return false, fmt.Errorf("%w: layer media type '%s'", zerr.ErrScanNotSupported, imageLayer.MediaType)
 		}
 	}
 


### PR DESCRIPTION
Old message example:
```
{"time":"2025-11-17T22:29:29.434073547Z","level":"debug","message":"image is not scannable","digest":"sha256:99155f2825186175c7f7e4df4f77d5d0ba68a018603afd9c014063d4ca11c0d6","mediaType":"application/vnd.oci.image.manifest.v1+json","error":"image 'nginx@sha256:99155f2825186175c7f7e4df4f77d5d0ba68a018603afd9c014063d4ca11c0d6' scanning is not supported for given image media type","caller":"zotregistry.dev/zot/v2/pkg/extensions/search/cve/cve.go:513","func":"zotregistry.dev/zot/v2/pkg/extensions/search/cve.BaseCveInfo.GetCVESummaryForImageMedia","goroutine":1246}
```

New message example:
```
{"time":"2025-11-17T22:25:10.33273421Z","level":"debug","message":"image is not scannable","digest":"sha256:99155f2825186175c7f7e4df4f77d5d0ba68a018603afd9c014063d4ca11c0d6","mediaType":"application/vnd.oci.image.manifest.v1+json","error":"image 'nginx@sha256:99155f2825186175c7f7e4df4f77d5d0ba68a018603afd9c014063d4ca11c0d6' scanning is not supported for given media type: layer media type 'application/octet-stream'","caller":"zotregistry.dev/zot/v2/pkg/extensions/search/cve/cve.go:513","func":"zotregistry.dev/zot/v2/pkg/extensions/search/cve.BaseCveInfo.GetCVESummaryForImageMedia","goroutine":1316}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
