### PR TITLE
fix(sync): properly handle CommitAll errors in syncImage and skip failed temp sync dirs

### DIFF
--- a/pkg/extensions/sync/on_demand.go
+++ b/pkg/extensions/sync/on_demand.go
@@ -114,6 +114,7 @@ func (onDemand *BaseOnDemand) syncReferrers(ctx context.Context, repo, subjectDi
 			if errors.Is(err, zerr.ErrManifestNotFound) ||
 				errors.Is(err, zerr.ErrSyncImageFilteredOut) ||
 				errors.Is(err, zerr.ErrSyncImageNotSigned) ||
+				errors.Is(err, zerr.ErrRepoNotFound) ||
 				// some public registries may return 401 for not found.
 				errors.Is(err, zerr.ErrUnauthorizedAccess) {
 				continue
@@ -170,6 +171,7 @@ func (onDemand *BaseOnDemand) syncImage(ctx context.Context, repo, reference str
 			if errors.Is(err, zerr.ErrManifestNotFound) ||
 				errors.Is(err, zerr.ErrSyncImageFilteredOut) ||
 				errors.Is(err, zerr.ErrSyncImageNotSigned) ||
+				errors.Is(err, zerr.ErrRepoNotFound) ||
 				// some public registries may return 401 for not found.
 				errors.Is(err, zerr.ErrUnauthorizedAccess) {
 				continue

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -430,8 +430,10 @@ func (service *BaseService) SyncRepo(ctx context.Context, repo string) error {
 			if errors.Is(err, zerr.ErrSyncImageNotSigned) ||
 				errors.Is(err, zerr.ErrUnauthorizedAccess) ||
 				errors.Is(err, zerr.ErrMediaTypeNotSupported) ||
-				errors.Is(err, zerr.ErrManifestNotFound) {
-				// skip unsigned images or unsupported image mediatype
+				errors.Is(err, zerr.ErrManifestNotFound) ||
+				errors.Is(err, zerr.ErrRepoNotFound) {
+				// skip unsigned images, unsupported image mediatype, or temp sync dir issues
+				// ErrRepoNotFound from temp sync dir is skippable since each tag uses a different temp directory
 				continue
 			}
 
@@ -637,6 +639,8 @@ func (service *BaseService) syncImage(ctx context.Context, localRepo, remoteRepo
 	if err != nil {
 		service.log.Error().Str("errorType", common.TypeOf(err)).Str("repo", localRepo).
 			Err(err).Msg("failed to commit image")
+
+		return err
 	}
 
 	service.log.Info().Str("repo", localRepo).Str("reference", tag).Msg("successfully synced image")


### PR DESCRIPTION

- Return CommitAll errors instead of ignoring them
- Skip ErrRepoNotFound from temp sync dirs to allow other tags to sync
- Each tag uses separate temp directory, so failures are isolated

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
