### PR TITLE
fix: Add HTTP client timeouts to prevent indefinite hangs in sync operations

### DIFF
--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -28,6 +28,7 @@ import (
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
 	eventsconf "zotregistry.dev/zot/v2/pkg/extensions/config/events"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
 )
@@ -663,15 +664,18 @@ func applyDefaultValues(config *config.Config, viperInstance *viper.Viper, logge
 				config.Extensions.Sync.Enable = &defaultVal
 			}
 
-			defaultSyncTimeout := 3 * time.Hour
-
-			for idx, regCfg := range config.Extensions.Sync.Registries {
+			for idx := range config.Extensions.Sync.Registries {
+				regCfg := &config.Extensions.Sync.Registries[idx]
 				if regCfg.TLSVerify == nil {
-					config.Extensions.Sync.Registries[idx].TLSVerify = &defaultVal
+					regCfg.TLSVerify = &defaultVal
 				}
 
-				if config.Extensions.Sync.Registries[idx].SyncTimeout == 0 {
-					config.Extensions.Sync.Registries[idx].SyncTimeout = defaultSyncTimeout
+				if regCfg.SyncTimeout == 0 {
+					regCfg.SyncTimeout = syncConstants.DefaultSyncTimeout
+				}
+
+				if regCfg.ResponseHeaderTimeout == 0 {
+					regCfg.ResponseHeaderTimeout = syncConstants.DefaultResponseHeaderTimeout
 				}
 			}
 		}

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -23,18 +23,19 @@ type Config struct {
 }
 
 type RegistryConfig struct {
-	URLs             []string
-	PollInterval     time.Duration
-	Content          []Content
-	TLSVerify        *bool
-	OnDemand         bool
-	CertDir          string
-	MaxRetries       *int
-	RetryDelay       *time.Duration
-	OnlySigned       *bool
-	CredentialHelper string
-	PreserveDigest   bool          // sync without converting
-	SyncTimeout      time.Duration // timeout for on-demand sync operations; if zero or unset, defaults to 3 hours
+	URLs                  []string
+	PollInterval          time.Duration
+	Content               []Content
+	TLSVerify             *bool
+	OnDemand              bool
+	CertDir               string
+	MaxRetries            *int
+	RetryDelay            *time.Duration
+	OnlySigned            *bool
+	CredentialHelper      string
+	PreserveDigest        bool          // sync without converting
+	SyncTimeout           time.Duration // overall HTTP client timeout for all sync operations
+	ResponseHeaderTimeout time.Duration `yaml:"-"` // response header timeout; set in root.go
 }
 
 type Content struct {

--- a/pkg/extensions/sync/constants/constants.go
+++ b/pkg/extensions/sync/constants/constants.go
@@ -1,9 +1,17 @@
 package constants
 
+import "time"
+
 // references type.
 const (
 	Cosign            = "CosignSignature"
 	OCI               = "OCIReference"
 	Tag               = "TagReference"
 	SyncBlobUploadDir = ".sync"
+)
+
+// Default timeout settings for sync operations.
+const (
+	DefaultSyncTimeout           = 3 * time.Hour    // default timeout for all sync operations (on-demand and periodic)
+	DefaultResponseHeaderTimeout = 30 * time.Second // default timeout for reading response headers
 )


### PR DESCRIPTION
Configure HTTP client with ResponseHeaderTimeout and overall request timeout to prevent sync operations from hanging indefinitely when upstream registries don't respond.

- Set ResponseHeaderTimeout to 30 seconds (default) to prevent hanging when servers connect but don't send response headers. This timeout is set programmatically in root.go and is not user-configurable (hidden from config files via yaml:"-" tag).
- Use SyncTimeout for overall HTTP client timeout (defaults to 3 hours)
- Move timeout constants to pkg/extensions/sync/constants/constants.go for centralized configuration
- Critical for periodic sync operations (catalog listing, SyncRepo, getTags) which don't use on-demand timeout contexts and could otherwise hang indefinitely if upstream registry doesn't respond

The timeout is applied to all regclient HTTP requests, ensuring that both on-demand and periodic sync operations have protection against unresponsive upstream registries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
