### PR TITLE
refactor: optimize code with modern Go patterns and pre-allocation

### DIFF
--- a/pkg/cli/client/client.go
+++ b/pkg/cli/client/client.go
@@ -445,7 +445,8 @@ func fetchManifestStruct(ctx context.Context, repo, manifestReference string, se
 	imageSize += manifestResp.Config.Size
 	imageSize += manifestSize
 
-	layers := []common.LayerSummary{}
+	// Pre-allocate slice with known capacity
+	layers := make([]common.LayerSummary, 0, len(manifestResp.Layers))
 
 	for _, entry := range manifestResp.Layers {
 		imageSize += entry.Size

--- a/pkg/cli/client/search_functions.go
+++ b/pkg/cli/client/search_functions.go
@@ -51,7 +51,8 @@ func SearchAllImagesGQL(config SearchConfig) error {
 		return err
 	}
 
-	imageListData := []imageStruct{}
+	// Pre-allocate slice with known capacity
+	imageListData := make([]imageStruct, 0, len(imageList.Results))
 
 	for _, image := range imageList.Results {
 		imageListData = append(imageListData, imageStruct(image))
@@ -103,7 +104,8 @@ func SearchImageByNameGQL(config SearchConfig, imageName string) error {
 		return err
 	}
 
-	imageListData := []imageStruct{}
+	// Pre-allocate slice with known capacity (may be filtered, but worst case is all results)
+	imageListData := make([]imageStruct, 0, len(imageList.Results))
 
 	for _, image := range imageList.Results {
 		if tag == "" || image.Tag == tag {
@@ -152,7 +154,8 @@ func SearchDerivedImageListGQL(config SearchConfig, derivedImage string) error {
 		return err
 	}
 
-	imageListData := []imageStruct{}
+	// Pre-allocate slice with known capacity
+	imageListData := make([]imageStruct, 0, len(imageList.DerivedImageList.Results))
 
 	for _, image := range imageList.DerivedImageList.Results {
 		imageListData = append(imageListData, imageStruct(image))
@@ -173,7 +176,8 @@ func SearchBaseImageListGQL(config SearchConfig, baseImage string) error {
 		return err
 	}
 
-	imageListData := []imageStruct{}
+	// Pre-allocate slice with known capacity
+	imageListData := make([]imageStruct, 0, len(imageList.BaseImageList.Results))
 
 	for _, image := range imageList.BaseImageList.Results {
 		imageListData = append(imageListData, imageStruct(image))
@@ -193,7 +197,8 @@ func SearchImagesForDigestGQL(config SearchConfig, digest string) error {
 		return err
 	}
 
-	imageListData := []imageStruct{}
+	// Pre-allocate slice with known capacity
+	imageListData := make([]imageStruct, 0, len(imageList.Results))
 
 	for _, image := range imageList.Results {
 		imageListData = append(imageListData, imageStruct(image))
@@ -344,7 +349,8 @@ func SearchImagesByCVEIDGQL(config SearchConfig, repo, cveid string) error {
 		return err
 	}
 
-	imageListData := []imageStruct{}
+	// Pre-allocate slice with known capacity
+	imageListData := make([]imageStruct, 0, len(imageList.Results))
 
 	for _, image := range imageList.Results {
 		imageListData = append(imageListData, imageStruct(image))
@@ -403,13 +409,14 @@ func GlobalSearchGQL(config SearchConfig, query string) error {
 		return err
 	}
 
-	imagesList := []imageStruct{}
+	// Pre-allocate slices with known capacity
+	imagesList := make([]imageStruct, 0, len(globalSearchResult.Images))
 
 	for _, image := range globalSearchResult.Images {
 		imagesList = append(imagesList, imageStruct(image))
 	}
 
-	reposList := []repoStruct{}
+	reposList := make([]repoStruct, 0, len(globalSearchResult.Repos))
 
 	for _, repo := range globalSearchResult.Repos {
 		reposList = append(reposList, repoStruct(repo))

--- a/pkg/cli/client/service.go
+++ b/pkg/cli/client/service.go
@@ -403,7 +403,9 @@ func (service searchService) getTagsForCVEGQL(ctx context.Context, config Search
 		return result, nil
 	}
 
+	// Pre-allocate filtered results slice with estimated capacity
 	filteredResults := &common.ImagesForCve{}
+	filteredResults.Results = make([]common.ImageSummary, 0, len(result.Results))
 
 	for _, image := range result.Results {
 		if image.RepoName == repo {
@@ -476,7 +478,8 @@ func (service searchService) getReferrers(ctx context.Context, config SearchConf
 		return referrersResult{}, err
 	}
 
-	referrersList := referrersResult{}
+	// Pre-allocate referrers list with known capacity
+	referrersList := make(referrersResult, 0, len(referrerResp.Manifests))
 
 	for _, referrer := range referrerResp.Manifests {
 		referrersList = append(referrersList, common.Referrer{
@@ -954,7 +957,8 @@ func (ref referrersResult) stringPlainText(maxArtifactTypeLen int) (string, erro
 	var builder strings.Builder
 
 	maxDigestWidth := digestWidth
-	rows := [][]string{}
+	// Pre-allocate rows slice with known capacity
+	rows := make([][]string, 0, len(ref))
 
 	for _, referrer := range ref {
 		artifactType := ellipsize(referrer.ArtifactType, maxArtifactTypeLen, ellipsis)
@@ -1390,12 +1394,14 @@ func (service searchService) getRepos(ctx context.Context, config SearchConfig, 
 	fmt.Fprintln(config.ResultWriter, "\nREPOSITORY NAME")
 
 	if config.SortBy == SortByAlphabeticAsc {
-		for i := 0; i < len(catalog.Repositories); i++ {
-			fmt.Fprintln(config.ResultWriter, catalog.Repositories[i])
+		for _, repo := range catalog.Repositories {
+			fmt.Fprintln(config.ResultWriter, repo)
 		}
 	} else {
-		for i := len(catalog.Repositories) - 1; i >= 0; i-- {
-			fmt.Fprintln(config.ResultWriter, catalog.Repositories[i])
+		// Iterate in reverse order
+		repos := catalog.Repositories
+		for i := len(repos) - 1; i >= 0; i-- {
+			fmt.Fprintln(config.ResultWriter, repos[i])
 		}
 	}
 }

--- a/pkg/cli/client/utils.go
+++ b/pkg/cli/client/utils.go
@@ -93,9 +93,9 @@ func collectResults(config SearchConfig, wg *sync.WaitGroup, imageErr chan strin
 
 func getUsernameAndPassword(user string) (string, string) {
 	if strings.Contains(user, ":") {
-		split := strings.Split(user, ":")
+		username, password, _ := strings.Cut(user, ":")
 
-		return split[0], split[1]
+		return username, password
 	}
 
 	return "", ""

--- a/pkg/extensions/search/convert/metadb.go
+++ b/pkg/extensions/search/convert/metadb.go
@@ -73,7 +73,8 @@ func getAnnotationsFromMap(annotationsMap map[string]string) []*gql_generated.An
 func getImageBlobsInfo(manifestDigest string, manifestSize int64, configDigest string, configSize int64,
 	layers []ispec.Descriptor,
 ) (int64, map[string]int64) {
-	imageBlobsMap := map[string]int64{}
+	// Pre-allocate map with known size: config + manifest + layers
+	imageBlobsMap := make(map[string]int64, 2+len(layers))
 	imageSize := int64(0)
 
 	// add config size

--- a/pkg/extensions/search/pagination/pagination_test.go
+++ b/pkg/extensions/search/pagination/pagination_test.go
@@ -27,35 +27,61 @@ func TestImgSumPagination(t *testing.T) {
 	Convey("Sort Functions", t, func() {
 		Convey("ImgSortByAlphabeticAsc", func() {
 			// Case: repo1 is < repo2
-			pageBuff := []*gql_generated.ImageSummary{
-				{RepoName: ref("repo1:1")},
-				{RepoName: ref("repo2:2")},
-			}
+			image1 := &gql_generated.ImageSummary{RepoName: ref("repo1:1")}
+			image2 := &gql_generated.ImageSummary{RepoName: ref("repo2:2")}
 
-			sortFunc := pagination.ImgSortByAlphabeticAsc(pageBuff)
-			So(sortFunc(0, 1), ShouldBeTrue)
+			So(pagination.ImgSortByAlphabeticAsc(image1, image2), ShouldEqual, -1)
 		})
 
 		Convey("ImgSortByAlphabeticDsc", func() {
 			// Case: repo1 is < repo2
-			pageBuff := []*gql_generated.ImageSummary{
-				{RepoName: ref("repo1:1")},
-				{RepoName: ref("repo2:2")},
-			}
+			image1 := &gql_generated.ImageSummary{RepoName: ref("repo1:1")}
+			image2 := &gql_generated.ImageSummary{RepoName: ref("repo2:2")}
 
-			sortFunc := pagination.ImgSortByAlphabeticDsc(pageBuff)
-			So(sortFunc(0, 1), ShouldBeFalse)
+			So(pagination.ImgSortByAlphabeticDsc(image1, image2), ShouldEqual, 1)
 		})
 
 		Convey("ImgSortByRelevance", func() {
 			// Case: repo1 is < repo2
-			pageBuff := []*gql_generated.ImageSummary{
-				{RepoName: ref("repo1:1")},
-				{RepoName: ref("repo2:2")},
-			}
+			image1 := &gql_generated.ImageSummary{RepoName: ref("repo1:1")}
+			image2 := &gql_generated.ImageSummary{RepoName: ref("repo2:2")}
 
-			sortFunc := pagination.ImgSortByRelevance(pageBuff)
-			So(sortFunc(0, 1), ShouldBeTrue)
+			So(pagination.ImgSortByRelevance(image1, image2), ShouldEqual, -1)
+		})
+
+		Convey("ImgSortByUpdateTime with nil LastUpdated", func() {
+			time1 := time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC)
+			time2 := time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)
+
+			// Both nil - should be equal
+			image1 := &gql_generated.ImageSummary{RepoName: ref("repo1"), Tag: ref("tag1"), LastUpdated: nil}
+			image2 := &gql_generated.ImageSummary{RepoName: ref("repo2"), Tag: ref("tag2"), LastUpdated: nil}
+			So(pagination.ImgSortByUpdateTime(image1, image2), ShouldEqual, 0)
+
+			// a is nil, b is not - a should come after b (return 1)
+			image1.LastUpdated = nil
+			image2.LastUpdated = &time1
+			So(pagination.ImgSortByUpdateTime(image1, image2), ShouldEqual, 1)
+
+			// b is nil, a is not - a should come before b (return -1)
+			image1.LastUpdated = &time1
+			image2.LastUpdated = nil
+			So(pagination.ImgSortByUpdateTime(image1, image2), ShouldEqual, -1)
+
+			// Both non-nil - normal comparison (a is newer, should come first in descending sort)
+			image1.LastUpdated = &time1
+			image2.LastUpdated = &time2
+			So(pagination.ImgSortByUpdateTime(image1, image2), ShouldEqual, -1)
+
+			// Both non-nil - normal comparison (b is newer, should come first in descending sort)
+			image1.LastUpdated = &time2
+			image2.LastUpdated = &time1
+			So(pagination.ImgSortByUpdateTime(image1, image2), ShouldEqual, 1)
+
+			// Both non-nil and equal
+			image1.LastUpdated = &time1
+			image2.LastUpdated = &time1
+			So(pagination.ImgSortByUpdateTime(image1, image2), ShouldEqual, 0)
 		})
 	})
 }
@@ -70,6 +96,8 @@ func TestRepoSumPagination(t *testing.T) {
 
 		_, err = pagination.NewRepoSumPageFinder(0, 0, "unknown")
 		So(err, ShouldNotBeNil)
+		// Verify it's the specific error for unsupported sort criteria
+		So(err.Error(), ShouldContainSubstring, "sorting repos by 'unknown' is not supported")
 	})
 }
 
@@ -146,7 +174,7 @@ func TestPagination(t *testing.T) {
 				&imgSum1, &imgSum2, &imgSum3, &imgSum4,
 			})
 
-			// ImgSortByUpdateTime
+			// ImgSortByUpdateTime (sorts by image LastUpdated descending)
 			imagePageFinder, err = pagination.NewImgSumPageFinder(4, 0, pagination.UpdateTime)
 			So(err, ShouldBeNil)
 			imagePageFinder.Add(&imgSum1)
@@ -154,8 +182,9 @@ func TestPagination(t *testing.T) {
 			imagePageFinder.Add(&imgSum3)
 			imagePageFinder.Add(&imgSum4)
 			page, _ = imagePageFinder.Page()
+			// Expected order: imgSum2 (2020), imgSum4 (2012), imgSum3 (2011), imgSum1 (2010)
 			So(page, ShouldEqual, []*gql_generated.ImageSummary{
-				&imgSum2, &imgSum1, &imgSum4, &imgSum3,
+				&imgSum2, &imgSum4, &imgSum3, &imgSum1,
 			})
 
 			// ImgSortByDownloads
@@ -171,6 +200,148 @@ func TestPagination(t *testing.T) {
 			})
 		})
 
+		Convey("ImgSortByUpdateTime with nil LastUpdated in pagination", func() {
+			// Test pagination with images that have nil LastUpdated
+			imgSumWithTime := gql_generated.ImageSummary{
+				RepoName:    ref("repo1"),
+				Tag:         ref("tag1"),
+				LastUpdated: ref(time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC)),
+			}
+			imgSumNil1 := gql_generated.ImageSummary{
+				RepoName:    ref("repo2"),
+				Tag:         ref("tag2"),
+				LastUpdated: nil,
+			}
+			imgSumNil2 := gql_generated.ImageSummary{
+				RepoName:    ref("repo3"),
+				Tag:         ref("tag3"),
+				LastUpdated: nil,
+			}
+			imgSumOlder := gql_generated.ImageSummary{
+				RepoName:    ref("repo4"),
+				Tag:         ref("tag4"),
+				LastUpdated: ref(time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)),
+			}
+
+			imagePageFinder, err := pagination.NewImgSumPageFinder(4, 0, pagination.UpdateTime)
+			So(err, ShouldBeNil)
+			imagePageFinder.Add(&imgSumNil1)
+			imagePageFinder.Add(&imgSumWithTime)
+			imagePageFinder.Add(&imgSumNil2)
+			imagePageFinder.Add(&imgSumOlder)
+			page, _ := imagePageFinder.Page()
+
+			// Expected order: imgSumWithTime (2020), imgSumOlder (2010), then nil values (imgSumNil1, imgSumNil2)
+			So(len(page), ShouldEqual, 4)
+			So(*page[0].RepoName, ShouldEqual, "repo1") // 2020 - newest
+			So(*page[1].RepoName, ShouldEqual, "repo4") // 2010 - older
+			// Nil values should come last
+			So(page[2].LastUpdated == nil || page[3].LastUpdated == nil, ShouldBeTrue)
+		})
+
+		Convey("Tie-breaking when values match", func() {
+			// Test tie-breaking for AlphabeticAsc - when RepoName and Tag are equal
+			imagePageFinder, err := pagination.NewImgSumPageFinder(10, 0, pagination.AlphabeticAsc)
+			So(err, ShouldBeNil)
+
+			// Add images with same RepoName and Tag but different LastUpdated to verify stable sort
+			imgSum1 := gql_generated.ImageSummary{
+				RepoName:    ref("repo1"),
+				Tag:         ref("tag1"),
+				LastUpdated: ref(time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)),
+			}
+			imgSum2 := gql_generated.ImageSummary{
+				RepoName:    ref("repo1"),
+				Tag:         ref("tag1"),
+				LastUpdated: ref(time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC)),
+			}
+			imagePageFinder.Add(&imgSum1)
+			imagePageFinder.Add(&imgSum2)
+
+			page, _ := imagePageFinder.Page()
+			// When RepoName and Tag are equal, sort is stable - first added stays first
+			So(len(page), ShouldEqual, 2)
+			So(*page[0].RepoName, ShouldEqual, "repo1")
+			So(*page[0].Tag, ShouldEqual, "tag1")
+			So(page[0].LastUpdated.Equal(time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)), ShouldBeTrue) // First added
+			So(*page[1].RepoName, ShouldEqual, "repo1")
+			So(*page[1].Tag, ShouldEqual, "tag1")
+			So(page[1].LastUpdated.Equal(time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC)), ShouldBeTrue) // Second added
+
+			// Test tie-breaking for AlphabeticDsc
+			imagePageFinder, err = pagination.NewImgSumPageFinder(10, 0, pagination.AlphabeticDsc)
+			So(err, ShouldBeNil)
+
+			imagePageFinder.Add(&imgSum1)
+			imagePageFinder.Add(&imgSum2)
+
+			page, _ = imagePageFinder.Page()
+			// When RepoName and Tag are equal, sort is stable - first added stays first
+			So(len(page), ShouldEqual, 2)
+			So(page[0].LastUpdated.Equal(time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)), ShouldBeTrue) // First added
+			So(page[1].LastUpdated.Equal(time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC)), ShouldBeTrue) // Second added
+
+			// Test tie-breaking for Relevance
+			imagePageFinder, err = pagination.NewImgSumPageFinder(10, 0, pagination.Relevance)
+			So(err, ShouldBeNil)
+
+			imagePageFinder.Add(&imgSum1)
+			imagePageFinder.Add(&imgSum2)
+
+			page, _ = imagePageFinder.Page()
+			// When RepoName and Tag are equal, sort is stable - first added stays first
+			So(len(page), ShouldEqual, 2)
+			So(page[0].LastUpdated.Equal(time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)), ShouldBeTrue) // First added
+			So(page[1].LastUpdated.Equal(time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC)), ShouldBeTrue) // Second added
+
+			// Test tie-breaking for UpdateTime - when LastUpdated times are equal
+			imagePageFinder, err = pagination.NewImgSumPageFinder(10, 0, pagination.UpdateTime)
+			So(err, ShouldBeNil)
+
+			sameTime := time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)
+			imgSum3 := gql_generated.ImageSummary{
+				RepoName:    ref("repo1"),
+				Tag:         ref("tag1"),
+				LastUpdated: ref(sameTime),
+			}
+			imgSum4 := gql_generated.ImageSummary{
+				RepoName:    ref("repo2"),
+				Tag:         ref("tag2"),
+				LastUpdated: ref(sameTime),
+			}
+			imagePageFinder.Add(&imgSum3)
+			imagePageFinder.Add(&imgSum4)
+
+			page, _ = imagePageFinder.Page()
+			// When LastUpdated times are equal, sort is stable - first added stays first
+			So(len(page), ShouldEqual, 2)
+			So(*page[0].RepoName, ShouldEqual, "repo1") // First added
+			So(*page[1].RepoName, ShouldEqual, "repo2") // Second added
+
+			// Test tie-breaking for Downloads - when DownloadCount values are equal
+			imagePageFinder, err = pagination.NewImgSumPageFinder(10, 0, pagination.Downloads)
+			So(err, ShouldBeNil)
+
+			imgSum5 := gql_generated.ImageSummary{
+				RepoName:      ref("repo1"),
+				Tag:           ref("tag1"),
+				DownloadCount: ref(100),
+			}
+			imgSum6 := gql_generated.ImageSummary{
+				RepoName:      ref("repo2"),
+				Tag:           ref("tag2"),
+				DownloadCount: ref(100),
+			}
+			imagePageFinder.Add(&imgSum5)
+			imagePageFinder.Add(&imgSum6)
+
+			page, _ = imagePageFinder.Page()
+			// When DownloadCount values are equal, sort is stable - first added stays first
+			So(len(page), ShouldEqual, 2)
+			So(*page[0].RepoName, ShouldEqual, "repo1") // First added
+			So(*page[1].RepoName, ShouldEqual, "repo2") // Second added
+		})
+
 		Convey("Errors", func() {
 			imagePageFinder, err := pagination.NewImgSumPageFinder(2, 0, "")
 			So(err, ShouldBeNil)
@@ -182,13 +353,83 @@ func TestPagination(t *testing.T) {
 			_, err = pagination.NewImgSumPageFinder(1, -1, "")
 			So(err, ShouldNotBeNil)
 
-			_, err = pagination.NewImgSumPageFinder(1, -1, "bad sort func")
+			// Test invalid sortBy with valid limit and offset to ensure it reaches the sortBy validation
+			_, err = pagination.NewImgSumPageFinder(1, 0, "bad sort func")
 			So(err, ShouldNotBeNil)
+			// Verify it's the specific error for unsupported sort criteria
+			So(err.Error(), ShouldContainSubstring, "sorting repos by 'bad sort func' is not supported")
 		})
 	})
 
 	Convey("Repos Pagination", t, func() {
-		Convey("Sort functions", func() {
+		Convey("Sort Functions unit tests", func() {
+			Convey("RepoSortByAlphabeticAsc", func() {
+				// Case: repo1 is < repo2
+				repo1 := &gql_generated.RepoSummary{Name: ref("repo1")}
+				repo2 := &gql_generated.RepoSummary{Name: ref("repo2")}
+
+				So(pagination.RepoSortByAlphabeticAsc(repo1, repo2), ShouldEqual, -1)
+				So(pagination.RepoSortByAlphabeticAsc(repo2, repo1), ShouldEqual, 1)
+				So(pagination.RepoSortByAlphabeticAsc(repo1, repo1), ShouldEqual, 0)
+			})
+
+			Convey("RepoSortByAlphabeticDsc", func() {
+				// Case: repo1 is < repo2, so descending should return 1
+				repo1 := &gql_generated.RepoSummary{Name: ref("repo1")}
+				repo2 := &gql_generated.RepoSummary{Name: ref("repo2")}
+
+				So(pagination.RepoSortByAlphabeticDsc(repo1, repo2), ShouldEqual, 1)
+				So(pagination.RepoSortByAlphabeticDsc(repo2, repo1), ShouldEqual, -1)
+				So(pagination.RepoSortByAlphabeticDsc(repo1, repo1), ShouldEqual, 0)
+			})
+
+			Convey("RepoSortByDownloads", func() {
+				// Case: repo1 has more downloads than repo2, so should return -1 (descending)
+				repo1 := &gql_generated.RepoSummary{DownloadCount: ref(100)}
+				repo2 := &gql_generated.RepoSummary{DownloadCount: ref(50)}
+
+				So(pagination.RepoSortByDownloads(repo1, repo2), ShouldEqual, -1)
+				So(pagination.RepoSortByDownloads(repo2, repo1), ShouldEqual, 1)
+				So(pagination.RepoSortByDownloads(repo1, repo1), ShouldEqual, 0)
+			})
+
+			Convey("RepoSortByUpdateTime with nil LastUpdated", func() {
+				time1 := time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC)
+				time2 := time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)
+
+				// Both nil - should be equal
+				repo1 := &gql_generated.RepoSummary{Name: ref("repo1"), LastUpdated: nil}
+				repo2 := &gql_generated.RepoSummary{Name: ref("repo2"), LastUpdated: nil}
+				So(pagination.RepoSortByUpdateTime(repo1, repo2), ShouldEqual, 0)
+
+				// a is nil, b is not - a should come after b (return 1)
+				repo1.LastUpdated = nil
+				repo2.LastUpdated = &time1
+				So(pagination.RepoSortByUpdateTime(repo1, repo2), ShouldEqual, 1)
+
+				// b is nil, a is not - a should come before b (return -1)
+				repo1.LastUpdated = &time1
+				repo2.LastUpdated = nil
+				So(pagination.RepoSortByUpdateTime(repo1, repo2), ShouldEqual, -1)
+
+				// Both non-nil - normal comparison (a is newer, should come first in descending sort)
+				repo1.LastUpdated = &time1
+				repo2.LastUpdated = &time2
+				So(pagination.RepoSortByUpdateTime(repo1, repo2), ShouldEqual, -1)
+
+				// Both non-nil - normal comparison (b is newer, should come first in descending sort)
+				repo1.LastUpdated = &time2
+				repo2.LastUpdated = &time1
+				So(pagination.RepoSortByUpdateTime(repo1, repo2), ShouldEqual, 1)
+
+				// Both non-nil and equal
+				repo1.LastUpdated = &time1
+				repo2.LastUpdated = &time1
+				So(pagination.RepoSortByUpdateTime(repo1, repo2), ShouldEqual, 0)
+			})
+		})
+
+		Convey("Repo page finder tests", func() {
 			repoSum1 := gql_generated.RepoSummary{
 				Name:          ref("1"),
 				LastUpdated:   ref(time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)),
@@ -278,7 +519,42 @@ func TestPagination(t *testing.T) {
 			})
 		})
 
-		Convey("Errors", func() {
+		Convey("RepoSortByUpdateTime with nil LastUpdated in pagination", func() {
+			// Test pagination with repos that have nil LastUpdated
+			repoSumWithTime := gql_generated.RepoSummary{
+				Name:        ref("repo1"),
+				LastUpdated: ref(time.Date(2020, 1, 1, 1, 1, 1, 1, time.UTC)),
+			}
+			repoSumNil1 := gql_generated.RepoSummary{
+				Name:        ref("repo2"),
+				LastUpdated: nil,
+			}
+			repoSumNil2 := gql_generated.RepoSummary{
+				Name:        ref("repo3"),
+				LastUpdated: nil,
+			}
+			repoSumOlder := gql_generated.RepoSummary{
+				Name:        ref("repo4"),
+				LastUpdated: ref(time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)),
+			}
+
+			repoPageFinder, err := pagination.NewRepoSumPageFinder(4, 0, pagination.UpdateTime)
+			So(err, ShouldBeNil)
+			repoPageFinder.Add(&repoSumNil1)
+			repoPageFinder.Add(&repoSumWithTime)
+			repoPageFinder.Add(&repoSumNil2)
+			repoPageFinder.Add(&repoSumOlder)
+			page, _ := repoPageFinder.Page()
+
+			// Expected order: repoSumWithTime (2020), repoSumOlder (2010), then nil values (repoSumNil1, repoSumNil2)
+			So(len(page), ShouldEqual, 4)
+			So(*page[0].Name, ShouldEqual, "repo1") // 2020 - newest
+			So(*page[1].Name, ShouldEqual, "repo4") // 2010 - older
+			// Nil values should come last
+			So(page[2].LastUpdated == nil || page[3].LastUpdated == nil, ShouldBeTrue)
+		})
+
+		Convey("Repo page finder error tests", func() {
 			repoPageFinder, err := pagination.NewRepoSumPageFinder(2, 0, "")
 			So(err, ShouldBeNil)
 			So(repoPageFinder, ShouldNotBeNil)
@@ -289,8 +565,11 @@ func TestPagination(t *testing.T) {
 			_, err = pagination.NewRepoSumPageFinder(1, -1, "")
 			So(err, ShouldNotBeNil)
 
-			_, err = pagination.NewRepoSumPageFinder(1, -1, "bad sort func")
+			// Test invalid sortBy with valid limit and offset to ensure it reaches the sortBy validation
+			_, err = pagination.NewRepoSumPageFinder(1, 0, "bad sort func")
 			So(err, ShouldNotBeNil)
+			// Verify it's the specific error for unsupported sort criteria
+			So(err.Error(), ShouldContainSubstring, "sorting repos by 'bad sort func' is not supported")
 		})
 	})
 }

--- a/pkg/extensions/search/pagination/repo_pagination.go
+++ b/pkg/extensions/search/pagination/repo_pagination.go
@@ -2,11 +2,19 @@ package pagination
 
 import (
 	"fmt"
-	"sort"
+	"slices"
+	"sync"
 
 	zerr "zotregistry.dev/zot/v2/errors"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
 	gql_gen "zotregistry.dev/zot/v2/pkg/extensions/search/gql_generated"
+)
+
+var (
+	//nolint:gochecknoglobals // lazy initialization with sync.Once to avoid reallocation
+	repoSortFunctionsOnce sync.Once
+	//nolint:gochecknoglobals // cached map initialized once, effectively immutable
+	repoSortFunctions map[SortCriteria]func(a, b *gql_gen.RepoSummary) int
 )
 
 type RepoSummariesPageFinder struct {
@@ -29,7 +37,8 @@ func NewRepoSumPageFinder(limit, offset int, sortBy SortCriteria) (*RepoSummarie
 		return nil, zerr.ErrOffsetIsNegative
 	}
 
-	if _, found := RepoSumSortFuncs()[sortBy]; !found {
+	sortFuncs := getRepoSortFunctions()
+	if _, found := sortFuncs[sortBy]; !found {
 		return nil, fmt.Errorf("sorting repos by '%s' is not supported %w",
 			sortBy, zerr.ErrSortCriteriaNotSupported)
 	}
@@ -38,7 +47,7 @@ func NewRepoSumPageFinder(limit, offset int, sortBy SortCriteria) (*RepoSummarie
 		limit:      limit,
 		offset:     offset,
 		sortBy:     sortBy,
-		pageBuffer: []*gql_gen.RepoSummary{},
+		pageBuffer: make([]*gql_gen.RepoSummary, 0),
 	}, nil
 }
 
@@ -53,7 +62,13 @@ func (pf *RepoSummariesPageFinder) Page() ([]*gql_gen.RepoSummary, zcommon.PageI
 
 	pageInfo := zcommon.PageInfo{}
 
-	sort.Slice(pf.pageBuffer, RepoSumSortFuncs()[pf.sortBy](pf.pageBuffer))
+	sortFuncs := getRepoSortFunctions()
+	sortFn, ok := sortFuncs[pf.sortBy]
+	if !ok {
+		// Fallback to default (should not happen due to validation in NewRepoSumPageFinder)
+		sortFn = sortFuncs[AlphabeticAsc]
+	}
+	slices.SortFunc(pf.pageBuffer, sortFn)
 
 	// the offset and limit are calculated in terms of repos counted
 	start := pf.offset
@@ -83,44 +98,92 @@ func (pf *RepoSummariesPageFinder) Page() ([]*gql_gen.RepoSummary, zcommon.PageI
 	return page, pageInfo
 }
 
-func RepoSumSortFuncs() map[SortCriteria]func(pageBuffer []*gql_gen.RepoSummary) func(i, j int) bool {
-	return map[SortCriteria]func(pageBuffer []*gql_gen.RepoSummary) func(i, j int) bool{
-		AlphabeticAsc: RepoSortByAlphabeticAsc,
-		AlphabeticDsc: RepoSortByAlphabeticDsc,
-		Relevance:     RepoSortByRelevance,
-		UpdateTime:    RepoSortByUpdateTime,
-		Downloads:     RepoSortByDownloads,
-	}
+// getRepoSortFunctions returns a cached map of sort functions.
+// The map is initialized once using sync.Once to avoid reallocation.
+func getRepoSortFunctions() map[SortCriteria]func(a, b *gql_gen.RepoSummary) int {
+	repoSortFunctionsOnce.Do(func() {
+		repoSortFunctions = map[SortCriteria]func(a, b *gql_gen.RepoSummary) int{
+			AlphabeticAsc: RepoSortByAlphabeticAsc,
+			AlphabeticDsc: RepoSortByAlphabeticDsc,
+			Relevance:     RepoSortByRelevance,
+			UpdateTime:    RepoSortByUpdateTime,
+			Downloads:     RepoSortByDownloads,
+		}
+	})
+
+	return repoSortFunctions
 }
 
-func RepoSortByAlphabeticAsc(pageBuffer []*gql_gen.RepoSummary) func(i, j int) bool {
-	return func(i, j int) bool {
-		return *pageBuffer[i].Name < *pageBuffer[j].Name
+// RepoSortByAlphabeticAsc sorts alphabetically ascending.
+func RepoSortByAlphabeticAsc(a, b *gql_gen.RepoSummary) int {
+	if *a.Name < *b.Name {
+		return -1
 	}
+	if *a.Name == *b.Name {
+		return 0
+	}
+
+	return 1
 }
 
-func RepoSortByAlphabeticDsc(pageBuffer []*gql_gen.RepoSummary) func(i, j int) bool {
-	return func(i, j int) bool {
-		return *pageBuffer[i].Name > *pageBuffer[j].Name
+// RepoSortByAlphabeticDsc sorts alphabetically descending.
+func RepoSortByAlphabeticDsc(a, b *gql_gen.RepoSummary) int {
+	if *a.Name > *b.Name {
+		return -1
 	}
+	if *a.Name == *b.Name {
+		return 0
+	}
+
+	return 1
 }
 
-func RepoSortByRelevance(pageBuffer []*gql_gen.RepoSummary) func(i, j int) bool {
-	return func(i, j int) bool {
-		return *pageBuffer[i].Rank < *pageBuffer[j].Rank
+// RepoSortByRelevance sorts by relevance.
+func RepoSortByRelevance(a, b *gql_gen.RepoSummary) int {
+	if *a.Rank < *b.Rank {
+		return -1
 	}
+	if *a.Rank == *b.Rank {
+		return 0
+	}
+
+	return 1
 }
 
 // RepoSortByUpdateTime sorts descending by time.
-func RepoSortByUpdateTime(pageBuffer []*gql_gen.RepoSummary) func(i, j int) bool {
-	return func(i, j int) bool {
-		return pageBuffer[i].LastUpdated.After(*pageBuffer[j].LastUpdated)
+func RepoSortByUpdateTime(a, b *gql_gen.RepoSummary) int { //nolint:varnamelen // standard comparison func signature
+	// Handle nil cases: nil values are treated as oldest (come last in descending sort)
+	if a.LastUpdated == nil && b.LastUpdated == nil {
+		return 0
 	}
+
+	if a.LastUpdated == nil {
+		return 1 // a is nil, b is not - a comes after b
+	}
+
+	if b.LastUpdated == nil {
+		return -1 // b is nil, a is not - a comes before b
+	}
+
+	if a.LastUpdated.After(*b.LastUpdated) {
+		return -1
+	}
+
+	if a.LastUpdated.Equal(*b.LastUpdated) {
+		return 0
+	}
+
+	return 1
 }
 
 // RepoSortByDownloads returns a comparison function for descendant sorting by downloads.
-func RepoSortByDownloads(pageBuffer []*gql_gen.RepoSummary) func(i, j int) bool {
-	return func(i, j int) bool {
-		return *pageBuffer[i].DownloadCount > *pageBuffer[j].DownloadCount
+func RepoSortByDownloads(a, b *gql_gen.RepoSummary) int {
+	if *a.DownloadCount > *b.DownloadCount {
+		return -1
 	}
+	if *a.DownloadCount == *b.DownloadCount {
+		return 0
+	}
+
+	return 1
 }

--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -2169,8 +2169,8 @@ func TestDerivedImageList(t *testing.T) {
 		layers = [][]byte{
 			{10, 11, 10, 11},
 			{11, 11, 11, 11},
-			{10, 10, 10, 10},
 			{10, 10, 10, 11},
+			{10, 10, 10, 10},
 			{11, 11, 10, 10},
 			{11, 10, 10, 10},
 		}
@@ -2613,7 +2613,7 @@ func TestBaseImageList(t *testing.T) {
 		// create image with less layers than the given image, but which are in the given image
 		layers = [][]byte{
 			{10, 11, 10, 11},
-			{10, 10, 10, 11},
+			{11, 11, 11, 11},
 		}
 
 		manifest = ispec.Manifest{

--- a/pkg/extensions/sync/utils.go
+++ b/pkg/extensions/sync/utils.go
@@ -46,7 +46,7 @@ func parseReference(reference string) (digest.Digest, bool) {
 
 // Given a list of registry string URLs parse them and return *url.URLs slice.
 func parseRegistryURLs(rawURLs []string) ([]*url.URL, error) {
-	urls := make([]*url.URL, 0)
+	urls := make([]*url.URL, 0, len(rawURLs))
 
 	for _, rawURL := range rawURLs {
 		u, err := url.Parse(rawURL)

--- a/pkg/test/oci-utils/oci_layout.go
+++ b/pkg/test/oci-utils/oci_layout.go
@@ -1,4 +1,4 @@
-//go:build sync && scrub && metrics && search
+//go:build search
 
 package ociutils
 


### PR DESCRIPTION
This commit modernizes code across multiple packages by:
- Using Go 1.18+ features (slices.IndexFunc, strings.Cut)
- Pre-allocating slices and maps with known capacity
- Consolidating defensive checks and improving code clarity
- Fixing test data and build tag issues

CLI client improvements:
- Pre-allocate slices in search functions and service methods
- Replace strings.Split with strings. Cut for username:password parsing
- Use range-based iteration instead of manual index loops

Search extension optimizations:
- Cache sort functions in pagination modules
- Pre-allocate page buffers and maps
- Consolidate defensive checks in filterBaseImages/filterDerivedImages
- Fix image base and derived logic allowing out-of-sequence layers for base images
- Fix image pagination reporting images groupped by repos when sorted by update time
- Remove duplicate resolver_test.go file

Monitoring extension:
- Replace manual loops with slices.IndexFunc
- Pre-allocate bucketsFloat2String map

Sync extension:
- Pre-allocate slice in parseRegistryURLs

Test utilities:
- Fix build tags in oci_layout.go

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
