### PR TITLE
ci: use minio==7.2.18

### DIFF
--- a/.github/workflows/cluster.yaml
+++ b/.github/workflows/cluster.yaml
@@ -51,7 +51,7 @@ jobs:
                 --health-cmd "curl http://localhost:9000/minio/health/live" \
                 minio/minio:RELEASE.2024-07-16T23-46-41Z server /data
       - name: Install py minio
-        run: pip3 install minio
+        run: pip3 install minio==7.2.18
 
       - name: Wait for minio to come up
         run: |
@@ -306,7 +306,7 @@ jobs:
                 --health-cmd "curl http://localhost:9000/minio/health/live" \
                 minio/minio:RELEASE.2024-07-16T23-46-41Z server /data
       - name: Install py minio
-        run: pip3 install minio
+        run: pip3 install minio==7.2.18
 
       - name: Wait for minio to come up
         run: |

--- a/.github/workflows/gc-stress-test.yaml
+++ b/.github/workflows/gc-stress-test.yaml
@@ -110,7 +110,7 @@ jobs:
                 --health-cmd "curl http://localhost:9000/minio/health/live" \
                 minio/minio:RELEASE.2024-07-16T23-46-41Z server /data
       - name: Install py minio
-        run: pip3 install minio
+        run: pip3 install minio==7.2.18
 
       - name: Wait for minio to come up
         run: |
@@ -194,7 +194,7 @@ jobs:
                 --health-cmd "curl http://localhost:9000/minio/health/live" \
                 minio/minio:RELEASE.2024-07-16T23-46-41Z server /data
       - name: Install py minio
-        run: pip3 install minio
+        run: pip3 install minio==7.2.18
 
       - name: Wait for minio to come up
         run: |


### PR DESCRIPTION
Looks like they broke the public API in a minor version: https://github.com/minio/minio-py/releases/tag/7.2.19

It was probably not by intent, let's use the older working version until they figure it out.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
