### PR TITLE
fix(meta): handle cases when substores are nested

### DIFF
--- a/pkg/cli/server/verify_retention_test.go
+++ b/pkg/cli/server/verify_retention_test.go
@@ -1138,6 +1138,7 @@ func TestRetentionCheckWithSubpaths(t *testing.T) {
 		port := GetFreePort()
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
+		subpathStoreDir := path.Join(testDir, "storage2")
 		configFile := path.Join(testDir, "zot-config.json")
 		logFile := path.Join(testDir, "retention-check.log")
 
@@ -1165,7 +1166,7 @@ func TestRetentionCheckWithSubpaths(t *testing.T) {
 			},
 				"subPaths": {
 					"/a": {
-						"rootDirectory": "%s/a",
+						"rootDirectory": "%s",
 						"gc": true,
 						"gcDelay": %q,
 					"gcInterval": "1m",
@@ -1195,7 +1196,7 @@ func TestRetentionCheckWithSubpaths(t *testing.T) {
 				"level": "debug"
 			}
 		}
-		`, storageDir, testGCDelay, storageDir, testGCDelay, port)
+		`, storageDir, testGCDelay, subpathStoreDir, testGCDelay, port)
 		err := os.WriteFile(configFile, content, 0o600)
 		So(err, ShouldBeNil)
 
@@ -1208,7 +1209,7 @@ func TestRetentionCheckWithSubpaths(t *testing.T) {
 		metricsServer := monitoring.NewMetricsServer(false, zlog.NewLogger("info", ""))
 		imgStore := local.NewImageStore(storageDir, false, false, zlog.NewLogger("info", ""), metricsServer,
 			nil, nil, nil, nil)
-		subpathStore := local.NewImageStore(path.Join(storageDir, "a"), false, false,
+		subpathStore := local.NewImageStore(subpathStoreDir, false, false,
 			zlog.NewLogger("info", ""), metricsServer, nil, nil, nil, nil)
 		params := boltdb.DBParameters{
 			RootDir: storageDir,
@@ -1438,6 +1439,7 @@ func TestRetentionCheckWithGCIntervalOverride(t *testing.T) {
 	Convey("config with gc-interval override", t, func(c C) {
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
+		subpathStoreDir := path.Join(testDir, "storage2")
 		configFile := path.Join(testDir, "zot-config.json")
 		logFile := path.Join(testDir, "retention-check.log")
 		port := GetFreePort()
@@ -1451,7 +1453,7 @@ func TestRetentionCheckWithGCIntervalOverride(t *testing.T) {
 				"gcInterval": "1m",
 				"subPaths": {
 					"/a": {
-						"rootDirectory": "%s/a",
+						"rootDirectory": "%s",
 						"gc": true,
 						"gcDelay": %q,
 						"gcInterval": "1m"
@@ -1466,7 +1468,7 @@ func TestRetentionCheckWithGCIntervalOverride(t *testing.T) {
 				"level": "debug"
 			}
 		}
-		`, storageDir, testGCDelay, storageDir, testGCDelay, port)
+		`, storageDir, testGCDelay, subpathStoreDir, testGCDelay, port)
 		err := os.WriteFile(configFile, content, 0o600)
 		So(err, ShouldBeNil)
 

--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -3260,9 +3260,7 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		subpath := "/a"
 
 		dir := t.TempDir()
-		subDir := t.TempDir()
-
-		subRootDir := path.Join(subDir, subpath)
+		subRootDir := t.TempDir()
 
 		port := GetFreePort()
 		baseURL := GetBaseURL(port)
@@ -3592,9 +3590,7 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		subpath := "/a"
 
 		dir := t.TempDir()
-		subDir := t.TempDir()
-
-		subRootDir := path.Join(subDir, subpath)
+		subRootDir := t.TempDir()
 
 		port := GetFreePort()
 		baseURL := GetBaseURL(port)
@@ -5060,9 +5056,7 @@ func TestMetaDBWhenSigningImages(t *testing.T) {
 		subpath := "/a"
 
 		dir := t.TempDir()
-		subDir := t.TempDir()
-
-		subRootDir := path.Join(subDir, subpath)
+		subRootDir := t.TempDir()
 
 		port := GetFreePort()
 		baseURL := GetBaseURL(port)


### PR DESCRIPTION
Note this is a case of bad configuration: having multiple stores in the same tree structure. Guard against it in parse.go.

Fix getAllRepos to prevent duplicate repositories in metaDB when substore directories are nested under the default store root directory.
This is not the intended use case for substores, and it may have caused: https://github.com/project-zot/zot/actions/runs/19665302669/job/56320640980

The fix processes substores first, then the default store, using a map-based deduplication approach to skip repositories that have already been added. This ensures that when both the default store and substores contain repositories with the same name (e.g., when a substore is nested within the default store), only one instance is added to the repository list.

Add test TestNoDuplicateReposWithSubstoresAndNestedRepoNames to verify the deduplication logic works correctly with nested substores.

Also update the other tests to avoid these issues in the future, since this is not a valid configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
