### PR TITLE
Fix error handling: return nil explicitly on successful completion

### DIFF
--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -950,7 +950,7 @@ func (rc *RedisDB) SearchRepos(ctx context.Context, searchText string) ([]mTypes
 		foundRepos = append(foundRepos, repoMeta)
 	}
 
-	return foundRepos, err
+	return foundRepos, nil
 }
 
 // SearchTags searches for images(repo:tag) given a search string.
@@ -1036,7 +1036,7 @@ func (rc *RedisDB) SearchTags(ctx context.Context, searchText string) ([]mTypes.
 		}
 	}
 
-	return images, err
+	return images, nil
 }
 
 // FilterTags filters for images given a filter function.
@@ -1196,7 +1196,7 @@ func (rc *RedisDB) GetRepoMeta(ctx context.Context, repo string) (mTypes.RepoMet
 	protoRepoMeta.IsBookmarked = slices.Contains(userBookmarks, repo)
 	protoRepoMeta.IsStarred = slices.Contains(userStars, repo)
 
-	return mConvert.GetRepoMeta(protoRepoMeta), err
+	return mConvert.GetRepoMeta(protoRepoMeta), nil
 }
 
 // GetFullImageMeta returns the full information about an image.
@@ -1260,7 +1260,7 @@ func (rc *RedisDB) GetImageMeta(digest godigest.Digest) (mTypes.ImageMeta, error
 
 	imageMeta = mConvert.GetImageMeta(protoImageMeta)
 
-	return imageMeta, err
+	return imageMeta, nil
 }
 
 // GetMultipleRepoMeta returns a list of all repos that match the given filter function.
@@ -1736,7 +1736,7 @@ func (rc *RedisDB) GetReferrersInfo(repo string, referredDigest godigest.Digest,
 		})
 	}
 
-	return referrersInfoResult, err
+	return referrersInfoResult, nil
 }
 
 // UpdateStatsOnDownload adds 1 to the download count of an image and sets the timestamp of download.


### PR DESCRIPTION
Several functions in pkg/meta/redis/redis.go were returning 'err' at the end of successful execution paths, which could lead to incorrect error handling when 'err' was overwritten in loops or conditionals.

Changed the following functions to return nil explicitly when all operations succeed:
- SearchRepos: return nil instead of err after successful loop
- SearchTags: return nil instead of err after successful loop
- GetRepoMeta: return nil instead of err after successful operations
- GetImageMeta: return nil instead of err after successful operations
- GetReferrersInfo: return nil instead of err after successful loop

This ensures that when functions complete successfully, they explicitly return nil rather than relying on the last value of err, which may have been overwritten during execution. This fixes TestRedisUnreachable which was failing because SearchRepos was incorrectly returning nil error when Redis was unreachable.

See failure in: https://github.com/project-zot/zot/actions/runs/19729927463/job/56528529923?pr=3599

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
