### PR TITLE
refactor(test): new apis for creating temporary files

### DIFF
--- a/pkg/api/authn_test.go
+++ b/pkg/api/authn_test.go
@@ -99,9 +99,7 @@ func TestAPIKeys(t *testing.T) {
 
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		mockOIDCServer, err := authutils.MockOIDCRun()
 		if err != nil {
@@ -871,9 +869,7 @@ func TestAPIKeysOpenDBError(t *testing.T) {
 		conf := config.New()
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		mockOIDCServer, err := authutils.MockOIDCRun()
 		if err != nil {
@@ -1154,9 +1150,7 @@ func TestCookieSecureFlag(t *testing.T) {
 
 		username, _ := test.GenerateRandomString()
 		password, _ := test.GenerateRandomString()
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		mockOIDCConfig := mockOIDCServer.Config()
 		defaultVal := true

--- a/pkg/api/config/redis/redis_test.go
+++ b/pkg/api/config/redis/redis_test.go
@@ -15,12 +15,13 @@ import (
 	rediscfg "zotregistry.dev/zot/v2/pkg/api/config/redis"
 	"zotregistry.dev/zot/v2/pkg/cli/server"
 	"zotregistry.dev/zot/v2/pkg/log"
+	test "zotregistry.dev/zot/v2/pkg/test/common"
 )
 
 func TestRedisLogger(t *testing.T) {
 	Convey("Print using Redis logger", t, func() {
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
-		So(err, ShouldBeNil)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 		logger := log.NewLoggerWithWriter("debug", writers)

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -493,12 +493,10 @@ func TestAutoPortSelection(t *testing.T) {
 		conf := config.New()
 		conf.HTTP.Port = "0"
 
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		conf.Log.Output = logFile.Name()
-
-		defer os.Remove(logFile.Name()) // clean up
 
 		ctlr := makeController(conf, t.TempDir())
 
@@ -508,12 +506,7 @@ func TestAutoPortSelection(t *testing.T) {
 
 		defer cm.StopServer()
 
-		file, err := os.Open(logFile.Name())
-		So(err, ShouldBeNil)
-
-		defer file.Close()
-
-		scanner := bufio.NewScanner(file)
+		scanner := bufio.NewScanner(logFile)
 
 		var contents bytes.Buffer
 
@@ -736,8 +729,7 @@ func TestHtpasswdSingleCred(t *testing.T) {
 					conf := config.New()
 					conf.HTTP.Port = port
 
-					htpasswdPath := test.MakeHtpasswdFileFromString(testString)
-					defer os.Remove(htpasswdPath)
+					htpasswdPath := test.MakeHtpasswdFileFromString(t, testString)
 					conf.HTTP.Auth = &config.AuthConfig{
 						HTPasswd: config.AuthHTPasswd{
 							Path: htpasswdPath,
@@ -790,9 +782,7 @@ func TestAllowMethodsHeader(t *testing.T) {
 
 		simpleUser := "simpleUser"
 		simpleUserPassword := "simpleUserPass"
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(simpleUser, simpleUserPassword))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(simpleUser, simpleUserPassword))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -883,8 +873,7 @@ func TestHtpasswdTwoCreds(t *testing.T) {
 				conf := config.New()
 				conf.HTTP.Port = port
 
-				htpasswdPath := test.MakeHtpasswdFileFromString(testString)
-				defer os.Remove(htpasswdPath)
+				htpasswdPath := test.MakeHtpasswdFileFromString(t, testString)
 
 				conf.HTTP.Auth = &config.AuthConfig{
 					HTPasswd: config.AuthHTPasswd{
@@ -935,9 +924,7 @@ func TestHtpasswdFiveCreds(t *testing.T) {
 			baseURL := test.GetBaseURL(port)
 			conf := config.New()
 			conf.HTTP.Port = port
-			htpasswdPath := test.MakeHtpasswdFileFromString(credString.String())
-
-			defer os.Remove(htpasswdPath)
+			htpasswdPath := test.MakeHtpasswdFileFromString(t, credString.String())
 			conf.HTTP.Auth = &config.AuthConfig{
 				HTPasswd: config.AuthHTPasswd{
 					Path: htpasswdPath,
@@ -1081,9 +1068,7 @@ func TestBasicAuth(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -1370,9 +1355,7 @@ func TestScaleOutRequestProxy(t *testing.T) {
 
 		username, _ := test.GenerateRandomString()
 		password, _ := test.GenerateRandomString()
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		resty.SetTLSClientConfig(&tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12})
 
@@ -1655,12 +1638,10 @@ func TestPrintTracebackOnPanic(t *testing.T) {
 		conf := config.New()
 		conf.HTTP.Port = port
 
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		conf.Log.Output = logFile.Name()
-
-		defer os.Remove(logFile.Name()) // clean up
 
 		ctlr := makeController(conf, t.TempDir())
 		cm := test.NewControllerManager(ctlr)
@@ -1942,9 +1923,7 @@ func TestMultipleInstance(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -1986,9 +1965,7 @@ func TestMultipleInstance(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -2036,9 +2013,7 @@ func TestMultipleInstance(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -2090,9 +2065,7 @@ func TestTLSWithBasicAuth(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		port := test.GetFreePort()
 		baseURL := test.GetBaseURL(port)
@@ -2161,9 +2134,7 @@ func TestTLSWithBasicAuthAllowReadAccess(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		port := test.GetFreePort()
 		baseURL := test.GetBaseURL(port)
@@ -2835,9 +2806,7 @@ func TestTLSMutualAndBasicAuth(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		port := test.GetFreePort()
 		baseURL := test.GetBaseURL(port)
@@ -2922,9 +2891,7 @@ func TestTLSMutualAndBasicAuthAllowReadAccess(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		port := test.GetFreePort()
 		baseURL := test.GetBaseURL(port)
@@ -4588,9 +4555,7 @@ func TestOpenIDMiddleware(t *testing.T) {
 	// need a username different than ldap one, to test both logic
 	htpasswdUsername, seedUser := test.GenerateRandomString()
 	htpasswdPassword, seedPass := test.GenerateRandomString()
-	htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
-
-	defer os.Remove(htpasswdPath)
+	htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
 
 	ldapServer := newTestLDAPServer()
 	port = test.GetFreePort()
@@ -5004,9 +4969,7 @@ func TestOpenIDMiddlewareWithRedisSessionDriver(t *testing.T) {
 	// need a username different than ldap one, to test both logic
 	htpasswdUsername, seedUser := test.GenerateRandomString()
 	htpasswdPassword, seedPass := test.GenerateRandomString()
-	htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
-
-	defer os.Remove(htpasswdPath)
+	htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
 
 	ldapServer := newTestLDAPServer()
 	port = test.GetFreePort()
@@ -5490,9 +5453,7 @@ func TestAuthnSessionErrors(t *testing.T) {
 		htpasswdUsername, seedUser := test.GenerateRandomString()
 		htpasswdPassword, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
 
 		ldapServer := newTestLDAPServer()
 		port = test.GetFreePort()
@@ -5895,9 +5856,7 @@ func TestAuthnMetaDBErrors(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		mockOIDCServer, err := authutils.MockOIDCRun()
 		if err != nil {
@@ -6008,9 +5967,7 @@ func TestAuthorization(t *testing.T) {
 		conf.HTTP.Port = port
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -6128,9 +6085,7 @@ func TestGetUsername(t *testing.T) {
 
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		conf := config.New()
 		conf.HTTP.Port = port
@@ -6201,9 +6156,7 @@ func TestAuthorizationMountBlob(t *testing.T) {
 
 		content := test.GetBcryptCredString(username1, password1) + test.GetBcryptCredString(username2, password2)
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(content)
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, content)
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -6557,9 +6510,7 @@ func TestAuthorizationWithAnonymousPolicyBasicAuthAndSessionHeader(t *testing.T)
 		badpassphrase := "bad"
 		htpasswdUsername, seedUser := test.GenerateRandomString()
 		htpasswdPassword, seedPass := test.GenerateRandomString()
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
 
 		img := CreateRandomImage()
 		tagAnonymous := "1.0-anon"
@@ -6769,9 +6720,7 @@ func TestAuthorizationWithMultiplePolicies(t *testing.T) {
 		password2, seedPass2 := test.GenerateRandomString()
 		content := test.GetBcryptCredString(username1, password1) + test.GetBcryptCredString(username2, password2)
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(content)
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, content)
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -6926,9 +6875,7 @@ func TestInvalidCases(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -7005,8 +6952,7 @@ func TestHTTPReadOnly(t *testing.T) {
 					},
 				}
 
-				htpasswdPath := test.MakeHtpasswdFileFromString(testString)
-				defer os.Remove(htpasswdPath)
+				htpasswdPath := test.MakeHtpasswdFileFromString(t, testString)
 				conf.HTTP.Auth = &config.AuthConfig{
 					HTPasswd: config.AuthHTPasswd{
 						Path: htpasswdPath,
@@ -7057,9 +7003,7 @@ func TestCrossRepoMount(t *testing.T) {
 		conf.HTTP.Port = port
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -7272,9 +7216,7 @@ func TestCrossRepoMount(t *testing.T) {
 
 		conf := config.New()
 		conf.HTTP.Port = port
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -7416,11 +7358,7 @@ func TestParallelRequests(t *testing.T) {
 	conf.HTTP.Port = port
 	username, seedUser := test.GenerateRandomString()
 	password, seedPass := test.GenerateRandomString()
-	htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-	t.Cleanup(func() {
-		os.Remove(htpasswdPath)
-	})
+	htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 	conf.HTTP.Auth = &config.AuthConfig{
 		HTPasswd: config.AuthHTPasswd{
@@ -8979,9 +8917,7 @@ func TestPagedRepositoriesWithAuthorization(t *testing.T) {
 	conf.HTTP.Port = port
 	username, _ := test.GenerateRandomString()
 	password, _ := test.GenerateRandomString()
-	htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-	defer os.Remove(htpasswdPath)
+	htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 	conf.HTTP.Auth = &config.AuthConfig{
 		HTPasswd: config.AuthHTPasswd{
@@ -11882,11 +11818,8 @@ func TestGCSignaturesAndUntaggedManifestsWithMetaDB(t *testing.T) {
 			baseURL := test.GetBaseURL(port)
 			conf := config.New()
 			conf.HTTP.Port = port
-
-			logFile, err := os.CreateTemp("", "zot-log*.txt")
-			So(err, ShouldBeNil)
-
-			conf.Log.Audit = logFile.Name()
+			conf.Log.Output = test.MakeTempFilePath(t, "zot-log.txt")
+			conf.Log.Audit = test.MakeTempFilePath(t, "zot-audit.log")
 
 			value := true
 			searchConfig := &extconf.SearchConfig{
@@ -11898,10 +11831,8 @@ func TestGCSignaturesAndUntaggedManifestsWithMetaDB(t *testing.T) {
 				Search: searchConfig,
 			}
 
-			ctlr := makeController(conf, t.TempDir())
-
 			dir := t.TempDir()
-			ctlr.Config.Storage.RootDirectory = dir
+			ctlr := makeController(conf, dir)
 			ctlr.Config.Storage.GC = true
 			ctlr.Config.Storage.GCDelay = 1 * time.Millisecond
 			ctlr.Config.Storage.Retention = config.ImageRetention{
@@ -11930,7 +11861,7 @@ func TestGCSignaturesAndUntaggedManifestsWithMetaDB(t *testing.T) {
 
 			img := CreateDefaultImage()
 
-			err = UploadImage(img, baseURL, repoName, tag)
+			err := UploadImage(img, baseURL, repoName, tag)
 			So(err, ShouldBeNil)
 
 			gc := gc.NewGarbageCollect(ctlr.StoreController.DefaultStore, ctlr.MetaDB,
@@ -12143,10 +12074,8 @@ func TestGCSignaturesAndUntaggedManifestsWithMetaDB(t *testing.T) {
 			conf := config.New()
 			conf.HTTP.Port = port
 
-			ctlr := makeController(conf, t.TempDir())
-
 			dir := t.TempDir()
-			ctlr.Config.Storage.RootDirectory = dir
+			ctlr := makeController(conf, dir)
 			ctlr.Config.Storage.GC = true
 			ctlr.Config.Storage.GCDelay = 1 * time.Second
 			ctlr.Config.Storage.Retention = config.ImageRetention{
@@ -12244,12 +12173,8 @@ func TestPeriodicGC(t *testing.T) {
 		conf.HTTP.Port = port
 		conf.Storage.RemoteCache = false
 
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		conf.Log.Output = logFile.Name()
-
-		defer os.Remove(logFile.Name()) // clean up
+		logPath := test.MakeTempFilePath(t, "zot-log.txt")
+		conf.Log.Output = logPath
 
 		ctlr := api.NewController(conf)
 		dir := t.TempDir()
@@ -12259,7 +12184,7 @@ func TestPeriodicGC(t *testing.T) {
 		ctlr.Config.Storage.GCInterval = 1 * time.Hour
 		ctlr.Config.Storage.GCDelay = 1 * time.Second
 
-		err = WriteImageToFileSystem(CreateDefaultImage(), repoName, "0.0.1",
+		err := WriteImageToFileSystem(CreateDefaultImage(), repoName, "0.0.1",
 			ociutils.GetDefaultStoreController(dir, ctlr.Log))
 		So(err, ShouldBeNil)
 
@@ -12270,7 +12195,7 @@ func TestPeriodicGC(t *testing.T) {
 
 		time.Sleep(5000 * time.Millisecond)
 
-		data, err := os.ReadFile(logFile.Name())
+		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
 		So(string(data), ShouldContainSubstring,
 			"\"GC\":true,\"Commit\":false,\"GCDelay\":1000000000,\"GCInterval\":3600000000000")
@@ -12285,12 +12210,8 @@ func TestPeriodicGC(t *testing.T) {
 		conf := config.New()
 		conf.HTTP.Port = port
 
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		conf.Log.Output = logFile.Name()
-
-		defer os.Remove(logFile.Name()) // clean up
+		logPath := test.MakeTempFilePath(t, "zot-log.txt")
+		conf.Log.Output = logPath
 
 		dir := t.TempDir()
 		ctlr := makeController(conf, dir)
@@ -12314,7 +12235,7 @@ func TestPeriodicGC(t *testing.T) {
 
 		defer cm.StopServer()
 
-		data, err := os.ReadFile(logFile.Name())
+		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
 
 		// periodic GC is enabled by default for default store with a default interval
@@ -12334,12 +12255,8 @@ func TestPeriodicGC(t *testing.T) {
 		conf.HTTP.Port = port
 		conf.Storage.RemoteCache = false
 
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		conf.Log.Output = logFile.Name()
-
-		defer os.Remove(logFile.Name()) // clean up
+		logPath := test.MakeTempFilePath(t, "zot-log.txt")
+		conf.Log.Output = logPath
 
 		ctlr := api.NewController(conf)
 		dir := t.TempDir()
@@ -12350,7 +12267,7 @@ func TestPeriodicGC(t *testing.T) {
 		ctlr.Config.Storage.GCInterval = 1 * time.Hour
 		ctlr.Config.Storage.GCDelay = 1 * time.Second
 
-		err = WriteImageToFileSystem(CreateDefaultImage(), repoName, "0.0.1",
+		err := WriteImageToFileSystem(CreateDefaultImage(), repoName, "0.0.1",
 			ociutils.GetDefaultStoreController(dir, ctlr.Log))
 		So(err, ShouldBeNil)
 
@@ -12367,7 +12284,7 @@ func TestPeriodicGC(t *testing.T) {
 
 		time.Sleep(5000 * time.Millisecond)
 
-		data, err := os.ReadFile(logFile.Name())
+		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
 		So(string(data), ShouldContainSubstring,
 			"\"GC\":true,\"Commit\":false,\"GCDelay\":1000000000,\"GCInterval\":3600000000000")
@@ -12390,9 +12307,7 @@ func TestSearchRoutes(t *testing.T) {
 			password1 := "test"
 			testString1 := test.GetBcryptCredString(user1, password1)
 
-			htpasswdPath := test.MakeHtpasswdFileFromString(testString1)
-
-			defer os.Remove(htpasswdPath)
+			htpasswdPath := test.MakeHtpasswdFileFromString(t, testString1)
 
 			conf.HTTP.Auth = &config.AuthConfig{
 				HTPasswd: config.AuthHTPasswd{
@@ -12533,9 +12448,7 @@ func TestSearchRoutes(t *testing.T) {
 			group1 := "testgroup3"
 			testString1 := test.GetBcryptCredString(user1, password1)
 
-			htpasswdPath := test.MakeHtpasswdFileFromString(testString1)
-
-			defer os.Remove(htpasswdPath)
+			htpasswdPath := test.MakeHtpasswdFileFromString(t, testString1)
 
 			conf.HTTP.Auth = &config.AuthConfig{
 				HTPasswd: config.AuthHTPasswd{
@@ -12620,9 +12533,7 @@ func TestSearchRoutes(t *testing.T) {
 			group1 := "testgroup1"
 			group2 := "secondtestgroup"
 			testString1 := test.GetBcryptCredString(user1, password1)
-			htpasswdPath := test.MakeHtpasswdFileFromString(testString1)
-
-			defer os.Remove(htpasswdPath)
+			htpasswdPath := test.MakeHtpasswdFileFromString(t, testString1)
 			conf.HTTP.Auth = &config.AuthConfig{
 				HTPasswd: config.AuthHTPasswd{
 					Path: htpasswdPath,
@@ -12690,9 +12601,7 @@ func TestSearchRoutes(t *testing.T) {
 			password1 := "test3"
 			group1 := "testgroup"
 			testString1 := test.GetBcryptCredString(user1, password1)
-			htpasswdPath := test.MakeHtpasswdFileFromString(testString1)
-
-			defer os.Remove(htpasswdPath)
+			htpasswdPath := test.MakeHtpasswdFileFromString(t, testString1)
 			conf.HTTP.Auth = &config.AuthConfig{
 				HTPasswd: config.AuthHTPasswd{
 					Path: htpasswdPath,
@@ -12761,9 +12670,7 @@ func TestSearchRoutes(t *testing.T) {
 			group1 := "testgroup1"
 			testString1 := test.GetBcryptCredString(user1, password1)
 
-			htpasswdPath := test.MakeHtpasswdFileFromString(testString1)
-
-			defer os.Remove(htpasswdPath)
+			htpasswdPath := test.MakeHtpasswdFileFromString(t, testString1)
 
 			conf.HTTP.Auth = &config.AuthConfig{
 				HTPasswd: config.AuthHTPasswd{
@@ -12832,9 +12739,7 @@ func TestSearchRoutes(t *testing.T) {
 			password1 := "test5"
 			group1 := "testgroup2"
 			testString1 := test.GetBcryptCredString(user1, password1)
-			htpasswdPath := test.MakeHtpasswdFileFromString(testString1)
-
-			defer os.Remove(htpasswdPath)
+			htpasswdPath := test.MakeHtpasswdFileFromString(t, testString1)
 			conf.HTTP.Auth = &config.AuthConfig{
 				HTPasswd: config.AuthHTPasswd{
 					Path: htpasswdPath,
@@ -12891,8 +12796,8 @@ func TestSearchRoutes(t *testing.T) {
 			user1, seedUser1 := test.GenerateRandomString()
 			password1, seedPass1 := test.GenerateRandomString()
 
-			htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(user1, password1))
-			defer os.Remove(htpasswdPath)
+			tempDir := t.TempDir()
+			htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(user1, password1))
 
 			conf.HTTP.Auth = &config.AuthConfig{
 				HTPasswd: config.AuthHTPasswd{
@@ -12955,6 +12860,7 @@ func TestDistSpecExtensions(t *testing.T) {
 		baseURL := test.GetBaseURL(port)
 
 		conf.HTTP.Port = port
+		conf.Log.Output = test.MakeTempFilePath(t, "zot-log.txt")
 
 		defaultVal := true
 
@@ -12968,13 +12874,6 @@ func TestDistSpecExtensions(t *testing.T) {
 		conf.Extensions.Trust.Enable = &defaultVal
 		conf.Extensions.Trust.Cosign = defaultVal
 		conf.Extensions.Trust.Notation = defaultVal
-
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		conf.Log.Output = logFile.Name()
-
-		defer os.Remove(logFile.Name()) // clean up
 
 		ctlr := makeController(conf, t.TempDir())
 
@@ -13019,13 +12918,7 @@ func TestDistSpecExtensions(t *testing.T) {
 		conf.Extensions = &extconf.ExtensionConfig{}
 		conf.Extensions.Search = &extconf.SearchConfig{}
 		conf.Extensions.Search.Enable = &defaultVal
-
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		conf.Log.Output = logFile.Name()
-
-		defer os.Remove(logFile.Name()) // clean up
+		conf.Log.Output = test.MakeTempFilePath(t, "zot-log.txt")
 
 		ctlr := makeController(conf, t.TempDir())
 
@@ -13067,12 +12960,7 @@ func TestDistSpecExtensions(t *testing.T) {
 
 		conf.HTTP.Port = port
 
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		conf.Log.Output = logFile.Name()
-
-		defer os.Remove(logFile.Name()) // clean up
+		conf.Log.Output = test.MakeTempFilePath(t, "zot-log.txt")
 
 		ctlr := makeController(conf, t.TempDir())
 
@@ -13100,13 +12988,7 @@ func TestDistSpecExtensions(t *testing.T) {
 		baseURL := test.GetBaseURL(port)
 
 		conf.HTTP.Port = port
-
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		conf.Log.Output = logFile.Name()
-
-		defer os.Remove(logFile.Name()) // clean up
+		conf.Log.Output = test.MakeTempFilePath(t, "zot-log.txt")
 
 		ctlr := makeController(conf, t.TempDir())
 

--- a/pkg/api/htpasswd_test.go
+++ b/pkg/api/htpasswd_test.go
@@ -20,9 +20,7 @@ func TestHTPasswdWatcherOriginal(t *testing.T) {
 		username, _ := test.GenerateRandomString()
 		password1, _ := test.GenerateRandomString()
 		password2, _ := test.GenerateRandomString()
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password1))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password1))
 
 		htp := api.NewHTPasswd(logger)
 
@@ -99,11 +97,8 @@ func TestHTPasswdWatcher(t *testing.T) {
 			username2, _ := test.GenerateRandomString()
 			password2, _ := test.GenerateRandomString()
 
-			htpasswdPath1 := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username1, password1))
-			htpasswdPath2 := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username2, password2))
-
-			defer os.Remove(htpasswdPath1)
-			defer os.Remove(htpasswdPath2)
+			htpasswdPath1 := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username1, password1))
+			htpasswdPath2 := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username2, password2))
 
 			htp := api.NewHTPasswd(logger)
 			htw, err := api.NewHTPasswdWatcher(htp, "")
@@ -196,11 +191,8 @@ func TestHTPasswdWatcher(t *testing.T) {
 			username2, _ := test.GenerateRandomString()
 			password2, _ := test.GenerateRandomString()
 
-			htpasswdPath1 := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username1, password1))
-			htpasswdPath2 := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username2, password2))
-
-			defer os.Remove(htpasswdPath1)
-			defer os.Remove(htpasswdPath2)
+			htpasswdPath1 := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username1, password1))
+			htpasswdPath2 := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username2, password2))
 
 			htp := api.NewHTPasswd(capturingLogger)
 			htw, err := api.NewHTPasswdWatcher(htp, htpasswdPath1)
@@ -238,8 +230,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			So(present, ShouldBeTrue)
 
 			// Test file rename (should not trigger reload)
-			htpasswdPath3 := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username1, password1))
-			defer os.Remove(htpasswdPath3)
+			htpasswdPath3 := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username1, password1))
 			err = htw.ChangeFile(htpasswdPath3)
 			So(err, ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
@@ -307,11 +298,8 @@ func TestHTPasswdWatcher(t *testing.T) {
 			username2, _ := test.GenerateRandomString()
 			password2, _ := test.GenerateRandomString()
 
-			htpasswdPath1 := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username1, password1))
-			htpasswdPath2 := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username2, password2))
-
-			defer os.Remove(htpasswdPath1)
-			defer os.Remove(htpasswdPath2)
+			htpasswdPath1 := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username1, password1))
+			htpasswdPath2 := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username2, password2))
 
 			htp := api.NewHTPasswd(capturingLogger)
 			htw, err := api.NewHTPasswdWatcher(htp, "")
@@ -413,9 +401,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			// Test 2: File watching with fsnotify resources cleanup
 			username, _ := test.GenerateRandomString()
 			password, _ := test.GenerateRandomString()
-			htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-			defer os.Remove(htpasswdPath)
+			htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 			htp2 := api.NewHTPasswd(capturingLogger)
 			htw2, err := api.NewHTPasswdWatcher(htp2, htpasswdPath)
@@ -477,8 +463,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			htp := api.NewHTPasswd(capturingLogger)
 
 			// Test file with only colons (malformed)
-			colonPath := test.MakeHtpasswdFileFromString(":::")
-			defer os.Remove(colonPath)
+			colonPath := test.MakeHtpasswdFileFromString(t, ":::")
 			htw1, err := api.NewHTPasswdWatcher(htp, colonPath)
 			So(err, ShouldBeNil)
 			htw1.Run()
@@ -496,9 +481,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 
 			// Test file with empty lines and comments
 			content := "\n\n" + test.GetBcryptCredString(username, password) + "\n# comment\n"
-			commentedPath := test.MakeHtpasswdFileFromString(content)
-
-			defer os.Remove(commentedPath)
+			commentedPath := test.MakeHtpasswdFileFromString(t, content)
 			htw2, err := api.NewHTPasswdWatcher(htp, commentedPath)
 			So(err, ShouldBeNil)
 			htw2.Run()
@@ -525,8 +508,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// Load some initial data
-			htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-			defer os.Remove(htpasswdPath)
+			htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 			// Load initial file (this will populate the store)
 			err = htw.ChangeFile(htpasswdPath)

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/google/uuid"
@@ -45,9 +44,7 @@ func TestRoutes(t *testing.T) {
 
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		mockOIDCServer, err := mockoidc.Run()
 		if err != nil {

--- a/pkg/cli/client/config_cmd_test.go
+++ b/pkg/cli/client/config_cmd_test.go
@@ -20,8 +20,7 @@ func TestConfigCmdBasics(t *testing.T) {
 	Convey("Test config help", t, func() {
 		args := []string{"--help"}
 
-		configPath := makeConfigFile("showspinner = false")
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, "showspinner = false")
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -36,8 +35,7 @@ func TestConfigCmdBasics(t *testing.T) {
 		Convey("with the shorthand", func() {
 			args[0] = "-h"
 
-			configPath := makeConfigFile("showspinner = false")
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, "showspinner = false")
 
 			cmd := client.NewConfigCommand()
 			buff := bytes.NewBufferString("")
@@ -54,8 +52,7 @@ func TestConfigCmdBasics(t *testing.T) {
 	Convey("Test config no args", t, func() {
 		args := []string{}
 
-		configPath := makeConfigFile("showspinner = false")
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, "showspinner = false")
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -73,8 +70,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test add config", t, func() {
 		args := []string{"add", "configtest1", "https://test-url.com"}
 
-		file := makeConfigFile("")
-		defer os.Remove(file)
+		configPath := makeConfigFile(t, "")
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -83,7 +79,7 @@ func TestConfigCmdMain(t *testing.T) {
 		cmd.SetArgs(args)
 		_ = cmd.Execute()
 
-		actual, err := os.ReadFile(file)
+		actual, err := os.ReadFile(configPath)
 		if err != nil {
 			panic(err)
 		}
@@ -95,8 +91,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test error on home directory", t, func() {
 		args := []string{"add", "configtest1", "https://test-url.com"}
 
-		file := makeConfigFile("")
-		defer os.Remove(file)
+		_ = makeConfigFile(t, "")
 
 		err := os.Setenv("HOME", "nonExistentDirectory")
 		if err != nil {
@@ -125,8 +120,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test error on home directory at new add config", t, func() {
 		args := []string{"add", "configtest1", "https://test-url.com"}
 
-		file := makeConfigFile("")
-		defer os.Remove(file)
+		_ = makeConfigFile(t, "")
 
 		err := os.Setenv("HOME", "nonExistentDirectory")
 		if err != nil {
@@ -155,8 +149,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test add config with invalid format", t, func() {
 		args := []string{"--list"}
 
-		configPath := makeConfigFile(`{"configs":{"_name":"configtest","url":"https://test-url.com","showspinner":false}}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":{"_name":"configtest","url":"https://test-url.com","showspinner":false}}`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -170,8 +163,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test add config with invalid URL", t, func() {
 		args := []string{"add", "configtest1", "test..com"}
 
-		file := makeConfigFile("")
-		defer os.Remove(file)
+		_ = makeConfigFile(t, "")
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -186,8 +178,8 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test remove config entry successfully", t, func() {
 		args := []string{"remove", "configtest"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		configPath := makeConfigFile(t,
+			`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -206,8 +198,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test remove missing config entry", t, func() {
 		args := []string{"remove", "configtest"}
 
-		configPath := makeConfigFile(`{"configs":[]`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[]`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -222,8 +213,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test remove bad config file content", t, func() {
 		args := []string{"remove", "configtest"}
 
-		configPath := makeConfigFile(`{"asdf":[]`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"asdf":[]`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -238,8 +228,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test remove bad config file entry", t, func() {
 		args := []string{"remove", "configtest"}
 
-		configPath := makeConfigFile(`{"configs":[asdad]`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[asdad]`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -253,11 +242,11 @@ func TestConfigCmdMain(t *testing.T) {
 
 	Convey("Test remove config bad permissions", t, func() {
 		args := []string{"remove", "configtest"}
-		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
+		configPath := makeConfigFile(t,
+			`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 		defer func() {
 			_ = os.Chmod(configPath, 0o600)
-			os.Remove(configPath)
 		}()
 
 		err := os.Chmod(configPath, 0o400) // Read-only, so we fail only on updating the file, not reading
@@ -276,8 +265,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test fetch all config", t, func() {
 		args := []string{"--list"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -292,8 +280,7 @@ func TestConfigCmdMain(t *testing.T) {
 		Convey("with the shorthand", func() {
 			args := []string{"-l"}
 
-			configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 			cmd := client.NewConfigCommand()
 			buff := bytes.NewBufferString("")
@@ -310,8 +297,7 @@ func TestConfigCmdMain(t *testing.T) {
 		Convey("From empty file", func() {
 			args := []string{"-l"}
 
-			configPath := makeConfigFile(``)
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, ``)
 
 			cmd := client.NewConfigCommand()
 			buff := bytes.NewBufferString("")
@@ -329,8 +315,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test fetch a config", t, func() {
 		args := []string{"configtest", "--list"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -347,8 +332,7 @@ func TestConfigCmdMain(t *testing.T) {
 		Convey("with the shorthand", func() {
 			args := []string{"configtest", "-l"}
 
-			configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 			cmd := client.NewConfigCommand()
 			buff := bytes.NewBufferString("")
@@ -366,8 +350,7 @@ func TestConfigCmdMain(t *testing.T) {
 		Convey("From empty file", func() {
 			args := []string{"configtest", "-l"}
 
-			configPath := makeConfigFile(``)
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, ``)
 
 			cmd := client.NewConfigCommand()
 			buff := bytes.NewBufferString("")
@@ -385,8 +368,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test fetch a config val", t, func() {
 		args := []string{"configtest", "url"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -401,8 +383,7 @@ func TestConfigCmdMain(t *testing.T) {
 		Convey("From empty file", func() {
 			args := []string{"configtest", "url"}
 
-			configPath := makeConfigFile(``)
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, ``)
 
 			cmd := client.NewConfigCommand()
 			buff := bytes.NewBufferString("")
@@ -420,8 +401,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test add a config val", t, func() {
 		args := []string{"configtest", "showspinner", "false"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com"}]}`)
-		defer os.Remove(configPath)
+		configPath := makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com"}]}`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -443,8 +423,7 @@ func TestConfigCmdMain(t *testing.T) {
 		Convey("To an empty file", func() {
 			args := []string{"configtest", "showspinner", "false"}
 
-			configPath := makeConfigFile(``)
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, ``)
 
 			cmd := client.NewConfigCommand()
 			buff := bytes.NewBufferString("")
@@ -462,8 +441,8 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test overwrite a config", t, func() {
 		args := []string{"configtest", "url", "https://new-url.com"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		configPath := makeConfigFile(t,
+			`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -487,8 +466,8 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test reset a config val", t, func() {
 		args := []string{"configtest", "showspinner", "--reset"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		configPath := makeConfigFile(t,
+			`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -511,8 +490,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test reset a url", t, func() {
 		args := []string{"configtest", "url", "--reset"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")
@@ -529,8 +507,7 @@ func TestConfigCmdMain(t *testing.T) {
 	Convey("Test add a config with an existing saved name", t, func() {
 		args := []string{"add", "configtest", "https://test-url.com/new"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := client.NewConfigCommand()
 		buff := bytes.NewBufferString("")

--- a/pkg/cli/client/cve_cmd_internal_test.go
+++ b/pkg/cli/client/cve_cmd_internal_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -47,8 +46,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE help", t, func() {
 		args := []string{"--help"}
 
-		configPath := makeConfigFile("")
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, "")
 
 		cmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -64,8 +62,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE help - with the shorthand", t, func() {
 		args := []string{"-h"}
 
-		configPath := makeConfigFile("")
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, "")
 
 		cmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -81,8 +78,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE no url", t, func() {
 		args := []string{"affected", "CVE-cveIdRandom", "--config", "cvetest"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -97,8 +93,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE invalid url", t, func() {
 		args := []string{"list", "dummyImageName:tag", "--url", "invalidUrl"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cmd := NewCVECommand(new(searchService))
 		buff := bytes.NewBufferString("")
@@ -114,8 +109,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE invalid url port", t, func() {
 		args := []string{"list", "dummyImageName:tag", "--url", "http://localhost:99999"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cmd := NewCVECommand(new(searchService))
 		buff := bytes.NewBufferString("")
@@ -130,8 +124,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE unreachable", t, func() {
 		args := []string{"list", "dummyImageName:tag", "--url", "http://localhost:9999"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cmd := NewCVECommand(new(searchService))
 		buff := bytes.NewBufferString("")
@@ -145,8 +138,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE url from config", t, func() {
 		args := []string{"list", "dummyImageName:tag", "--config", "cvetest"}
 
-		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, baseURL))
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, baseURL))
 
 		cmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -177,8 +169,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test debug flag", t, func() {
 		args := []string{"list", "dummyImageName:tag", "--debug", "--config", "cvetest"}
 
-		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, baseURL))
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, baseURL))
 
 		cmd := NewCVECommand(new(searchService))
 		buff := bytes.NewBufferString("")
@@ -195,8 +186,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE by name and CVE ID - long option", t, func() {
 		args := []string{"affected", "CVE-CVEID", "--repo", "dummyImageName", "--url", baseURL}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -215,8 +205,7 @@ func TestSearchCVECmd(t *testing.T) {
 		args := []string{"affected", "CVE-CVEID", "--repo", "dummyImageName", "--url", baseURL}
 		buff := bytes.NewBufferString("")
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(new(mockService))
 		cveCmd.SetOut(buff)
@@ -233,8 +222,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE by image name - in text format", t, func() {
 		args := []string{"list", "dummyImageName:tag", "--url", baseURL}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -265,8 +253,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE by image name - in text format - in verbose mode", t, func() {
 		args := []string{"list", "dummyImageName:tag", "--url", baseURL, "--verbose"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -304,8 +291,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE by image name - in json format", t, func() {
 		args := []string{"list", "dummyImageName:tag", "--url", baseURL, "-f", "json"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -326,8 +312,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE by image name - in yaml format", t, func() {
 		args := []string{"list", "dummyImageName:tag", "--url", baseURL, "-f", "yaml"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -346,8 +331,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test CVE by image name - invalid format", t, func() {
 		args := []string{"list", "dummyImageName:tag", "--url", baseURL, "-f", "random"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -366,8 +350,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test images by CVE ID - positive", t, func() {
 		args := []string{"affected", "CVE-CVEID", "--repo", "anImage", "--url", baseURL}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -385,8 +368,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test images by CVE ID - positive with retries", t, func() {
 		args := []string{"affected", "CVE-CVEID", "--repo", "anImage", "--url", baseURL}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		mockService := mockServiceForRetry{succeedOn: 2} // CVE info will be provided in 2nd attempt
 		cveCmd := NewCVECommand(&mockService)
@@ -408,8 +390,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test images by CVE ID - failed after retries", t, func() {
 		args := []string{"affected", "CVE-CVEID", "--url", baseURL}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		mockService := mockServiceForRetry{succeedOn: -1} // CVE info will be unavailable on all retries
 		cveCmd := NewCVECommand(&mockService)
@@ -431,8 +412,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test images by CVE ID - invalid CVE ID", t, func() {
 		args := []string{"affected", "CVE-invalidCVEID", "--config", "cvetest"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -446,8 +426,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test images by CVE ID - invalid url", t, func() {
 		args := []string{"affected", "CVE-CVEID", "--url", "invalidURL"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(NewSearchService())
 		buff := bytes.NewBufferString("")
@@ -463,8 +442,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test fixed tags by and image name CVE ID - positive", t, func() {
 		args := []string{"fixed", "fixedImage", "CVE-CVEID", "--url", baseURL}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -482,8 +460,7 @@ func TestSearchCVECmd(t *testing.T) {
 	Convey("Test fixed tags by and image name CVE ID - invalid image name", t, func() {
 		args := []string{"affected", "CVE-CVEID", "--image", "invalidImageName", "--config", "cvetest"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"cvetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
 		cveCmd := NewCVECommand(NewSearchService())
 		buff := bytes.NewBufferString("")
@@ -516,8 +493,7 @@ func TestCVECommandGQL(t *testing.T) {
 	defer cm.StopServer()
 
 	Convey("commands without gql", t, func() {
-		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, baseURL))
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, baseURL))
 
 		Convey("cveid", func() {
 			args := []string{"affected", "CVE-1942", "--config", "cvetest"}
@@ -538,9 +514,8 @@ func TestCVECommandGQL(t *testing.T) {
 			count := 0
 			args := []string{"affected", "CVE-12345", "--config", "cvetest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 
 			cmd := NewCVECommand(mockService{
 				getTagsForCVEGQLFn: func(ctx context.Context, config SearchConfig, username, password,
@@ -587,9 +562,8 @@ func TestCVECommandGQL(t *testing.T) {
 			count := 0
 			args := []string{"fixed", "repo", "CVE-2222", "--config", "cvetest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 
 			cmd := NewCVECommand(mockService{
 				getFixedTagsForCVEGQLFn: func(ctx context.Context, config SearchConfig, username, password,
@@ -639,9 +613,8 @@ func TestCVECommandGQL(t *testing.T) {
 			count := 0
 			args := []string{"list", "repo:vuln", "--config", "cvetest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 
 			cmd := NewCVECommand(mockService{
 				getCveByImageGQLFn: func(ctx context.Context, config SearchConfig, username, password,
@@ -691,8 +664,7 @@ func TestCVECommandErrors(t *testing.T) {
 	defer cm.StopServer()
 
 	Convey("commands without gql", t, func() {
-		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, baseURL))
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, baseURL))
 
 		Convey("cveid", func() {
 			args := []string{"affected", "CVE-1942"}

--- a/pkg/cli/client/elevated_test.go
+++ b/pkg/cli/client/elevated_test.go
@@ -101,11 +101,9 @@ func TestElevatedPrivilegesTLSNewControllerPrivilegedCert(t *testing.T) {
 		defer cm.StopServer()
 
 		Convey("Certs in privileged path", func() {
-			configPath := makeConfigFile(
+			_ = makeConfigFile(t,
 				fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s%s%s","showspinner":false}]}`,
 					BaseSecureURL2, constants.RoutePrefix, constants.ExtCatalogPrefix))
-
-			defer os.Remove(configPath)
 
 			args := []string{"list", "--config", "imagetest"}
 			imageCmd := client.NewImageCommand(client.NewSearchService())

--- a/pkg/cli/client/image_cmd_internal_test.go
+++ b/pkg/cli/client/image_cmd_internal_test.go
@@ -35,8 +35,7 @@ func TestSearchImageCmd(t *testing.T) {
 	Convey("Test image help", t, func() {
 		args := []string{"--help"}
 
-		configPath := makeConfigFile("")
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, "")
 
 		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -51,8 +50,7 @@ func TestSearchImageCmd(t *testing.T) {
 		Convey("with the shorthand", func() {
 			args[0] = "-h"
 
-			configPath := makeConfigFile("")
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, "")
 
 			cmd := NewImageCommand(new(mockService))
 			buff := bytes.NewBufferString("")
@@ -69,8 +67,7 @@ func TestSearchImageCmd(t *testing.T) {
 	Convey("Test image no url", t, func() {
 		args := []string{"name", "dummyIdRandom", "--config", "imagetest"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
 		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -85,8 +82,7 @@ func TestSearchImageCmd(t *testing.T) {
 	Convey("Test image invalid home directory", t, func() {
 		args := []string{"name", "dummyImageName", "--config", "imagetest"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 
 		err := os.Setenv("HOME", "nonExistentDirectory")
 		if err != nil {
@@ -115,8 +111,7 @@ func TestSearchImageCmd(t *testing.T) {
 	Convey("Test image no params", t, func() {
 		args := []string{"--url", "someUrl"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
 		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -130,8 +125,7 @@ func TestSearchImageCmd(t *testing.T) {
 	Convey("Test image invalid url", t, func() {
 		args := []string{"name", "dummyImageName", "--url", "invalidUrl"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
 		cmd := NewImageCommand(new(searchService))
 		buff := bytes.NewBufferString("")
@@ -147,8 +141,7 @@ func TestSearchImageCmd(t *testing.T) {
 	Convey("Test image invalid url port", t, func() {
 		args := []string{"name", "dummyImageName", "--url", "http://localhost:99999"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
 		cmd := NewImageCommand(new(searchService))
 		buff := bytes.NewBufferString("")
@@ -162,8 +155,7 @@ func TestSearchImageCmd(t *testing.T) {
 		Convey("without flags", func() {
 			args := []string{"list", "--url", "http://localhost:99999"}
 
-			configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
 			cmd := NewImageCommand(new(searchService))
 			buff := bytes.NewBufferString("")
@@ -179,8 +171,7 @@ func TestSearchImageCmd(t *testing.T) {
 	Convey("Test image unreachable", t, func() {
 		args := []string{"name", "dummyImageName", "--url", "http://localhost:9999"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
 		cmd := NewImageCommand(new(searchService))
 		buff := bytes.NewBufferString("")
@@ -194,8 +185,7 @@ func TestSearchImageCmd(t *testing.T) {
 	Convey("Test image url from config", t, func() {
 		args := []string{"name", "dummyImageName", "--config", "imagetest"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -213,8 +203,7 @@ func TestSearchImageCmd(t *testing.T) {
 	Convey("Test image by name", t, func() {
 		args := []string{"name", "dummyImageName", "--url", "http://127.0.0.1:8080"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
 		imageCmd := NewImageCommand(new(mockService))
 		buff := &bytes.Buffer{}
@@ -257,8 +246,7 @@ func TestListRepos(t *testing.T) {
 	Convey("Test listing repositories with debug flag", t, func() {
 		args := []string{"list", "--config", "config-test", "--debug"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"config-test","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := NewRepoCommand(new(searchService))
 
@@ -277,8 +265,7 @@ func TestListRepos(t *testing.T) {
 	Convey("Test error on home directory", t, func() {
 		args := []string{"list", "--config", "config-test"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"config-test","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test","url":"https://test-url.com","showspinner":false}]}`)
 
 		err := os.Setenv("HOME", "nonExistentDirectory")
 		if err != nil {
@@ -307,9 +294,8 @@ func TestListRepos(t *testing.T) {
 	Convey("Test listing repositories error", t, func() {
 		args := []string{"list", "--config", "config-test"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"config-test",
+		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test",
         	"url":"https://invalid.invalid","showspinner":false}]}`)
-		defer os.Remove(configPath)
 
 		cmd := NewRepoCommand(new(searchService))
 		buff := bytes.NewBufferString("")
@@ -323,8 +309,7 @@ func TestListRepos(t *testing.T) {
 	Convey("Test unable to get config value", t, func() {
 		args := []string{"list", "--config", "config-test-nonexistent"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"config-test","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := NewRepoCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -338,8 +323,7 @@ func TestListRepos(t *testing.T) {
 	Convey("Test error - no url provided", t, func() {
 		args := []string{"list", "--config", "config-test"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"config-test","url":"","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test","url":"","showspinner":false}]}`)
 
 		cmd := NewRepoCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -353,9 +337,8 @@ func TestListRepos(t *testing.T) {
 	Convey("Test error - spinner config invalid", t, func() {
 		args := []string{"list", "--config", "config-test"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"config-test",
+		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test",
        		"url":"https://test-url.com","showspinner":invalid}]}`)
-		defer os.Remove(configPath)
 
 		cmd := NewRepoCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -369,9 +352,8 @@ func TestListRepos(t *testing.T) {
 	Convey("Test error - verifyTLSConfig fails", t, func() {
 		args := []string{"list", "--config", "config-test"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"config-test",
+		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test",
         	"verify-tls":"invalid", "url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
 
 		cmd := NewRepoCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -387,8 +369,7 @@ func TestOutputFormat(t *testing.T) {
 	Convey("Test text", t, func() {
 		args := []string{"name", "dummyImageName", "--config", "imagetest", "-f", "text"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -406,8 +387,7 @@ func TestOutputFormat(t *testing.T) {
 	Convey("Test json", t, func() {
 		args := []string{"name", "dummyImageName", "--config", "imagetest", "-f", "json"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -437,8 +417,7 @@ func TestOutputFormat(t *testing.T) {
 	Convey("Test yaml", t, func() {
 		args := []string{"name", "dummyImageName", "--config", "imagetest", "-f", "yaml"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -473,11 +452,10 @@ func TestOutputFormat(t *testing.T) {
 		Convey("Test yml", func() {
 			args := []string{"name", "dummyImageName", "--config", "imagetest", "-f", "yml"}
 
-			configPath := makeConfigFile(
-				`{"configs":[{"_name":"imagetest",` +
+			_ = makeConfigFile(t,
+				`{"configs":[{"_name":"imagetest",`+
 					`"url":"https://test-url.com","showspinner":false}]}`,
 			)
-			defer os.Remove(configPath)
 
 			cmd := NewImageCommand(new(mockService))
 			buff := bytes.NewBufferString("")
@@ -513,8 +491,7 @@ func TestOutputFormat(t *testing.T) {
 	Convey("Test invalid", t, func() {
 		args := []string{"name", "dummyImageName", "--config", "imagetest", "-f", "random"}
 
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
-		defer os.Remove(configPath)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 
 		cmd := NewImageCommand(new(mockService))
 		buff := bytes.NewBufferString("")
@@ -565,9 +542,8 @@ func TestImagesCommandGQL(t *testing.T) {
 			err = UploadImage(derivedImage, baseURL, "repo", "derived")
 			So(err, ShouldBeNil)
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 			args := []string{"base", "repo:derived", "--config", "imagetest"}
 
 			cmd := NewImageCommand(NewSearchService())
@@ -654,9 +630,8 @@ func TestImagesCommandGQL(t *testing.T) {
 			err := UploadImage(image, baseURL, "repo", "img")
 			So(err, ShouldBeNil)
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 			args := []string{"digest", image.DigestStr(), "--config", "imagetest"}
 
 			cmd := NewImageCommand(NewSearchService())
@@ -711,9 +686,8 @@ func TestImagesCommandGQL(t *testing.T) {
 			err := UploadImage(image, baseURL, "repo", "img")
 			So(err, ShouldBeNil)
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 			args := []string{"list", "--config", "imagetest"}
 
 			cmd := NewImageCommand(NewSearchService())
@@ -763,9 +737,8 @@ func TestImagesCommandGQL(t *testing.T) {
 			err = UploadImage(CreateRandomImage(), baseURL, "repo", "img2")
 			So(err, ShouldBeNil)
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 			args := []string{"name", "repo:img", "--config", "imagetest"}
 
 			cmd := NewImageCommand(NewSearchService())
@@ -821,9 +794,8 @@ func TestImagesCommandGQL(t *testing.T) {
 			err := UploadImage(vulnImage, baseURL, "repo", "vuln")
 			So(err, ShouldBeNil)
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 			args := []string{"cve", "repo:vuln", "--config", "imagetest"}
 			cmd := NewImageCommand(mockService{})
 			buff := bytes.NewBufferString("")
@@ -842,9 +814,8 @@ func TestImagesCommandGQL(t *testing.T) {
 		Convey("CVE errors", func() {
 			count := 0
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 
 			args := []string{"cve", "repo:vuln", "--config", "imagetest"}
 			cmd := NewImageCommand(mockService{
@@ -875,6 +846,8 @@ func TestImagesCommandGQL(t *testing.T) {
 	})
 
 	Convey("Config error", t, func() {
+		// Create config file with a different config name to test error when config doesn't exist
+		_ = makeConfigFile(t, `{"configs":[{"_name":"other-config","url":"https://test-url.com","showspinner":false}]}`)
 		args := []string{"base", "repo:derived", "--config", "imagetest"}
 		cmd := NewImageCommand(NewSearchService())
 		buff := bytes.NewBufferString("")
@@ -964,9 +937,8 @@ func TestImageCommandREST(t *testing.T) {
 			err = UploadImage(derivedImage, baseURL, "repo", "derived")
 			So(err, ShouldBeNil)
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 			args := []string{"base", "repo:derived", "--config", "imagetest"}
 			cmd := NewImageCommand(NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -992,9 +964,8 @@ func TestImageCommandREST(t *testing.T) {
 			err := UploadImage(image, baseURL, "repo", "img")
 			So(err, ShouldBeNil)
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 			args := []string{"digest", image.DigestStr(), "--config", "imagetest"}
 			cmd := NewImageCommand(NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -1011,9 +982,8 @@ func TestImageCommandREST(t *testing.T) {
 			err := UploadImage(image, baseURL, "repo", "img")
 			So(err, ShouldBeNil)
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 			args := []string{"list", "--config", "imagetest"}
 			cmd := NewImageCommand(NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -1035,9 +1005,8 @@ func TestImageCommandREST(t *testing.T) {
 			err = UploadImage(CreateRandomImage(), baseURL, "repo", "img2")
 			So(err, ShouldBeNil)
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 			args := []string{"name", "repo:img", "--config", "imagetest"}
 			cmd := NewImageCommand(NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -1056,9 +1025,8 @@ func TestImageCommandREST(t *testing.T) {
 			So(err, ShouldBeNil)
 			args := []string{"cve", "repo:vuln", "--config", "imagetest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
-			defer os.Remove(configPath)
 
 			cmd := NewImageCommand(mockService{})
 			buff := bytes.NewBufferString("")
@@ -1534,8 +1502,9 @@ func (service mockService) getImagesByDigest(ctx context.Context, config SearchC
 	service.getImageByName(ctx, config, username, password, "anImage", rch, wtgrp)
 }
 
-func makeConfigFile(content string) string {
-	os.Setenv("HOME", os.TempDir())
+func makeConfigFile(t *testing.T, content string) string {
+	tempDir := t.TempDir()
+	os.Setenv("HOME", tempDir)
 
 	home, err := os.UserHomeDir()
 	if err != nil {

--- a/pkg/cli/client/image_cmd_test.go
+++ b/pkg/cli/client/image_cmd_test.go
@@ -369,8 +369,7 @@ func TestOutputFormatGQL(t *testing.T) {
 			t.Logf("%s", ctlr.Config.Storage.RootDirectory)
 			args := []string{"name", "repo7", "--config", "imagetest", "-f", "json"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 			cmd := client.NewImageCommand(client.NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -417,8 +416,7 @@ func TestOutputFormatGQL(t *testing.T) {
 		Convey("Test yaml", func() {
 			args := []string{"name", "repo7", "--config", "imagetest", "-f", "yaml"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 			cmd := client.NewImageCommand(client.NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -468,8 +466,7 @@ func TestOutputFormatGQL(t *testing.T) {
 		Convey("Test yml", func() {
 			args := []string{"name", "repo7", "--config", "imagetest", "-f", "yml"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 			cmd := client.NewImageCommand(client.NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -519,8 +516,7 @@ func TestOutputFormatGQL(t *testing.T) {
 		Convey("Test invalid", func() {
 			args := []string{"name", "repo7", "--config", "imagetest", "-f", "random"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 			cmd := client.NewImageCommand(client.NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -560,8 +556,7 @@ func TestServerResponseGQL(t *testing.T) {
 			t.Logf("%s", ctlr.Config.Storage.RootDirectory)
 			args := []string{"list", "--config", "imagetest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 			cmd := client.NewImageCommand(client.NewSearchService())
 			buff := &bytes.Buffer{}
@@ -579,8 +574,7 @@ func TestServerResponseGQL(t *testing.T) {
 			Convey("Test all images invalid output format", func() {
 				args := []string{"list", "--config", "imagetest", "-f", "random"}
 
-				configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-				defer os.Remove(configPath)
+				_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 				cmd := client.NewImageCommand(client.NewSearchService())
 				buff := bytes.NewBufferString("")
@@ -596,8 +590,7 @@ func TestServerResponseGQL(t *testing.T) {
 		Convey("Test all images verbose", func() {
 			args := []string{"list", "--config", "imagetest", "--verbose"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 			cmd := client.NewImageCommand(client.NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -623,8 +616,7 @@ func TestServerResponseGQL(t *testing.T) {
 		Convey("Test all images with debug flag", func() {
 			args := []string{"list", "--config", "imagetest", "--debug"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 			cmd := client.NewImageCommand(client.NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -648,8 +640,7 @@ func TestServerResponseGQL(t *testing.T) {
 		Convey("Test image by name config url", func() {
 			args := []string{"name", "repo7", "--config", "imagetest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 			cmd := client.NewImageCommand(client.NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -671,8 +662,7 @@ func TestServerResponseGQL(t *testing.T) {
 			Convey("invalid output format", func() {
 				args := []string{"name", "repo7", "--config", "imagetest", "-f", "random"}
 
-				configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-				defer os.Remove(configPath)
+				_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 				cmd := client.NewImageCommand(client.NewSearchService())
 				buff := bytes.NewBufferString("")
@@ -688,8 +678,7 @@ func TestServerResponseGQL(t *testing.T) {
 		Convey("Test image by digest", func() {
 			args := []string{"digest", "51e18f50", "--config", "imagetest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 			cmd := client.NewImageCommand(client.NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -712,8 +701,7 @@ func TestServerResponseGQL(t *testing.T) {
 			Convey("nonexistent digest", func() {
 				args := []string{"digest", "d1g35t", "--config", "imagetest"}
 
-				configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-				defer os.Remove(configPath)
+				_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 				cmd := client.NewImageCommand(client.NewSearchService())
 				buff := bytes.NewBufferString("")
@@ -728,8 +716,7 @@ func TestServerResponseGQL(t *testing.T) {
 			Convey("invalid output format", func() {
 				args := []string{"digest", "51e18f50", "--config", "imagetest", "-f", "random"}
 
-				configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-				defer os.Remove(configPath)
+				_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 				cmd := client.NewImageCommand(client.NewSearchService())
 				buff := bytes.NewBufferString("")
@@ -745,8 +732,7 @@ func TestServerResponseGQL(t *testing.T) {
 		Convey("Test image by name nonexistent name", func() {
 			args := []string{"name", "repo777", "--config", "imagetest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`, url))
 
 			cmd := client.NewImageCommand(client.NewSearchService())
 			buff := bytes.NewBufferString("")
@@ -761,9 +747,8 @@ func TestServerResponseGQL(t *testing.T) {
 		Convey("Test list repos error", func() {
 			args := []string{"list", "--config", "config-test"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"config-test",
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"config-test",
             "url":"%s","showspinner":false}]}`, url))
-			defer os.Remove(configPath)
 
 			cmd := client.NewRepoCommand(client.NewSearchService())
 			buff := &bytes.Buffer{}

--- a/pkg/cli/client/repo_test.go
+++ b/pkg/cli/client/repo_test.go
@@ -5,7 +5,6 @@ package client_test
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -38,9 +37,8 @@ func TestReposCommand(t *testing.T) {
 		err = UploadImage(CreateRandomImage(), baseURL, "repo2", "tag2")
 		So(err, ShouldBeNil)
 
-		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"repostest","url":"%s","showspinner":false}]}`,
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"repostest","url":"%s","showspinner":false}]}`,
 			baseURL))
-		defer os.Remove(configPath)
 
 		args := []string{"list", "--config", "repostest"}
 		cmd := client.NewRepoCommand(client.NewSearchService())

--- a/pkg/cli/client/search_cmd_internal_test.go
+++ b/pkg/cli/client/search_cmd_internal_test.go
@@ -5,7 +5,6 @@ package client
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -40,9 +39,8 @@ func TestSearchCommandGQL(t *testing.T) {
 	defer cm.StopServer()
 
 	Convey("commands without gql", t, func() {
-		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
 			baseURL))
-		defer os.Remove(configPath)
 
 		Convey("query", func() {
 			args := []string{"query", "repo/al", "--config", "searchtest"}
@@ -120,9 +118,8 @@ func TestSearchCommandREST(t *testing.T) {
 	defer cm.StopServer()
 
 	Convey("commands without gql", t, func() {
-		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
 			baseURL))
-		defer os.Remove(configPath)
 
 		Convey("query", func() {
 			args := []string{"query", "repo/al", "--config", "searchtest"}

--- a/pkg/cli/client/search_cmd_test.go
+++ b/pkg/cli/client/search_cmd_test.go
@@ -5,7 +5,6 @@ package client_test
 import (
 	"bytes"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -83,9 +82,8 @@ func TestReferrerCLI(t *testing.T) {
 
 		args := []string{"subject", repo + "@" + image.DigestStr(), "--config", "reftest"}
 
-		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
 			baseURL))
-		defer os.Remove(configPath)
 
 		cmd := client.NewSearchCommand(client.NewSearchService())
 
@@ -104,13 +102,10 @@ func TestReferrerCLI(t *testing.T) {
 
 		fmt.Println(buff.String())
 
-		os.Remove(configPath)
-
 		args = []string{"subject", repo + ":" + "tag", "--config", "reftest"}
 
-		configPath = makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
 			baseURL))
-		defer os.Remove(configPath)
 
 		cmd = client.NewSearchCommand(client.NewSearchService())
 
@@ -182,7 +177,7 @@ func TestReferrerCLI(t *testing.T) {
 		// get referrers by digest
 		args := []string{"subject", repo + "@" + image.DigestStr(), "--config", "reftest"}
 
-		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
 			baseURL))
 
 		cmd := client.NewSearchCommand(client.NewSearchService())
@@ -201,13 +196,10 @@ func TestReferrerCLI(t *testing.T) {
 		So(str, ShouldContainSubstring, "custom.art.type.v2 611 B "+ref3.DigestStr())
 		fmt.Println(buff.String())
 
-		os.Remove(configPath)
-
 		args = []string{"subject", repo + ":" + "tag", "--config", "reftest"}
 
-		configPath = makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
 			baseURL))
-		defer os.Remove(configPath)
 
 		buff = &bytes.Buffer{}
 		cmd.SetOut(buff)
@@ -279,10 +271,8 @@ func TestFormatsReferrersCLI(t *testing.T) {
 		Convey("JSON format", func() {
 			args := []string{"subject", repo + "@" + image.DigestStr(), "--format", "json", "--config", "reftest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
 				baseURL))
-
-			defer os.Remove(configPath)
 
 			cmd := client.NewSearchCommand(client.NewSearchService())
 
@@ -297,10 +287,8 @@ func TestFormatsReferrersCLI(t *testing.T) {
 		Convey("YAML format", func() {
 			args := []string{"subject", repo + "@" + image.DigestStr(), "--format", "yaml", "--config", "reftest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
 				baseURL))
-
-			defer os.Remove(configPath)
 
 			cmd := client.NewSearchCommand(client.NewSearchService())
 
@@ -315,10 +303,8 @@ func TestFormatsReferrersCLI(t *testing.T) {
 		Convey("Invalid format", func() {
 			args := []string{"subject", repo + "@" + image.DigestStr(), "--format", "invalid_format", "--config", "reftest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"reftest","url":"%s","showspinner":false}]}`,
 				baseURL))
-
-			defer os.Remove(configPath)
 
 			cmd := client.NewSearchCommand(client.NewSearchService())
 
@@ -339,9 +325,7 @@ func TestReferrersCLIErrors(t *testing.T) {
 		Convey("no url provided", func() {
 			args := []string{"query", "repo/alpine", "--format", "invalid", "--config", "reftest"}
 
-			configPath := makeConfigFile(`{"configs":[{"_name":"reftest","showspinner":false}]}`)
-
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, `{"configs":[{"_name":"reftest","showspinner":false}]}`)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -354,9 +338,7 @@ func TestReferrersCLIErrors(t *testing.T) {
 		Convey("getConfigValue", func() {
 			args := []string{"subject", "repo/alpine", "--config", "reftest"}
 
-			configPath := makeConfigFile(`bad-json`)
-
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, `bad-json`)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -369,9 +351,7 @@ func TestReferrersCLIErrors(t *testing.T) {
 		Convey("bad showspinnerConfig ", func() {
 			args := []string{"query", "repo", "--config", "reftest"}
 
-			configPath := makeConfigFile(`{"configs":[{"_name":"reftest", "url":"http://127.0.0.1:8080", "showspinner":"bad"}]}`)
-
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, `{"configs":[{"_name":"reftest", "url":"http://127.0.0.1:8080", "showspinner":"bad"}]}`)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -384,10 +364,8 @@ func TestReferrersCLIErrors(t *testing.T) {
 		Convey("bad verifyTLSConfig ", func() {
 			args := []string{"query", "repo", "reftest"}
 
-			configPath := makeConfigFile(
+			_ = makeConfigFile(t,
 				`{"configs":[{"_name":"reftest", "url":"http://127.0.0.1:8080", "showspinner":false, "verify-tls": "bad"}]}`)
-
-			defer os.Remove(configPath)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -400,9 +378,7 @@ func TestReferrersCLIErrors(t *testing.T) {
 		Convey("url from config is empty", func() {
 			args := []string{"subject", "repo/alpine", "--config", "reftest"}
 
-			configPath := makeConfigFile(`{"configs":[{"_name":"reftest", "url":"", "showspinner":false}]}`)
-
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, `{"configs":[{"_name":"reftest", "url":"", "showspinner":false}]}`)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -415,9 +391,7 @@ func TestReferrersCLIErrors(t *testing.T) {
 		Convey("bad params combination", func() {
 			args := []string{"query", "repo", "reftest"}
 
-			configPath := makeConfigFile(`{"configs":[{"_name":"reftest", "url":"http://127.0.0.1:8080", "showspinner":false}]}`)
-
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, `{"configs":[{"_name":"reftest", "url":"http://127.0.0.1:8080", "showspinner":false}]}`)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -497,9 +471,8 @@ func TestSearchCLI(t *testing.T) {
 
 		args := []string{"query", "test/alpin", "--verbose", "--config", "searchtest"}
 
-		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
 			baseURL))
-		defer os.Remove(configPath)
 
 		cmd := client.NewSearchCommand(client.NewSearchService())
 
@@ -518,16 +491,12 @@ func TestSearchCLI(t *testing.T) {
 
 		fmt.Println("\n", buff.String())
 
-		os.Remove(configPath)
-
 		cmd = client.NewSearchCommand(client.NewSearchService())
 
 		args = []string{"query", "repo/alpine:", "--config", "searchtest"}
 
-		configPath = makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
 			baseURL))
-
-		defer os.Remove(configPath)
 
 		buff = &bytes.Buffer{}
 		cmd.SetOut(buff)
@@ -601,10 +570,8 @@ func TestFormatsSearchCLI(t *testing.T) {
 		Convey("JSON format", func() {
 			args := []string{"query", "repo/alpine", "--format", "json", "--config", "searchtest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
 				baseURL))
-
-			defer os.Remove(configPath)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -618,10 +585,8 @@ func TestFormatsSearchCLI(t *testing.T) {
 		Convey("YAML format", func() {
 			args := []string{"query", "repo/alpine", "--format", "yaml", "--config", "searchtest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
 				baseURL))
-
-			defer os.Remove(configPath)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -635,10 +600,8 @@ func TestFormatsSearchCLI(t *testing.T) {
 		Convey("Invalid format", func() {
 			args := []string{"query", "repo/alpine", "--format", "invalid", "--config", "searchtest"}
 
-			configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
+			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"searchtest","url":"%s","showspinner":false}]}`,
 				baseURL))
-
-			defer os.Remove(configPath)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -657,9 +620,7 @@ func TestSearchCLIErrors(t *testing.T) {
 		Convey("no url provided", func() {
 			args := []string{"query", "repo/alpine", "--format", "invalid", "--config", "searchtest"}
 
-			configPath := makeConfigFile(`{"configs":[{"_name":"searchtest","showspinner":false}]}`)
-
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, `{"configs":[{"_name":"searchtest","showspinner":false}]}`)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -672,9 +633,7 @@ func TestSearchCLIErrors(t *testing.T) {
 		Convey("getConfigValue", func() {
 			args := []string{"query", "repo/alpine", "--format", "invalid", "--config", "searchtest"}
 
-			configPath := makeConfigFile(`bad-json`)
-
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, `bad-json`)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -687,10 +646,8 @@ func TestSearchCLIErrors(t *testing.T) {
 		Convey("bad showspinnerConfig ", func() {
 			args := []string{"query", "repo/alpine", "--config", "searchtest"}
 
-			configPath := makeConfigFile(
+			_ = makeConfigFile(t,
 				`{"configs":[{"_name":"searchtest", "url":"http://127.0.0.1:8080", "showspinner":"bad"}]}`)
-
-			defer os.Remove(configPath)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -703,10 +660,8 @@ func TestSearchCLIErrors(t *testing.T) {
 		Convey("bad verifyTLSConfig ", func() {
 			args := []string{"query", "repo/alpine", "--config", "searchtest"}
 
-			configPath := makeConfigFile(
+			_ = makeConfigFile(t,
 				`{"configs":[{"_name":"searchtest", "url":"http://127.0.0.1:8080", "showspinner":false, "verify-tls": "bad"}]}`)
-
-			defer os.Remove(configPath)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)
@@ -719,9 +674,7 @@ func TestSearchCLIErrors(t *testing.T) {
 		Convey("url from config is empty", func() {
 			args := []string{"query", "repo/alpine", "--format", "invalid", "--config", "searchtest"}
 
-			configPath := makeConfigFile(`{"configs":[{"_name":"searchtest", "url":"", "showspinner":false}]}`)
-
-			defer os.Remove(configPath)
+			_ = makeConfigFile(t, `{"configs":[{"_name":"searchtest", "url":"", "showspinner":false}]}`)
 
 			buff := &bytes.Buffer{}
 			cmd.SetOut(buff)

--- a/pkg/cli/client/search_functions_internal_test.go
+++ b/pkg/cli/client/search_functions_internal_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -859,24 +858,22 @@ func TestUtils(t *testing.T) {
 		So(verifyTLS, ShouldBeFalse)
 
 		// bad showspinner
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":"bad", "verify-tls": false}]}`)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":"bad", "verify-tls": false}]}`)
 		cmd = &cobra.Command{}
 		cmd.Flags().String(ConfigFlag, "imagetest", "")
 		isSpinner, verifyTLS, err = GetCliConfigOptions(cmd)
 		So(err, ShouldNotBeNil)
 		So(isSpinner, ShouldBeFalse)
 		So(verifyTLS, ShouldBeFalse)
-		os.Remove(configPath)
 
 		// bad verify-tls
-		configPath = makeConfigFile(`{"configs":[{"_name":"imagetest","showspinner":false, "verify-tls": "bad"}]}`)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false, "verify-tls": "bad"}]}`)
 		cmd = &cobra.Command{}
 		cmd.Flags().String(ConfigFlag, "imagetest", "")
 		isSpinner, verifyTLS, err = GetCliConfigOptions(cmd)
 		So(err, ShouldNotBeNil)
 		So(isSpinner, ShouldBeFalse)
 		So(verifyTLS, ShouldBeFalse)
-		os.Remove(configPath)
 	})
 
 	Convey("GetServerURLFromFlags", t, func() {
@@ -893,22 +890,20 @@ func TestUtils(t *testing.T) {
 		So(err, ShouldNotBeNil)
 
 		// err ulr from config is empty
-		configPath := makeConfigFile(`{"configs":[{"_name":"imagetest"}]}`)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest"}]}`)
 		cmd = &cobra.Command{}
 		cmd.Flags().String(ConfigFlag, "imagetest", "")
 		url, err = GetServerURLFromFlags(cmd)
 		So(url, ShouldResemble, "")
 		So(err, ShouldNotBeNil)
-		os.Remove(configPath)
 
 		// err reading the server url from config
-		configPath = makeConfigFile("{}")
+		_ = makeConfigFile(t, "{}")
 		cmd = &cobra.Command{}
 		cmd.Flags().String(ConfigFlag, "imagetest", "")
 		url, err = GetServerURLFromFlags(cmd)
 		So(url, ShouldResemble, "")
 		So(err, ShouldNotBeNil)
-		os.Remove(configPath)
 	})
 
 	Convey("CheckExtEndPointQuery", t, func() {

--- a/pkg/cli/client/server_info_cmd_test.go
+++ b/pkg/cli/client/server_info_cmd_test.go
@@ -40,9 +40,8 @@ func TestServerStatusCommand(t *testing.T) {
 		cm.StartAndWait(conf.HTTP.Port)
 		defer cm.StopServer()
 
-		configPath := makeConfigFile(fmt.Sprintf(`{"configs":[{"_name":"status-test","url":"%s","showspinner":false}]}`,
+		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"status-test","url":"%s","showspinner":false}]}`,
 			baseURL))
-		defer os.Remove(configPath)
 
 		args := []string{"status", "--config", "status-test"}
 		cmd := NewCliRootCmd()

--- a/pkg/cli/server/extensions_test.go
+++ b/pkg/cli/server/extensions_test.go
@@ -26,10 +26,6 @@ func TestVerifyExtensionsConfig(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	Convey("Test verify CVE warn for remote storage", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := fmt.Sprintf(`{
 			"storage":{
 				"rootDirectory":"%s",
@@ -58,10 +54,9 @@ func TestVerifyExtensionsConfig(t *testing.T) {
 			}
 		}`, t.TempDir())
 
-		err = os.WriteFile(tmpfile.Name(), []byte(content), 0o0600)
-		So(err, ShouldBeNil)
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
-		os.Args = []string{"cli_test", "verify", tmpfile.Name()}
+		os.Args = []string{"cli_test", "verify", tmpfile}
 
 		So(cli.NewServerRootCmd().Execute(), ShouldNotBeNil)
 
@@ -98,149 +93,99 @@ func TestVerifyExtensionsConfig(t *testing.T) {
 				}
 			}
 		}`, t.TempDir(), t.TempDir())
-		err = os.WriteFile(tmpfile.Name(), []byte(content), 0o0600)
-		So(err, ShouldBeNil)
+		tmpfile = MakeTempFileWithContent(t, "zot-test.json", content)
 
-		os.Args = []string{"cli_test", "verify", tmpfile.Name()}
+		os.Args = []string{"cli_test", "verify", tmpfile}
 
 		So(cli.NewServerRootCmd().Execute(), ShouldNotBeNil)
 	})
 
 	Convey("Test verify w/ sync and w/o filesystem storage", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := fmt.Sprintf(`{"storage":{"rootDirectory":"%s", "storageDriver": {"name": "s3"}},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
 							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
 							"maxRetries": 1, "retryDelay": "10s"}]}}}`, t.TempDir())
-		_, err = tmpfile.WriteString(content)
-		So(err, ShouldBeNil)
-		err = tmpfile.Close()
-		So(err, ShouldBeNil)
-		os.Args = []string{"cli_test", "verify", tmpfile.Name()}
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+		os.Args = []string{"cli_test", "verify", tmpfile}
 
 		So(cli.NewServerRootCmd().Execute(), ShouldNotBeNil)
 	})
 
 	Convey("Test verify w/ sync and w/ filesystem storage", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := fmt.Sprintf(`{"storage":{"rootDirectory":"%s"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
 							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
 							"maxRetries": 1, "retryDelay": "10s"}]}}}`, t.TempDir())
-		_, err = tmpfile.WriteString(content)
-		So(err, ShouldBeNil)
-		err = tmpfile.Close()
-		So(err, ShouldBeNil)
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
-		os.Args = []string{"cli_test", "verify", tmpfile.Name()}
+		os.Args = []string{"cli_test", "verify", tmpfile}
 
 		So(cli.NewServerRootCmd().Execute(), ShouldBeNil)
 	})
 
 	Convey("Test verify with bad sync prefixes", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := fmt.Sprintf(`{"storage":{"rootDirectory":"%s"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
 							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
 							"maxRetries": 1, "retryDelay": "10s",
 							"content": [{"prefix":"[repo^&["}]}]}}}`, t.TempDir())
-		_, err = tmpfile.WriteString(content)
-		So(err, ShouldBeNil)
-		err = tmpfile.Close()
-		So(err, ShouldBeNil)
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
-		os.Args = []string{"cli_test", "verify", tmpfile.Name()}
+		os.Args = []string{"cli_test", "verify", tmpfile}
 
 		So(cli.NewServerRootCmd().Execute(), ShouldNotBeNil)
 	})
 
 	Convey("Test verify with bad sync content config", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := fmt.Sprintf(`{"storage":{"rootDirectory":"%s"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
 							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
 							"maxRetries": 1, "retryDelay": "10s",
 							"content": [{"prefix":"zot-repo","stripPrefix":true,"destination":"/"}]}]}}}`, t.TempDir())
-		_, err = tmpfile.WriteString(content)
-		So(err, ShouldBeNil)
-		err = tmpfile.Close()
-		So(err, ShouldBeNil)
-		os.Args = []string{"cli_test", "verify", tmpfile.Name()}
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+		os.Args = []string{"cli_test", "verify", tmpfile}
 
 		So(cli.NewServerRootCmd().Execute(), ShouldNotBeNil)
 	})
 
 	Convey("Test verify with good sync content config", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := fmt.Sprintf(`{"storage":{"rootDirectory":"%s"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
 							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
 							"maxRetries": 1, "retryDelay": "10s",
 							"content": [{"prefix":"zot-repo/*","stripPrefix":true,"destination":"/"}]}]}}}`, t.TempDir())
-		_, err = tmpfile.WriteString(content)
-		So(err, ShouldBeNil)
-		err = tmpfile.Close()
-		So(err, ShouldBeNil)
-		os.Args = []string{"cli_test", "verify", tmpfile.Name()}
-		err = cli.NewServerRootCmd().Execute()
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+		os.Args = []string{"cli_test", "verify", tmpfile}
+		err := cli.NewServerRootCmd().Execute()
 		So(err, ShouldBeNil)
 	})
 
 	Convey("Test verify sync config default tls value", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := fmt.Sprintf(`{"storage":{"rootDirectory":"%s"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
 							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
 							"maxRetries": 1, "retryDelay": "10s",
 							"content": [{"prefix":"repo**"}]}]}}}`, t.TempDir())
-		_, err = tmpfile.WriteString(content)
-		So(err, ShouldBeNil)
-		err = tmpfile.Close()
-		So(err, ShouldBeNil)
-		os.Args = []string{"cli_test", "verify", tmpfile.Name()}
-		err = cli.NewServerRootCmd().Execute()
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+		os.Args = []string{"cli_test", "verify", tmpfile}
+		err := cli.NewServerRootCmd().Execute()
 		So(err, ShouldBeNil)
 	})
 
 	Convey("Test verify sync without retry options", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := fmt.Sprintf(`{"storage":{"rootDirectory":"%s"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
 							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
 							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
 							"maxRetries": 10, "content": [{"prefix":"repo**"}]}]}}}`, t.TempDir())
-		_, err = tmpfile.WriteString(content)
-		So(err, ShouldBeNil)
-		err = tmpfile.Close()
-		So(err, ShouldBeNil)
-		os.Args = []string{"cli_test", "verify", tmpfile.Name()}
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+		os.Args = []string{"cli_test", "verify", tmpfile}
 
 		So(cli.NewServerRootCmd().Execute(), ShouldNotBeNil)
 	})
@@ -249,12 +194,8 @@ func TestVerifyExtensionsConfig(t *testing.T) {
 func TestValidateExtensionsConfig(t *testing.T) {
 	Convey("Legacy extensions should not error", t, func(c C) {
 		config := config.New()
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
 
-		defer os.Remove(tmpfile.Name())
-
-		content := []byte(`{
+		content := `{
 			"storage": {
 				"rootDirectory": "%/tmp/zot"
 			},
@@ -273,22 +214,16 @@ func TestValidateExtensionsConfig(t *testing.T) {
 					"enable": "true"
 				}
 			}
-		}`)
-		err = os.WriteFile(tmpfile.Name(), content, 0o0600)
-		So(err, ShouldBeNil)
-		err = cli.LoadConfiguration(config, tmpfile.Name())
+		}`
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+		err := cli.LoadConfiguration(config, tmpfile)
 		So(err, ShouldBeNil)
 	})
 
 	Convey("Test missing extensions for UI to work", t, func(c C) {
 		config := config.New()
 
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-
-		defer os.Remove(tmpfile.Name())
-
-		content := []byte(`{
+		content := `{
 			"storage": {
 				"rootDirectory": "%/tmp/zot"
 			},
@@ -304,21 +239,15 @@ func TestValidateExtensionsConfig(t *testing.T) {
 					"enable": "true"
 				}
 			}
-		}`)
-		err = os.WriteFile(tmpfile.Name(), content, 0o0600)
-		So(err, ShouldBeNil)
-		err = cli.LoadConfiguration(config, tmpfile.Name())
+		}`
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+		err := cli.LoadConfiguration(config, tmpfile)
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("Test enabling UI extension with all prerequisites", t, func(c C) {
 		config := config.New()
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-
-		defer os.Remove(tmpfile.Name())
-
-		content := []byte(`{
+		content := `{
 			"storage": {
 				"rootDirectory": "%/tmp/zot"
 			},
@@ -337,21 +266,15 @@ func TestValidateExtensionsConfig(t *testing.T) {
 					"enable": "true"
 				}
 			}
-		}`)
-		err = os.WriteFile(tmpfile.Name(), content, 0o0600)
-		So(err, ShouldBeNil)
-		err = cli.LoadConfiguration(config, tmpfile.Name())
+		}`
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+		err := cli.LoadConfiguration(config, tmpfile)
 		So(err, ShouldBeNil)
 	})
 
 	Convey("Test extension are implicitly enabled", t, func(c C) {
 		config := config.New()
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-
-		defer os.Remove(tmpfile.Name())
-
-		content := []byte(`{
+		content := `{
 			"storage": {
 				"rootDirectory": "%/tmp/zot"
 			},
@@ -369,10 +292,9 @@ func TestValidateExtensionsConfig(t *testing.T) {
 				"trust": {},
 				"scrub": {}
 			}
-		}`)
-		err = os.WriteFile(tmpfile.Name(), content, 0o0600)
-		So(err, ShouldBeNil)
-		err = cli.LoadConfiguration(config, tmpfile.Name())
+		}`
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+		err := cli.LoadConfiguration(config, tmpfile)
 		So(err, ShouldBeNil)
 		So(config.Extensions.UI, ShouldNotBeNil)
 		So(*config.Extensions.UI.Enable, ShouldBeTrue)
@@ -395,10 +317,7 @@ func TestServeExtensions(t *testing.T) {
 	Convey("config file with no extensions", t, func(c C) {
 		port := GetFreePort()
 		baseURL := GetBaseURL(port)
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		defer os.Remove(logFile.Name()) // clean up
+		logPath := MakeTempFilePath(t, "zot-log.txt")
 
 		tmpFile := t.TempDir()
 
@@ -414,29 +333,22 @@ func TestServeExtensions(t *testing.T) {
 				"level": "debug",
 				"output": "%s"
 			}
-		}`, tmpFile, port, logFile.Name())
+		}`, tmpFile, port, logPath)
 
-		cfgfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(cfgfile.Name()) // clean up
+		cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
-		_, err = cfgfile.WriteString(content)
-		So(err, ShouldBeNil)
-		err = cfgfile.Close()
-		So(err, ShouldBeNil)
-
-		os.Args = []string{"cli_test", "serve", cfgfile.Name()}
+		os.Args = []string{"cli_test", "serve", cfgfile}
 
 		go func() {
 			Convey("run", t, func() {
-				err = cli.NewServerRootCmd().Execute()
+				err := cli.NewServerRootCmd().Execute()
 				So(err, ShouldBeNil)
 			})
 		}()
 
 		WaitTillServerReady(baseURL)
 
-		data, err := os.ReadFile(logFile.Name())
+		data, err := os.ReadFile(logPath)
 
 		So(err, ShouldBeNil)
 		So(string(data), ShouldContainSubstring, "\"Extensions\":null")
@@ -445,10 +357,7 @@ func TestServeExtensions(t *testing.T) {
 	Convey("config file with empty extensions", t, func(c C) {
 		port := GetFreePort()
 		baseURL := GetBaseURL(port)
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		defer os.Remove(logFile.Name()) // clean up
+		logPath := MakeTempFilePath(t, "zot-log.txt")
 
 		tmpFile := t.TempDir()
 
@@ -466,28 +375,21 @@ func TestServeExtensions(t *testing.T) {
 			},
 			"extensions": {
 			}
-		}`, tmpFile, port, logFile.Name())
+		}`, tmpFile, port, logPath)
 
-		cfgfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(cfgfile.Name()) // clean up
+		cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
-		_, err = cfgfile.WriteString(content)
-		So(err, ShouldBeNil)
-		err = cfgfile.Close()
-		So(err, ShouldBeNil)
-
-		os.Args = []string{"cli_test", "serve", cfgfile.Name()}
+		os.Args = []string{"cli_test", "serve", cfgfile}
 
 		go func() {
 			Convey("run", t, func() {
-				err = cli.NewServerRootCmd().Execute()
+				err := cli.NewServerRootCmd().Execute()
 				So(err, ShouldBeNil)
 			})
 		}()
 
 		WaitTillServerReady(baseURL)
-		data, err := os.ReadFile(logFile.Name())
+		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
 		So(string(data), ShouldContainSubstring,
 			"\"Extensions\":{\"Search\":null,\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":null,\"UI\":null,\"Mgmt\":null") //nolint:lll // gofumpt conflicts with lll
@@ -498,27 +400,16 @@ func testWithMetricsEnabled(t *testing.T, rootDir string, cfgContentFormat strin
 	t.Helper()
 	port := GetFreePort()
 	baseURL := GetBaseURL(port)
-	logFile, err := os.CreateTemp("", "zot-log*.txt")
-	So(err, ShouldBeNil)
+	logPath := MakeTempFilePath(t, "zot-log.txt")
 
-	defer os.Remove(logFile.Name()) // clean up
+	content := fmt.Sprintf(cfgContentFormat, rootDir, port, logPath)
+	cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
-	content := fmt.Sprintf(cfgContentFormat, rootDir, port, logFile.Name())
-	cfgfile, err := os.CreateTemp("", "zot-test*.json")
-	So(err, ShouldBeNil)
-
-	defer os.Remove(cfgfile.Name()) // clean up
-
-	_, err = cfgfile.WriteString(content)
-	So(err, ShouldBeNil)
-	err = cfgfile.Close()
-	So(err, ShouldBeNil)
-
-	os.Args = []string{"cli_test", "serve", cfgfile.Name()}
+	os.Args = []string{"cli_test", "serve", cfgfile}
 
 	go func() {
 		Convey("run", t, func() {
-			err = cli.NewServerRootCmd().Execute()
+			err := cli.NewServerRootCmd().Execute()
 			So(err, ShouldBeNil)
 		})
 	}()
@@ -532,7 +423,7 @@ func testWithMetricsEnabled(t *testing.T, rootDir string, cfgContentFormat strin
 	respStr := string(resp.Body())
 	So(respStr, ShouldContainSubstring, "zot_info")
 
-	data, err := os.ReadFile(logFile.Name())
+	data, err := os.ReadFile(logPath)
 	So(err, ShouldBeNil)
 	So(string(data), ShouldContainSubstring,
 		"\"Metrics\":{\"Enable\":true,\"Prometheus\":{\"Path\":\"/metrics\"}}")
@@ -619,11 +510,9 @@ func TestServeMetricsExtension(t *testing.T) {
 	Convey("with explicit disable", t, func(c C) {
 		port := GetFreePort()
 		baseURL := GetBaseURL(port)
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-		tmpFile := t.TempDir()
+		logPath := MakeTempFilePath(t, "zot-log.txt")
 
-		defer os.Remove(logFile.Name()) // clean up
+		tmpFile := t.TempDir()
 
 		content := fmt.Sprintf(`{
 					"storage": {
@@ -642,22 +531,15 @@ func TestServeMetricsExtension(t *testing.T) {
 							"enable": false
 						}
 					}
-				}`, tmpFile, port, logFile.Name())
+				}`, tmpFile, port, logPath)
 
-		cfgfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(cfgfile.Name()) // clean up
+		cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
-		_, err = cfgfile.WriteString(content)
-		So(err, ShouldBeNil)
-		err = cfgfile.Close()
-		So(err, ShouldBeNil)
-
-		os.Args = []string{"cli_test", "serve", cfgfile.Name()}
+		os.Args = []string{"cli_test", "serve", cfgfile}
 
 		go func() {
 			Convey("run", t, func() {
-				err = cli.NewServerRootCmd().Execute()
+				err := cli.NewServerRootCmd().Execute()
 				So(err, ShouldBeNil)
 			})
 		}()
@@ -669,7 +551,7 @@ func TestServeMetricsExtension(t *testing.T) {
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
 
-		data, err := os.ReadFile(logFile.Name())
+		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
 		So(string(data), ShouldContainSubstring,
 			"\"Metrics\":{\"Enable\":false,\"Prometheus\":{\"Path\":\"/metrics\"}}") //nolint:lll // gofumpt conflicts with lll
@@ -717,12 +599,10 @@ func TestServeSyncExtension(t *testing.T) {
 				}
 			}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		So(string(data), ShouldContainSubstring,
 			"\"Extensions\":{\"Search\":null,\"Sync\":{\"Enable\":true")
@@ -765,12 +645,10 @@ func TestServeSyncExtension(t *testing.T) {
 				}
 			}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		So(string(data), ShouldContainSubstring,
 			"\"Extensions\":{\"Search\":null,\"Sync\":{\"Enable\":true")
@@ -803,12 +681,10 @@ func TestServeSyncExtension(t *testing.T) {
 				}
 			}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		So(string(data), ShouldContainSubstring,
 			"\"Extensions\":{\"Search\":null,\"Sync\":{\"Enable\":false")
@@ -839,12 +715,10 @@ func TestServeScrubExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		dataStr := string(data)
 		So(dataStr, ShouldContainSubstring,
@@ -873,12 +747,10 @@ func TestServeScrubExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		// Even if in config we specified scrub interval=1h, the minimum interval is 2h
 		dataStr := string(data)
@@ -907,12 +779,10 @@ func TestServeScrubExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		dataStr := string(data)
 		So(dataStr, ShouldContainSubstring,
@@ -941,12 +811,10 @@ func TestServeScrubExtension(t *testing.T) {
 				}
 			}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		dataStr := string(data)
 		So(dataStr, ShouldContainSubstring, "\"Scrub\":{\"Enable\":false,\"Interval\":86400000000000}")
@@ -982,12 +850,10 @@ func TestServeLintExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		So(string(data), ShouldContainSubstring,
 			"\"Extensions\":{\"Search\":null,\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":{\"Enable\":true,\"MandatoryAnnotations\":") //nolint:lll // gofumpt conflicts with lll
@@ -1013,12 +879,10 @@ func TestServeLintExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		So(string(data), ShouldContainSubstring,
 			"\"Extensions\":{\"Search\":null,\"Sync\":null,\"Metrics\":null,\"Scrub\":null,\"Lint\":{\"Enable\":false,\"MandatoryAnnotations\":null}") //nolint:lll // gofumpt conflicts with lll
@@ -1049,11 +913,9 @@ func TestServeSearchEnabled(t *testing.T) {
 					}
 				}`
 
-		tempDir := t.TempDir()
-		logPath, err := runCLIWithConfig(tempDir, content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		// to avoid data race when multiple go routines write to trivy DB instance.
-		defer os.Remove(logPath) // clean up
 
 		substring := `"Extensions":{"Search":{"Enable":true,"CVE":null}`
 
@@ -1097,14 +959,11 @@ func TestServeSearchEnabledDefaultCVEDB(t *testing.T) {
 					}
 				}`
 
-		tempDir := t.TempDir()
-		logPath, err := runCLIWithConfig(tempDir, content)
+		logPath, rootDir, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 
-		defer os.Remove(logPath) // clean up
-
 		// to avoid data race when multiple go routines write to trivy DB instance.
-		WaitTillTrivyDBDownloadStarted(tempDir)
+		WaitTillTrivyDBDownloadStarted(rootDir)
 
 		// The default config handling logic will convert the 1h interval to a 2h interval
 		substring := "\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":7200000000000,\"Trivy\":" +
@@ -1154,11 +1013,8 @@ func TestServeSearchEnabledNoCVE(t *testing.T) {
 				}
 			}`
 
-		tempDir := t.TempDir()
-		logPath, err := runCLIWithConfig(tempDir, content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		substring := `"Extensions":{"Search":{"Enable":true,"CVE":null}` //nolint:lll // gofumpt conflicts with lll
 		found, err := ReadLogFileAndSearchString(logPath, substring, readLogFileTimeout)
@@ -1202,12 +1058,10 @@ func TestServeSearchDisabled(t *testing.T) {
 				}
 			}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		dataStr := string(data)
 		So(dataStr, ShouldContainSubstring,
@@ -1243,9 +1097,8 @@ func TestServeMgmtExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
-		defer os.Remove(logPath) // clean up
 
 		found, err := ReadLogFileAndSearchString(logPath, "setting up mgmt routes", 10*time.Second)
 
@@ -1276,9 +1129,8 @@ func TestServeMgmtExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
-		defer os.Remove(logPath) // clean up
 
 		found, err := ReadLogFileAndSearchString(logPath,
 			"skip enabling the mgmt route as the config prerequisites are not met", 10*time.Second)
@@ -1308,9 +1160,8 @@ func TestServeMgmtExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
-		defer os.Remove(logPath) // clean up
 
 		found, err := ReadLogFileAndSearchString(logPath,
 			"skip enabling the mgmt route as the config prerequisites are not met", 10*time.Second)
@@ -1351,9 +1202,8 @@ func TestServeImageTrustExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
-		defer os.Remove(logPath) // clean up
 
 		found, err := ReadLogFileAndSearchString(logPath,
 			"skip enabling the image trust routes as the config prerequisites are not met", 10*time.Second)
@@ -1388,9 +1238,8 @@ func TestServeImageTrustExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
-		defer os.Remove(logPath) // clean up
 
 		found, err := ReadLogFileAndSearchString(logPath,
 			"skip enabling the image trust routes as the config prerequisites are not met", 10*time.Second)
@@ -1427,9 +1276,8 @@ func TestServeImageTrustExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
-		defer os.Remove(logPath) // clean up
 
 		found, err := ReadLogFileAndSearchString(logPath,
 			"setting up image trust routes", 10*time.Second)
@@ -1463,10 +1311,6 @@ func TestOverlappingSyncRetentionConfig(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	Convey("Test verify without overlapping sync and retention", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := `{
 			"distSpecVersion": "1.1.1",
 			"storage": {
@@ -1521,21 +1365,15 @@ func TestOverlappingSyncRetentionConfig(t *testing.T) {
 			}
 		}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		So(string(data), ShouldNotContainSubstring, "overlapping sync content")
 	})
 
 	Convey("Test verify with overlapping sync and retention - retention would remove v4 tags", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := `{
 			"distSpecVersion": "1.1.1",
 			"storage": {
@@ -1588,21 +1426,15 @@ func TestOverlappingSyncRetentionConfig(t *testing.T) {
 			}
 		}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		So(string(data), ShouldContainSubstring, "overlapping sync content\":{\"Prefix\":\"infra/*")
 	})
 
 	Convey("Test verify with overlapping sync and retention - retention would remove tags from repo", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := `{
 			"distSpecVersion": "1.1.1",
 			"storage": {
@@ -1653,21 +1485,15 @@ func TestOverlappingSyncRetentionConfig(t *testing.T) {
 		}
 		`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		So(string(data), ShouldContainSubstring, "overlapping sync content\":{\"Prefix\":\"**")
 	})
 
 	Convey("Test verify with overlapping sync and retention - retention would remove tags from subpath", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := `{
 			"distSpecVersion": "1.1.1",
 			"storage": {
@@ -1721,12 +1547,10 @@ func TestOverlappingSyncRetentionConfig(t *testing.T) {
 		}
 		`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		So(string(data), ShouldContainSubstring, "overlapping sync content\":{\"Prefix\":\"prod/*")
 	})
@@ -1738,10 +1562,6 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	Convey("Test verify sync with remote storage works if sync.tmpdir is provided", t, func(c C) {
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-		defer os.Remove(tmpfile.Name()) // clean up
-
 		content := `{
 			"distSpecVersion": "1.1.1",
 			"storage": {
@@ -1787,13 +1607,11 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 			}
 		}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
 
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logPath) // clean up
 
 		So(string(data), ShouldNotContainSubstring,
 			"using both sync and remote storage features needs config.Extensions.Sync.DownloadDir to be specified")
@@ -1801,15 +1619,7 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 
 	Convey("Test verify sync with remote storage panics if sync.tmpdir is not provided", t, func(c C) {
 		port := GetFreePort()
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		defer os.Remove(logFile.Name()) // clean up
-
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-
-		defer os.Remove(tmpfile.Name()) // clean up
+		logPath := MakeTempFilePath(t, "zot-log.txt")
 
 		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
@@ -1853,19 +1663,16 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 					]
 				}
 			}
-		}`, t.TempDir(), port, logFile.Name())
+		}`, t.TempDir(), port, logPath)
 
-		err = os.WriteFile(tmpfile.Name(), []byte(content), 0o0600)
-		So(err, ShouldBeNil)
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
-		os.Args = []string{"cli_test", "serve", tmpfile.Name()}
-		err = cli.NewServerRootCmd().Execute()
+		os.Args = []string{"cli_test", "serve", tmpfile}
+		err := cli.NewServerRootCmd().Execute()
 		So(err, ShouldNotBeNil)
 
-		data, err := os.ReadFile(logFile.Name())
+		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-
-		defer os.Remove(logFile.Name()) // clean up
 
 		So(string(data), ShouldContainSubstring,
 			"using both sync and remote storage features needs config.Extensions.Sync.DownloadDir to be specified")
@@ -1873,15 +1680,7 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 
 	Convey("Test verify sync with remote storage on subpath panics if sync.tmpdir is not provided", t, func(c C) {
 		port := GetFreePort()
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		defer os.Remove(logFile.Name()) // clean up
-
-		tmpfile, err := os.CreateTemp("", "zot-test*.json")
-		So(err, ShouldBeNil)
-
-		defer os.Remove(tmpfile.Name()) // clean up
+		logPath := MakeTempFilePath(t, "zot-log.txt")
 
 		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
@@ -1929,18 +1728,16 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 					]
 				}
 			}
-		}`, t.TempDir(), t.TempDir(), port, logFile.Name())
+		}`, t.TempDir(), t.TempDir(), port, logPath)
 
-		err = os.WriteFile(tmpfile.Name(), []byte(content), 0o0600)
-		So(err, ShouldBeNil)
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
-		os.Args = []string{"cli_test", "serve", tmpfile.Name()}
-		err = cli.NewServerRootCmd().Execute()
+		os.Args = []string{"cli_test", "serve", tmpfile}
+		err := cli.NewServerRootCmd().Execute()
 		So(err, ShouldNotBeNil)
 
-		data, err := os.ReadFile(logFile.Name())
+		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
-		defer os.Remove(logFile.Name()) // clean up
 
 		So(string(data), ShouldContainSubstring,
 			"using both sync and remote storage features needs config.Extensions.Sync.DownloadDir to be specified")
@@ -1972,9 +1769,8 @@ func TestEventsExtension(t *testing.T) {
 				}
 			}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
+		logPath, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldBeNil)
-		defer os.Remove(logPath) // clean up
 
 		found, err := ReadLogFileAndSearchString(logPath,
 			"events disabled in configuration", 10*time.Second)
@@ -2012,12 +1808,7 @@ func TestEventsExtension(t *testing.T) {
 					}
 				}`
 
-		logPath, err := runCLIWithConfig(t.TempDir(), content)
-		defer func(p string) {
-			if p != "" {
-				os.Remove(p)
-			}
-		}(logPath) // clean up
+		_, _, err := runCLIWithConfig(t, content)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring, zerr.ErrUnsupportedEventSink.Error())
 	})

--- a/pkg/cli/server/verify_retention_test.go
+++ b/pkg/cli/server/verify_retention_test.go
@@ -50,37 +50,33 @@ func TestRetentionCheckNegative(t *testing.T) {
 	})
 
 	Convey("non-existent config", t, func(c C) {
-		os.Args = []string{"cli_test", "verify-feature", "retention", path.Join(os.TempDir(), "/x.yaml")}
+		tempDir := t.TempDir()
+		os.Args = []string{"cli_test", "verify-feature", "retention", path.Join(tempDir, "/x.yaml")}
 		err := cli.NewServerRootCmd().Execute()
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("unknown config", t, func(c C) {
-		os.Args = []string{"cli_test", "verify-feature", "retention", path.Join(os.TempDir(), "/x")}
+		tempDir := t.TempDir()
+		os.Args = []string{"cli_test", "verify-feature", "retention", path.Join(tempDir, "/x")}
 		err := cli.NewServerRootCmd().Execute()
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("bad config", t, func(c C) {
-		testDir := t.TempDir()
-		configFile := path.Join(testDir, "zot-config.json")
-
-		content := []byte(`{"log":{}}`)
-		err := os.WriteFile(configFile, content, 0o600)
-		So(err, ShouldBeNil)
+		configFile := MakeTempFileWithContent(t, "zot-config.json", `{"log":{}}`)
 
 		os.Args = []string{"cli_test", "verify-feature", "retention", "-t", "30s", configFile}
-		err = cli.NewServerRootCmd().Execute()
+		err := cli.NewServerRootCmd().Execute()
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("config with GC disabled", t, func(c C) {
 		testDir := t.TempDir()
-		configFile := path.Join(testDir, "zot-config.json")
-		logFile := path.Join(testDir, "retention-check.log")
+		logFile := MakeTempFilePath(t, "retention-check.log")
 		port := GetFreePort()
 
-		content := fmt.Appendf([]byte{}, `{
+		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
 			"storage": {
 				"rootDirectory": "%s",
@@ -91,11 +87,10 @@ func TestRetentionCheckNegative(t *testing.T) {
 				"port": "%s"
 			}
 		}`, testDir, port)
-		err := os.WriteFile(configFile, content, 0o600)
-		So(err, ShouldBeNil)
+		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "30s", configFile}
-		err = cli.NewServerRootCmd().Execute()
+		err := cli.NewServerRootCmd().Execute()
 
 		// Verify the specific error
 		So(err, ShouldNotBeNil)
@@ -118,8 +113,7 @@ func TestRetentionCheckNegative(t *testing.T) {
 
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
-		configFile := path.Join(testDir, "zot-config.json")
-		logFile := path.Join(testDir, "retention-check.log")
+		logFile := MakeTempFilePath(t, "retention-check.log")
 
 		controller.Config.Storage.RootDirectory = storageDir
 		controller.Config.Storage.GC = true
@@ -128,7 +122,7 @@ func TestRetentionCheckNegative(t *testing.T) {
 
 		defer ctrlManager.StopServer()
 
-		content := fmt.Appendf([]byte{}, `{
+		content := fmt.Sprintf(`{
 			"storage": {
 				"rootDirectory": "%s",
 				"gc": true,
@@ -155,11 +149,10 @@ func TestRetentionCheckNegative(t *testing.T) {
 			}
 		}
 		`, storageDir, port)
-		err := os.WriteFile(configFile, content, 0o600)
-		So(err, ShouldBeNil)
+		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "30s", configFile}
-		err = cli.NewServerRootCmd().Execute()
+		err := cli.NewServerRootCmd().Execute()
 		So(err, ShouldNotBeNil)
 		So(err, ShouldEqual, zerr.ErrServerIsRunning)
 
@@ -184,10 +177,9 @@ func TestRetentionCheckNegative(t *testing.T) {
 		for _, testCase := range testCases {
 			Convey(testCase.name, func() {
 				testDir := t.TempDir()
-				configFile := path.Join(testDir, "zot-config.json")
 				port := GetFreePort()
 
-				content := fmt.Appendf([]byte{}, `{
+				content := fmt.Sprintf(`{
 					"distSpecVersion": "1.1.1",
 					"storage": {
 						"rootDirectory": "%s",
@@ -198,8 +190,7 @@ func TestRetentionCheckNegative(t *testing.T) {
 						"port": "%s"
 					}
 				}`, testDir, port)
-				err := os.WriteFile(configFile, content, 0o600)
-				So(err, ShouldBeNil)
+				configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 				os.Args = []string{"cli_test", "verify-feature", "retention", "-l", testCase.logFile, "-t", "30s", configFile}
 				// This panics during logger initialization due to invalid log file location
@@ -223,11 +214,10 @@ func TestRetentionCheckNegative(t *testing.T) {
 		for _, testCase := range testCases {
 			Convey(testCase.name, func() {
 				testDir := t.TempDir()
-				configFile := path.Join(testDir, "zot-config.json")
-				logFile := path.Join(testDir, "retention-check.log")
+				logFile := MakeTempFilePath(t, "retention-check.log")
 				port := GetFreePort()
 
-				content := fmt.Appendf([]byte{}, `{
+				content := fmt.Sprintf(`{
 					"distSpecVersion": "1.1.1",
 					"storage": {
 						"rootDirectory": "%s",
@@ -238,8 +228,7 @@ func TestRetentionCheckNegative(t *testing.T) {
 						"port": "%s"
 					}
 				}`, testDir, port)
-				err := os.WriteFile(configFile, content, 0o600)
-				So(err, ShouldBeNil)
+				configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 				args := []string{
 					"cli_test", "verify-feature", "retention", "-l", logFile,
@@ -253,7 +242,7 @@ func TestRetentionCheckNegative(t *testing.T) {
 				args = append(args, configFile)
 				os.Args = args
 
-				err = cli.NewServerRootCmd().Execute()
+				err := cli.NewServerRootCmd().Execute()
 				// Flag parsing should fail before reaching RunE
 				So(err, ShouldNotBeNil)
 				So(err.Error(), ShouldContainSubstring, "invalid duration")
@@ -272,10 +261,9 @@ func TestRetentionCheckWithRetentionEnabledAndRedisDriver(t *testing.T) {
 		port := GetFreePort()
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
-		configFile := path.Join(testDir, "zot-config.json")
-		logFile := path.Join(testDir, "retention-check.log")
+		logFile := MakeTempFilePath(t, "retention-check.log")
 
-		content := fmt.Appendf([]byte{}, `{
+		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
 			"storage": {
 				"rootDirectory": "%s",
@@ -311,12 +299,11 @@ func TestRetentionCheckWithRetentionEnabledAndRedisDriver(t *testing.T) {
 			}
 		}
 		`, storageDir, testGCDelay, miniRedis.Addr(), port)
-		err := os.WriteFile(configFile, content, 0o600)
-		So(err, ShouldBeNil)
+		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		// Create complex image setup before running verify-feature retention
 		conf := config.New()
-		err = cli.LoadConfiguration(conf, configFile)
+		err := cli.LoadConfiguration(conf, configFile)
 		So(err, ShouldBeNil)
 
 		// Initialize storage and metaDB using the same approach as gc tests
@@ -510,10 +497,9 @@ func TestRetentionCheckWithRetentionEnabled(t *testing.T) {
 		port := GetFreePort()
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
-		configFile := path.Join(testDir, "zot-config.json")
-		logFile := path.Join(testDir, "retention-check.log")
+		logFile := MakeTempFilePath(t, "retention-check.log")
 
-		content := fmt.Appendf([]byte{}, `{
+		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
 			"storage": {
 				"rootDirectory": "%s",
@@ -544,12 +530,11 @@ func TestRetentionCheckWithRetentionEnabled(t *testing.T) {
 			}
 		}
 		`, storageDir, testGCDelay, port)
-		err := os.WriteFile(configFile, content, 0o600)
-		So(err, ShouldBeNil)
+		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		// Create complex image setup before running verify-feature retention
 		conf := config.New()
-		err = cli.LoadConfiguration(conf, configFile)
+		err := cli.LoadConfiguration(conf, configFile)
 		So(err, ShouldBeNil)
 
 		// Initialize storage and metaDB using the same approach as gc tests
@@ -801,10 +786,9 @@ func TestRetentionCheckWithDeleteReferrers(t *testing.T) {
 		port := GetFreePort()
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
-		configFile := path.Join(testDir, "zot-config.json")
-		logFile := path.Join(testDir, "retention-check.log")
+		logFile := MakeTempFilePath(t, "retention-check.log")
 
-		content := fmt.Appendf([]byte{}, `{
+		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
 			"storage": {
 				"rootDirectory": "%s",
@@ -836,12 +820,11 @@ func TestRetentionCheckWithDeleteReferrers(t *testing.T) {
 			}
 		}
 		`, storageDir, testGCDelay, port)
-		err := os.WriteFile(configFile, content, 0o600)
-		So(err, ShouldBeNil)
+		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		// Create image setup before running verify-feature retention
 		conf := config.New()
-		err = cli.LoadConfiguration(conf, configFile)
+		err := cli.LoadConfiguration(conf, configFile)
 		So(err, ShouldBeNil)
 
 		// Initialize storage and metaDB
@@ -982,10 +965,9 @@ func TestRetentionCheckWithRetentionDisabled(t *testing.T) {
 		port := GetFreePort()
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
-		configFile := path.Join(testDir, "zot-config.json")
-		logFile := path.Join(testDir, "retention-check.log")
+		logFile := MakeTempFilePath(t, "retention-check.log")
 
-		content := fmt.Appendf([]byte{}, `{
+		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
 			"storage": {
 				"rootDirectory": "%s",
@@ -1002,12 +984,11 @@ func TestRetentionCheckWithRetentionDisabled(t *testing.T) {
 			}
 		}
 		`, storageDir, testGCDelay, port)
-		err := os.WriteFile(configFile, content, 0o600)
-		So(err, ShouldBeNil)
+		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		// Create image setup for GC testing (no retention, no MetaDB needed)
 		conf := config.New()
-		err = cli.LoadConfiguration(conf, configFile)
+		err := cli.LoadConfiguration(conf, configFile)
 		So(err, ShouldBeNil)
 
 		// Initialize storage only (no MetaDB needed when retention is disabled)
@@ -1139,10 +1120,9 @@ func TestRetentionCheckWithSubpaths(t *testing.T) {
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
 		subpathStoreDir := path.Join(testDir, "storage2")
-		configFile := path.Join(testDir, "zot-config.json")
-		logFile := path.Join(testDir, "retention-check.log")
+		logFile := MakeTempFilePath(t, "retention-check.log")
 
-		content := fmt.Appendf([]byte{}, `{
+		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
 			"storage": {
 				"rootDirectory": "%s",
@@ -1197,12 +1177,11 @@ func TestRetentionCheckWithSubpaths(t *testing.T) {
 			}
 		}
 		`, storageDir, testGCDelay, subpathStoreDir, testGCDelay, port)
-		err := os.WriteFile(configFile, content, 0o600)
-		So(err, ShouldBeNil)
+		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		// Create image setup before running verify-feature retention
 		conf := config.New()
-		err = cli.LoadConfiguration(conf, configFile)
+		err := cli.LoadConfiguration(conf, configFile)
 		So(err, ShouldBeNil)
 
 		// Initialize storage and metaDB
@@ -1440,11 +1419,10 @@ func TestRetentionCheckWithGCIntervalOverride(t *testing.T) {
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
 		subpathStoreDir := path.Join(testDir, "storage2")
-		configFile := path.Join(testDir, "zot-config.json")
-		logFile := path.Join(testDir, "retention-check.log")
+		logFile := MakeTempFilePath(t, "retention-check.log")
 		port := GetFreePort()
 
-		content := fmt.Appendf([]byte{}, `{
+		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
 			"storage": {
 				"rootDirectory": "%s",
@@ -1469,15 +1447,14 @@ func TestRetentionCheckWithGCIntervalOverride(t *testing.T) {
 			}
 		}
 		`, storageDir, testGCDelay, subpathStoreDir, testGCDelay, port)
-		err := os.WriteFile(configFile, content, 0o600)
-		So(err, ShouldBeNil)
+		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		gcDelay, _ := time.ParseDuration(testGCDelay)
 		time.Sleep(gcDelay + 50*time.Millisecond) // wait for GC delay to pass
 
 		// Override GC interval from 1m to 30s using -i flag
 		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-i", "30s", "-t", "5ms", configFile}
-		err = cli.NewServerRootCmd().Execute()
+		err := cli.NewServerRootCmd().Execute()
 		So(err, ShouldBeNil)
 
 		// Verify log file was created and contains expected messages

--- a/pkg/debug/pprof/pprof_test.go
+++ b/pkg/debug/pprof/pprof_test.go
@@ -4,7 +4,6 @@ package pprof_test
 
 import (
 	"net/http"
-	"os"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -29,9 +28,7 @@ func TestProfilingAuthz(t *testing.T) {
 
 		testCreds := test.GetBcryptCredString(adminUsername, adminPassword) +
 			test.GetBcryptCredString(username, password)
-		htpasswdPath := test.MakeHtpasswdFileFromString(testCreds)
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, testCreds)
 
 		conf := config.New()
 		conf.HTTP.Port = port

--- a/pkg/extensions/extension_events_disabled_test.go
+++ b/pkg/extensions/extension_events_disabled_test.go
@@ -23,9 +23,7 @@ func TestEventsExtension(t *testing.T) {
 		globalDir := t.TempDir()
 		defaultValue := true
 
-		logFile, err := os.CreateTemp(globalDir, "zot-log*.txt")
-		So(err, ShouldBeNil)
-		defer os.Remove(logFile.Name())
+		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		conf.HTTP.Port = port
 		conf.Storage.RootDirectory = globalDir
@@ -35,7 +33,7 @@ func TestEventsExtension(t *testing.T) {
 			Enable: &defaultValue,
 		}
 		conf.Log.Level = "warn"
-		conf.Log.Output = logFile.Name()
+		conf.Log.Output = logPath
 
 		ctlr := api.NewController(conf)
 		ctlrManager := test.NewControllerManager(ctlr)
@@ -43,7 +41,7 @@ func TestEventsExtension(t *testing.T) {
 		ctlrManager.StartAndWait(port)
 		defer ctlrManager.StopServer()
 
-		data, err := os.ReadFile(logFile.Name())
+		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
 
 		So(string(data), ShouldContainSubstring,

--- a/pkg/extensions/extension_image_trust_disabled_test.go
+++ b/pkg/extensions/extension_image_trust_disabled_test.go
@@ -22,9 +22,7 @@ func TestImageTrustExtension(t *testing.T) {
 		globalDir := t.TempDir()
 		defaultValue := true
 
-		logFile, err := os.CreateTemp(globalDir, "zot-log*.txt")
-		So(err, ShouldBeNil)
-		defer os.Remove(logFile.Name())
+		logFile := test.MakeTempFile(t, "zot-log.txt")
 
 		conf.HTTP.Port = port
 		conf.Storage.RootDirectory = globalDir

--- a/pkg/extensions/extension_image_trust_test.go
+++ b/pkg/extensions/extension_image_trust_test.go
@@ -204,9 +204,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 
 		baseURL := test.GetBaseURL(port)
 
-		logFile, err := os.CreateTemp(globalDir, "zot-log*.txt")
-		defer os.Remove(logFile.Name()) // cleanup
-		So(err, ShouldBeNil)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 		logger := log.NewLoggerWithWriter("debug", writers)
@@ -219,7 +218,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		}
 
 		image := CreateRandomImage()
-		err = WriteImageToFileSystem(image, repo, tag, storeController)
+		err := WriteImageToFileSystem(image, repo, tag, storeController)
 		So(err, ShouldBeNil)
 
 		ctlr := api.NewController(conf)
@@ -324,9 +323,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 
 		baseURL := test.GetBaseURL(port)
 
-		logFile, err := os.CreateTemp(globalDir, "zot-log*.txt")
-		defer os.Remove(logFile.Name()) // cleanup
-		So(err, ShouldBeNil)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 		logger := log.NewLoggerWithWriter("debug", writers)
@@ -339,7 +337,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		}
 
 		image := CreateRandomImage()
-		err = WriteImageToFileSystem(image, repo, tag, storeController)
+		err := WriteImageToFileSystem(image, repo, tag, storeController)
 		So(err, ShouldBeNil)
 
 		ctlr := api.NewController(conf)
@@ -431,9 +429,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		baseURL := test.GetBaseURL(port)
 		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, constants.FullSearchPrefix)
 
-		logFile, err := os.CreateTemp(globalDir, "zot-log*.txt")
-		defer os.Remove(logFile.Name()) // cleanup
-		So(err, ShouldBeNil)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 		logger := log.NewLoggerWithWriter("debug", writers)
@@ -446,7 +443,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		}
 
 		image := CreateRandomImage()
-		err = WriteImageToFileSystem(image, repo, tag, storeController)
+		err := WriteImageToFileSystem(image, repo, tag, storeController)
 		So(err, ShouldBeNil)
 
 		ctlr := api.NewController(conf)
@@ -593,9 +590,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		baseURL := test.GetBaseURL(port)
 		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, constants.FullSearchPrefix)
 
-		logFile, err := os.CreateTemp(globalDir, "zot-log*.txt")
-		defer os.Remove(logFile.Name()) // cleanup
-		So(err, ShouldBeNil)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 		logger := log.NewLoggerWithWriter("debug", writers)
@@ -608,7 +604,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		}
 
 		image := CreateRandomImage()
-		err = WriteImageToFileSystem(image, repo, tag, storeController)
+		err := WriteImageToFileSystem(image, repo, tag, storeController)
 		So(err, ShouldBeNil)
 
 		ctlr := api.NewController(conf)
@@ -744,8 +740,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		port := test.GetFreePort()
 		testCreds := test.GetBcryptCredString("admin", "admin") + "\n" + test.GetBcryptCredString("test", "test")
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(testCreds)
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, testCreds)
 
 		conf := config.New()
 		conf.HTTP.Port = port
@@ -770,9 +765,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 
 		baseURL := test.GetBaseURL(port)
 
-		logFile, err := os.CreateTemp(globalDir, "zot-log*.txt")
-		defer os.Remove(logFile.Name()) // cleanup
-		So(err, ShouldBeNil)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 
@@ -854,9 +848,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		baseURL := test.GetBaseURL(port)
 		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, constants.FullSearchPrefix)
 
-		logFile, err := os.CreateTemp(globalDir, "zot-log*.txt")
-		defer os.Remove(logFile.Name()) // cleanup
-		So(err, ShouldBeNil)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 		logger := log.NewLoggerWithWriter("debug", writers)
@@ -871,7 +864,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		// Write image
 		image := CreateRandomImage()
 
-		err = WriteImageToFileSystem(image, repo, tag, storeController)
+		err := WriteImageToFileSystem(image, repo, tag, storeController)
 		So(err, ShouldBeNil)
 
 		// Write signature

--- a/pkg/extensions/extension_ui_test.go
+++ b/pkg/extensions/extension_ui_test.go
@@ -29,11 +29,10 @@ func TestUIExtension(t *testing.T) {
 
 		// we won't use the logging config feature as we want logs in both
 		// stdout and a file
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
-		So(err, ShouldBeNil)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		logPath := logFile.Name()
-		defer os.Remove(logPath)
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 

--- a/pkg/extensions/get_extensions_disabled_test.go
+++ b/pkg/extensions/get_extensions_disabled_test.go
@@ -4,7 +4,6 @@ package extensions_test
 
 import (
 	"encoding/json"
-	"os"
 	"testing"
 
 	distext "github.com/opencontainers/distribution-spec/specs-go/v1/extensions"
@@ -35,12 +34,9 @@ func TestGetExensionsDisabled(t *testing.T) {
 		conf.Extensions.UI = &extconf.UIConfig{}
 		conf.Extensions.UI.Enable = &defaultVal
 
-		logFile, err := os.CreateTemp("", "zot-log*.txt")
-		So(err, ShouldBeNil)
+		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
-		conf.Log.Output = logFile.Name()
-
-		defer os.Remove(logFile.Name()) // clean up
+		conf.Log.Output = logPath
 
 		ctlr := makeController(conf, t.TempDir())
 

--- a/pkg/extensions/imagetrust/image_trust_test.go
+++ b/pkg/extensions/imagetrust/image_trust_test.go
@@ -1208,11 +1208,8 @@ func RunVerificationTests(t *testing.T, dbDriverParams map[string]any) { //nolin
 	Convey("verify signatures are trusted", func() {
 		defaultValue := true
 		rootDir := t.TempDir()
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
-		So(err, ShouldBeNil)
-
-		logPath := logFile.Name()
-		defer os.Remove(logPath)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 
@@ -1247,14 +1244,14 @@ func RunVerificationTests(t *testing.T, dbDriverParams map[string]any) { //nolin
 		Convey("verify running an image trust with context done", func() {
 			image := CreateRandomImage()
 
-			err = UploadImage(image, baseURL, repo, tag)
+			err := UploadImage(image, baseURL, repo, tag)
 			So(err, ShouldBeNil)
 		})
 
 		Convey("verify cosign signature is trusted", func() {
 			image := CreateRandomImage()
 
-			err = UploadImage(image, baseURL, repo, tag)
+			err := UploadImage(image, baseURL, repo, tag)
 			So(err, ShouldBeNil)
 
 			cwd, err := os.Getwd()
@@ -1347,7 +1344,7 @@ func RunVerificationTests(t *testing.T, dbDriverParams map[string]any) { //nolin
 		Convey("verify notation signature is trusted", func() {
 			image := CreateRandomImage()
 
-			err = UploadImage(image, baseURL, repo, tag)
+			err := UploadImage(image, baseURL, repo, tag)
 			So(err, ShouldBeNil)
 
 			notationDir := t.TempDir()

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -172,8 +172,7 @@ func TestMetricsAuthentication(t *testing.T) {
 		metricspass := generateRandomString()
 		content := test.GetBcryptCredString(username, password) + "\n" + test.GetBcryptCredString(metricsuser, metricspass)
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(content)
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, content)
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -237,8 +236,7 @@ func TestMetricsAuthorization(t *testing.T) {
 		metricspass := generateRandomString()
 		content := test.GetBcryptCredString(username, password) + "\n" + test.GetBcryptCredString(metricsuser, metricspass)
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(content)
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, content)
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -439,13 +437,10 @@ func TestPopulateStorageMetrics(t *testing.T) {
 			Prometheus: &extconf.PrometheusConfig{Path: "/metrics"},
 		}
 
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
-		if err != nil {
-			panic(err)
-		}
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		logPath := logFile.Name()
-		defer os.Remove(logPath)
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 
@@ -455,7 +450,7 @@ func TestPopulateStorageMetrics(t *testing.T) {
 
 		// Write images before starting controller to avoid race condition with garbage collection
 		srcStorageCtlr := ociutils.GetDefaultStoreController(rootDir, ctlr.Log)
-		err = WriteImageToFileSystem(CreateDefaultImage(), "alpine", "0.0.1", srcStorageCtlr)
+		err := WriteImageToFileSystem(CreateDefaultImage(), "alpine", "0.0.1", srcStorageCtlr)
 		So(err, ShouldBeNil)
 		err = WriteImageToFileSystem(CreateDefaultImage(), "busybox", "0.0.1", srcStorageCtlr)
 		So(err, ShouldBeNil)

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -424,8 +424,7 @@ func TestCVESearchDisabled(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -444,13 +443,10 @@ func TestCVESearchDisabled(t *testing.T) {
 			Search: searchConfig,
 		}
 
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
-		if err != nil {
-			panic(err)
-		}
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		logPath := logFile.Name()
-		defer os.Remove(logPath)
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 
@@ -493,8 +489,7 @@ func TestCVESearch(t *testing.T) {
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		dbDir, err := testSetup(t)
 		So(err, ShouldBeNil)
@@ -523,13 +518,10 @@ func TestCVESearch(t *testing.T) {
 			Search: searchConfig,
 		}
 
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
-		if err != nil {
-			panic(err)
-		}
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		logPath := logFile.Name()
-		defer os.Remove(logPath)
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 
@@ -1753,11 +1745,10 @@ func TestFixedTagsWithIndex(t *testing.T) {
 			},
 		}
 
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
-		So(err, ShouldBeNil)
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		logPath := logFile.Name()
-		defer os.Remove(logPath)
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 
@@ -1782,7 +1773,7 @@ func TestFixedTagsWithIndex(t *testing.T) {
 
 		multiArchImage := CreateMultiarchWith().Images([]Image{vulnSingleArchImage, fixedSingleArchImage}).Build()
 
-		err = UploadMultiarchImage(multiArchImage, baseURL, "repo", "multi-arch-tag")
+		err := UploadMultiarchImage(multiArchImage, baseURL, "repo", "multi-arch-tag")
 		So(err, ShouldBeNil)
 
 		// oldest vulnerability

--- a/pkg/extensions/search/cve/scan_test.go
+++ b/pkg/extensions/search/cve/scan_test.go
@@ -45,12 +45,10 @@ func TestScanGeneratorWithMockedData(t *testing.T) { //nolint: gocyclo
 		repo1 := "repo1"
 		repoIndex := "repoIndex"
 
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
+
 		logPath := logFile.Name()
-
-		So(err, ShouldBeNil)
-
-		defer os.Remove(logFile.Name()) // clean up
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 		logger := log.NewLoggerWithWriter("debug", writers)
@@ -485,12 +483,10 @@ func TestScanGeneratorWithRealData(t *testing.T) {
 	Convey("Test CVE scanning task scheduler real data", t, func() {
 		rootDir := t.TempDir()
 
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
+
 		logPath := logFile.Name()
-
-		So(err, ShouldBeNil)
-
-		defer os.Remove(logFile.Name()) // clean up
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 		logger := log.NewLoggerWithWriter("debug", writers)

--- a/pkg/extensions/search/cve/update_test.go
+++ b/pkg/extensions/search/cve/update_test.go
@@ -25,12 +25,10 @@ import (
 
 func TestCVEDBGenerator(t *testing.T) {
 	Convey("Test CVE DB task scheduler reset", t, func() {
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
+
 		logPath := logFile.Name()
-
-		So(err, ShouldBeNil)
-
-		defer os.Remove(logFile.Name()) // clean up
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 		logger := log.NewLoggerWithWriter("debug", writers)

--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -678,11 +678,10 @@ func TestRepoListWithNewestImage(t *testing.T) {
 
 		// we won't use the logging config feature as we want logs in both
 		// stdout and a file
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
-		So(err, ShouldBeNil)
+		logFile := MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		logPath := logFile.Name()
-		defer os.Remove(logPath)
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 
@@ -3619,11 +3618,10 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 
 		// we won't use the logging config feature as we want logs in both
 		// stdout and a file
-		logFile, err := os.CreateTemp(t.TempDir(), "zot-log*.txt")
-		So(err, ShouldBeNil)
+		logFile := MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
 
 		logPath := logFile.Name()
-		defer os.Remove(logPath)
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 

--- a/pkg/extensions/search/userprefs_test.go
+++ b/pkg/extensions/search/userprefs_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -43,11 +42,11 @@ func TestUserData(t *testing.T) {
 		content := test.GetBcryptCredString(adminUser, adminPassword) +
 			test.GetBcryptCredString(simpleUser, simpleUserPassword)
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(content)
-		defer os.Remove(htpasswdPath)
+		tempDir := t.TempDir()
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, content)
 
 		conf := config.New()
-		conf.Storage.RootDirectory = t.TempDir()
+		conf.Storage.RootDirectory = tempDir
 		conf.HTTP.Port = port
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -455,11 +454,11 @@ func TestChangingRepoState(t *testing.T) {
 	forbiddenRepo := "forbidden"
 	accesibleRepo := "accesible"
 
-	htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(simpleUser, simpleUserPassword))
-	defer os.Remove(htpasswdPath)
+	tempDir := t.TempDir()
+	htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(simpleUser, simpleUserPassword))
 
 	conf := config.New()
-	conf.Storage.RootDirectory = t.TempDir()
+	conf.Storage.RootDirectory = tempDir
 	conf.HTTP.Port = port
 	conf.HTTP.Auth = &config.AuthConfig{
 		HTPasswd: config.AuthHTPasswd{
@@ -606,8 +605,7 @@ func TestGlobalSearchWithUserPrefFiltering(t *testing.T) {
 		simpleUser := "simpleUser"
 		simpleUserPassword := "simpleUserPass"
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(simpleUser, simpleUserPassword))
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(simpleUser, simpleUserPassword))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -801,8 +799,7 @@ func TestExpandedRepoInfoWithUserPrefs(t *testing.T) {
 		simpleUser := "simpleUser"
 		simpleUserPassword := "simpleUserPass"
 
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(simpleUser, simpleUserPassword))
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(simpleUser, simpleUserPassword))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{

--- a/pkg/extensions/sync/sync_disabled_test.go
+++ b/pkg/extensions/sync/sync_disabled_test.go
@@ -25,9 +25,7 @@ func TestSyncExtension(t *testing.T) {
 		globalDir := t.TempDir()
 		defaultValue := true
 
-		logFile, err := os.CreateTemp(globalDir, "zot-log*.txt")
-		So(err, ShouldBeNil)
-		defer os.Remove(logFile.Name())
+		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		conf.HTTP.Port = port
 		conf.Storage.RootDirectory = globalDir
@@ -37,7 +35,7 @@ func TestSyncExtension(t *testing.T) {
 			Enable: &defaultValue,
 		}
 		conf.Log.Level = "warn"
-		conf.Log.Output = logFile.Name()
+		conf.Log.Output = logPath
 
 		ctlr := api.NewController(conf)
 		ctlrManager := test.NewControllerManager(ctlr)
@@ -58,7 +56,7 @@ func TestSyncExtension(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
 
-			data, err := os.ReadFile(logFile.Name())
+			data, err := os.ReadFile(logPath)
 			So(err, ShouldBeNil)
 
 			So(string(data), ShouldContainSubstring,

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -42,7 +42,7 @@ func TestService(t *testing.T) {
 			URLs: []string{"http://localhost"},
 		}
 
-		service, err := New(conf, "", nil, os.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
 		So(err, ShouldBeNil)
 
 		err = service.SyncRepo(context.Background(), "repo")
@@ -54,7 +54,7 @@ func TestService(t *testing.T) {
 			URLs: []string{"http://localhost"},
 		}
 
-		service, err := New(conf, "", nil, os.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
 		So(err, ShouldBeNil)
 
 		// Create a context that's already cancelled
@@ -71,7 +71,7 @@ func TestService(t *testing.T) {
 			URLs: []string{"http://localhost"},
 		}
 
-		service, err := New(conf, "", nil, os.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
 		So(err, ShouldBeNil)
 
 		// Create a mock remote that returns tags so we can reach the loop
@@ -96,7 +96,7 @@ func TestService(t *testing.T) {
 			URLs: []string{"http://localhost"},
 		}
 
-		service, err := New(conf, "", nil, os.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
 		So(err, ShouldBeNil)
 
 		// Create a minimal mock remote that only returns tags
@@ -133,7 +133,7 @@ func TestService(t *testing.T) {
 			OnlySigned: &onlySigned,
 		}
 
-		service, err := New(conf, "", nil, os.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
 		So(err, ShouldBeNil)
 
 		// Create a mock remote that returns an invalid reference to trigger ReferrerList error
@@ -169,7 +169,7 @@ func TestService(t *testing.T) {
 			URLs: []string{"http://localhost"},
 		}
 
-		service, err := New(conf, "", nil, os.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
 		So(err, ShouldBeNil)
 
 		// Create a mock remote that returns valid references
@@ -215,7 +215,7 @@ func TestService(t *testing.T) {
 			RetryDelay: &retryDelay,
 		}
 
-		service, err := New(conf, "", nil, os.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
 		So(err, ShouldBeNil)
 
 		onDemand := NewOnDemand(log.NewTestLogger())
@@ -333,7 +333,7 @@ func TestService(t *testing.T) {
 			}},
 		}
 
-		service1, err := New(conf1, "", nil, os.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		service1, err := New(conf1, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
 		So(err, ShouldBeNil)
 
 		// Create second service for normal processing
@@ -346,7 +346,7 @@ func TestService(t *testing.T) {
 			}},
 		}
 
-		service2, err := New(conf2, "", nil, os.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		service2, err := New(conf2, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
 		So(err, ShouldBeNil)
 
 		onDemand := NewOnDemand(log.NewTestLogger())
@@ -378,7 +378,7 @@ func TestService(t *testing.T) {
 				}},
 			}
 
-			service, err := New(conf, "", nil, os.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+			service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
 			So(err, ShouldBeNil)
 
 			onDemand := NewOnDemand(log.NewTestLogger())
@@ -418,7 +418,7 @@ func TestService(t *testing.T) {
 				}},
 			}
 
-			service, err := New(conf, "", nil, os.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+			service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
 			So(err, ShouldBeNil)
 
 			onDemand := NewOnDemand(log.NewTestLogger())

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -52,9 +52,7 @@ func TestAuditLogMessages(t *testing.T) {
 
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
-		htpasswdPath := test.MakeHtpasswdFileFromString(test.GetBcryptCredString(username, password))
-
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
 
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -35,6 +35,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/storage/gc"
 	"zotregistry.dev/zot/v2/pkg/storage/local"
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
+	test "zotregistry.dev/zot/v2/pkg/test/common"
 	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
 	"zotregistry.dev/zot/v2/pkg/test/signature"
@@ -1970,11 +1971,9 @@ func TestGarbageCollectForImageStore(t *testing.T) {
 		ctx := context.Background()
 
 		Convey("Garbage collect continues when manifest blob is missing", func() {
-			logFile, _ := os.CreateTemp("", "zot-log*.txt")
+			logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
-			defer os.Remove(logFile.Name()) // clean up
-
-			log := zlog.NewLogger("debug", logFile.Name())
+			log := zlog.NewLogger("debug", logPath)
 			audit := zlog.NewAuditLogger("debug", "")
 
 			metrics := monitoring.NewMetricsServer(false, log)
@@ -2013,7 +2012,7 @@ func TestGarbageCollectForImageStore(t *testing.T) {
 
 			time.Sleep(500 * time.Millisecond)
 
-			data, err := os.ReadFile(logFile.Name())
+			data, err := os.ReadFile(logPath)
 			So(err, ShouldBeNil)
 			// Verify that GC logged a warning about skipping the missing manifest
 			So(string(data), ShouldContainSubstring, "skipping missing")
@@ -2021,11 +2020,9 @@ func TestGarbageCollectForImageStore(t *testing.T) {
 		})
 
 		Convey("Garbage collect error - not enough permissions to access index.json", func() {
-			logFile, _ := os.CreateTemp("", "zot-log*.txt")
+			logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
-			defer os.Remove(logFile.Name()) // clean up
-
-			log := zlog.NewLogger("debug", logFile.Name())
+			log := zlog.NewLogger("debug", logPath)
 			audit := zlog.NewAuditLogger("debug", "")
 
 			metrics := monitoring.NewMetricsServer(false, log)
@@ -2056,7 +2053,7 @@ func TestGarbageCollectForImageStore(t *testing.T) {
 
 			time.Sleep(500 * time.Millisecond)
 
-			data, err := os.ReadFile(logFile.Name())
+			data, err := os.ReadFile(logPath)
 			So(err, ShouldBeNil)
 			So(string(data), ShouldContainSubstring,
 				"failed to run GC for "+path.Join(imgStore.RootDir(), repoName))
@@ -2137,11 +2134,9 @@ func TestGarbageCollectForImageStore(t *testing.T) {
 		})
 
 		Convey("Garbage collect error - not enough permissions to access blob upload", func() {
-			logFile, _ := os.CreateTemp("", "zot-log*.txt")
+			logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
-			defer os.Remove(logFile.Name()) // clean up
-
-			log := zlog.NewLogger("debug", logFile.Name())
+			log := zlog.NewLogger("debug", logPath)
 			audit := zlog.NewAuditLogger("debug", "")
 
 			metrics := monitoring.NewMetricsServer(false, log)
@@ -2202,7 +2197,7 @@ func TestGarbageCollectForImageStore(t *testing.T) {
 			So(err, ShouldNotBeNil)
 			So(isPresent, ShouldBeFalse)
 
-			data, err := os.ReadFile(logFile.Name())
+			data, err := os.ReadFile(logPath)
 			So(err, ShouldBeNil)
 			So(string(data), ShouldContainSubstring,
 				"failed to run GC for "+path.Join(imgStore.RootDir(), repoName))

--- a/pkg/test/common/fs.go
+++ b/pkg/test/common/fs.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/GehirnInc/crypt"
@@ -308,8 +309,41 @@ func GetSHA512CredString(username, password string) string {
 	return usernameAndHash
 }
 
-func MakeHtpasswdFileFromString(fileContent string) string {
-	htpasswdFile, err := os.CreateTemp("", "htpasswd-")
+func MakeTempFile(tb testing.TB, filename string) *os.File {
+	tb.Helper()
+	tempDir := tb.TempDir()
+	file, err := os.Create(filepath.Join(tempDir, filename))
+	if err != nil {
+		panic(err)
+	}
+
+	return file
+}
+
+// MakeTempFilePath creates an empty temporary file and returns its path.
+func MakeTempFilePath(tb testing.TB, filename string) string {
+	tb.Helper()
+
+	return filepath.Join(tb.TempDir(), filename)
+}
+
+// MakeTempFileWithContent creates a temporary file with the given filename and content, and returns its path.
+func MakeTempFileWithContent(tb testing.TB, filename, content string) string {
+	tb.Helper()
+	tmpfile := MakeTempFile(tb, filename)
+	path := tmpfile.Name()
+	tmpfile.Close() // Close immediately, we'll write using os.WriteFile
+	if err := os.WriteFile(path, []byte(content), 0o0600); err != nil {
+		panic(err)
+	}
+
+	return path
+}
+
+func MakeHtpasswdFileFromString(tb testing.TB, fileContent string) string {
+	tb.Helper()
+	tempDir := tb.TempDir()
+	htpasswdFile, err := os.Create(filepath.Join(tempDir, "htpasswd"))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/test/image-utils/upload_test.go
+++ b/pkg/test/image-utils/upload_test.go
@@ -180,8 +180,7 @@ func TestUploadImage(t *testing.T) {
 		password1 := "test"
 		testString1 := tcommon.GetBcryptCredString(user1, password1)
 
-		htpasswdPath := tcommon.MakeHtpasswdFileFromString(testString1)
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := tcommon.MakeHtpasswdFileFromString(t, testString1)
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
 				Path: htpasswdPath,
@@ -497,8 +496,7 @@ func TestInjectUploadImageWithBasicAuth(t *testing.T) {
 		password := "password"
 		testString := tcommon.GetBcryptCredString(user, password)
 
-		htpasswdPath := tcommon.MakeHtpasswdFileFromString(testString)
-		defer os.Remove(htpasswdPath)
+		htpasswdPath := tcommon.MakeHtpasswdFileFromString(t, testString)
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
 				Path: htpasswdPath,


### PR DESCRIPTION
Replace MakeTempFile usage with MakeTempFilePath and MakeTempFileWithContent
helpers that automatically handle file lifecycle. This prevents resource
leaks by ensuring temporary files are properly closed.

Shoudld also make the tests easier to read.

Signed-off-by: Andrei Aaron <andreifdaaron@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
