### PR TITLE
fix(sync): initialize the temporary image store index before we copy content over there

### DIFF
--- a/pkg/extensions/sync/destination.go
+++ b/pkg/extensions/sync/destination.go
@@ -86,6 +86,14 @@ func (registry *DestinationRegistry) GetImageReference(repo, reference string) (
 	return registry.tempStorage.GetImageReference(repo, reference)
 }
 
+// InitTempRepo initializes the temporary repository before ImageCopy is called.
+// This ensures index.json exists so ImageCopy can properly update it.
+func (registry *DestinationRegistry) InitTempRepo(repo string, imageReference ref.Ref) error {
+	tempImageStore := getImageStoreFromImageReference(repo, imageReference, registry.log)
+
+	return tempImageStore.InitRepo(repo)
+}
+
 // CommitAll finalizes a syncing image.
 func (registry *DestinationRegistry) CommitAll(repo string, imageReference ref.Ref) error {
 	tempImageStore := getImageStoreFromImageReference(repo, imageReference, registry.log)

--- a/pkg/extensions/sync/sync.go
+++ b/pkg/extensions/sync/sync.go
@@ -89,6 +89,8 @@ type Destination interface {
 	Registry
 	// Check if descriptors are already synced
 	CanSkipImage(repo string, tag string, digest godigest.Digest) (bool, error)
+	// InitTempRepo initializes the temporary repository before ImageCopy is called
+	InitTempRepo(repo string, imageReference ref.Ref) error
 	// CommitAll moves a synced repo and all its manifests from temporary oci layout to ImageStore
 	CommitAll(repo string, imageReference ref.Ref) error
 	// Removes image reference, used when copy.Image() errors out

--- a/pkg/test/mocks/sync_remote_mock.go
+++ b/pkg/test/mocks/sync_remote_mock.go
@@ -73,6 +73,7 @@ type SyncDestinationMock struct {
 	// Methods required by sync Destination interface.
 	GetImageReferenceFn func(repo string, tag string) (ref.Ref, error)
 	CanSkipImageFn      func(repo string, tag string, digest digest.Digest) (bool, error)
+	InitTempRepoFn      func(repo string, imageReference ref.Ref) error
 	CommitAllFn         func(repo string, imageReference ref.Ref) error
 	CleanupImageFn      func(imageReference ref.Ref, repo string) error
 }
@@ -93,6 +94,14 @@ func (dest SyncDestinationMock) CanSkipImage(repo string, tag string, digest dig
 	}
 
 	return false, nil
+}
+
+func (dest SyncDestinationMock) InitTempRepo(repo string, imageReference ref.Ref) error {
+	if dest.InitTempRepoFn != nil {
+		return dest.InitTempRepoFn(repo, imageReference)
+	}
+
+	return nil
 }
 
 func (dest SyncDestinationMock) CommitAll(repo string, imageReference ref.Ref) error {


### PR DESCRIPTION
This should prevent the "repository not found" errors during sync operations.
https://github.com/project-zot/zot/issues/3560

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
