### PR TITLE
fix(trivy): prevent temp file accumulation in /tmp with configurable TMPDIR management

### DIFF
--- a/pkg/cli/server/extensions_test.go
+++ b/pkg/cli/server/extensions_test.go
@@ -1108,7 +1108,8 @@ func TestServeSearchEnabledDefaultCVEDB(t *testing.T) {
 
 		// The default config handling logic will convert the 1h interval to a 2h interval
 		substring := "\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":7200000000000,\"Trivy\":" +
-			"{\"DBRepository\":\"ghcr.io/aquasecurity/trivy-db\",\"JavaDBRepository\":\"ghcr.io/aquasecurity/trivy-java-db\"}}}"
+			"{\"DBRepository\":\"ghcr.io/aquasecurity/trivy-db\",\"JavaDBRepository\":" +
+			"\"ghcr.io/aquasecurity/trivy-java-db\",\"OverrideTmpDir\":false}}}"
 
 		found, err := ReadLogFileAndSearchString(logPath, substring, readLogFileTimeout)
 

--- a/pkg/extensions/config/config.go
+++ b/pkg/extensions/config/config.go
@@ -60,6 +60,11 @@ type CVEConfig struct {
 type TrivyConfig struct {
 	DBRepository     string // default is "ghcr.io/aquasecurity/trivy-db"
 	JavaDBRepository string // default is "ghcr.io/aquasecurity/trivy-java-db"
+	// OverrideTmpDir controls whether to override TMPDIR and clean up temporary files.
+	// When true, TMPDIR is overridden to cacheDir/tmp and temp files are cleaned up during DB updates.
+	// When false, TMPDIR is not modified and temp files are not cleaned up.
+	// Default is false to preserve old behavior (backward compatibility).
+	OverrideTmpDir bool `mapstructure:",omitempty"`
 }
 
 type MetricsConfig struct {

--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -41,8 +41,9 @@ func GetCveScanner(conf *config.Config, storeController storage.StoreController,
 	cveConfig := extensionsConfig.GetSearchCVEConfig()
 	dbRepository := cveConfig.Trivy.DBRepository
 	javaDBRepository := cveConfig.Trivy.JavaDBRepository
+	overrideTmpDir := cveConfig.Trivy.OverrideTmpDir // defaults to false if not set
 
-	return cveinfo.NewScanner(storeController, metaDB, dbRepository, javaDBRepository, log)
+	return cveinfo.NewScanner(storeController, metaDB, dbRepository, javaDBRepository, overrideTmpDir, log)
 }
 
 func EnableSearchExtension(conf *config.Config, storeController storage.StoreController,

--- a/pkg/extensions/search/cve/cve.go
+++ b/pkg/extensions/search/cve/cve.go
@@ -45,9 +45,9 @@ type BaseCveInfo struct {
 }
 
 func NewScanner(storeController storage.StoreController, metaDB mTypes.MetaDB,
-	dbRepository, javaDBRepository string, log log.Logger,
+	dbRepository, javaDBRepository string, overrideTmpDir bool, log log.Logger,
 ) Scanner {
-	return trivy.NewScanner(storeController, metaDB, dbRepository, javaDBRepository, log)
+	return trivy.NewScanner(storeController, metaDB, dbRepository, javaDBRepository, overrideTmpDir, log)
 }
 
 func NewCVEInfo(scanner Scanner, metaDB mTypes.MetaDB, log log.Logger) *BaseCveInfo {

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -334,7 +334,7 @@ func TestImageFormat(t *testing.T) {
 		err = meta.ParseStorage(metaDB, storeController, log)
 		So(err, ShouldBeNil)
 
-		scanner := cveinfo.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", log)
+		scanner := cveinfo.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, log)
 
 		isValidImage, err := scanner.IsImageFormatScannable("zot-test", "")
 		So(err, ShouldNotBeNil)
@@ -407,7 +407,7 @@ func TestImageFormat(t *testing.T) {
 			DefaultStore: mocks.MockedImageStore{},
 		}
 
-		scanner := cveinfo.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", log)
+		scanner := cveinfo.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, log)
 
 		isScanable, err := scanner.IsImageFormatScannable("repo", "tag")
 		So(err, ShouldBeNil)

--- a/pkg/extensions/search/cve/scan_test.go
+++ b/pkg/extensions/search/cve/scan_test.go
@@ -517,7 +517,7 @@ func TestScanGeneratorWithRealData(t *testing.T) {
 		err = meta.ParseStorage(metaDB, storeController, logger)
 		So(err, ShouldBeNil)
 
-		scanner := cveinfo.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", logger)
+		scanner := cveinfo.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, logger)
 		err = scanner.UpdateDB(context.Background())
 		So(err, ShouldBeNil)
 

--- a/pkg/extensions/search/cve/trivy/scanner_internal_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_internal_test.go
@@ -79,7 +79,7 @@ func TestMultipleStoragePath(t *testing.T) {
 		metaDB, err := boltdb.New(boltDriver, log)
 		So(err, ShouldBeNil)
 
-		scanner := NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", log)
+		scanner := NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, log)
 
 		So(scanner.storeController.DefaultStore, ShouldNotBeNil)
 		So(scanner.storeController.SubStore, ShouldNotBeNil)
@@ -195,7 +195,7 @@ func TestTrivyLibraryErrors(t *testing.T) {
 		img := "zot-test:0.0.1" //nolint:goconst
 
 		// Download DB fails for invalid DB url
-		scanner := NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-not-db", "", log)
+		scanner := NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-not-db", "", true, log)
 
 		ctx := context.Background()
 
@@ -210,14 +210,14 @@ func TestTrivyLibraryErrors(t *testing.T) {
 
 		// Download DB fails for invalid Java DB
 		scanner = NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db",
-			"ghcr.io/project-zot/trivy-not-db", log)
+			"ghcr.io/project-zot/trivy-not-db", true, log)
 
 		err = scanner.UpdateDB(ctx)
 		So(err, ShouldNotBeNil)
 
 		// Download DB passes for valid Trivy DB url, and missing Trivy Java DB url
 		// Download DB is necessary since DB download on scan is disabled
-		scanner = NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", log)
+		scanner = NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, log)
 
 		// UpdateDB with good ctx
 		err = scanner.UpdateDB(ctx)
@@ -318,7 +318,7 @@ func TestImageScannable(t *testing.T) {
 	storeController.DefaultStore = store
 
 	scanner := NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db",
-		"ghcr.io/project-zot/trivy-java-db", log)
+		"ghcr.io/project-zot/trivy-java-db", true, log)
 
 	Convey("Valid image should be scannable", t, func() {
 		result, err := scanner.IsImageFormatScannable("repo1", "valid")
@@ -388,7 +388,7 @@ func TestTrivyDBUrl(t *testing.T) {
 		// But we are getting `response status code 429: toomanyrequests` from
 		// `ghcr.io/aquasecurity/trivy-db` and `ghcr.io/aquasecurity/trivy-java-db`
 		scanner := NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db",
-			"ghcr.io/project-zot/trivy-java-db", log)
+			"ghcr.io/project-zot/trivy-java-db", true, log)
 
 		ctx := context.Background()
 

--- a/pkg/extensions/search/cve/trivy/scanner_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_test.go
@@ -59,7 +59,7 @@ func TestScanBigTestFile(t *testing.T) {
 		cm.StartAndWait(port)
 		defer cm.StopServer()
 		// scan
-		scanner := trivy.NewScanner(ctlr.StoreController, ctlr.MetaDB, "ghcr.io/project-zot/trivy-db", "", ctlr.Log)
+		scanner := trivy.NewScanner(ctlr.StoreController, ctlr.MetaDB, "ghcr.io/project-zot/trivy-db", "", true, ctlr.Log)
 
 		err = scanner.UpdateDB(context.Background())
 		So(err, ShouldBeNil)
@@ -103,7 +103,7 @@ func TestScanningByDigest(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// scan
-		scanner := trivy.NewScanner(ctlr.StoreController, ctlr.MetaDB, "ghcr.io/project-zot/trivy-db", "", ctlr.Log)
+		scanner := trivy.NewScanner(ctlr.StoreController, ctlr.MetaDB, "ghcr.io/project-zot/trivy-db", "", true, ctlr.Log)
 
 		ctx := context.Background()
 
@@ -189,7 +189,7 @@ func TestVulnerableLayer(t *testing.T) {
 		err = meta.ParseStorage(metaDB, storeController, log)
 		So(err, ShouldBeNil)
 
-		scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", log)
+		scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, log)
 
 		err = scanner.UpdateDB(context.Background())
 		So(err, ShouldBeNil)
@@ -261,7 +261,7 @@ func TestVulnerableLayer(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db",
-			"ghcr.io/project-zot/trivy-java-db", log)
+			"ghcr.io/project-zot/trivy-java-db", true, log)
 
 		err = scanner.UpdateDB(context.Background())
 		So(err, ShouldBeNil)
@@ -298,7 +298,7 @@ func TestScannerErrors(t *testing.T) {
 			metaDB.GetImageMetaFn = func(digest godigest.Digest) (types.ImageMeta, error) {
 				return types.ImageMeta{}, ErrTestError
 			}
-			scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", log)
+			scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, log)
 
 			_, err := scanner.IsImageFormatScannable("repo", godigest.FromString("dig").String())
 			So(err, ShouldNotBeNil)
@@ -308,7 +308,7 @@ func TestScannerErrors(t *testing.T) {
 			metaDB.GetImageMetaFn = func(digest godigest.Digest) (types.ImageMeta, error) {
 				return types.ImageMeta{}, ErrTestError
 			}
-			scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", log)
+			scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, log)
 
 			Convey("Manifest", func() {
 				_, err := scanner.IsImageMediaScannable("repo", godigest.FromString("dig").String(), ispec.MediaTypeImageManifest)
@@ -322,7 +322,7 @@ func TestScannerErrors(t *testing.T) {
 				metaDB.GetImageMetaFn = func(digest godigest.Digest) (types.ImageMeta, error) {
 					return types.ImageMeta{}, nil
 				}
-				scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", log)
+				scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, log)
 
 				_, err := scanner.IsImageMediaScannable("repo", godigest.FromString("dig").String(), ispec.MediaTypeImageIndex)
 				So(err, ShouldNotBeNil)
@@ -338,7 +338,7 @@ func TestScannerErrors(t *testing.T) {
 						}}},
 					}, nil
 				}
-				scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", log)
+				scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, log)
 
 				_, err := scanner.IsImageMediaScannable("repo", godigest.FromString("dig").String(), ispec.MediaTypeImageIndex)
 				So(err, ShouldBeNil)
@@ -350,7 +350,7 @@ func TestScannerErrors(t *testing.T) {
 				return types.ImageMeta{}, ErrTestError
 			}
 
-			scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", log)
+			scanner := trivy.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, log)
 
 			_, err := scanner.ScanImage(context.Background(), "image@"+godigest.FromString("digest").String())
 			So(err, ShouldNotBeNil)

--- a/pkg/extensions/search/cve/update_test.go
+++ b/pkg/extensions/search/cve/update_test.go
@@ -57,7 +57,7 @@ func TestCVEDBGenerator(t *testing.T) {
 			},
 		}
 
-		cveScanner := cveinfo.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", logger)
+		cveScanner := cveinfo.NewScanner(storeController, metaDB, "ghcr.io/project-zot/trivy-db", "", true, logger)
 		generator := cveinfo.NewDBUpdateTaskGenerator(time.Minute, cveScanner, logger)
 
 		sch.SubmitGenerator(generator, 12000*time.Millisecond, scheduler.HighPriority)

--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -704,7 +704,7 @@ func TestRepoListWithNewestImage(t *testing.T) {
 		defer ctlr.Shutdown()
 
 		substring := "{\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":3600000000000," +
-			"\"Trivy\":{\"DBRepository\":\"ghcr.io/project-zot/trivy-db\",\"JavaDBRepository\":\"\"}}}"
+			"\"Trivy\":{\"DBRepository\":\"ghcr.io/project-zot/trivy-db\",\"JavaDBRepository\":\"\",\"OverrideTmpDir\":false}}}"
 		found, err := readFileAndSearchString(logPath, substring, 2*time.Minute)
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
@@ -3646,7 +3646,7 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 
 		// Wait for trivy db to download
 		substring := "{\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":3600000000000," +
-			"\"Trivy\":{\"DBRepository\":\"ghcr.io/project-zot/trivy-db\",\"JavaDBRepository\":\"\"}}}"
+			"\"Trivy\":{\"DBRepository\":\"ghcr.io/project-zot/trivy-db\",\"JavaDBRepository\":\"\",\"OverrideTmpDir\":false}}}"
 		found, err := readFileAndSearchString(logPath, substring, 2*time.Minute)
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)


### PR DESCRIPTION
This commit addresses the issue where Trivy temporary directories (trivy-xxxxxx) were accumulating in /tmp/, causing disk space issues.

Changes:
- Set TMPDIR to use _trivy/tmp directory instead of system /tmp/ during scans
- Add automatic cleanup of temp directories during DB updates
- Add OverrideTmpDir configuration option to enable/disable TMPDIR management
- Default OverrideTmpDir to false to preserve old behavior (backward compatible)
- Restore original TMPDIR value after each scan completes

The cleanup removes all contents from _trivy/tmp directories for all stores (default and substores) during periodic DB updates.

Users can enable this feature by setting:
```
  "extensions": {
    "search": {
      "cve": {
        "trivy": {
          "overrideTmpDir": true
        }
      }
    }
  }
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
