### PR TITLE
ci: save unified coverage as build artifact

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -172,6 +172,13 @@ jobs:
           cp coverage-devmode/* .
           cp coverage-needprivileges/* .
           make covhtml
+          mkdir unified-coverage
+          cp coverage.txt coverage.html unified-coverage/
+      - name: upload html coverage
+        uses: actions/upload-artifact@v5
+        with:
+          name: unified-coverage
+          path: unified-coverage/*
       - name: upload code coverage
         uses: codecov/codecov-action@v5
         with:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
