### PR TITLE
refactor: enhance TLS cert generation and refactor HTTP client architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,18 +211,18 @@ test-prereq: check-skopeo $(TESTDATA) $(ORAS)
 
 .PHONY: test-extended
 test-extended: $(if $(findstring ui,$(BUILD_LABELS)), ui)
-test-extended: test-prereq
+test-extended: testdata-images
 	env GOEXPERIMENT=jsonv2 go test -failfast $(GO_CMD_TAGS) -trimpath -race -timeout 20m -cover -coverpkg ./... -coverprofile=coverage-extended.txt -covermode=atomic ./...
 	rm -rf /tmp/getter*; rm -rf /tmp/trivy*
 
 .PHONY: test-minimal
-test-minimal: test-prereq
+test-minimal: testdata-images
 	env GOEXPERIMENT=jsonv2 go test -failfast -trimpath -race -cover -coverpkg ./... -coverprofile=coverage-minimal.txt -covermode=atomic ./...
 	rm -rf /tmp/getter*; rm -rf /tmp/trivy*
 
 .PHONY: test-devmode
 test-devmode: $(if $(findstring ui,$(BUILD_LABELS)), ui)
-test-devmode: testdata-certs
+test-devmode:
 	env GOEXPERIMENT=jsonv2 go test -failfast -tags dev,$(BUILD_LABELS) -trimpath -race -timeout 15m -cover -coverpkg ./... -coverprofile=coverage-dev-extended.txt -covermode=atomic ./pkg/test/... ./pkg/api/... ./pkg/storage/... ./pkg/extensions/sync/... -run ^TestInject
 	rm -rf /tmp/getter*; rm -rf /tmp/trivy*
 	env GOEXPERIMENT=jsonv2 go test -failfast -tags dev -trimpath -race -cover -coverpkg ./... -coverprofile=coverage-dev-minimal.txt -covermode=atomic ./pkg/test/... ./pkg/storage/... ./pkg/extensions/sync/... -run ^TestInject
@@ -235,7 +235,7 @@ test: test-extended test-minimal test-devmode
 
 .PHONY: privileged-test
 privileged-test: $(if $(findstring ui,$(BUILD_LABELS)), ui)
-privileged-test: testdata-certs
+privileged-test:
 	env GOEXPERIMENT=jsonv2 go test -failfast -tags needprivileges,$(BUILD_LABELS) -trimpath -race -timeout 15m -cover -coverpkg ./... -coverprofile=coverage-needprivileges.txt -covermode=atomic ./pkg/storage/local/... ./pkg/cli/client/... -run ^TestElevatedPrivileges
 
 .PHONY: testdata-certs

--- a/pkg/cli/client/cve_cmd_internal_test.go
+++ b/pkg/cli/client/cve_cmd_internal_test.go
@@ -48,7 +48,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, "")
 
-		cmd := NewCVECommand(new(mockService))
+		cmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -64,7 +64,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, "")
 
-		cmd := NewCVECommand(new(mockService))
+		cmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -80,7 +80,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cmd := NewCVECommand(new(mockService))
+		cmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -95,7 +95,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cmd := NewCVECommand(new(searchService))
+		cmd := NewCVECommand(NewSearchService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -111,7 +111,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cmd := NewCVECommand(new(searchService))
+		cmd := NewCVECommand(NewSearchService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -126,7 +126,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cmd := NewCVECommand(new(searchService))
+		cmd := NewCVECommand(NewSearchService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -140,7 +140,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, baseURL))
 
-		cmd := NewCVECommand(new(mockService))
+		cmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -171,7 +171,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`, baseURL))
 
-		cmd := NewCVECommand(new(searchService))
+		cmd := NewCVECommand(NewSearchService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -188,7 +188,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cveCmd := NewCVECommand(new(mockService))
+		cveCmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cveCmd.SetOut(buff)
 		cveCmd.SetErr(buff)
@@ -207,7 +207,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cveCmd := NewCVECommand(new(mockService))
+		cveCmd := NewCVECommand(newMockService())
 		cveCmd.SetOut(buff)
 		cveCmd.SetErr(buff)
 		cveCmd.SetArgs(args)
@@ -224,7 +224,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cveCmd := NewCVECommand(new(mockService))
+		cveCmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cveCmd.SetOut(buff)
 		cveCmd.SetErr(buff)
@@ -255,7 +255,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cveCmd := NewCVECommand(new(mockService))
+		cveCmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cveCmd.SetOut(buff)
 		cveCmd.SetErr(buff)
@@ -293,7 +293,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cveCmd := NewCVECommand(new(mockService))
+		cveCmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cveCmd.SetOut(buff)
 		cveCmd.SetErr(buff)
@@ -314,7 +314,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cveCmd := NewCVECommand(new(mockService))
+		cveCmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cveCmd.SetOut(buff)
 		cveCmd.SetErr(buff)
@@ -333,7 +333,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cveCmd := NewCVECommand(new(mockService))
+		cveCmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cveCmd.SetOut(buff)
 		cveCmd.SetErr(buff)
@@ -352,7 +352,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cveCmd := NewCVECommand(new(mockService))
+		cveCmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cveCmd.SetOut(buff)
 		cveCmd.SetErr(buff)
@@ -370,7 +370,10 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		mockService := mockServiceForRetry{succeedOn: 2} // CVE info will be provided in 2nd attempt
+		mockService := mockServiceForRetry{
+			mockService: *newMockService(),
+			succeedOn:   2, // CVE info will be provided in 2nd attempt
+		}
 		cveCmd := NewCVECommand(&mockService)
 		buff := bytes.NewBufferString("")
 		cveCmd.SetOut(buff)
@@ -392,7 +395,10 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		mockService := mockServiceForRetry{succeedOn: -1} // CVE info will be unavailable on all retries
+		mockService := mockServiceForRetry{
+			mockService: *newMockService(),
+			succeedOn:   -1, // CVE info will be unavailable on all retries
+		}
 		cveCmd := NewCVECommand(&mockService)
 		buff := bytes.NewBufferString("")
 		cveCmd.SetOut(buff)
@@ -414,7 +420,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cveCmd := NewCVECommand(new(mockService))
+		cveCmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cveCmd.SetOut(buff)
 		cveCmd.SetErr(buff)
@@ -444,7 +450,7 @@ func TestSearchCVECmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"cvetest","showspinner":false}]}`)
 
-		cveCmd := NewCVECommand(new(mockService))
+		cveCmd := NewCVECommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cveCmd.SetOut(buff)
 		cveCmd.SetErr(buff)
@@ -497,7 +503,7 @@ func TestCVECommandGQL(t *testing.T) {
 
 		Convey("cveid", func() {
 			args := []string{"affected", "CVE-1942", "--config", "cvetest"}
-			cmd := NewCVECommand(mockService{})
+			cmd := NewCVECommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -517,7 +523,8 @@ func TestCVECommandGQL(t *testing.T) {
 			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`,
 				baseURL))
 
-			cmd := NewCVECommand(mockService{
+			cmd := NewCVECommand(&mockService{
+				httpClient: NewHTTPClient(),
 				getTagsForCVEGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 					imageName, cveID string) (*zcommon.ImagesForCve, error,
 				) {
@@ -545,7 +552,7 @@ func TestCVECommandGQL(t *testing.T) {
 
 		Convey("fixed", func() {
 			args := []string{"fixed", "image-name", "CVE-123", "--config", "cvetest"}
-			cmd := NewCVECommand(mockService{})
+			cmd := NewCVECommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -565,7 +572,8 @@ func TestCVECommandGQL(t *testing.T) {
 			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`,
 				baseURL))
 
-			cmd := NewCVECommand(mockService{
+			cmd := NewCVECommand(&mockService{
+				httpClient: NewHTTPClient(),
 				getFixedTagsForCVEGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 					imageName, cveID string) (*zcommon.ImageListWithCVEFixedResponse, error,
 				) {
@@ -593,7 +601,7 @@ func TestCVECommandGQL(t *testing.T) {
 
 		Convey("image", func() {
 			args := []string{"list", "repo:tag", "--config", "cvetest"}
-			cmd := NewCVECommand(mockService{})
+			cmd := NewCVECommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -616,7 +624,8 @@ func TestCVECommandGQL(t *testing.T) {
 			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"cvetest","url":"%s","showspinner":false}]}`,
 				baseURL))
 
-			cmd := NewCVECommand(mockService{
+			cmd := NewCVECommand(&mockService{
+				httpClient: NewHTTPClient(),
 				getCveByImageGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 					imageName, searchedCVE string) (*cveResult, error,
 				) {
@@ -668,7 +677,7 @@ func TestCVECommandErrors(t *testing.T) {
 
 		Convey("cveid", func() {
 			args := []string{"affected", "CVE-1942"}
-			cmd := NewCVECommand(mockService{})
+			cmd := NewCVECommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -680,7 +689,7 @@ func TestCVECommandErrors(t *testing.T) {
 		Convey("cveid error", func() {
 			// too many args
 			args := []string{"too", "many", "args"}
-			cmd := NewImagesByCVEIDCommand(mockService{})
+			cmd := NewImagesByCVEIDCommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -690,7 +699,7 @@ func TestCVECommandErrors(t *testing.T) {
 
 			// bad args
 			args = []string{"not-a-cve-id"}
-			cmd = NewImagesByCVEIDCommand(mockService{})
+			cmd = NewImagesByCVEIDCommand(newMockService())
 			buff = bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -700,7 +709,7 @@ func TestCVECommandErrors(t *testing.T) {
 
 			// no URL
 			args = []string{"CVE-1942"}
-			cmd = NewImagesByCVEIDCommand(mockService{})
+			cmd = NewImagesByCVEIDCommand(newMockService())
 			buff = bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -711,7 +720,7 @@ func TestCVECommandErrors(t *testing.T) {
 
 		Convey("fixed command", func() {
 			args := []string{"fixed", "image-name", "CVE-123"}
-			cmd := NewCVECommand(mockService{})
+			cmd := NewCVECommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -723,7 +732,7 @@ func TestCVECommandErrors(t *testing.T) {
 		Convey("fixed command error", func() {
 			// too many args
 			args := []string{"too", "many", "args", "args"}
-			cmd := NewFixedTagsCommand(mockService{})
+			cmd := NewFixedTagsCommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -733,7 +742,7 @@ func TestCVECommandErrors(t *testing.T) {
 
 			// bad args
 			args = []string{"repo-tag-instead-of-just-repo:fail-here", "CVE-123"}
-			cmd = NewFixedTagsCommand(mockService{})
+			cmd = NewFixedTagsCommand(newMockService())
 			buff = bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -743,7 +752,7 @@ func TestCVECommandErrors(t *testing.T) {
 
 			// no URL
 			args = []string{"CVE-1942"}
-			cmd = NewFixedTagsCommand(mockService{})
+			cmd = NewFixedTagsCommand(newMockService())
 			buff = bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -754,7 +763,7 @@ func TestCVECommandErrors(t *testing.T) {
 
 		Convey("image", func() {
 			args := []string{"list", "repo:tag"}
-			cmd := NewCVECommand(mockService{})
+			cmd := NewCVECommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -766,7 +775,7 @@ func TestCVECommandErrors(t *testing.T) {
 		Convey("image command error", func() {
 			// too many args
 			args := []string{"too", "many", "args", "args"}
-			cmd := NewCveForImageCommand(mockService{})
+			cmd := NewCveForImageCommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -776,7 +785,7 @@ func TestCVECommandErrors(t *testing.T) {
 
 			// bad args
 			args = []string{"repo-tag-instead-of-just-repo:fail-here", "CVE-123"}
-			cmd = NewCveForImageCommand(mockService{})
+			cmd = NewCveForImageCommand(newMockService())
 			buff = bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -786,7 +795,7 @@ func TestCVECommandErrors(t *testing.T) {
 
 			// no URL
 			args = []string{"CVE-1942"}
-			cmd = NewCveForImageCommand(mockService{})
+			cmd = NewCveForImageCommand(newMockService())
 			buff = bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)

--- a/pkg/cli/client/discover.go
+++ b/pkg/cli/client/discover.go
@@ -101,7 +101,8 @@ func CheckExtEndPointQuery(config SearchConfig, requiredQueries ...GQLQuery) err
 
 	discoverResponse := &distext.ExtensionList{}
 
-	_, err = makeGETRequest(ctx, discoverEndPoint, username, password, config.VerifyTLS,
+	_, err = config.SearchService.getHTTPClient().makeGETRequest(
+		ctx, discoverEndPoint, username, password, config.VerifyTLS,
 		config.Debug, &discoverResponse, config.ResultWriter)
 	if err != nil {
 		return err
@@ -152,7 +153,8 @@ func CheckExtEndPointQuery(config SearchConfig, requiredQueries ...GQLQuery) err
 
 	queryResponse := &schemaList{}
 
-	err = makeGraphQLRequest(ctx, searchEndPoint, schemaQuery, username, password, config.VerifyTLS,
+	err = config.SearchService.getHTTPClient().makeGraphQLRequest(
+		ctx, searchEndPoint, schemaQuery, username, password, config.VerifyTLS,
 		config.Debug, queryResponse, config.ResultWriter)
 	if err != nil {
 		return fmt.Errorf("gql query failed: %w", err)

--- a/pkg/cli/client/gql_queries_test.go
+++ b/pkg/cli/client/gql_queries_test.go
@@ -37,11 +37,12 @@ func TestGQLQueries(t *testing.T) {
 	defer cm.StopServer()
 
 	searchConfig := client.SearchConfig{
-		ServURL:      baseURL,
-		User:         "",
-		VerifyTLS:    false,
-		Debug:        false,
-		ResultWriter: io.Discard,
+		ServURL:       baseURL,
+		User:          "",
+		VerifyTLS:     false,
+		Debug:         false,
+		ResultWriter:  io.Discard,
+		SearchService: client.NewSearchService(),
 	}
 
 	Convey("Make sure the current CLI used the right queries in case they change", t, func() {

--- a/pkg/cli/client/image_cmd_internal_test.go
+++ b/pkg/cli/client/image_cmd_internal_test.go
@@ -37,7 +37,7 @@ func TestSearchImageCmd(t *testing.T) {
 
 		_ = makeConfigFile(t, "")
 
-		cmd := NewImageCommand(new(mockService))
+		cmd := NewImageCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -52,7 +52,7 @@ func TestSearchImageCmd(t *testing.T) {
 
 			_ = makeConfigFile(t, "")
 
-			cmd := NewImageCommand(new(mockService))
+			cmd := NewImageCommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -69,7 +69,7 @@ func TestSearchImageCmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
-		cmd := NewImageCommand(new(mockService))
+		cmd := NewImageCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -89,7 +89,7 @@ func TestSearchImageCmd(t *testing.T) {
 			panic(err)
 		}
 
-		cmd := NewImageCommand(new(mockService))
+		cmd := NewImageCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -113,7 +113,7 @@ func TestSearchImageCmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
-		cmd := NewImageCommand(new(mockService))
+		cmd := NewImageCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -127,7 +127,7 @@ func TestSearchImageCmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
-		cmd := NewImageCommand(new(searchService))
+		cmd := NewImageCommand(NewSearchService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -143,7 +143,7 @@ func TestSearchImageCmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
-		cmd := NewImageCommand(new(searchService))
+		cmd := NewImageCommand(NewSearchService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -157,7 +157,7 @@ func TestSearchImageCmd(t *testing.T) {
 
 			_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
-			cmd := NewImageCommand(new(searchService))
+			cmd := NewImageCommand(NewSearchService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -173,7 +173,7 @@ func TestSearchImageCmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
-		cmd := NewImageCommand(new(searchService))
+		cmd := NewImageCommand(NewSearchService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -187,7 +187,7 @@ func TestSearchImageCmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 
-		cmd := NewImageCommand(new(mockService))
+		cmd := NewImageCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -205,7 +205,7 @@ func TestSearchImageCmd(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","showspinner":false}]}`)
 
-		imageCmd := NewImageCommand(new(mockService))
+		imageCmd := NewImageCommand(newMockService())
 		buff := &bytes.Buffer{}
 		imageCmd.SetOut(buff)
 		imageCmd.SetErr(buff)
@@ -219,7 +219,7 @@ func TestSearchImageCmd(t *testing.T) {
 	})
 
 	Convey("Test image by digest", t, func() {
-		searchConfig := getTestSearchConfig("http://127.0.0.1:8080", new(mockService))
+		searchConfig := getTestSearchConfig("http://127.0.0.1:8080", newMockService())
 		buff := &bytes.Buffer{}
 		searchConfig.ResultWriter = buff
 		err := SearchImagesByDigest(searchConfig, "6e2f80bf")
@@ -234,7 +234,7 @@ func TestSearchImageCmd(t *testing.T) {
 }
 
 func TestListRepos(t *testing.T) {
-	searchConfig := getTestSearchConfig("https://test-url.com", new(mockService))
+	searchConfig := getTestSearchConfig("https://test-url.com", newMockService())
 
 	Convey("Test listing repositories", t, func() {
 		buff := &bytes.Buffer{}
@@ -248,7 +248,7 @@ func TestListRepos(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test","url":"https://test-url.com","showspinner":false}]}`)
 
-		cmd := NewRepoCommand(new(searchService))
+		cmd := NewRepoCommand(NewSearchService())
 
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
@@ -272,7 +272,7 @@ func TestListRepos(t *testing.T) {
 			panic(err)
 		}
 
-		cmd := NewRepoCommand(new(mockService))
+		cmd := NewRepoCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -297,7 +297,7 @@ func TestListRepos(t *testing.T) {
 		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test",
         	"url":"https://invalid.invalid","showspinner":false}]}`)
 
-		cmd := NewRepoCommand(new(searchService))
+		cmd := NewRepoCommand(NewSearchService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -311,7 +311,7 @@ func TestListRepos(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test","url":"https://test-url.com","showspinner":false}]}`)
 
-		cmd := NewRepoCommand(new(mockService))
+		cmd := NewRepoCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -325,7 +325,7 @@ func TestListRepos(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test","url":"","showspinner":false}]}`)
 
-		cmd := NewRepoCommand(new(mockService))
+		cmd := NewRepoCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -340,7 +340,7 @@ func TestListRepos(t *testing.T) {
 		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test",
        		"url":"https://test-url.com","showspinner":invalid}]}`)
 
-		cmd := NewRepoCommand(new(mockService))
+		cmd := NewRepoCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -355,7 +355,7 @@ func TestListRepos(t *testing.T) {
 		_ = makeConfigFile(t, `{"configs":[{"_name":"config-test",
         	"verify-tls":"invalid", "url":"https://test-url.com","showspinner":false}]}`)
 
-		cmd := NewRepoCommand(new(mockService))
+		cmd := NewRepoCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -371,7 +371,7 @@ func TestOutputFormat(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 
-		cmd := NewImageCommand(new(mockService))
+		cmd := NewImageCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -389,7 +389,7 @@ func TestOutputFormat(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 
-		cmd := NewImageCommand(new(mockService))
+		cmd := NewImageCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -419,7 +419,7 @@ func TestOutputFormat(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 
-		cmd := NewImageCommand(new(mockService))
+		cmd := NewImageCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -457,7 +457,7 @@ func TestOutputFormat(t *testing.T) {
 					`"url":"https://test-url.com","showspinner":false}]}`,
 			)
 
-			cmd := NewImageCommand(new(mockService))
+			cmd := NewImageCommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -493,7 +493,7 @@ func TestOutputFormat(t *testing.T) {
 
 		_ = makeConfigFile(t, `{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false}]}`)
 
-		cmd := NewImageCommand(new(mockService))
+		cmd := NewImageCommand(newMockService())
 		buff := bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -797,7 +797,7 @@ func TestImagesCommandGQL(t *testing.T) {
 			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
 			args := []string{"cve", "repo:vuln", "--config", "imagetest"}
-			cmd := NewImageCommand(mockService{})
+			cmd := NewImageCommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -818,7 +818,8 @@ func TestImagesCommandGQL(t *testing.T) {
 				baseURL))
 
 			args := []string{"cve", "repo:vuln", "--config", "imagetest"}
-			cmd := NewImageCommand(mockService{
+			cmd := NewImageCommand(&mockService{
+				httpClient: NewHTTPClient(),
 				getCveByImageGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 					imageName, searchedCVE string) (*cveResult, error,
 				) {
@@ -895,7 +896,7 @@ func TestImagesCommandGQL(t *testing.T) {
 		So(err, ShouldNotBeNil)
 
 		args = []string{"cve", "repo:vuln"}
-		cmd = NewImageCommand(mockService{})
+		cmd = NewImageCommand(newMockService())
 		buff = bytes.NewBufferString("")
 		cmd.SetOut(buff)
 		cmd.SetErr(buff)
@@ -1028,7 +1029,7 @@ func TestImageCommandREST(t *testing.T) {
 			_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s","showspinner":false}]}`,
 				baseURL))
 
-			cmd := NewImageCommand(mockService{})
+			cmd := NewImageCommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -1093,9 +1094,22 @@ type mockService struct {
 	getCVEDiffListGQLFn func(ctx context.Context, config SearchConfig, username, password string,
 		minuend, subtrahend ImageIdentifier,
 	) (*cveDiffListResp, error)
+
+	httpClient *HTTPClient
 }
 
-func (service mockService) getCVEDiffListGQL(ctx context.Context, config SearchConfig, username, password string,
+// newMockService creates a new mockService with httpClient initialized.
+func newMockService() *mockService {
+	return &mockService{
+		httpClient: NewHTTPClient(),
+	}
+}
+
+func (service *mockService) getHTTPClient() *HTTPClient {
+	return service.httpClient
+}
+
+func (service *mockService) getCVEDiffListGQL(ctx context.Context, config SearchConfig, username, password string,
 	minuend, subtrahend ImageIdentifier,
 ) (*cveDiffListResp, error) {
 	if service.getCVEDiffListGQLFn != nil {
@@ -1105,7 +1119,7 @@ func (service mockService) getCVEDiffListGQL(ctx context.Context, config SearchC
 	return &cveDiffListResp{}, nil
 }
 
-func (service mockService) getRepos(ctx context.Context, config SearchConfig, username,
+func (service *mockService) getRepos(ctx context.Context, config SearchConfig, username,
 	password string, channel chan stringResult, wtgrp *sync.WaitGroup,
 ) {
 	defer wtgrp.Done()
@@ -1117,7 +1131,7 @@ func (service mockService) getRepos(ctx context.Context, config SearchConfig, us
 	fmt.Fprintln(config.ResultWriter, "repo2")
 }
 
-func (service mockService) getReferrers(ctx context.Context, config SearchConfig, username, password string,
+func (service *mockService) getReferrers(ctx context.Context, config SearchConfig, username, password string,
 	repo, digest string,
 ) (referrersResult, error) {
 	if service.getReferrersFn != nil {
@@ -1134,7 +1148,7 @@ func (service mockService) getReferrers(ctx context.Context, config SearchConfig
 	}, nil
 }
 
-func (service mockService) globalSearchGQL(ctx context.Context, config SearchConfig, username, password string,
+func (service *mockService) globalSearchGQL(ctx context.Context, config SearchConfig, username, password string,
 	query string,
 ) (*common.GlobalSearch, error) {
 	if service.globalSearchGQLFn != nil {
@@ -1166,7 +1180,7 @@ func (service mockService) globalSearchGQL(ctx context.Context, config SearchCon
 	}, nil
 }
 
-func (service mockService) getReferrersGQL(ctx context.Context, config SearchConfig, username, password string,
+func (service *mockService) getReferrersGQL(ctx context.Context, config SearchConfig, username, password string,
 	repo, digest string,
 ) (*common.ReferrersResp, error) {
 	if service.getReferrersGQLFn != nil {
@@ -1187,7 +1201,7 @@ func (service mockService) getReferrersGQL(ctx context.Context, config SearchCon
 	}, nil
 }
 
-func (service mockService) getDerivedImageListGQL(ctx context.Context, config SearchConfig, username, password string,
+func (service *mockService) getDerivedImageListGQL(ctx context.Context, config SearchConfig, username, password string,
 	derivedImage string,
 ) (*common.DerivedImageListResponse, error) {
 	if service.getDerivedImageListGQLFn != nil {
@@ -1215,7 +1229,7 @@ func (service mockService) getDerivedImageListGQL(ctx context.Context, config Se
 	return imageListGQLResponse, nil
 }
 
-func (service mockService) getBaseImageListGQL(ctx context.Context, config SearchConfig, username, password string,
+func (service *mockService) getBaseImageListGQL(ctx context.Context, config SearchConfig, username, password string,
 	baseImage string,
 ) (*common.BaseImageListResponse, error) {
 	if service.getBaseImageListGQLFn != nil {
@@ -1243,7 +1257,7 @@ func (service mockService) getBaseImageListGQL(ctx context.Context, config Searc
 	return imageListGQLResponse, nil
 }
 
-func (service mockService) getImagesGQL(ctx context.Context, config SearchConfig, username, password string,
+func (service *mockService) getImagesGQL(ctx context.Context, config SearchConfig, username, password string,
 	imageName string,
 ) (*common.ImageListResponse, error) {
 	if service.getImagesGQLFn != nil {
@@ -1273,7 +1287,7 @@ func (service mockService) getImagesGQL(ctx context.Context, config SearchConfig
 	return imageListGQLResponse, nil
 }
 
-func (service mockService) getImagesForDigestGQL(ctx context.Context, config SearchConfig, username, password string,
+func (service *mockService) getImagesForDigestGQL(ctx context.Context, config SearchConfig, username, password string,
 	digest string,
 ) (*common.ImagesForDigest, error) {
 	if service.getImagesForDigestGQLFn != nil {
@@ -1303,7 +1317,7 @@ func (service mockService) getImagesForDigestGQL(ctx context.Context, config Sea
 	return imageListGQLResponse, nil
 }
 
-func (service mockService) getTagsForCVEGQL(ctx context.Context, config SearchConfig, username, password,
+func (service *mockService) getTagsForCVEGQL(ctx context.Context, config SearchConfig, username, password,
 	imageName, cveID string,
 ) (*common.ImagesForCve, error) {
 	if service.getTagsForCVEGQLFn != nil {
@@ -1329,7 +1343,7 @@ func (service mockService) getTagsForCVEGQL(ctx context.Context, config SearchCo
 	return images, nil
 }
 
-func (service mockService) getFixedTagsForCVEGQL(ctx context.Context, config SearchConfig, username, password,
+func (service *mockService) getFixedTagsForCVEGQL(ctx context.Context, config SearchConfig, username, password,
 	imageName, cveID string,
 ) (*common.ImageListWithCVEFixedResponse, error) {
 	if service.getFixedTagsForCVEGQLFn != nil {
@@ -1351,7 +1365,7 @@ func (service mockService) getFixedTagsForCVEGQL(ctx context.Context, config Sea
 	return fixedTags, nil
 }
 
-func (service mockService) getCveByImageGQL(ctx context.Context, config SearchConfig, username, password,
+func (service *mockService) getCveByImageGQL(ctx context.Context, config SearchConfig, username, password,
 	imageName, searchedCVE string,
 ) (*cveResult, error) {
 	if service.getCveByImageGQLFn != nil {
@@ -1411,7 +1425,7 @@ func (service mockService) getMockedImageByName(imageName string) imageStruct {
 	return image
 }
 
-func (service mockService) getAllImages(ctx context.Context, config SearchConfig, username, password string,
+func (service *mockService) getAllImages(ctx context.Context, config SearchConfig, username, password string,
 	channel chan stringResult, wtgrp *sync.WaitGroup,
 ) {
 	defer wtgrp.Done()
@@ -1449,7 +1463,7 @@ func (service mockService) getAllImages(ctx context.Context, config SearchConfig
 	channel <- stringResult{str, nil}
 }
 
-func (service mockService) getImageByName(ctx context.Context, config SearchConfig,
+func (service *mockService) getImageByName(ctx context.Context, config SearchConfig,
 	username, password, imageName string, channel chan stringResult, wtgrp *sync.WaitGroup,
 ) {
 	defer wtgrp.Done()
@@ -1487,7 +1501,7 @@ func (service mockService) getImageByName(ctx context.Context, config SearchConf
 	channel <- stringResult{str, nil}
 }
 
-func (service mockService) getImagesByDigest(ctx context.Context, config SearchConfig, username,
+func (service *mockService) getImagesByDigest(ctx context.Context, config SearchConfig, username,
 	password, digest string, rch chan stringResult, wtgrp *sync.WaitGroup,
 ) {
 	if service.getImagesByDigestFn != nil {

--- a/pkg/cli/client/search_cmd_internal_test.go
+++ b/pkg/cli/client/search_cmd_internal_test.go
@@ -44,7 +44,7 @@ func TestSearchCommandGQL(t *testing.T) {
 
 		Convey("query", func() {
 			args := []string{"query", "repo/al", "--config", "searchtest"}
-			cmd := NewSearchCommand(mockService{})
+			cmd := NewSearchCommand(newMockService())
 
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
@@ -62,7 +62,7 @@ func TestSearchCommandGQL(t *testing.T) {
 		Convey("query command errors", func() {
 			// no url
 			args := []string{"repo/al", "--config", "searchtest"}
-			cmd := NewSearchQueryCommand(mockService{})
+			cmd := NewSearchQueryCommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -76,7 +76,7 @@ func TestSearchCommandGQL(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			args := []string{"subject", "repo:tag", "--config", "searchtest"}
-			cmd := NewSearchCommand(mockService{})
+			cmd := NewSearchCommand(newMockService())
 
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
@@ -93,7 +93,7 @@ func TestSearchCommandGQL(t *testing.T) {
 		Convey("subject command errors", func() {
 			// no url
 			args := []string{"repo:tag", "--config", "searchtest"}
-			cmd := NewSearchSubjectCommand(mockService{})
+			cmd := NewSearchSubjectCommand(newMockService())
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
 			cmd.SetErr(buff)
@@ -123,7 +123,7 @@ func TestSearchCommandREST(t *testing.T) {
 
 		Convey("query", func() {
 			args := []string{"query", "repo/al", "--config", "searchtest"}
-			cmd := NewSearchCommand(mockService{})
+			cmd := NewSearchCommand(newMockService())
 
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)
@@ -138,7 +138,7 @@ func TestSearchCommandREST(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			args := []string{"subject", "repo:tag", "--config", "searchtest"}
-			cmd := NewSearchCommand(mockService{})
+			cmd := NewSearchCommand(newMockService())
 
 			buff := bytes.NewBufferString("")
 			cmd.SetOut(buff)

--- a/pkg/cli/client/search_functions_internal_test.go
+++ b/pkg/cli/client/search_functions_internal_test.go
@@ -26,7 +26,8 @@ import (
 func TestSearchAllImages(t *testing.T) {
 	Convey("SearchAllImages", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getAllImagesFn: func(ctx context.Context, config SearchConfig, username, password string,
 				channel chan stringResult, wtgrp *sync.WaitGroup,
 			) {
@@ -48,7 +49,8 @@ func TestSearchAllImages(t *testing.T) {
 func TestSearchAllImagesGQL(t *testing.T) {
 	Convey("SearchAllImagesGQL", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getImagesGQLFn: func(ctx context.Context, config SearchConfig, username, password, imageName string,
 			) (*common.ImageListResponse, error) {
 				return &common.ImageListResponse{ImageList: common.ImageList{
@@ -69,7 +71,8 @@ func TestSearchAllImagesGQL(t *testing.T) {
 
 	Convey("SearchAllImagesGQL error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getImagesGQLFn: func(ctx context.Context, config SearchConfig, username, password, imageName string,
 			) (*common.ImageListResponse, error) {
 				return &common.ImageListResponse{ImageList: common.ImageList{
@@ -88,7 +91,8 @@ func TestSearchAllImagesGQL(t *testing.T) {
 func TestSearchImageByName(t *testing.T) {
 	Convey("SearchImageByName", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getImageByNameFn: func(ctx context.Context, config SearchConfig, username string, password string, imageName string,
 				channel chan stringResult, wtgrp *sync.WaitGroup,
 			) {
@@ -108,7 +112,8 @@ func TestSearchImageByName(t *testing.T) {
 
 	Convey("SearchImageByName error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getImageByNameFn: func(ctx context.Context, config SearchConfig, username string, password string, imageName string,
 				channel chan stringResult, wtgrp *sync.WaitGroup,
 			) {
@@ -124,7 +129,8 @@ func TestSearchImageByName(t *testing.T) {
 func TestSearchImageByNameGQL(t *testing.T) {
 	Convey("SearchImageByNameGQL", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getImagesGQLFn: func(ctx context.Context, config SearchConfig, username, password, imageName string,
 			) (*common.ImageListResponse, error) {
 				return &common.ImageListResponse{ImageList: common.ImageList{
@@ -145,7 +151,8 @@ func TestSearchImageByNameGQL(t *testing.T) {
 
 	Convey("SearchImageByNameGQL error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getImagesGQLFn: func(ctx context.Context, config SearchConfig, username, password, imageName string,
 			) (*common.ImageListResponse, error) {
 				return &common.ImageListResponse{ImageList: common.ImageList{
@@ -164,7 +171,8 @@ func TestSearchImageByNameGQL(t *testing.T) {
 func TestSearchImagesByDigest(t *testing.T) {
 	Convey("SearchImagesByDigest", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getImagesByDigestFn: func(ctx context.Context, config SearchConfig, username string, password string, digest string,
 				rch chan stringResult, wtgrp *sync.WaitGroup,
 			) {
@@ -184,7 +192,8 @@ func TestSearchImagesByDigest(t *testing.T) {
 
 	Convey("SearchImagesByDigest error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getImagesByDigestFn: func(ctx context.Context, config SearchConfig, username string, password string, digest string,
 				rch chan stringResult, wtgrp *sync.WaitGroup,
 			) {
@@ -200,7 +209,8 @@ func TestSearchImagesByDigest(t *testing.T) {
 func TestSearchDerivedImageListGQL(t *testing.T) {
 	Convey("SearchDerivedImageListGQL", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getDerivedImageListGQLFn: func(ctx context.Context, config SearchConfig, username string, password string,
 				derivedImage string) (*common.DerivedImageListResponse, error,
 			) {
@@ -224,7 +234,8 @@ func TestSearchDerivedImageListGQL(t *testing.T) {
 
 	Convey("SearchDerivedImageListGQL error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getDerivedImageListGQLFn: func(ctx context.Context, config SearchConfig, username string, password string,
 				derivedImage string) (*common.DerivedImageListResponse, error,
 			) {
@@ -242,7 +253,8 @@ func TestSearchDerivedImageListGQL(t *testing.T) {
 func TestSearchBaseImageListGQL(t *testing.T) {
 	Convey("SearchBaseImageListGQL", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getBaseImageListGQLFn: func(ctx context.Context, config SearchConfig, username string, password string,
 				derivedImage string) (*common.BaseImageListResponse, error,
 			) {
@@ -264,7 +276,8 @@ func TestSearchBaseImageListGQL(t *testing.T) {
 
 	Convey("SearchBaseImageListGQL error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getBaseImageListGQLFn: func(ctx context.Context, config SearchConfig, username string, password string,
 				derivedImage string) (*common.BaseImageListResponse, error,
 			) {
@@ -282,7 +295,8 @@ func TestSearchBaseImageListGQL(t *testing.T) {
 func TestSearchImagesForDigestGQL(t *testing.T) {
 	Convey("SearchImagesForDigestGQL", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getImagesForDigestGQLFn: func(ctx context.Context, config SearchConfig, username string,
 				password string, digest string) (*common.ImagesForDigest, error,
 			) {
@@ -304,7 +318,8 @@ func TestSearchImagesForDigestGQL(t *testing.T) {
 
 	Convey("SearchImagesForDigestGQL error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getImagesForDigestGQLFn: func(ctx context.Context, config SearchConfig, username string,
 				password string, digest string) (*common.ImagesForDigest, error,
 			) {
@@ -322,7 +337,8 @@ func TestSearchImagesForDigestGQL(t *testing.T) {
 func TestSearchCVEForImageGQL(t *testing.T) {
 	Convey("SearchCVEForImageGQL normal mode", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getCveByImageGQLFn: func(ctx context.Context, config SearchConfig, username string, password string,
 				imageName string, searchedCVE string) (*cveResult, error,
 			) {
@@ -406,7 +422,8 @@ func TestSearchCVEForImageGQL(t *testing.T) {
 
 	Convey("SearchCVEForImageGQL verbose mode", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getCveByImageGQLFn: func(ctx context.Context, config SearchConfig, username string, password string,
 				imageName string, searchedCVE string) (*cveResult, error,
 			) {
@@ -530,7 +547,8 @@ func TestSearchCVEForImageGQL(t *testing.T) {
 
 	Convey("SearchCVEForImageGQL with injected error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getCveByImageGQLFn: func(ctx context.Context, config SearchConfig, username string, password string,
 				imageName string, searchedCVE string) (*cveResult, error,
 			) {
@@ -546,7 +564,8 @@ func TestSearchCVEForImageGQL(t *testing.T) {
 func TestSearchImagesByCVEIDGQL(t *testing.T) {
 	Convey("SearchImagesByCVEIDGQL", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getTagsForCVEGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 				imageName, cveID string) (*common.ImagesForCve, error,
 			) {
@@ -572,7 +591,8 @@ func TestSearchImagesByCVEIDGQL(t *testing.T) {
 
 	Convey("SearchImagesByCVEIDGQL error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getTagsForCVEGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 				imageName, cveID string) (*common.ImagesForCve, error,
 			) {
@@ -592,7 +612,8 @@ func TestSearchImagesByCVEIDGQL(t *testing.T) {
 func TestSearchFixedTagsGQL(t *testing.T) {
 	Convey("SearchFixedTagsGQL", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getFixedTagsForCVEGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 				imageName, cveID string) (*common.ImageListWithCVEFixedResponse, error,
 			) {
@@ -616,7 +637,8 @@ func TestSearchFixedTagsGQL(t *testing.T) {
 
 	Convey("SearchFixedTagsGQL error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getFixedTagsForCVEGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 				imageName, cveID string) (*common.ImageListWithCVEFixedResponse, error,
 			) {
@@ -636,7 +658,8 @@ func TestSearchFixedTagsGQL(t *testing.T) {
 func TestSearchReferrersGQL(t *testing.T) {
 	Convey("SearchReferrersGQL", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getReferrersGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 				repo, digest string) (*common.ReferrersResp, error,
 			) {
@@ -664,7 +687,8 @@ func TestSearchReferrersGQL(t *testing.T) {
 
 	Convey("SearchReferrersGQL error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getReferrersGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 				repo, digest string) (*common.ReferrersResp, error,
 			) {
@@ -680,7 +704,8 @@ func TestSearchReferrersGQL(t *testing.T) {
 func TestGlobalSearchGQL(t *testing.T) {
 	Convey("GlobalSearchGQL", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			globalSearchGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 				query string) (*common.GlobalSearch, error,
 			) {
@@ -705,7 +730,8 @@ func TestGlobalSearchGQL(t *testing.T) {
 
 	Convey("GlobalSearchGQL error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			globalSearchGQLFn: func(ctx context.Context, config SearchConfig, username, password,
 				query string) (*common.GlobalSearch, error,
 			) {
@@ -721,7 +747,8 @@ func TestGlobalSearchGQL(t *testing.T) {
 func TestSearchReferrers(t *testing.T) {
 	Convey("SearchReferrers", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getReferrersFn: func(ctx context.Context, config SearchConfig, username string, password string,
 				repo string, digest string) (referrersResult, error,
 			) {
@@ -747,7 +774,8 @@ func TestSearchReferrers(t *testing.T) {
 
 	Convey("SearchReferrers error", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient(),
 			getReferrersFn: func(ctx context.Context, config SearchConfig, username string, password string,
 				repo string, digest string) (referrersResult, error,
 			) {
@@ -763,7 +791,8 @@ func TestSearchReferrers(t *testing.T) {
 func TestSearchRepos(t *testing.T) {
 	Convey("SearchRepos", t, func() {
 		buff := bytes.NewBufferString("")
-		searchConfig := getMockSearchConfig(buff, mockService{})
+		searchConfig := getMockSearchConfig(buff, &mockService{
+			httpClient: NewHTTPClient()})
 
 		err := SearchRepos(searchConfig)
 		So(err, ShouldBeNil)
@@ -775,7 +804,7 @@ func TestSearchRepos(t *testing.T) {
 	})
 }
 
-func getMockSearchConfig(buff *bytes.Buffer, mockService mockService) SearchConfig {
+func getMockSearchConfig(buff *bytes.Buffer, mockService *mockService) SearchConfig {
 	return SearchConfig{
 		ResultWriter:  buff,
 		User:          "",
@@ -909,18 +938,20 @@ func TestUtils(t *testing.T) {
 	Convey("CheckExtEndPointQuery", t, func() {
 		// invalid url
 		err := CheckExtEndPointQuery(SearchConfig{
-			User:    "",
-			ServURL: "bad-url",
+			User:          "",
+			ServURL:       "bad-url",
+			SearchService: NewSearchService(),
 		})
 		So(err, ShouldNotBeNil)
 
 		// good url but no connection
 		err = CheckExtEndPointQuery(SearchConfig{
-			User:         "",
-			ServURL:      "http://127.0.0.1:5000",
-			VerifyTLS:    false,
-			Debug:        false,
-			ResultWriter: io.Discard,
+			User:          "",
+			ServURL:       "http://127.0.0.1:5000",
+			VerifyTLS:     false,
+			Debug:         false,
+			ResultWriter:  io.Discard,
+			SearchService: NewSearchService(),
 		})
 		So(err, ShouldNotBeNil)
 	})

--- a/pkg/cli/client/server_info_cmd.go
+++ b/pkg/cli/client/server_info_cmd.go
@@ -58,7 +58,8 @@ func GetServerStatus(config SearchConfig) error {
 		return err
 	}
 
-	_, err = makeGETRequest(ctx, checkAPISupportEndpoint, username, password, config.VerifyTLS, config.Debug,
+	_, err = config.SearchService.getHTTPClient().makeGETRequest(
+		ctx, checkAPISupportEndpoint, username, password, config.VerifyTLS, config.Debug,
 		nil, config.ResultWriter)
 	if err != nil {
 		serverInfo := ServerInfo{}
@@ -87,7 +88,8 @@ func GetServerStatus(config SearchConfig) error {
 
 	serverInfo := ServerInfo{}
 
-	_, err = makeGETRequest(ctx, mgmtEndpoint, username, password, config.VerifyTLS, config.Debug,
+	_, err = config.SearchService.getHTTPClient().makeGETRequest(
+		ctx, mgmtEndpoint, username, password, config.VerifyTLS, config.Debug,
 		&serverInfo, config.ResultWriter)
 
 	switch {

--- a/pkg/cli/client/server_info_cmd_test.go
+++ b/pkg/cli/client/server_info_cmd_test.go
@@ -112,15 +112,17 @@ func TestServerStatusCommandErrors(t *testing.T) {
 
 		// invalid URL
 		err = GetServerStatus(SearchConfig{
-			ServURL:      "a: ds",
-			ResultWriter: os.Stdout,
+			ServURL:       "a: ds",
+			ResultWriter:  os.Stdout,
+			SearchService: NewSearchService(),
 		})
 		So(err, ShouldNotBeNil)
 
 		// fail Get request
 		err = GetServerStatus(SearchConfig{
-			ServURL:      "http://127.0.0.1:8000",
-			ResultWriter: os.Stdout,
+			ServURL:       "http://127.0.0.1:8000",
+			ResultWriter:  os.Stdout,
+			SearchService: NewSearchService(),
 		})
 		So(err, ShouldBeNil)
 	})
@@ -129,7 +131,7 @@ func TestServerStatusCommandErrors(t *testing.T) {
 		port := test.GetFreePort()
 		result := bytes.NewBuffer([]byte{})
 		searchConfig := SearchConfig{
-			SearchService: mockService{},
+			SearchService: newMockService(),
 			ServURL:       fmt.Sprintf("http://127.0.0.1:%v", port),
 			User:          "",
 			OutputFormat:  "text",

--- a/pkg/cli/client/utils.go
+++ b/pkg/cli/client/utils.go
@@ -37,7 +37,8 @@ func fetchImageDigest(repo, ref, username, password string, config SearchConfig)
 		return "", err
 	}
 
-	res, err := makeHEADRequest(context.Background(), url, username, password, config.VerifyTLS, false)
+	res, err := config.SearchService.getHTTPClient().makeHEADRequest(
+		context.Background(), url, username, password, config.VerifyTLS, false)
 
 	digestStr := res.Get(constants.DistContentDigestKey)
 

--- a/pkg/cli/client/utils_internal_test.go
+++ b/pkg/cli/client/utils_internal_test.go
@@ -26,12 +26,13 @@ func getDefaultSearchConf(baseURL string) SearchConfig {
 	outputFormat := "text"
 
 	return SearchConfig{
-		ServURL:      baseURL,
-		ResultWriter: io.Discard,
-		VerifyTLS:    verifyTLS,
-		Debug:        debug,
-		Verbose:      verbose,
-		OutputFormat: outputFormat,
+		ServURL:       baseURL,
+		ResultWriter:  io.Discard,
+		VerifyTLS:     verifyTLS,
+		Debug:         debug,
+		Verbose:       verbose,
+		OutputFormat:  outputFormat,
+		SearchService: NewSearchService(),
 	}
 }
 
@@ -88,7 +89,8 @@ func TestDoHTTPRequest(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, nil)
 		So(err, ShouldBeNil)
 
-		So(func() { _, _ = doHTTPRequest(req, false, false, nil, io.Discard) }, ShouldNotPanic)
+		httpClient := NewHTTPClient()
+		So(func() { _, _ = httpClient.doHTTPRequest(req, false, false, nil, io.Discard) }, ShouldNotPanic)
 	})
 
 	Convey("doHTTPRequest bad return json", t, func() {
@@ -112,21 +114,25 @@ func TestDoHTTPRequest(t *testing.T) {
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 		So(err, ShouldBeNil)
 
-		So(func() { _, _ = doHTTPRequest(req, false, false, &ispec.Manifest{}, io.Discard) }, ShouldNotPanic)
+		httpClient := NewHTTPClient()
+		So(func() { _, _ = httpClient.doHTTPRequest(req, false, false, &ispec.Manifest{}, io.Discard) }, ShouldNotPanic)
 	})
 
 	Convey("makeGraphQLRequest bad request context", t, func() {
-		err := makeGraphQLRequest(nil, "", "", "", "", false, false, nil, io.Discard) //nolint:staticcheck
+		httpClient := NewHTTPClient()
+		err := httpClient.makeGraphQLRequest(nil, "", "", "", "", false, false, nil, io.Discard) //nolint:staticcheck
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("makeHEADRequest bad request context", t, func() {
-		_, err := makeHEADRequest(nil, "", "", "", false, false) //nolint:staticcheck
+		httpClient := NewHTTPClient()
+		_, err := httpClient.makeHEADRequest(nil, "", "", "", false, false) //nolint:staticcheck
 		So(err, ShouldNotBeNil)
 	})
 
 	Convey("makeGETRequest bad request context", t, func() {
-		_, err := makeGETRequest(nil, "", "", "", false, false, nil, io.Discard) //nolint:staticcheck
+		httpClient := NewHTTPClient()
+		_, err := httpClient.makeGETRequest(nil, "", "", "", false, false, nil, io.Discard) //nolint:staticcheck
 		So(err, ShouldNotBeNil)
 	})
 


### PR DESCRIPTION
- Refactored HTTP client from global cache to struct-based approach (global state was shared between tests, including what certificates to use)
- Enhanced pkg/test/tls to support ECDSA and ED25519 key types
- Replaced static certificate files with dynamic generation in golang tests
- Fixed test cleanup issues and improved resource management

This eliminates dependency on external cert generation scripts and improves test maintainability.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
