### PR TITLE
fix(api): resolve OCI conformance issues and refactor blob upload handling

### DIFF
--- a/.github/workflows/oci-conformance-action.yaml
+++ b/.github/workflows/oci-conformance-action.yaml
@@ -17,10 +17,11 @@ permissions: read-all
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   run:
+    name: Run official conformance tests
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - name: Install go 1.23
+    - name: Install go
       uses: actions/setup-go@v6
       with:
         cache: false
@@ -64,3 +65,111 @@ jobs:
         name: oci-test-results-${{ github.sha }}
         path: .out/
       if: github.event_name == 'push'
+
+  run-v2:
+    name: Run conformance tests (pr-conformance-v2)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install go
+      uses: actions/setup-go@v6
+      with:
+        cache: false
+        go-version: 1.25.x
+    - name: Checkout this PR
+      uses: actions/checkout@v6
+    - name: Start zot server
+      id: start-server
+      run: |
+          cd $GITHUB_WORKSPACE
+          make binary
+          ./bin/zot-linux-amd64 serve examples/config-conformance.json & echo $! > zot.PID
+          IP=`hostname -I | awk '{print $1}'`
+          # Check if zot server is running
+          cat /proc/$(cat zot.PID)/status | grep State || exit 1
+          curl --connect-timeout 3 --max-time 5 --retry 60 --retry-delay 1 --retry-max-time 180 --retry-connrefused http://${IP}:8080/v2/
+    - name: Checkout distribution-spec
+      uses: actions/checkout@v6
+      with:
+        repository: sudo-bmitch/distribution-spec
+        ref: pr-conformance-v2
+        path: distribution-spec-v2
+    - name: Build conformance binary
+      run: |
+        cd distribution-spec-v2/conformance2
+        go build -o conformance .
+        mv conformance $GITHUB_WORKSPACE/
+    - name: Create conformance config
+      run: |
+        IP=`hostname -I | awk '{print $1}'`
+        cat > conformance-config.yaml <<EOF
+        resultsDir: ./results
+        version: "1.1"
+        registry: ${IP}:8080
+        tls: disabled
+        repo1: conformance/repo1
+        repo2: conformance/repo2
+        username: ""
+        password: ""
+        logging: warn
+        apis:
+          pull: true
+          push: true
+          blobs:
+            atomic: true
+            delete: true
+            mountAnonymous: true
+          manifests:
+            atomic: true
+            delete: true
+          tags:
+            atomic: true
+            delete: true
+            list: true
+          referrer: true
+        data:
+          image: true
+          index: true
+          indexList: true
+          sparse: false
+          artifact: true
+          subject: true
+          subjectMissing: true
+          artifactList: true
+          subjectList: true
+          dataField: true
+          nondistributable: true
+          customFields: true
+          emptyBlob: true
+          sha512: true
+        roData:
+          tags: []
+          manifests: []
+          blobs: []
+          referrers: []
+        EOF
+    - name: Run conformance v2
+      env:
+        OCI_CONFIGURATION: conformance-config.yaml
+      run: |
+        ./conformance
+    - name: Collect test results
+      run: |
+        mkdir -p .out-v2/
+        if [ -f results/report.html ]; then
+          mv results/report.html .out-v2/report.html
+        fi
+        if [ -f results/junit.xml ]; then
+          mv results/junit.xml .out-v2/junit.xml
+        fi
+      if: always()
+    - name: Upload test results v2 as build artifact
+      uses: actions/upload-artifact@v5
+      with:
+        name: oci-test-results-v2-${{ github.sha }}
+        path: .out-v2/
+      if: always()
+    - name: Cleanup
+      if: always()
+      run: |
+        cd $GITHUB_WORKSPACE
+        [[ -f zot.PID ]] && kill $(cat zot.PID) 2>/dev/null || true

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -5753,11 +5753,13 @@ func TestAuthorizationMountBlob(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
 
-		/* a HEAD request by user1 on blob digest (found in user1Repo) should return 200
-		because user1 has permission to read user1Repo */
+		/* a HEAD request by user1 on blob digest from user1/mysecondrepo should return 404
+		because the blob doesn't exist in that repository (even though user1 has permission
+		to read user1/myrepo where the blob exists). Per OCI spec, HEAD must check if the
+		blob exists "in the repository" (the specific repository requested). */
 		resp, err = userClient1.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", username1+"/"+"mysecondrepo", blobDigest))
 		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
 
 		// user2 can upload without dedupe
 		err = UploadImageWithBasicAuth(img, baseURL, repoName2, tag, username2, password2)
@@ -5767,6 +5769,32 @@ func TestAuthorizationMountBlob(t *testing.T) {
 		resp, err = userClient2.R().SetQueryParams(params).Post(baseURL + "/v2/" + repoName2 + "/blobs/uploads/")
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		// Test cross-repo mount with "from" parameter
+		// user1 tries to mount from repoName1 to a new repo
+		paramsWithFrom := make(map[string]string)
+		paramsWithFrom["mount"] = blobDigest.String()
+		paramsWithFrom["from"] = repoName1
+
+		repoName3 := username1 + "/" + "mythirdrepo"
+		resp, err = userClient1.R().SetQueryParams(paramsWithFrom).Post(baseURL + "/v2/" + repoName3 + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		// user2 tries to mount from repoName1 (user1's repo) - should fail due to no permission
+		resp, err = userClient2.R().SetQueryParams(paramsWithFrom).Post(baseURL + "/v2/" + repoName2 + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted) // 202 because no permission to read from repoName1
+
+		// user1 tries to mount a non-existent blob from a non-existent repo - should return 202 (cache won't find it)
+		// Use a blob digest that doesn't exist anywhere in the system
+		nonExistentDigest := godigest.FromBytes([]byte("non-existent-blob-content"))
+		paramsWithFrom["mount"] = nonExistentDigest.String()
+		paramsWithFrom["from"] = username1 + "/nonexistent"
+		repoName4 := username1 + "/" + "myfourthrepo"
+		resp, err = userClient1.R().SetQueryParams(paramsWithFrom).Post(baseURL + "/v2/" + repoName4 + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted) // 202 because blob not found in cache
 	})
 }
 
@@ -6701,10 +6729,34 @@ func TestCrossRepoMount(t *testing.T) {
 
 		So(os.SameFile(cacheFi, linkFi), ShouldEqual, true)
 
+		// Test mounting from zot-d-test (where blob was originally uploaded)
+		params["from"] = "zot-d-test"
+		postResponse, err = client.R().
+			SetBasicAuth(username, password).SetQueryParams(params).
+			Post(baseURL + "/v2/zot-mount2-test/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(postResponse.StatusCode(), ShouldEqual, http.StatusCreated)
+		So(test.Location(baseURL, postResponse), ShouldEqual, fmt.Sprintf("%s%s/zot-mount2-test/%s/%s:%s",
+			baseURL, constants.RoutePrefix, constants.Blobs, godigest.SHA256, blob))
+
+		// Test mounting from non-existent repository with non-existent blob - should return 202 (cache won't find it)
+		// Use a blob digest that doesn't exist anywhere in the system
+		nonExistentDigest := godigest.FromBytes([]byte("non-existent-blob-for-mount-test"))
+		params["mount"] = nonExistentDigest.String()
+		params["from"] = "zot-nonexistent"
+		postResponse, err = client.R().
+			SetBasicAuth(username, password).SetQueryParams(params).
+			Post(baseURL + "/v2/zot-mount3-test/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(postResponse.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+		// HEAD request to zot-cv-test should return 404 because the blob was never mounted to that repository.
+		// Per OCI spec, HEAD must check if the blob exists "in the repository" (the specific repository requested),
+		// not in the cache or other repositories.
 		headResponse, err = client.R().SetBasicAuth(username, password).
 			Head(fmt.Sprintf("%s/v2/zot-cv-test/blobs/%s", baseURL, manifestDigest))
 		So(err, ShouldBeNil)
-		So(headResponse.StatusCode(), ShouldEqual, http.StatusOK)
+		So(headResponse.StatusCode(), ShouldEqual, http.StatusNotFound)
 
 		// Invalid request
 		params = make(map[string]string)

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -499,7 +499,7 @@ func TestRoutes(t *testing.T) {
 			statusCode := testCheckBlob(
 				map[string]string{
 					"name":   "ErrBadBlobDigest",
-					"digest": "1234",
+					"digest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 				},
 				&mocks.MockedImageStore{
 					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
@@ -512,7 +512,7 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrRepoNotFound",
-					"digest": "1234",
+					"digest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 				},
 				&mocks.MockedImageStore{
 					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
@@ -525,7 +525,7 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrBlobNotFound",
-					"digest": "1234",
+					"digest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 				},
 				&mocks.MockedImageStore{
 					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
@@ -538,7 +538,7 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrUnexpectedError",
-					"digest": "1234",
+					"digest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 				},
 				&mocks.MockedImageStore{
 					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
@@ -551,7 +551,7 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "Check Blob Not Ok",
-					"digest": "1234",
+					"digest": "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08",
 				},
 				&mocks.MockedImageStore{
 					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
@@ -646,7 +646,7 @@ func TestRoutes(t *testing.T) {
 					NewBlobUploadFn: func(repo string) (string, error) {
 						return "", zerr.ErrRepoNotFound
 					},
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobForMountFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -663,7 +663,7 @@ func TestRoutes(t *testing.T) {
 					NewBlobUploadFn: func(repo string) (string, error) {
 						return "", zerr.ErrRepoNotFound
 					},
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobForMountFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -681,7 +681,7 @@ func TestRoutes(t *testing.T) {
 					NewBlobUploadFn: func(repo string) (string, error) {
 						return "", zerr.ErrRepoNotFound
 					},
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobForMountFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -701,12 +701,12 @@ func TestRoutes(t *testing.T) {
 						return sessionStr, 0, zerr.ErrBadBlobDigest
 					},
 				})
-			So(statusCode, ShouldEqual, http.StatusInternalServerError)
+			So(statusCode, ShouldEqual, http.StatusBadRequest)
 
 			// digest prezent bad length
 			statusCode = testCreateBlobUpload(
 				[]struct{ k, v string }{
-					{"digest", "1234"},
+					{"digest", "sha256:9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08"},
 				},
 				map[string]string{
 					"Content-Type":   constants.BinaryMediaType,

--- a/pkg/storage/cache/dynamodb.go
+++ b/pkg/storage/cache/dynamodb.go
@@ -175,6 +175,9 @@ func (d *DynamoDBDriver) GetAllBlobs(digest godigest.Digest) ([]string, error) {
 		}
 	}
 
+	// Sort to ensure consistent ordering (DynamoDB doesn't guarantee list order)
+	slices.Sort(blobPaths)
+
 	return blobPaths, nil
 }
 

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -51,6 +51,7 @@ type ImageStore interface { //nolint:interfacebloat
 	DeleteBlobUpload(repo, uuid string) error
 	BlobPath(repo string, digest godigest.Digest) string
 	CheckBlob(repo string, digest godigest.Digest) (bool, int64, error)
+	CheckBlobForMount(repo string, digest godigest.Digest) (bool, int64, error)
 	StatBlob(repo string, digest godigest.Digest) (bool, int64, time.Time, error)
 	GetBlob(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error)
 	GetBlobPartial(repo string, digest godigest.Digest, mediaType string, from, to int64,

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -40,6 +40,7 @@ type MockedImageStore struct {
 	DeleteBlobUploadFn     func(repo string, uuid string) error
 	BlobPathFn             func(repo string, digest godigest.Digest) string
 	CheckBlobFn            func(repo string, digest godigest.Digest) (bool, int64, error)
+	CheckBlobForMountFn    func(repo string, digest godigest.Digest) (bool, int64, error)
 	StatBlobFn             func(repo string, digest godigest.Digest) (bool, int64, time.Time, error)
 	GetBlobPartialFn       func(repo string, digest godigest.Digest, mediaType string, from, to int64,
 	) (io.ReadCloser, int64, int64, error)
@@ -308,6 +309,14 @@ func (is MockedImageStore) BlobPath(repo string, digest godigest.Digest) string 
 func (is MockedImageStore) CheckBlob(repo string, digest godigest.Digest) (bool, int64, error) {
 	if is.CheckBlobFn != nil {
 		return is.CheckBlobFn(repo, digest)
+	}
+
+	return true, 0, nil
+}
+
+func (is MockedImageStore) CheckBlobForMount(repo string, digest godigest.Digest) (bool, int64, error) {
+	if is.CheckBlobForMountFn != nil {
+		return is.CheckBlobForMountFn(repo, digest)
 	}
 
 	return true, 0, nil


### PR DESCRIPTION
This commit fixes several OCI Distribution Spec conformance issues found while running the tests in: https://github.com/sudo-bmitch/distribution-spec/tree/pr-conformance-v2

Add a new CI job running the conformance actions.

Conformance Fixes:
1. Fix empty blob upload: allow Content-Length: 0 for POST/PUT requests instead of returning 400
2. Fix empty blob retrieval: return 404 when blob not found in repository instead of returning 400
3. Fix bad digest handling: return 400 Bad Request with DIGEST_INVALID for invalid digest formats and mismatched digests
4. Fix blob delete after mount: return 404 after blob was deleted from repository, even if it exists in cache (other repositories)
5. Fix chunked upload PUT: make Content-Length and Content-Range optional when finishing chunked uploads

Other changes:
- Given point 4, we can't auto-mount blobs from cache on HEAD requests, this code was removed. Since the tests uses HEAD after DELETE, auto-mounting from another repository would results in 200 instead of 404
- Since the above could result in re-uploads by clients, implement the "from" parameter and check user permissions on that repository

Refactoring:
- Add CheckBlobForMount method for mount operations that check cache
- Extract handleBlobUploadError helper to consolidate duplicate error handling logic
- Extract checkEmptyBlobUpload helper to reduce UpdateBlobUpload complexity
- Remove goto statement from UpdateBlobUpload

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
