### PR TITLE
fix: do not reject requests having an Authorization header if basic auth is disabled

### DIFF
--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -440,10 +440,6 @@ func (amw *AuthnMiddleware) tryAuthnHandlers(ctlr *Controller) mux.MiddlewareFun
 			case !isAuthorizationHeaderEmpty(request) && authConfig.IsBasicAuthnEnabled():
 				authenticated, err = amw.basicAuthn(ctlr, userAc, response, request)
 
-			// The authorization header is given but basic auth is not enabled
-			case !isAuthorizationHeaderEmpty(request) && !authConfig.IsBasicAuthnEnabled():
-				authenticated = false
-
 			// The session header is an explicit attempt to use session authentication
 			case hasSessionHeader(request):
 				authenticated, err = amw.sessionAuthn(ctlr, userAc, response, request)


### PR DESCRIPTION
See https://github.com/project-zot/zot/issues/3662

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
