### PR TITLE
fix: graphql playground documentation was hardcoded to an unrelated example

### DIFF
--- a/pkg/debug/gqlplayground/index.html.tmpl
+++ b/pkg/debug/gqlplayground/index.html.tmpl
@@ -67,7 +67,7 @@
       import 'graphiql/setup-workers/esm.sh';
 
       const fetcher = createGraphiQLFetcher({
-        url: 'https://countries.trevorblades.com',
+        url: '{{.Target}}',
       });
       const plugins = [HISTORY_PLUGIN, explorerPlugin()];
 


### PR DESCRIPTION
Missed it in https://github.com/project-zot/zot/commit/e6dee9f1e6495bf33291c5520ed3c8d935dad592

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
