### PR TITLE
fix(fips): flaky fips blackbox test and add missing curves

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -224,8 +224,11 @@ func (c *Controller) Run() error {
 
 		// This is a subset of the default curve preferences in defaultCurvePreferencesFIPS for TLS 1.2
 		// see https://cs.opensource.google/go/go/+/refs/tags/go1.24.9:src/crypto/tls/defaults.go;l=106
+		// P-256, P-384, and P-521 are all FIPS-compliant NIST curves
 		curvePreferences := []tls.CurveID{
 			tls.CurveP256,
+			tls.CurveP384,
+			tls.CurveP521,
 		}
 		if !fips140.Enabled() {
 			// X25519 is not FIPS-compliant

--- a/test/blackbox/fips140_authn.bats
+++ b/test/blackbox/fips140_authn.bats
@@ -123,6 +123,11 @@ function verify_auth_and_push() {
     
     zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
    
+    # Disable TLS for regctl to avoid X25519 issues when regctl runs in FIPS mode
+    # This must be done before regctl registry login, as login automatically pings the registry
+    run regctl registry set localhost:${zot_port} --tls disabled
+    [ "$status" -eq 0 ]
+
     # anonymous authn is set for zot, so all auth is ignored for the /v2/ ping
     run regctl registry login localhost:${zot_port} -u ${user} -p ${pass}
     [ "$status" -eq 0 ]


### PR DESCRIPTION
2 unrelated issues:
 - See https://github.com/project-zot/zot/actions/runs/21336958408/job/61410298444?pr=3731 for details.
 - Also add missing fips curves https://cs.opensource.google/go/go/+/refs/tags/go1.25.6:src/crypto/tls/defaults_fips140.go;l=33


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
