### PR TITLE
fix(meta): fixes for LastUpdated and TaggedTimestamp

### DIFF
--- a/pkg/cli/client/image_cmd_internal_test.go
+++ b/pkg/cli/client/image_cmd_internal_test.go
@@ -407,7 +407,8 @@ func TestOutputFormat(t *testing.T) {
 			`"score":0}],"history":null,"vulnerabilities":{"maxSeverity":"","unknownCount":0,"lowCount":0,`+
 			`"mediumCount":0,"highCount":0,"criticalCount":0,"count":0},`+
 			`"referrers":null,"artifactType":"","signatureInfo":null}],"size":"123445",`+
-			`"downloadCount":0,"lastUpdated":"0001-01-01T00:00:00Z","description":"","isSigned":false,"licenses":"",`+
+			`"downloadCount":0,"lastUpdated":"0001-01-01T00:00:00Z","lastPullTimestamp":"0001-01-01T00:00:00Z",`+
+			`"pushTimestamp":"0001-01-01T00:00:00Z","taggedTimestamp":"0001-01-01T00:00:00Z","description":"","isSigned":false,"licenses":"",`+
 			`"labels":"","title":"","source":"","documentation":"","authors":"","vendor":"",`+
 			`"vulnerabilities":{"maxSeverity":"","unknownCount":0,"lowCount":0,"mediumCount":0,"highCount":0,`+
 			`"criticalCount":0,"count":0},"referrers":null,"signatureInfo":null}`+"\n")
@@ -442,7 +443,9 @@ func TestOutputFormat(t *testing.T) {
 				`unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 0 criticalcount: 0 count: 0 `+
 				`referrers: [] artifacttype: "" `+
 				`signatureinfo: [] size: "123445" downloadcount: 0 `+
-				`lastupdated: 0001-01-01T00:00:00Z description: "" issigned: false licenses: "" labels: "" `+
+				`lastupdated: 0001-01-01T00:00:00Z lastpulltimestamp: 0001-01-01T00:00:00Z `+
+				`pushtimestamp: 0001-01-01T00:00:00Z taggedtimestamp: 0001-01-01T00:00:00Z `+
+				`description: "" issigned: false licenses: "" labels: "" `+
 				`title: "" source: "" documentation: "" authors: "" vendor: "" vulnerabilities: maxseverity: "" `+
 				`unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 0 criticalcount: 0 `+
 				`count: 0 referrers: [] signatureinfo: []`,
@@ -479,7 +482,9 @@ func TestOutputFormat(t *testing.T) {
 					`history: [] vulnerabilities: maxseverity: "" unknowncount: 0 lowcount: 0 mediumcount: 0 `+
 					`highcount: 0 criticalcount: 0 count: 0 referrers: [] artifacttype: "" `+
 					`signatureinfo: [] size: "123445" downloadcount: 0 `+
-					`lastupdated: 0001-01-01T00:00:00Z description: "" issigned: false licenses: "" labels: "" `+
+					`lastupdated: 0001-01-01T00:00:00Z lastpulltimestamp: 0001-01-01T00:00:00Z `+
+					`pushtimestamp: 0001-01-01T00:00:00Z taggedtimestamp: 0001-01-01T00:00:00Z `+
+					`description: "" issigned: false licenses: "" labels: "" `+
 					`title: "" source: "" documentation: "" authors: "" vendor: "" vulnerabilities: maxseverity: "" `+
 					`unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 0 criticalcount: 0 `+
 					`count: 0 referrers: [] signatureinfo: []`,

--- a/pkg/cli/client/image_cmd_test.go
+++ b/pkg/cli/client/image_cmd_test.go
@@ -389,7 +389,9 @@ func TestOutputFormatGQL(t *testing.T) {
 				`"history":null,"vulnerabilities":{"maxSeverity":"","unknownCount":0,"lowCount":0,"mediumCount":0,` +
 				`"highCount":0,"criticalCount":0,"count":0},` +
 				`"referrers":null,"artifactType":"","signatureInfo":null}],` +
-				`"size":"528","downloadCount":0,"lastUpdated":"2023-01-01T12:00:00Z","description":"","isSigned":false,` +
+				`"size":"528","downloadCount":0,"lastUpdated":"2023-01-01T12:00:00Z","lastPullTimestamp":"0001-01-01T00:00:00Z",` +
+				`"pushTimestamp":"0001-01-01T00:00:00Z","taggedTimestamp":"0001-01-01T00:00:00Z",` +
+				`"description":"","isSigned":false,` +
 				`"licenses":"","labels":"","title":"","source":"","documentation":"","authors":"","vendor":"",` +
 				`"vulnerabilities":{"maxSeverity":"","unknownCount":0,"lowCount":0,"mediumCount":0,` +
 				`"highCount":0,"criticalCount":0,"count":0},"referrers":null,"signatureInfo":null}` + "\n" +
@@ -404,7 +406,9 @@ func TestOutputFormatGQL(t *testing.T) {
 				`"history":null,"vulnerabilities":{"maxSeverity":"","unknownCount":0,"lowCount":0,"mediumCount":0,` +
 				`"highCount":0,"criticalCount":0,"count":0},` +
 				`"referrers":null,"artifactType":"","signatureInfo":null}],` +
-				`"size":"528","downloadCount":0,"lastUpdated":"2023-01-01T12:00:00Z","description":"","isSigned":false,` +
+				`"size":"528","downloadCount":0,"lastUpdated":"2023-01-01T12:00:00Z","lastPullTimestamp":"0001-01-01T00:00:00Z",` +
+				`"pushTimestamp":"0001-01-01T00:00:00Z","taggedTimestamp":"0001-01-01T00:00:00Z",` +
+				`"description":"","isSigned":false,` +
 				`"licenses":"","labels":"","title":"","source":"","documentation":"","authors":"","vendor":"",` +
 				`"vulnerabilities":{"maxSeverity":"","unknownCount":0,"lowCount":0,"mediumCount":0,` +
 				`"highCount":0,"criticalCount":0,"count":0},"referrers":null,"signatureInfo":null}` + "\n"
@@ -438,7 +442,9 @@ func TestOutputFormatGQL(t *testing.T) {
 				`history: [] vulnerabilities: maxseverity: "" ` +
 				`unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 0 criticalcount: 0 count: 0 ` +
 				`referrers: [] artifacttype: "" signatureinfo: [] ` +
-				`size: "528" downloadcount: 0 lastupdated: 2023-01-01T12:00:00Z description: "" ` +
+				`size: "528" downloadcount: 0 lastupdated: 2023-01-01T12:00:00Z ` +
+				`lastpulltimestamp: 0001-01-01T00:00:00Z pushtimestamp: 0001-01-01T00:00:00Z ` +
+				`taggedtimestamp: 0001-01-01T00:00:00Z description: "" ` +
 				`issigned: false licenses: "" labels: "" title: "" source: "" documentation: "" ` +
 				`authors: "" vendor: "" vulnerabilities: maxseverity: "" ` +
 				`unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 0 criticalcount: 0 count: 0 ` +
@@ -454,7 +460,9 @@ func TestOutputFormatGQL(t *testing.T) {
 				`history: [] vulnerabilities: maxseverity: "" ` +
 				`unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 0 criticalcount: 0 count: 0 ` +
 				`referrers: [] artifacttype: "" signatureinfo: [] ` +
-				`size: "528" downloadcount: 0 lastupdated: 2023-01-01T12:00:00Z description: "" ` +
+				`size: "528" downloadcount: 0 lastupdated: 2023-01-01T12:00:00Z ` +
+				`lastpulltimestamp: 0001-01-01T00:00:00Z pushtimestamp: 0001-01-01T00:00:00Z ` +
+				`taggedtimestamp: 0001-01-01T00:00:00Z description: "" ` +
 				`issigned: false licenses: "" labels: "" title: "" source: "" documentation: "" ` +
 				`authors: "" vendor: "" vulnerabilities: maxseverity: "" ` +
 				`unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 0 criticalcount: 0 count: 0 ` +
@@ -488,7 +496,9 @@ func TestOutputFormatGQL(t *testing.T) {
 				`history: [] vulnerabilities: maxseverity: "" ` +
 				`unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 0 criticalcount: 0 count: 0 ` +
 				`referrers: [] artifacttype: "" signatureinfo: [] ` +
-				`size: "528" downloadcount: 0 lastupdated: 2023-01-01T12:00:00Z description: "" ` +
+				`size: "528" downloadcount: 0 lastupdated: 2023-01-01T12:00:00Z ` +
+				`lastpulltimestamp: 0001-01-01T00:00:00Z pushtimestamp: 0001-01-01T00:00:00Z ` +
+				`taggedtimestamp: 0001-01-01T00:00:00Z description: "" ` +
 				`issigned: false licenses: "" labels: "" title: "" source: "" documentation: "" ` +
 				`authors: "" vendor: "" vulnerabilities: maxseverity: "" ` +
 				`unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 0 criticalcount: 0 count: 0 ` +
@@ -504,7 +514,9 @@ func TestOutputFormatGQL(t *testing.T) {
 				`history: [] vulnerabilities: maxseverity: "" ` +
 				`unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 0 criticalcount: 0 count: 0 ` +
 				`referrers: [] artifacttype: "" signatureinfo: [] ` +
-				`size: "528" downloadcount: 0 lastupdated: 2023-01-01T12:00:00Z description: "" ` +
+				`size: "528" downloadcount: 0 lastupdated: 2023-01-01T12:00:00Z ` +
+				`lastpulltimestamp: 0001-01-01T00:00:00Z pushtimestamp: 0001-01-01T00:00:00Z ` +
+				`taggedtimestamp: 0001-01-01T00:00:00Z description: "" ` +
 				`issigned: false licenses: "" labels: "" title: "" source: "" documentation: "" ` +
 				`authors: "" vendor: "" vulnerabilities: maxseverity: "" ` +
 				`unknowncount: 0 lowcount: 0 mediumcount: 0 highcount: 0 criticalcount: 0 count: 0 ` +

--- a/pkg/cli/client/search_cmd_test.go
+++ b/pkg/cli/client/search_cmd_test.go
@@ -485,7 +485,8 @@ func TestSearchCLI(t *testing.T) {
 		space := regexp.MustCompile(`\s+`)
 		str := strings.TrimSpace(space.ReplaceAllString(buff.String(), " "))
 		So(str, ShouldContainSubstring, "NAME SIZE LAST UPDATED DOWNLOADS STARS PLATFORMS")
-		So(str, ShouldContainSubstring, "repo/test/alpine 1.1kB 2010-01-01 01:01:01 +0000 UTC 0 0")
+		So(str, ShouldContainSubstring, "repo/test/alpine 1.1kB")
+		So(str, ShouldContainSubstring, "+0000 UTC 0 0")
 		So(str, ShouldContainSubstring, "Os/Arch")
 		So(str, ShouldContainSubstring, "linux/amd64")
 

--- a/pkg/cli/server/verify_retention_test.go
+++ b/pkg/cli/server/verify_retention_test.go
@@ -476,7 +476,7 @@ func TestRetentionCheckWithRetentionEnabledAndRedisDriver(t *testing.T) {
 
 		defer ctrlManager.StopServer()
 
-		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "1s", configFile}
+		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "2s", configFile}
 		err = cli.NewServerRootCmd().Execute()
 		So(err, ShouldBeNil)
 
@@ -720,7 +720,7 @@ func TestRetentionCheckWithRetentionEnabled(t *testing.T) {
 		gcDelay, _ := time.ParseDuration(testGCDelay)
 		time.Sleep(gcDelay + 50*time.Millisecond) // wait for GC delay to pass
 
-		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "1s", configFile}
+		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "2s", configFile}
 		err = cli.NewServerRootCmd().Execute()
 		So(err, ShouldBeNil)
 
@@ -935,7 +935,7 @@ func TestRetentionCheckWithDeleteReferrers(t *testing.T) {
 		gcDelay, _ := time.ParseDuration(testGCDelay)
 		time.Sleep(gcDelay + 50*time.Millisecond) // wait for GC delay to pass
 
-		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "1s", configFile}
+		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "2s", configFile}
 		err = cli.NewServerRootCmd().Execute()
 		So(err, ShouldBeNil)
 
@@ -1080,7 +1080,7 @@ func TestRetentionCheckWithRetentionDisabled(t *testing.T) {
 		gcDelay, _ := time.ParseDuration(testGCDelay)
 		time.Sleep(gcDelay + 50*time.Millisecond) // wait for GC delay to pass
 
-		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "1s", configFile}
+		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "2s", configFile}
 		err = cli.NewServerRootCmd().Execute()
 		So(err, ShouldBeNil)
 
@@ -1354,7 +1354,7 @@ func TestRetentionCheckWithSubpaths(t *testing.T) {
 		gcDelay, _ := time.ParseDuration(testGCDelay)
 		time.Sleep(gcDelay + 50*time.Millisecond) // wait for GC delay to pass
 
-		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "1s", configFile}
+		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "2s", configFile}
 		err = cli.NewServerRootCmd().Execute()
 		So(err, ShouldBeNil)
 

--- a/pkg/common/model.go
+++ b/pkg/common/model.go
@@ -33,26 +33,29 @@ type PaginatedImagesResult struct {
 }
 
 type ImageSummary struct {
-	RepoName        string                    `json:"repoName"`
-	Tag             string                    `json:"tag"`
-	Digest          string                    `json:"digest"`
-	MediaType       string                    `json:"mediaType"`
-	Manifests       []ManifestSummary         `json:"manifests"`
-	Size            string                    `json:"size"`
-	DownloadCount   int                       `json:"downloadCount"`
-	LastUpdated     time.Time                 `json:"lastUpdated"`
-	Description     string                    `json:"description"`
-	IsSigned        bool                      `json:"isSigned"`
-	Licenses        string                    `json:"licenses"`
-	Labels          string                    `json:"labels"`
-	Title           string                    `json:"title"`
-	Source          string                    `json:"source"`
-	Documentation   string                    `json:"documentation"`
-	Authors         string                    `json:"authors"`
-	Vendor          string                    `json:"vendor"`
-	Vulnerabilities ImageVulnerabilitySummary `json:"vulnerabilities"`
-	Referrers       []Referrer                `json:"referrers"`
-	SignatureInfo   []SignatureSummary        `json:"signatureInfo"`
+	RepoName          string                    `json:"repoName"`
+	Tag               string                    `json:"tag"`
+	Digest            string                    `json:"digest"`
+	MediaType         string                    `json:"mediaType"`
+	Manifests         []ManifestSummary         `json:"manifests"`
+	Size              string                    `json:"size"`
+	DownloadCount     int                       `json:"downloadCount"`
+	LastUpdated       time.Time                 `json:"lastUpdated"`
+	LastPullTimestamp time.Time                 `json:"lastPullTimestamp"`
+	PushTimestamp     time.Time                 `json:"pushTimestamp"`
+	TaggedTimestamp   time.Time                 `json:"taggedTimestamp"`
+	Description       string                    `json:"description"`
+	IsSigned          bool                      `json:"isSigned"`
+	Licenses          string                    `json:"licenses"`
+	Labels            string                    `json:"labels"`
+	Title             string                    `json:"title"`
+	Source            string                    `json:"source"`
+	Documentation     string                    `json:"documentation"`
+	Authors           string                    `json:"authors"`
+	Vendor            string                    `json:"vendor"`
+	Vulnerabilities   ImageVulnerabilitySummary `json:"vulnerabilities"`
+	Referrers         []Referrer                `json:"referrers"`
+	SignatureInfo     []SignatureSummary        `json:"signatureInfo"`
 }
 
 type ManifestSummary struct {

--- a/pkg/extensions/search/cve/update_test.go
+++ b/pkg/extensions/search/cve/update_test.go
@@ -66,7 +66,7 @@ func TestCVEDBGenerator(t *testing.T) {
 
 		// Wait for trivy db to download
 		found, err := test.ReadLogFileAndCountStringOccurence(logPath,
-			"cve-db update completed, next update scheduled after interval", 140*time.Second, 2)
+			"cve-db update completed, next update scheduled after interval", 240*time.Second, 2)
 		So(err, ShouldBeNil)
 		So(found, ShouldBeTrue)
 	})

--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -1182,7 +1182,12 @@ func (bdw *BoltDB) ResetRepoReferences(repo string, tagsToKeep map[string]bool) 
 		repoMetaBlob := buck.Get([]byte(repo))
 
 		protoRepoMeta, err := unmarshalProtoRepoMeta(repo, repoMetaBlob)
-		if err != nil && !errors.Is(err, zerr.ErrRepoMetaNotFound) {
+		if err != nil {
+			if errors.Is(err, zerr.ErrRepoMetaNotFound) {
+				// Repo doesn't exist, nothing to reset
+				return nil
+			}
+
 			return err
 		}
 

--- a/pkg/meta/boltdb/boltdb_test.go
+++ b/pkg/meta/boltdb/boltdb_test.go
@@ -308,6 +308,43 @@ func TestWrapperErrors(t *testing.T) {
 		})
 
 		Convey("ResetRepoReferences", func() {
+			Convey("repo doesn't exist - returns early without error", func() {
+				ctx := context.Background()
+
+				// Verify repo doesn't exist
+				_, err := boltdbWrapper.GetRepoMeta(ctx, "nonexistent-repo")
+				So(err, ShouldNotBeNil)
+				So(errors.Is(err, zerr.ErrRepoMetaNotFound), ShouldBeTrue)
+
+				// ResetRepoReferences should return early without error
+				err = boltdbWrapper.ResetRepoReferences("nonexistent-repo", nil)
+				So(err, ShouldBeNil)
+
+				// Verify repo still doesn't exist
+				_, err = boltdbWrapper.GetRepoMeta(ctx, "nonexistent-repo")
+				So(err, ShouldNotBeNil)
+				So(errors.Is(err, zerr.ErrRepoMetaNotFound), ShouldBeTrue)
+			})
+
+			Convey("repo doesn't exist with tagsToKeep - returns early without error", func() {
+				ctx := context.Background()
+
+				// Verify repo doesn't exist
+				_, err := boltdbWrapper.GetRepoMeta(ctx, "nonexistent-repo2")
+				So(err, ShouldNotBeNil)
+				So(errors.Is(err, zerr.ErrRepoMetaNotFound), ShouldBeTrue)
+
+				// ResetRepoReferences should return early without error even with tagsToKeep
+				tagsToKeep := map[string]bool{"tag1": true}
+				err = boltdbWrapper.ResetRepoReferences("nonexistent-repo2", tagsToKeep)
+				So(err, ShouldBeNil)
+
+				// Verify repo still doesn't exist
+				_, err = boltdbWrapper.GetRepoMeta(ctx, "nonexistent-repo2")
+				So(err, ShouldNotBeNil)
+				So(errors.Is(err, zerr.ErrRepoMetaNotFound), ShouldBeTrue)
+			})
+
 			Convey("unmarshalProtoRepoMeta error", func() {
 				err := setRepoMeta("repo", badProtoBlob, boltdbWrapper.DB)
 				So(err, ShouldBeNil)

--- a/pkg/meta/common/common.go
+++ b/pkg/meta/common/common.go
@@ -258,6 +258,7 @@ func AddImageMetaToRepoMeta(repoMeta *proto_go.RepoMeta, repoBlobs *proto_go.Rep
 	repoMeta.Size = size
 
 	imageBlobInfo := repoBlobs.Blobs[imageMeta.Digest.String()]
+
 	repoMeta.LastUpdatedImage = mConvert.GetProtoEarlierUpdatedImage(repoMeta.LastUpdatedImage,
 		&proto_go.RepoLastUpdatedImage{
 			LastUpdated: imageBlobInfo.LastUpdated,

--- a/pkg/meta/parse.go
+++ b/pkg/meta/parse.go
@@ -69,7 +69,9 @@ func ParseStorage(metaDB mTypes.MetaDB, storeController stypes.StoreController, 
 
 		metaLastUpdated := metaDB.GetRepoLastUpdated(repo)
 
-		if storageLastUpdated.Before(metaLastUpdated) {
+		// If repo metadata doesn't exist (zero time), always parse it
+		// Otherwise, only parse if storage is newer than metadata
+		if !metaLastUpdated.IsZero() && storageLastUpdated.Before(metaLastUpdated) {
 			continue
 		}
 

--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -2009,7 +2009,12 @@ func (rc *RedisDB) ResetRepoReferences(repo string, tagsToKeep map[string]bool) 
 
 	err := rc.withRSLocks(ctx, []string{rc.getRepoLockKey(repo)}, func() error {
 		protoRepoMeta, err := rc.getProtoRepoMeta(ctx, repo)
-		if err != nil && !errors.Is(err, zerr.ErrRepoMetaNotFound) {
+		if err != nil {
+			if errors.Is(err, zerr.ErrRepoMetaNotFound) {
+				// Repo doesn't exist, nothing to reset
+				return nil
+			}
+
 			return err
 		}
 


### PR DESCRIPTION
1. Parse repos without metadata in ParseStorage

The timestamp check in ParseStorage was skipping repos that exist in
storage but don't have metadata. When GetRepoLastUpdated returns zero
time (no metadata), we should always parse the repo to create its
metadata. Check if metaLastUpdated is zero before comparing timestamps.
If zero, always parse regardless of storageLastUpdated.

2. Change the logic of how LastUpdated is computed in RepoSummary

It is not the latest tagged timestamp from the available images or
the last updated image created timestamp, based on whichever is the
latest.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
