### PR TITLE
ci: improvements for the Ecosystem tools job

### DIFF
--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -114,7 +114,7 @@ jobs:
         with:
           name: zot-scale-out-dynamodb-logs
           path: /tmp/zot-ft-logs
-          if-no-files-found: error
+          if-no-files-found: ignore
       - name: DynamoDB multi-hop detection
         id: dynamodb_multihop
         run: |

--- a/test/blackbox/cve.bats
+++ b/test/blackbox/cve.bats
@@ -20,7 +20,8 @@ function verify_prerequisites {
 }
 
 function setup_file() {
-    export REGISTRY_NAME=main
+    # Use unique config name based on test file name and test run to avoid conflicts
+    export REGISTRY_NAME=$(basename "${BASH_SOURCE[0]}" .bats)-$(basename "${BATS_FILE_TMPDIR}")
     # Verify prerequisites are available
     if ! $(verify_prerequisites); then
         exit 1
@@ -69,10 +70,14 @@ EOF
 function teardown() {
     # conditionally printing on failure is possible from teardown but not from from teardown_file
     cat ${BATS_FILE_TMPDIR}/zot.log
+    # Show zli config for debugging
+    zli_show_config ${REGISTRY_NAME}
 }
 
 function teardown_file() {
     zot_stop_all
+    # Clean up zli config
+    zli_delete_config ${REGISTRY_NAME}
 }
 
 @test "cve by image name and tag" {

--- a/test/blackbox/helpers_zot.bash
+++ b/test/blackbox/helpers_zot.bash
@@ -121,6 +121,16 @@ function zli_add_config() {
     ${ZLI_PATH} config add ${registry_name} ${registry_url}
 }
 
+function zli_show_config() {
+    local registry_name=${1}
+    ${ZLI_PATH} config ${registry_name} -l || true
+}
+
+function zli_delete_config() {
+    local registry_name=${1}
+    ${ZLI_PATH} config remove ${registry_name} || true
+}
+
 function zb_run() {
     local zot_address=${1}
     ${ZB_PATH} -c 10 -n 30 -o stdout ${zot_address} --skip-cleanup

--- a/test/blackbox/upgrade.bats
+++ b/test/blackbox/upgrade.bats
@@ -7,7 +7,8 @@ load helpers_upgrade
 load ../port_helper
 
 function setup_file() {
-    export REGISTRY_NAME=main
+    # Use unique config name based on test file name and test run to avoid conflicts
+    export REGISTRY_NAME=$(basename "${BASH_SOURCE[0]}" .bats)-$(basename "${BATS_FILE_TMPDIR}")
     # Verify prerequisites are available
     if ! $(verify_prerequisites); then
         exit 1


### PR DESCRIPTION
A mutated zli config could be the cause of https://github.com/project-zot/zot/actions/runs/21560982825/job/62141227950

1. show zli configuration after cve.basts finishes running
2. ensure the zli config is removed in between test files
3. ensure the zli configs use different names, not "main"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
