### PR TITLE
fix(imagestore): normalize paths to prevent panic on Windows

### DIFF
--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -1308,6 +1308,7 @@ func (is *ImageStore) GetAllDedupeReposCandidates(digest godigest.Digest) ([]str
 			blobPath, _ = filepath.Rel(is.rootDir, blobPath)
 		}
 
+		blobPath = filepath.ToSlash(blobPath)
 		blobsDirIndex := strings.LastIndex(blobPath, "/blobs/")
 
 		repos = append(repos, blobPath[:blobsDirIndex])


### PR DESCRIPTION
**What type of PR is this?**

bug

**What does this PR do / Why do we need it**:

The `GetAllDedupeReposCandidates` function assumes paths use forward slashes ("/") when searching for the "/blobs/" substring.

On Windows, `filepath.Rel` returns paths with backslashes, causing `strings.LastIndex` to return -1. This resulted in a "slice bounds out of range" runtime panic.

This PR introduces `filepath.ToSlash` to standardize path separators before string manipulation, ensuring cross-platform compatibility.

**If an issue # is not available please add repro steps and logs showing the issue**:

Running zot on a Windows environment triggers a panic during dedupe candidates calculation:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.