### PR TITLE
Skip OCI conversion for already-synced images

### DIFF
--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -622,16 +622,12 @@ func (service *BaseService) syncImage(ctx context.Context, localRepo, remoteRepo
 		return err
 	}
 
-	if skipped {
-		return nil
-	}
-
 	if withReferrers {
 		_ = service.syncReferrers(ctx, repoTags, localRepo, remoteRepo, localImageRef, remoteImageRef)
 	}
 
 	// convert image to oci if needed
-	if isConverted && !service.config.PreserveDigest {
+	if !skipped && isConverted && !service.config.PreserveDigest {
 		localImageRef, err = mod.Apply(ctx, service.rc, localImageRef,
 			mod.WithRefTgt(localImageRef),
 			mod.WithManifestToOCI(),


### PR DESCRIPTION
Have syncRef return a boolean flag to indicate if an image was skipped. The caller can then return early without attempting OCI conversion, which was causing misleading errors. Fixes #3823.