### PR TITLE
feat(sync): allow optionally skip digest-tags and recursive referrer syncs

### DIFF
--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -36,6 +36,17 @@ type RegistryConfig struct {
 	PreserveDigest        bool          // sync without converting
 	SyncTimeout           time.Duration // overall HTTP client timeout for all sync operations
 	ResponseHeaderTimeout time.Duration `yaml:"-"` // response header timeout; set in root.go
+	// SkipTagBasedReferrerSync disables syncing referrers that are stored as digest-encoded tags
+	// (e.g. sha256-<hex>.sig, sha256-<hex>.att, sha256-<hex>.sbom used by legacy cosign tooling).
+	// When true, only OCI-spec referrers discovered via the Referrers API are synced.
+	// Eliminates the expensive tag-listing round-trip on every on-demand referrer request.
+	// Default false to preserve backwards-compatible behaviour.
+	SkipTagBasedReferrerSync bool
+	// SkipRecursiveReferrerSync disables recursive traversal of referrer graphs.
+	// When true, only the direct referrers of the queried digest are synced; referrers-of-referrers
+	// are synced lazily when explicitly requested by a client.
+	// Default false to preserve backwards-compatible behaviour.
+	SkipRecursiveReferrerSync bool
 }
 
 type Content struct {

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -343,12 +343,21 @@ func (service *BaseService) SyncReferrers(ctx context.Context, repo string,
 	service.log.Info().Str("remote", remoteURL).Str("repository", repo).Str("subject", subjectDigestStr).
 		Interface("reference types", referenceTypes).Msg("syncing reference for image")
 
-	tags, err := service.getTags(ctx, remoteRepo, false)
-	if err != nil {
-		service.log.Error().Str("errorType", common.TypeOf(err)).Str("repo", repo).
-			Err(err).Msg("error while getting tags for repo")
+	// When SkipTagBasedReferrerSync is set we do not need the tag list at all:
+	// the cosign/digest-tag discovery path in syncReferrers is bypassed, so
+	// fetching all tags would be wasted work.
+	var tags []string
 
-		return err
+	if !service.config.SkipTagBasedReferrerSync {
+		var tagsErr error
+
+		tags, tagsErr = service.getTags(ctx, remoteRepo, false)
+		if tagsErr != nil {
+			service.log.Error().Str("errorType", common.TypeOf(tagsErr)).Str("repo", repo).
+				Err(tagsErr).Msg("error while getting tags for repo")
+
+			return tagsErr
+		}
 	}
 
 	remoteImageRef, err := service.remote.GetImageReference(remoteRepo, subjectDigestStr)
@@ -681,15 +690,18 @@ func (service *BaseService) getTags(ctx context.Context, repo string, noCache bo
 	return tags, nil
 }
 
-// syncs all referrers recursively.
+// syncReferrers syncs all referrers recursively.
 func (service *BaseService) syncReferrers(ctx context.Context, tags []string, localRepo, remoteRepo string,
 	localImageRef ref.Ref, remoteImageRef ref.Ref,
 ) error {
 	seen := []string{}
 
-	var err error
-
-	if len(tags) == 0 {
+	// Fetch the tag list only when tag-based referrer sync is enabled.
+	// When SkipTagBasedReferrerSync=true we set the tags to empty.
+	if service.config.SkipTagBasedReferrerSync {
+		tags = []string{}
+	} else if len(tags) == 0 {
+		var err error
 		tags, err = service.getTags(ctx, remoteRepo, false)
 		if err != nil {
 			service.log.Error().Str("errorType", common.TypeOf(err)).Str("repo", remoteRepo).
@@ -744,10 +756,12 @@ func (service *BaseService) syncReferrers(ctx context.Context, tags []string, lo
 					Str("remote reference", remoteImageRef.Tag).Msg("failed to sync referrer")
 			}
 
-			_ = inner(ctx, tags, localRepo, remoteRepo, localImageRef, remoteImageRef, seen)
+			// Recurse into referrers-of-referrers unless the caller has opted out.
+			if !service.config.SkipRecursiveReferrerSync {
+				_ = inner(ctx, tags, localRepo, remoteRepo, localImageRef, remoteImageRef, seen)
+			}
 		}
 
-		// try cosign
 		prefix := fmt.Sprintf("%s-%s.", remoteDigest.Algorithm(), remoteDigest.Encoded())
 		for _, tag := range tags {
 			if strings.Contains(tag, prefix) {
@@ -762,7 +776,9 @@ func (service *BaseService) syncReferrers(ctx context.Context, tags []string, lo
 						Str("remote reference", remoteImageRef.Tag).Msg("failed to sync referrer")
 				}
 
-				_ = inner(ctx, tags, localRepo, remoteRepo, localImageRef, remoteImageRef, seen)
+				if !service.config.SkipRecursiveReferrerSync {
+					_ = inner(ctx, tags, localRepo, remoteRepo, localImageRef, remoteImageRef, seen)
+				}
 			}
 		}
 

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -18,6 +18,7 @@ import (
 
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/types/ref"
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -632,6 +633,140 @@ func TestService(t *testing.T) {
 			So(err, ShouldNotBeNil)
 			So(err.Error(), ShouldEqual, "guaranteed referrer channel error")
 		})
+	})
+}
+
+func TestSkipTagBasedReferrerSync(t *testing.T) {
+	Convey("SkipTagBasedReferrerSync=true skips getTags and the digest-tag loop", t, func() {
+		getTagsCallCount := 0
+
+		conf := syncconf.RegistryConfig{
+			URLs:                     []string{"http://localhost"},
+			SkipTagBasedReferrerSync: true,
+		}
+
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		service.rc = regclient.New()
+
+		// GetTags should NOT be called when SkipTagBasedReferrerSync=true.
+		mockRemote := &mocks.SyncRemoteMock{
+			GetTagsFn: func(ctx context.Context, repo string) ([]string, error) {
+				getTagsCallCount++
+				// Any call here is a bug — the flag should have prevented it.
+				return nil, errors.New("getTags must not be called with SkipTagBasedReferrerSync=true")
+			},
+			GetImageReferenceFn: func(repo, tag string) (ref.Ref, error) {
+				return ref.New(repo + "@" + tag)
+			},
+			GetDigestFn: func(ctx context.Context, repo, tag string) (godigest.Digest, error) {
+				return godigest.Digest("sha256:" + strings.Repeat("a", 64)), nil
+			},
+		}
+		service.remote = mockRemote
+
+		mockDest := &mocks.SyncDestinationMock{
+			GetImageReferenceFn: func(repo, tag string) (ref.Ref, error) {
+				return ref.New("local/" + repo + "@" + tag)
+			},
+			CommitAllFn: func(repo string, imageReference ref.Ref) error {
+				return nil
+			},
+		}
+		service.destination = mockDest
+
+		ctx := context.Background()
+		digest := "sha256:" + strings.Repeat("a", 64)
+
+		err = service.SyncReferrers(ctx, "repo", digest, nil)
+		// We expect an error from rc.ReferrerList since it's not connected to a registry,
+		// but what we really care about is that getTags was NOT called.
+		So(getTagsCallCount, ShouldEqual, 0)
+	})
+
+	Convey("SkipTagBasedReferrerSync=false (default) still calls getTags", t, func() {
+		getTagsCallCount := 0
+
+		conf := syncconf.RegistryConfig{
+			URLs:                     []string{"http://localhost"},
+			SkipTagBasedReferrerSync: false,
+		}
+
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		// Provide a non-nil regclient
+		service.rc = regclient.New()
+
+		mockRemote := &mocks.SyncRemoteMock{
+			GetTagsFn: func(ctx context.Context, repo string) ([]string, error) {
+				getTagsCallCount++
+				return []string{"tag1"}, nil
+			},
+			GetImageReferenceFn: func(repo, tag string) (ref.Ref, error) {
+				return ref.New(repo + "@" + tag)
+			},
+		}
+		service.remote = mockRemote
+
+		mockDest := &mocks.SyncDestinationMock{
+			GetImageReferenceFn: func(repo, tag string) (ref.Ref, error) {
+				return ref.New("local/" + repo + "@" + tag)
+			},
+		}
+		service.destination = mockDest
+
+		ctx := context.Background()
+		digest := "sha256:" + strings.Repeat("a", 64)
+
+		err = service.SyncReferrers(ctx, "repo", digest, nil)
+		// Again, we don't care if it fails, only that getTags was called.
+		So(getTagsCallCount, ShouldEqual, 1)
+	})
+}
+
+func TestSkipRecursiveReferrerSync(t *testing.T) {
+	Convey("SkipRecursiveReferrerSync=true stops at direct referrers only", t, func() {
+		// Verify that recursive calls are not made when the flag is true.
+		// We use a non-nil regclient to avoid panics.
+
+		conf := syncconf.RegistryConfig{
+			URLs:                      []string{"http://localhost"},
+			SkipRecursiveReferrerSync: true,
+		}
+
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		service.rc = regclient.New()
+
+		mockRemote := &mocks.SyncRemoteMock{
+			GetImageReferenceFn: func(repo, tag string) (ref.Ref, error) {
+				return ref.New(repo + "@" + tag)
+			},
+			GetDigestFn: func(ctx context.Context, repo, tag string) (godigest.Digest, error) {
+				return godigest.Digest("sha256:" + strings.Repeat("a", 64)), nil
+			},
+			GetTagsFn: func(ctx context.Context, repo string) ([]string, error) {
+				return []string{}, nil
+			},
+		}
+		service.remote = mockRemote
+
+		mockDest := &mocks.SyncDestinationMock{
+			GetImageReferenceFn: func(repo, tag string) (ref.Ref, error) {
+				return ref.New("local/" + repo + "@" + tag)
+			},
+		}
+		service.destination = mockDest
+
+		ctx := context.Background()
+		digest := "sha256:" + strings.Repeat("a", 64)
+
+		err = service.SyncReferrers(ctx, "repo", digest, nil)
+		// It will fail because rc is not connected, but it shouldn't panic.
+		So(err, ShouldNotBeNil)
 	})
 }
 

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -7840,6 +7840,346 @@ func pushBlob(url string, repoName string, buf []byte) godigest.Digest {
 	return digest
 }
 
+// TestOnDemandReferrerSyncFlags verifies that SkipTagBasedReferrerSync and
+// SkipRecursiveReferrerSync behave correctly in a full upstream/downstream
+// server setup.
+//
+// Topology pushed to the upstream:
+//
+//	testImage:testImageTag  (base image)
+//	  ├── oci-referrer        (OCI-spec referrer — attached via subject field)
+//	  └── sha256-<hex>.sig    (legacy cosign-style digest-encoded tag)
+//
+// With SkipTagBasedReferrerSync=true, only the OCI referrer is expected to be
+// synced; the .sig tag must not appear on the downstream.
+// With SkipRecursiveReferrerSync=true, only direct referrers are synced (no
+// recursive traversal).
+func TestOnDemandReferrerSyncFlags(t *testing.T) {
+	Convey("SkipTagBasedReferrerSync=true syncs OCI referrers but not digest-tag referrers", t, func() {
+		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+
+		scm := test.NewControllerManager(sctlr)
+		scm.StartAndWait(sctlr.Config.HTTP.Port)
+
+		defer scm.StopServer()
+
+		// ── 1. Fetch the subject digest ──────────────────────────────────────
+		resp, err := resty.R().Get(srcBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		subjectDigest := resp.Header().Get("Docker-Content-Digest")
+		subjectSize := len(resp.Body())
+
+		// ── 2. Push an OCI referrer (attached via subject field) ─────────────
+		_ = pushBlob(srcBaseURL, testImage, ispec.DescriptorEmptyJSON.Data)
+
+		ociRef := ispec.Manifest{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			Subject: &ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    godigest.Digest(subjectDigest),
+				Size:      int64(subjectSize),
+			},
+			Config: ispec.Descriptor{
+				MediaType: ispec.MediaTypeEmptyJSON,
+				Digest:    ispec.DescriptorEmptyJSON.Digest,
+				Size:      2,
+			},
+			Layers: []ispec.Descriptor{{
+				MediaType: ispec.MediaTypeEmptyJSON,
+				Digest:    ispec.DescriptorEmptyJSON.Digest,
+				Size:      2,
+			}},
+			MediaType: ispec.MediaTypeImageManifest,
+		}
+
+		ociRefBlob, err := json.Marshal(ociRef)
+		So(err, ShouldBeNil)
+
+		resp, err = resty.R().
+			SetHeader("Content-type", ispec.MediaTypeImageManifest).
+			SetBody(ociRefBlob).
+			Put(srcBaseURL + "/v2/" + testImage + "/manifests/oci.ref")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		// ── 3. Push a legacy cosign digest-tag referrer (sha256-<hex>.sig) ───
+		sigTag := fmt.Sprintf("%s-%s.sig",
+			godigest.Digest(subjectDigest).Algorithm(),
+			godigest.Digest(subjectDigest).Encoded())
+
+		_ = pushBlob(srcBaseURL, testImage, ispec.DescriptorEmptyJSON.Data)
+
+		sigManifest := ispec.Manifest{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.dev.cosign.simplesigning.v1+json",
+				Digest:    ispec.DescriptorEmptyJSON.Digest,
+				Size:      2,
+			},
+			Layers: []ispec.Descriptor{{
+				MediaType: ispec.MediaTypeEmptyJSON,
+				Digest:    ispec.DescriptorEmptyJSON.Digest,
+				Size:      2,
+			}},
+			MediaType: ispec.MediaTypeImageManifest,
+		}
+
+		sigBlob, err := json.Marshal(sigManifest)
+		So(err, ShouldBeNil)
+
+		resp, err = resty.R().
+			SetHeader("Content-type", ispec.MediaTypeImageManifest).
+			SetBody(sigBlob).
+			Put(srcBaseURL + "/v2/" + testImage + "/manifests/" + sigTag)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		// Verify upstream has both the OCI referrer and the sig tag.
+		resp, err = resty.R().Get(srcBaseURL + "/v2/" + testImage + "/referrers/" + subjectDigest)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		var upstreamIdx ispec.Index
+
+		So(json.Unmarshal(resp.Body(), &upstreamIdx), ShouldBeNil)
+		So(len(upstreamIdx.Manifests), ShouldEqual, 1) // only OCI referrer in referrers API
+
+		resp, err = resty.R().Get(srcBaseURL + "/v2/" + testImage + "/tags/list")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+		So(resp.String(), ShouldContainSubstring, sigTag)
+
+		// ── 4. Start downstream with SkipTagBasedReferrerSync=true ───────────
+		var tlsVerify bool
+
+		skipTagBased := true
+
+		syncRegistryConfig := syncconf.RegistryConfig{
+			Content: []syncconf.Content{{
+				Prefix: testImage,
+			}},
+			URLs:                     []string{srcBaseURL},
+			TLSVerify:                &tlsVerify,
+			OnDemand:                 true,
+			SkipTagBasedReferrerSync: skipTagBased,
+		}
+
+		defaultVal := true
+		syncConfig := &syncconf.Config{
+			Enable:     &defaultVal,
+			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
+		}
+
+		dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+
+		dcm := test.NewControllerManager(dctlr)
+		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+
+		defer dcm.StopServer()
+
+		// ── 5. Trigger on-demand sync of the base image ──────────────────────
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		// ── 6. Trigger on-demand sync of referrers ───────────────────────────
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/referrers/" + subjectDigest)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		var downstreamIdx ispec.Index
+
+		So(json.Unmarshal(resp.Body(), &downstreamIdx), ShouldBeNil)
+		// OCI referrer must be present.
+		So(len(downstreamIdx.Manifests), ShouldEqual, 1)
+
+		// ── 7. The sig tag must NOT have been synced ──────────────────────────
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/tags/list")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+		So(resp.String(), ShouldNotContainSubstring, sigTag)
+	})
+
+	Convey("SkipRecursiveReferrerSync=true syncs only direct referrers", t, func() {
+		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+
+		scm := test.NewControllerManager(sctlr)
+		scm.StartAndWait(sctlr.Config.HTTP.Port)
+
+		defer scm.StopServer()
+
+		// ── 1. Fetch the subject digest ──────────────────────────────────────
+		resp, err := resty.R().Get(srcBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		subjectDigest := resp.Header().Get("Docker-Content-Digest")
+		subjectSize := len(resp.Body())
+
+		// ── 2. Push a direct OCI referrer ────────────────────────────────────
+		_ = pushBlob(srcBaseURL, testImage, ispec.DescriptorEmptyJSON.Data)
+
+		directRef := ispec.Manifest{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			Subject: &ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    godigest.Digest(subjectDigest),
+				Size:      int64(subjectSize),
+			},
+			Config: ispec.Descriptor{
+				MediaType: ispec.MediaTypeEmptyJSON,
+				Digest:    ispec.DescriptorEmptyJSON.Digest,
+				Size:      2,
+			},
+			Layers: []ispec.Descriptor{{
+				MediaType: ispec.MediaTypeEmptyJSON,
+				Digest:    ispec.DescriptorEmptyJSON.Digest,
+				Size:      2,
+			}},
+			MediaType:   ispec.MediaTypeImageManifest,
+			Annotations: map[string]string{"level": "direct"},
+		}
+
+		directRefBlob, err := json.Marshal(directRef)
+		So(err, ShouldBeNil)
+
+		resp, err = resty.R().
+			SetHeader("Content-type", ispec.MediaTypeImageManifest).
+			SetBody(directRefBlob).
+			Put(srcBaseURL + "/v2/" + testImage + "/manifests/direct.ref")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		directRefDigest := resp.Header().Get("Docker-Content-Digest")
+
+		// ── 3. Push a nested referrer (referrer-of-referrer) ─────────────────
+		nestedRef := ispec.Manifest{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			Subject: &ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    godigest.Digest(directRefDigest),
+				Size:      int64(len(directRefBlob)),
+			},
+			Config: ispec.Descriptor{
+				MediaType: ispec.MediaTypeEmptyJSON,
+				Digest:    ispec.DescriptorEmptyJSON.Digest,
+				Size:      2,
+			},
+			Layers: []ispec.Descriptor{{
+				MediaType: ispec.MediaTypeEmptyJSON,
+				Digest:    ispec.DescriptorEmptyJSON.Digest,
+				Size:      2,
+			}},
+			MediaType:   ispec.MediaTypeImageManifest,
+			Annotations: map[string]string{"level": "nested"},
+		}
+
+		nestedRefBlob, err := json.Marshal(nestedRef)
+		So(err, ShouldBeNil)
+
+		resp, err = resty.R().
+			SetHeader("Content-type", ispec.MediaTypeImageManifest).
+			SetBody(nestedRefBlob).
+			Put(srcBaseURL + "/v2/" + testImage + "/manifests/nested.ref")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		_ = resp.Header().Get("Docker-Content-Digest")
+
+		// Verify upstream has the referrer chain in place.
+		resp, err = resty.R().Get(srcBaseURL + "/v2/" + testImage + "/referrers/" + subjectDigest)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		var upstreamDirect ispec.Index
+
+		So(json.Unmarshal(resp.Body(), &upstreamDirect), ShouldBeNil)
+		So(len(upstreamDirect.Manifests), ShouldEqual, 1)
+
+		resp, err = resty.R().Get(srcBaseURL + "/v2/" + testImage + "/referrers/" + directRefDigest)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		var upstreamNested ispec.Index
+
+		So(json.Unmarshal(resp.Body(), &upstreamNested), ShouldBeNil)
+		So(len(upstreamNested.Manifests), ShouldEqual, 1)
+
+		// ── 4. Start downstream with SkipRecursiveReferrerSync=true ──────────
+		var tlsVerify bool
+
+		skipRecursive := true
+
+		syncRegistryConfig := syncconf.RegistryConfig{
+			Content: []syncconf.Content{{
+				Prefix: testImage,
+			}},
+			URLs:                      []string{srcBaseURL},
+			TLSVerify:                 &tlsVerify,
+			OnDemand:                  true,
+			SkipTagBasedReferrerSync:  true, // avoid tag listing noise
+			SkipRecursiveReferrerSync: skipRecursive,
+		}
+
+		defaultVal := true
+		syncConfig := &syncconf.Config{
+			Enable:     &defaultVal,
+			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
+		}
+
+		dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+
+		dcm := test.NewControllerManager(dctlr)
+		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+
+		defer dcm.StopServer()
+
+		// ── 5. Trigger on-demand sync of the base image ──────────────────────
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		// ── 6. Trigger on-demand sync of referrers for the base image ────────
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/referrers/" + subjectDigest)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		var downstreamDirect ispec.Index
+
+		So(json.Unmarshal(resp.Body(), &downstreamDirect), ShouldBeNil)
+		// The direct referrer must be synced.
+		So(len(downstreamDirect.Manifests), ShouldEqual, 1)
+
+		// ── 7. Verify the nested referrer is NOT synced ──────────────────────
+		// Because SkipRecursiveReferrerSync=true, syncing referrers for the base
+		// image should not have triggered a recursive sync of its referrers.
+		//
+		// We MUST NOT query the Referrers API on the downstream here, because
+		// that would trigger a SECOND on-demand sync for the direct referrer.
+		// Instead, we check the metaDB directly to see if any referrers are
+		// recorded for the directRefDigest.
+		refs, err := dctlr.MetaDB.GetReferrersInfo(testImage, godigest.Digest(directRefDigest), nil)
+		So(err, ShouldBeNil)
+		// If recursive sync had happened, this would be 1.
+		So(len(refs), ShouldEqual, 0)
+
+		// ── 8. Verify that nested referrer is synced when explicitly requested
+		resp, err = resty.R().Get(destBaseURL + "/v2/" + testImage + "/referrers/" + directRefDigest)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		var downstreamNested ispec.Index
+
+		So(json.Unmarshal(resp.Body(), &downstreamNested), ShouldBeNil)
+		So(len(downstreamNested.Manifests), ShouldEqual, 1)
+		refs, err = dctlr.MetaDB.GetReferrersInfo(testImage, godigest.Digest(directRefDigest), nil)
+		So(err, ShouldBeNil)
+		So(len(refs), ShouldEqual, 1)
+	})
+}
+
 // this is waiting for generator to finish working, it doesn't mean sync has finished though.
 func waitSyncFinish(logPath string) bool {
 	found, err := test.ReadLogFileAndSearchString(logPath,


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
https://github.com/project-zot/zot/issues/3839

**What does this PR do / Why do we need it**:
Add two boolean flags at `sync.RegistryConfig` to make referrer syncs lighter weight.
- `SkipTagBasedReferrerSync`: disable syncing pre-OCI 1.1 digest-tags that cosign produces
- `SkipRecursiveReferrerSync`: disable syncing referrers recursively.

**Testing done on this change**:

I've built and deployed it internally.
- functionally I didn't notice any issue
- observed >=35% latency improvement on `GET /referrers` related operations for a typical index __on both cold and warm requests__.

```yaml
Digest: sha256:aaa
Children:
  - sha256:bbb [linux/amd64]
    Referrers:
      - sha256:ccc: sha256-bbb.att
      - sha256:ddd: sha256-bbb.sig
  - sha256:eee [linux/arm64]
    Referrers:
      - sha256:fff: sha256-eee.att
      - sha256:ggg: sha256-eee.sig
Referrers:
  - sha256:hhh: sha256-aaa.sig
```

**Automation added to e2e**:

TBD

**Will this break upgrades or downgrades?**
No. Change is backwards compatible. If these two new flags aren't provided, the behaviour is same as before.

**Does this PR introduce any user-facing change?**:
Yes, TBD

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
