### PR TITLE
fix(cve): fall back to vendor severity when primary is unknown

### DIFF
--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -501,7 +501,7 @@ func (scanner Scanner) scanManifest(ctx context.Context, repo, digest string) (m
 					Title:       vulnerability.Title,
 					Description: vulnerability.Description,
 					Reference:   getCVEReference(vulnerability.PrimaryURL, vulnerability.References),
-					Severity:    convertSeverity(vulnerability.Severity),
+					Severity:    convertSeverity(vulnerability.Severity, vulnerability.VendorSeverity),
 					PackageList: newPkgList,
 				}
 			}
@@ -701,15 +701,32 @@ func findMediaTypeForDigest(metaDB mTypes.MetaDB, digest godigest.Digest) (bool,
 	return false, ""
 }
 
-func convertSeverity(detectedSeverity string) string {
-	trivySeverity, _ := dbTypes.NewSeverity(detectedSeverity)
-
+func convertSeverity(detectedSeverity string, vendorSeverity dbTypes.VendorSeverity) string {
 	sevMap := map[dbTypes.Severity]string{
 		dbTypes.SeverityUnknown:  cvemodel.SeverityUnknown,
 		dbTypes.SeverityLow:      cvemodel.SeverityLow,
 		dbTypes.SeverityMedium:   cvemodel.SeverityMedium,
 		dbTypes.SeverityHigh:     cvemodel.SeverityHigh,
 		dbTypes.SeverityCritical: cvemodel.SeverityCritical,
+	}
+
+	trivySeverity, _ := dbTypes.NewSeverity(detectedSeverity)
+
+	// When the primary severity is unknown (common due to NVD analysis backlog),
+	// fall back to the highest severity reported by any vendor-specific source
+	// (e.g. Alpine, Red Hat, Ubuntu). This matches standalone Trivy's behavior
+	// when using --vuln-severity-source.
+	if trivySeverity == dbTypes.SeverityUnknown && len(vendorSeverity) > 0 {
+		highest := dbTypes.SeverityUnknown
+		for _, sev := range vendorSeverity {
+			if sev > highest {
+				highest = sev
+			}
+		}
+
+		if highest > dbTypes.SeverityUnknown {
+			return sevMap[highest]
+		}
 	}
 
 	return sevMap[trivySeverity]

--- a/pkg/extensions/search/cve/trivy/scanner_internal_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_internal_test.go
@@ -13,6 +13,8 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
+	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
+
 	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/common"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
@@ -493,5 +495,54 @@ func TestGetCVEReference(t *testing.T) {
 
 		ref = getCVEReference("", []string{"https://nvd.nist.gov/vuln/detail/CVE-2023-2650"})
 		So(ref, ShouldResemble, "https://nvd.nist.gov/vuln/detail/CVE-2023-2650")
+	})
+}
+
+func TestConvertSeverity(t *testing.T) {
+	Convey("convertSeverity", t, func() {
+		Convey("returns correct severity for known primary severity", func() {
+			So(convertSeverity("CRITICAL", nil), ShouldEqual, model.SeverityCritical)
+			So(convertSeverity("HIGH", nil), ShouldEqual, model.SeverityHigh)
+			So(convertSeverity("MEDIUM", nil), ShouldEqual, model.SeverityMedium)
+			So(convertSeverity("LOW", nil), ShouldEqual, model.SeverityLow)
+			So(convertSeverity("UNKNOWN", nil), ShouldEqual, model.SeverityUnknown)
+			So(convertSeverity("", nil), ShouldEqual, model.SeverityUnknown)
+		})
+
+		Convey("falls back to vendor severity when primary is unknown", func() {
+			vendorSev := dbTypes.VendorSeverity{
+				"alpine": dbTypes.SeverityHigh,
+			}
+			So(convertSeverity("UNKNOWN", vendorSev), ShouldEqual, model.SeverityHigh)
+			So(convertSeverity("", vendorSev), ShouldEqual, model.SeverityHigh)
+		})
+
+		Convey("uses highest vendor severity when multiple vendors present", func() {
+			vendorSev := dbTypes.VendorSeverity{
+				"alpine":   dbTypes.SeverityMedium,
+				"redhat":   dbTypes.SeverityCritical,
+				"nvd":      dbTypes.SeverityLow,
+			}
+			So(convertSeverity("UNKNOWN", vendorSev), ShouldEqual, model.SeverityCritical)
+		})
+
+		Convey("does not override known primary severity with vendor severity", func() {
+			vendorSev := dbTypes.VendorSeverity{
+				"alpine": dbTypes.SeverityCritical,
+			}
+			So(convertSeverity("LOW", vendorSev), ShouldEqual, model.SeverityLow)
+		})
+
+		Convey("handles vendor severity with all unknown entries", func() {
+			vendorSev := dbTypes.VendorSeverity{
+				"alpine": dbTypes.SeverityUnknown,
+			}
+			So(convertSeverity("UNKNOWN", vendorSev), ShouldEqual, model.SeverityUnknown)
+		})
+
+		Convey("handles empty vendor severity map", func() {
+			vendorSev := dbTypes.VendorSeverity{}
+			So(convertSeverity("UNKNOWN", vendorSev), ShouldEqual, model.SeverityUnknown)
+		})
 	})
 }


### PR DESCRIPTION
## Summary

- When the primary `Severity` field on a CVE is empty or "UNKNOWN", fall back to the highest severity from the `VendorSeverity` map (Alpine, Red Hat, Ubuntu, etc.)
- This matches standalone Trivy's behavior and resolves #3886

## Changes

- **`pkg/extensions/search/cve/trivy/scanner.go`**: Updated `convertSeverity` to accept `VendorSeverity` and use the highest vendor-reported severity when the primary is unknown
- **`pkg/extensions/search/cve/trivy/scanner_internal_test.go`**: Added 6 test cases covering primary severity, vendor fallback, highest-wins logic, and edge cases

## Context

Due to the NVD analysis backlog (25,000+ unscored CVEs since 2024), many CVEs have no CVSS score in NVD. Standalone Trivy handles this via `--vuln-severity-source` which falls back to vendor data. Zot's embedded Trivy usage was only reading the primary `Severity` string, causing all such CVEs to show as "Unknown" in the UI.

## Test plan

- [x] Added unit tests for `convertSeverity` with vendor severity fallback
- [ ] Verify with a real image that previously showed all "Unknown" severities
- [ ] Confirm existing CVE tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)