### PR TITLE
Pin actions and tighten workflow permissions

### DIFF
--- a/.github/actions/setup-localstack/action.yaml
+++ b/.github/actions/setup-localstack/action.yaml
@@ -13,12 +13,12 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: docker/login-action@v4
+    - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
       with:
         registry: ghcr.io
         username: ${{ inputs.username }}
         password: ${{ inputs.password }}
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
     - shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,12 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions" # See documentation for possible values
     directory: "/" # Location of package manifests
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,10 +12,11 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-  - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     open-pull-requests-limit: 10
     schedule:
       interval: "weekly"
+      day: "monday"
     cooldown:
-      default-days: 7
+      default-days: 14

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      go-dependencies:
+        patterns:
+          - "*"
   - package-ecosystem: "github-actions"
     directory: "/"
     open-pull-requests-limit: 10
@@ -20,3 +24,7 @@ updates:
       day: "monday"
     cooldown:
       default-days: 14
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -14,10 +14,10 @@ jobs:
     name: Performance regression check
     runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -27,13 +27,13 @@ jobs:
         run: make BENCH_OUTPUT=ci-cd run-bench
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ./cache
           key: ${{ runner.os }}-gen1-benchmark
       # Run `github-action-benchmark` action
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1.22.0
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           # What benchmark tool the output.txt came from
           tool: 'customBiggerIsBetter'

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -15,6 +15,8 @@ jobs:
     runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false

--- a/.github/workflows/branch-cov.yaml
+++ b/.github/workflows/branch-cov.yaml
@@ -15,6 +15,8 @@ jobs:
     name: coverage
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false

--- a/.github/workflows/branch-cov.yaml
+++ b/.github/workflows/branch-cov.yaml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     name: coverage
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -25,18 +25,18 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - name: Check out source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
           go-version: 1.25.x
       - name: Cache go dependencies
         id: cache-go-dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/go/pkg/mod
@@ -45,7 +45,7 @@ jobs:
             ${{ runner.os }}-go-mod-
       - name: Cache go build output
         id: cache-go-build
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/.cache/go-build
@@ -99,7 +99,7 @@ jobs:
 
       - if: github.event_name == 'release' && github.event.action == 'published'
         name: Publish artifacts on releases
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: bin/z*
@@ -117,12 +117,12 @@ jobs:
       packages: write
     steps:
       - name: Download Release Artifacts
-        uses: robinraju/release-downloader@v1.12
+        uses: robinraju/release-downloader@daf26c55d821e836577a15f77d86ddc078948b05 # v1
         with:
           tag: ${{ github.ref_name }}
           fileName: "z*"
       - name: Generate checksum
-        uses: jmgilman/actions-generate-checksum@v1
+        uses: jmgilman/actions-generate-checksum@238073f4c02f2810adb91c96bdd1e276a5ae9ed6 # v1
         with:
           patterns: z*
           method: sha256
@@ -130,7 +130,7 @@ jobs:
       - name: Add wildcard character prefix to filenames in checksum file
         run: sed -i 's! ! \*!g' checksums.sha256.txt
       - name: Publish checksums on releases
-        uses: svenstaro/upload-release-action@v2
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # latest
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file: checksums.sha256.txt

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -122,7 +122,7 @@ jobs:
           tag: ${{ github.ref_name }}
           fileName: "z*"
       - name: Generate checksum
-        uses: jmgilman/actions-generate-checksum@238073f4c02f2810adb91c96bdd1e276a5ae9ed6 # v1
+        uses: jmgilman/actions-generate-checksum@3ea6dc9bf8eecf28e2ecc982fab683484a1a8561 # v1.0.1
         with:
           patterns: z*
           method: sha256

--- a/.github/workflows/cloc.yaml
+++ b/.github/workflows/cloc.yaml
@@ -25,6 +25,8 @@ jobs:
           go-version: 1.25.x
       - name: Check out source code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/cloc.yaml
+++ b/.github/workflows/cloc.yaml
@@ -18,13 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
           go-version: 1.25.x
       - name: Check out source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install dependencies

--- a/.github/workflows/cluster.yaml
+++ b/.github/workflows/cluster.yaml
@@ -16,10 +16,10 @@ jobs:
     name: Stateless zot with minio and boltdb
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -104,7 +104,7 @@ jobs:
             sed -i 's/\/dev\/null/\/tmp\/zot3.log/g' test/cluster/config-minio3.json
 
       - name: Free up disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: true
@@ -164,7 +164,7 @@ jobs:
             rm /tmp/*.log
 
       - name: Upload zot logs for push-pull tests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: logs-push-pull-bolt
@@ -206,7 +206,7 @@ jobs:
             rm /tmp/*.log
 
       - name: Upload zot logs for cidr tests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: logs-src-cidr-bolt
@@ -241,7 +241,7 @@ jobs:
             zip logs-src-ips-bolt.zip /tmp/*.log -r
 
       - name: Upload zot logs for src-ips tests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: logs-src-ips-bolt
@@ -250,13 +250,13 @@ jobs:
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ./cache
           key: ${{ runner.os }}-gen1-benchmark-stateless-cluster
       # Run `github-action-benchmark` action
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1.22.0
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           # What benchmark tool the output.txt came from
           tool: 'customBiggerIsBetter'
@@ -274,10 +274,10 @@ jobs:
     name: Stateless zot with minio and redis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -371,7 +371,7 @@ jobs:
             sed -i 's/\/dev\/null/\/tmp\/zot3.log/g' test/cluster/config-minio3.json
 
       - name: Free up disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
         with:
           # This might remove tools that are actually needed, if set to "true" but frees about 6 GB
           tool-cache: true
@@ -431,7 +431,7 @@ jobs:
             rm /tmp/*.log
 
       - name: Upload zot logs for push-pull tests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: logs-push-pull-redis
@@ -473,7 +473,7 @@ jobs:
             rm /tmp/*.log
 
       - name: Upload zot logs for cidr tests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: logs-src-cidr-redis
@@ -508,7 +508,7 @@ jobs:
             zip logs-src-ips-redis.zip /tmp/*.log -r
 
       - name: Upload zot logs for src-ips tests
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: logs-src-ips-redis
@@ -517,13 +517,13 @@ jobs:
 
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ./cache
           key: ${{ runner.os }}-gen1-benchmark-stateless-cluster-redis
       # Run `github-action-benchmark` action
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@v1.22.0
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           # What benchmark tool the output.txt came from
           tool: 'customBiggerIsBetter'

--- a/.github/workflows/cluster.yaml
+++ b/.github/workflows/cluster.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false
@@ -273,6 +275,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
 
     - name: Install go
       uses: actions/setup-go@v6

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,12 +44,12 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
 
     - name: Install go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         cache: false
         check-latest: true
@@ -57,7 +57,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4.35.1
+      uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -68,7 +68,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4.35.1
+      uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -81,4 +81,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4.35.1
+      uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1

--- a/.github/workflows/commit-msg.yaml
+++ b/.github/workflows/commit-msg.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Check Commit Type
         uses: gsactions/commit-message-checker@v2
         with:

--- a/.github/workflows/commit-msg.yaml
+++ b/.github/workflows/commit-msg.yaml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Check Commit Type
-        uses: gsactions/commit-message-checker@v2
+        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee # v2.0.0
         with:
           pattern: '^((build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\(.+\))?(!)?(: (.*\s*)*))'
           flags: 'gm'
@@ -32,7 +32,7 @@ jobs:
           checkAllCommitMessages: 'true'
           accessToken: ${{ secrets.GITHUB_TOKEN }}
       - name: Check Line Length
-        uses: gsactions/commit-message-checker@v2
+        uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee # v2.0.0
         with:
           pattern: '^[^#].{1,74}'
           error: 'The maximum line length of 74 characters is exceeded.'

--- a/.github/workflows/compare-binary-size.yaml
+++ b/.github/workflows/compare-binary-size.yaml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     name: compare-with-main
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true

--- a/.github/workflows/compare-binary-size.yaml
+++ b/.github/workflows/compare-binary-size.yaml
@@ -11,6 +11,8 @@ jobs:
     name: compare-with-main
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Set up Python 3.x
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/dco.yaml
+++ b/.github/workflows/dco.yaml
@@ -10,11 +10,11 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Set up Python 3.x
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.x'
     - name: Check DCO

--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false

--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -16,10 +16,10 @@ jobs:
     name: Check client tools
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -95,7 +95,7 @@ jobs:
         run: |
           find /tmp/zot-ft-logs -name '*.log' -print0 | xargs -0 cat
       - name: Upload DynamoDB zot logs as build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: zot-scale-out-dynamodb-logs
@@ -133,7 +133,7 @@ jobs:
         run: |
           find /tmp/zot-ft-logs/redis -name '*.log' -print0 | xargs -0 cat
       - name: Upload Redis zot logs as build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: zot-scale-out-redis-logs
@@ -158,7 +158,7 @@ jobs:
           echo "Redis scale-out tests failed"
           exit 1
       - name: Upload zb test results zip as build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: zb-cloud-scale-out-functional-results-${{ github.sha }}

--- a/.github/workflows/gc-stress-test.yaml
+++ b/.github/workflows/gc-stress-test.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false
@@ -57,6 +59,8 @@ jobs:
     runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false
@@ -97,6 +101,8 @@ jobs:
     runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false
@@ -182,6 +188,8 @@ jobs:
     runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false

--- a/.github/workflows/gc-stress-test.yaml
+++ b/.github/workflows/gc-stress-test.yaml
@@ -16,10 +16,10 @@ jobs:
     name: GC(with referrers) on filesystem with short interval
     runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -41,7 +41,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload zot logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: gc-referrers-bench-local
@@ -58,10 +58,10 @@ jobs:
     name: GC(without referrers) on filesystem with short interval
     runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -83,7 +83,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload zot logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: gc-bench-local
@@ -100,10 +100,10 @@ jobs:
     name: GC(with referrers) on S3(minio) with short interval
     runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -168,7 +168,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload zot logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: gc-referrers-bench-s3
@@ -187,10 +187,10 @@ jobs:
     name: GC(without referrers) on S3(minio) with short interval
     runs-on: oracle-vm-8cpu-32gb-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -255,7 +255,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload zot logs
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: gc-bench-s3

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -15,16 +15,16 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
           go-version: 1.25.x
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Run linter with GH action
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v2.6.2

--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -21,6 +21,8 @@ jobs:
           check-latest: true
           go-version: 1.25.x
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Run linter with GH action
         uses: golangci/golangci-lint-action@v9
         with:

--- a/.github/workflows/gqlgen.yaml
+++ b/.github/workflows/gqlgen.yaml
@@ -21,10 +21,10 @@ jobs:
     name: Check GQL generation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -43,7 +43,7 @@ jobs:
     name: Check GQL schema follows best practices
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install dependencies

--- a/.github/workflows/gqlgen.yaml
+++ b/.github/workflows/gqlgen.yaml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false
@@ -42,6 +44,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -19,6 +19,8 @@ jobs:
     name: License Check
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     name: License Check
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           check-latest: true
@@ -53,6 +55,8 @@ jobs:
     steps:
       - name: Check out source code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           check-latest: true
@@ -71,6 +75,8 @@ jobs:
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false
@@ -115,6 +121,8 @@ jobs:
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false
@@ -159,8 +167,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Check out source code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/clean-runner
       - name: Build image
         run: |
@@ -171,6 +183,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           check-latest: true
@@ -206,6 +220,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           check-latest: true
@@ -233,6 +249,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           check-latest: true
@@ -249,6 +267,8 @@ jobs:
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false
@@ -318,6 +338,8 @@ jobs:
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -18,10 +18,10 @@ jobs:
     name: Dedupe/restore blobs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version: 1.25.x
@@ -54,10 +54,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version: 1.25.x
@@ -74,10 +74,10 @@ jobs:
     name: GC(with referrers) on S3(localstack) with short interval
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -120,10 +120,10 @@ jobs:
     name: GC(without referrers) on S3(localstack) with short interval
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -166,11 +166,11 @@ jobs:
     name: Build docker image (for users still using Docker environments)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Check out source code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: ./.github/actions/clean-runner
@@ -182,10 +182,10 @@ jobs:
     name: Prometheus setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version: 1.25.x
@@ -203,13 +203,13 @@ jobs:
           sudo cp bin/skopeo /usr/bin
           skopeo -v
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ github.token }}
       - name: Free up disk space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
       - name: Run tests
         run: |
             sudo ./scripts/enable_userns.sh
@@ -219,10 +219,10 @@ jobs:
     name: OIDC Workload Identity E2E
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version: 1.25.x
@@ -234,7 +234,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap jq
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -248,10 +248,10 @@ jobs:
     name: AWS Secrets Manager Bearer Auth E2E
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           check-latest: true
           go-version: 1.25.x
@@ -266,10 +266,10 @@ jobs:
     name: s3+dynamodb scale-out
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -298,7 +298,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: fake
         continue-on-error: true
       - name: Upload zot logs as build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: zot-scale-out-dynamodb-logs
@@ -327,7 +327,7 @@ jobs:
           exit 1
       - name: Upload zb test results zip as build artifact
         if: steps.scale.outcome == 'success'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: zb-cloud-scale-out-perf-results-${{ github.sha }}
           path: ./zb-results/
@@ -337,10 +337,10 @@ jobs:
     name: s3+redis scale-out
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
@@ -369,7 +369,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: fake
         continue-on-error: true
       - name: Upload zot logs as build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         if: always()
         with:
           name: zot-scale-out-redis-logs
@@ -398,7 +398,7 @@ jobs:
           exit 1
       - name: Upload zb test results zip as build artifact
         if: steps.scale.outcome == 'success'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: zb-cloud-scale-out-redis-results-${{ github.sha }}
           path: ./zb-results/

--- a/.github/workflows/oci-conformance-action.yaml
+++ b/.github/workflows/oci-conformance-action.yaml
@@ -21,13 +21,13 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Install go 1.23
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
       with:
         cache: false
         check-latest: true
         go-version: 1.25.x
     - name: Checkout this PR
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         persist-credentials: false
     - name: Start zot server
@@ -37,7 +37,7 @@ jobs:
           RUNNER_TRACKING_ID="" && ./bin/zot-linux-amd64 serve examples/config-conformance.json &
           IP=`hostname -I | awk '{print $1}'`
           echo "SERVER_URL=http://${IP}:8080" >> $GITHUB_ENV
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         repository: opencontainers/distribution-spec
         ref: main
@@ -63,7 +63,7 @@ jobs:
     - run: mkdir -p .out/ && mv {report.html,junit.xml} .out/
       if: always()
     - name: Upload test results zip as build artifact
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: oci-test-results-${{ github.sha }}
         path: .out/

--- a/.github/workflows/oci-conformance-action.yaml
+++ b/.github/workflows/oci-conformance-action.yaml
@@ -28,6 +28,8 @@ jobs:
         go-version: 1.25.x
     - name: Checkout this PR
       uses: actions/checkout@v6
+      with:
+        persist-credentials: false
     - name: Start zot server
       run: |
           cd $GITHUB_WORKSPACE
@@ -40,6 +42,7 @@ jobs:
         repository: opencontainers/distribution-spec
         ref: main
         path: distribution-spec
+        persist-credentials: false
     - name: build conformance binary from main
       run: |
         (cd distribution-spec/ && make conformance-binary)

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -346,13 +346,13 @@ jobs:
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@users.noreply.github.com'
       - name: Update appVersion
-        uses: mikefarah/yq@3b2423e8713e34e93ee68ddc253cea8d040b48ae # master
+        uses: mikefarah/yq@0f4fb8d35ec1a939d78dd6862f494d19ec589f19 # v4.52.5
         with:
           cmd: yq -i '.appVersion = strenv(RELEASE_TAG)' 'helm-charts/charts/zot/Chart.yaml'
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
       - name: Update image tag
-        uses: mikefarah/yq@3b2423e8713e34e93ee68ddc253cea8d040b48ae # master
+        uses: mikefarah/yq@0f4fb8d35ec1a939d78dd6862f494d19ec589f19 # v4.52.5
         with:
           cmd: |
             yq e '.image.tag = strenv(RELEASE_TAG)' 'helm-charts/charts/zot/values.yaml' > values-updated.yaml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,6 +28,8 @@ jobs:
           fi
       - name: Check out the repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v4
         with:
@@ -113,6 +115,8 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v4
         with:
@@ -307,6 +311,7 @@ jobs:
         with:
           ref: main
           fetch-depth: '0'
+          persist-credentials: false
 
       - name: Checkout project-zot/helm-charts
         uses: actions/checkout@v6
@@ -316,6 +321,7 @@ jobs:
           fetch-depth: '0'
           token: ${{ secrets.HELM_PUSH_TOKEN }}
           path: ./helm-charts
+          persist-credentials: false
 
       - name: Configure Git
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -129,7 +129,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           make check-blackbox-prerequisites
           export PATH=${PATH}:${GITHUB_WORKSPACE}/hack/tools/bin
-          ./scripts/build_multiarch_image.sh --registry ghcr.io/${{ github.repository_owner }} \
+          ./scripts/build_multiarch_image.sh --registry ghcr.io/${GITHUB_REPOSITORY_OWNER} \
             --source-tag ${GITHUB_EVENT_RELEASE_TAG_NAME} \
             --destination-tags "${GITHUB_EVENT_RELEASE_TAG_NAME} latest" \
             --file build/multiarch-${{ matrix.image }}.json
@@ -151,7 +151,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run zot container image with docker
         run: |
-          docker run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot:${GITHUB_EVENT_RELEASE_TAG_NAME}
+          docker run -d -p 5000:5000 ghcr.io/${GITHUB_REPOSITORY_OWNER}/zot:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -164,7 +164,7 @@ jobs:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zot container image with podman
         run: |
-          podman run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot:${GITHUB_EVENT_RELEASE_TAG_NAME}
+          podman run -d -p 5000:5000 ghcr.io/${GITHUB_REPOSITORY_OWNER}/zot:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -177,7 +177,7 @@ jobs:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zot-minimal container image with docker
         run: |
-          docker run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot-minimal:${GITHUB_EVENT_RELEASE_TAG_NAME}
+          docker run -d -p 5000:5000 ghcr.io/${GITHUB_REPOSITORY_OWNER}/zot-minimal:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -190,7 +190,7 @@ jobs:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zot-minimal container image with podman
         run: |
-          podman run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot-minimal:${GITHUB_EVENT_RELEASE_TAG_NAME}
+          podman run -d -p 5000:5000 ghcr.io/${GITHUB_REPOSITORY_OWNER}/zot-minimal:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -203,7 +203,7 @@ jobs:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zot-exporter container image with docker
         run: |
-          docker run -d -p 5001:5001 ghcr.io/${{ github.repository_owner }}/zxp:${GITHUB_EVENT_RELEASE_TAG_NAME}
+          docker run -d -p 5001:5001 ghcr.io/${GITHUB_REPOSITORY_OWNER}/zxp:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -216,7 +216,7 @@ jobs:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zot-exporter container image with podman
         run: |
-          podman run -d -p 5001:5001 ghcr.io/${{ github.repository_owner }}/zxp:${GITHUB_EVENT_RELEASE_TAG_NAME}
+          podman run -d -p 5001:5001 ghcr.io/${GITHUB_REPOSITORY_OWNER}/zxp:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -229,12 +229,12 @@ jobs:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zb container image with docker
         run: |
-          docker run ghcr.io/${{ github.repository_owner }}/zb:${GITHUB_EVENT_RELEASE_TAG_NAME} --help
+          docker run ghcr.io/${GITHUB_REPOSITORY_OWNER}/zb:${GITHUB_EVENT_RELEASE_TAG_NAME} --help
         env:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zb container image with podman
         run: |
-          podman run ghcr.io/${{ github.repository_owner }}/zb:${GITHUB_EVENT_RELEASE_TAG_NAME} --help
+          podman run ghcr.io/${GITHUB_REPOSITORY_OWNER}/zb:${GITHUB_EVENT_RELEASE_TAG_NAME} --help
         env:
           GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
@@ -339,7 +339,7 @@ jobs:
           fetch-depth: '0'
           token: ${{ secrets.HELM_PUSH_TOKEN }}
           path: ./helm-charts
-          persist-credentials: false
+          persist-credentials: true
 
       - name: Configure Git
         run: |

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -348,12 +348,16 @@ jobs:
       - name: Update appVersion
         uses: mikefarah/yq@master
         with:
-          cmd: yq -i '.appVersion = "${{ github.event.release.tag_name }}"' 'helm-charts/charts/zot/Chart.yaml'
+          cmd: yq -i '.appVersion = strenv(RELEASE_TAG)' 'helm-charts/charts/zot/Chart.yaml'
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
       - name: Update image tag
         uses: mikefarah/yq@master
         with:
           cmd: |
-            yq e '.image.tag = "${{ github.event.release.tag_name }}"' 'helm-charts/charts/zot/values.yaml' > values-updated.yaml
+            yq e '.image.tag = strenv(RELEASE_TAG)' 'helm-charts/charts/zot/values.yaml' > values-updated.yaml
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
       - name: Patch values.yaml file
         run: |
           diff -b 'helm-charts/charts/zot/values.yaml' values-updated.yaml > values.diff || true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -27,17 +27,17 @@ jobs:
             echo "BASE_IMAGE=gcr.io/distroless/base-nossl-debian13:latest-${ARCH}" >> "$GITHUB_ENV"
           fi
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push zot container image
-        uses: project-stacker/stacker-build-push-action@main
+        uses: project-stacker/stacker-build-push-action@093acb5ad50bed0012616f46fdba73a8a7169db7 # main
         with:
           version: v1.1.0-rc3
           file: 'build/stacker.yaml'
@@ -53,7 +53,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push zot-minimal container image
-        uses: project-stacker/stacker-build-push-action@main
+        uses: project-stacker/stacker-build-push-action@093acb5ad50bed0012616f46fdba73a8a7169db7 # main
         with:
           version: v1.1.0-rc3
           file: 'build/stacker-minimal.yaml'
@@ -70,7 +70,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push zot-exporter container image
-        uses: project-stacker/stacker-build-push-action@main
+        uses: project-stacker/stacker-build-push-action@093acb5ad50bed0012616f46fdba73a8a7169db7 # main
         with:
           version: v1.1.0-rc3
           file: 'build/stacker-zxp.yaml'
@@ -86,7 +86,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push zb container image
-        uses: project-stacker/stacker-build-push-action@main
+        uses: project-stacker/stacker-build-push-action@093acb5ad50bed0012616f46fdba73a8a7169db7 # main
         with:
           version: v1.1.0-rc3
           file: 'build/stacker-zb.yaml'
@@ -114,11 +114,11 @@ jobs:
         image: [zot, zot-minimal, zxp, zb]
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -144,7 +144,7 @@ jobs:
       packages: read
     steps:
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -251,13 +251,13 @@ jobs:
         arch: [amd64, arm64]
     steps:
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 57a97c7
         with:
           image-ref: 'ghcr.io/${{ github.repository_owner }}/zot-${{ matrix.os }}-${{ matrix.arch }}:${{ github.event.release.tag_name }}'
           format: 'sarif'
@@ -266,7 +266,7 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Trivy vulnerability scanner (minimal)
-        uses: aquasecurity/trivy-action@57a97c7
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 57a97c7
         with:
           image-ref: 'ghcr.io/${{ github.repository_owner }}/zot-minimal-${{ matrix.os }}-${{ matrix.arch }}:${{ github.event.release.tag_name }}'
           format: 'sarif'
@@ -275,7 +275,7 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4.35.1
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -288,13 +288,13 @@ jobs:
       packages: read
     steps:
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@57a97c7
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 57a97c7
         with:
           image-ref: 'ghcr.io/${{ github.repository_owner }}/zot:${{ github.event.release.tag_name }}'
           format: 'sarif'
@@ -303,7 +303,7 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Trivy vulnerability scanner (minimal)
-        uses: aquasecurity/trivy-action@57a97c7
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 57a97c7
         with:
           image-ref: 'ghcr.io/${{ github.repository_owner }}/zot-minimal:${{ github.event.release.tag_name }}'
           format: 'sarif'
@@ -312,7 +312,7 @@ jobs:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v4.35.1
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: 'trivy-results.sarif'
 
@@ -325,14 +325,14 @@ jobs:
       packages: write
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
           fetch-depth: '0'
           persist-credentials: false
 
       - name: Checkout project-zot/helm-charts
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: project-zot/helm-charts
           ref: main
@@ -346,13 +346,13 @@ jobs:
           git config --global user.name 'github-actions'
           git config --global user.email 'github-actions@users.noreply.github.com'
       - name: Update appVersion
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@3b2423e8713e34e93ee68ddc253cea8d040b48ae # master
         with:
           cmd: yq -i '.appVersion = strenv(RELEASE_TAG)' 'helm-charts/charts/zot/Chart.yaml'
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
       - name: Update image tag
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@3b2423e8713e34e93ee68ddc253cea8d040b48ae # master
         with:
           cmd: |
             yq e '.image.tag = strenv(RELEASE_TAG)' 'helm-charts/charts/zot/values.yaml' > values-updated.yaml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -130,9 +130,11 @@ jobs:
           make check-blackbox-prerequisites
           export PATH=${PATH}:${GITHUB_WORKSPACE}/hack/tools/bin
           ./scripts/build_multiarch_image.sh --registry ghcr.io/${{ github.repository_owner }} \
-            --source-tag ${{ github.event.release.tag_name }} \
-            --destination-tags "${{ github.event.release.tag_name }} latest" \
+            --source-tag ${GITHUB_EVENT_RELEASE_TAG_NAME} \
+            --destination-tags "${GITHUB_EVENT_RELEASE_TAG_NAME} latest" \
             --file build/multiarch-${{ matrix.image }}.json
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
   test-image:
     name: Test OCI images published to GitHub Packages
@@ -149,7 +151,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Run zot container image with docker
         run: |
-          docker run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot:${{ github.event.release.tag_name }}
+          docker run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -158,9 +160,11 @@ jobs:
             --retry-connrefused \
             'http://localhost:5000/v2/'
           docker kill $(docker ps -q)
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zot container image with podman
         run: |
-          podman run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot:${{ github.event.release.tag_name }}
+          podman run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -169,9 +173,11 @@ jobs:
             --retry-connrefused \
             'http://localhost:5000/v2/'
           podman kill --all
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zot-minimal container image with docker
         run: |
-          docker run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot-minimal:${{ github.event.release.tag_name }}
+          docker run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot-minimal:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -180,9 +186,11 @@ jobs:
             --retry-connrefused \
             'http://localhost:5000/v2/'
           docker kill $(docker ps -q)
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zot-minimal container image with podman
         run: |
-          podman run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot-minimal:${{ github.event.release.tag_name }}
+          podman run -d -p 5000:5000 ghcr.io/${{ github.repository_owner }}/zot-minimal:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -191,9 +199,11 @@ jobs:
             --retry-connrefused \
             'http://localhost:5000/v2/'
           podman kill --all
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zot-exporter container image with docker
         run: |
-          docker run -d -p 5001:5001 ghcr.io/${{ github.repository_owner }}/zxp:${{ github.event.release.tag_name }}
+          docker run -d -p 5001:5001 ghcr.io/${{ github.repository_owner }}/zxp:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -202,9 +212,11 @@ jobs:
             --retry-connrefused \
             'http://localhost:5001/metrics'
           docker kill $(docker ps -q)
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zot-exporter container image with podman
         run: |
-          podman run -d -p 5001:5001 ghcr.io/${{ github.repository_owner }}/zxp:${{ github.event.release.tag_name }}
+          podman run -d -p 5001:5001 ghcr.io/${{ github.repository_owner }}/zxp:${GITHUB_EVENT_RELEASE_TAG_NAME}
           sleep 2
           curl --connect-timeout 5 \
             --max-time 10 \
@@ -213,12 +225,18 @@ jobs:
             --retry-connrefused \
             'http://localhost:5001/metrics'
           podman kill --all
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zb container image with docker
         run: |
-          docker run ghcr.io/${{ github.repository_owner }}/zb:${{ github.event.release.tag_name }} --help
+          docker run ghcr.io/${{ github.repository_owner }}/zb:${GITHUB_EVENT_RELEASE_TAG_NAME} --help
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
       - name: Run zb container image with podman
         run: |
-          podman run ghcr.io/${{ github.repository_owner }}/zb:${{ github.event.release.tag_name }} --help
+          podman run ghcr.io/${{ github.repository_owner }}/zb:${GITHUB_EVENT_RELEASE_TAG_NAME} --help
+        env:
+          GITHUB_EVENT_RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
 
   scan-image:
     name: Run Trivy scan on OCI images published to GitHub Packages

--- a/.github/workflows/scorecards.yaml
+++ b/.github/workflows/scorecards.yaml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6 # v3.0.0
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           persist-credentials: false
 
@@ -49,7 +49,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v7 # v3.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: SARIF file
           path: results.sarif
@@ -57,6 +57,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@v4.35.1
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -12,7 +12,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
           stale-pr-message: 'This PR is stale because it has been open 90 days with no activity. Remove stale label or comment or this will be closed in 10 days.'

--- a/.github/workflows/sync-3rdparty-images.yaml
+++ b/.github/workflows/sync-3rdparty-images.yaml
@@ -51,7 +51,7 @@ jobs:
           # setup oras
           make $PWD/hack/tools/bin/oras
           export PATH=$PATH:$PWD/hack/tools/bin
-          oras login -u ${GITHUB_ACTOR} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+          echo "${GITHUB_TOKEN}" | oras login -u "${GITHUB_ACTOR}" --password-stdin ghcr.io
           oras copy ghcr.io/aquasecurity/trivy-db:2 ghcr.io/${{ github.repository_owner }}/trivy-db:2
           oras copy ghcr.io/aquasecurity/trivy-db:latest ghcr.io/${{ github.repository_owner }}/trivy-db:latest
           oras copy ghcr.io/aquasecurity/trivy-java-db:1 ghcr.io/${{ github.repository_owner }}/trivy-java-db:1

--- a/.github/workflows/sync-3rdparty-images.yaml
+++ b/.github/workflows/sync-3rdparty-images.yaml
@@ -51,7 +51,7 @@ jobs:
           # setup oras
           make $PWD/hack/tools/bin/oras
           export PATH=$PATH:$PWD/hack/tools/bin
-          oras login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
+          oras login -u ${GITHUB_ACTOR} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
           oras copy ghcr.io/aquasecurity/trivy-db:2 ghcr.io/${{ github.repository_owner }}/trivy-db:2
           oras copy ghcr.io/aquasecurity/trivy-db:latest ghcr.io/${{ github.repository_owner }}/trivy-db:latest
           oras copy ghcr.io/aquasecurity/trivy-java-db:1 ghcr.io/${{ github.repository_owner }}/trivy-java-db:1

--- a/.github/workflows/sync-3rdparty-images.yaml
+++ b/.github/workflows/sync-3rdparty-images.yaml
@@ -45,6 +45,7 @@ jobs:
           sparse-checkout: |
             Makefile
           sparse-checkout-cone-mode: false
+          persist-credentials: false
       - name: Copy trivy-db using oras cli
         run: |
           # setup oras

--- a/.github/workflows/sync-3rdparty-images.yaml
+++ b/.github/workflows/sync-3rdparty-images.yaml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -40,7 +40,7 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           sparse-checkout: |
             Makefile
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Docker Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,18 +16,18 @@ jobs:
     name: Running zot without extensions tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
           go-version: 1.25.x
       - name: Cache go dependencies
         id: cache-go-dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/go/pkg/mod
@@ -50,7 +50,7 @@ jobs:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
       - name: upload coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-minimal
           path: coverage-minimal.txt
@@ -59,17 +59,17 @@ jobs:
     name: Run zot with extensions tests
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
           go-version: 1.25.x
       - name: Cache go dependencies
         id: cache-go-dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/go/pkg/mod
@@ -92,7 +92,7 @@ jobs:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
       - name: upload coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-extended
           path: coverage-extended.txt
@@ -101,17 +101,17 @@ jobs:
     name: Running development-mode tests on Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
           go-version: 1.25.x
       - name: Cache go dependencies
         id: cache-go-dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/go/pkg/mod
@@ -126,7 +126,7 @@ jobs:
       - name: run zot development-mode unit tests (possibly using failure injection)
         run: make test-devmode
       - name: upload coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-devmode
           path: coverage-dev-*.txt
@@ -134,17 +134,17 @@ jobs:
     name: Running privileged tests on Linux
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
           go-version: 1.25.x
       - name: Cache go dependencies
         id: cache-go-dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/go/pkg/mod
@@ -168,7 +168,7 @@ jobs:
           GCSMOCK_ENDPOINT: http://localhost:9000/
           STORAGE_EMULATOR_HOST: localhost:9000
       - name: upload coverage
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: coverage-needprivileges
           path: coverage-needprivileges-*.txt
@@ -179,16 +179,16 @@ jobs:
     if: always()
     needs: [test-run-minimal,test-run-extensions,test-run-devmode,test-run-privileged]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
           go-version: 1.25.x
       - name: download all workflow coverage files
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: merge code coverage
         run: |
           cd $GITHUB_WORKSPACE
@@ -200,12 +200,12 @@ jobs:
           mkdir unified-coverage
           cp coverage.txt coverage.html unified-coverage/
       - name: upload unified-coverage as build artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: unified-coverage
           path: unified-coverage/*
       - name: upload code coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install go
         uses: actions/setup-go@v6
         with:
@@ -58,6 +60,8 @@ jobs:
     runs-on: oracle-vm-16cpu-64gb-x86-64
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false
@@ -98,6 +102,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false
@@ -129,6 +135,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false
@@ -172,6 +180,8 @@ jobs:
     needs: [test-run-minimal,test-run-extensions,test-run-devmode,test-run-privileged]
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false

--- a/.github/workflows/tls.yaml
+++ b/.github/workflows/tls.yaml
@@ -22,10 +22,10 @@ jobs:
             godebug: "fips140=only"
     name: TLS check (${{ matrix.mode }})
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true

--- a/.github/workflows/tls.yaml
+++ b/.github/workflows/tls.yaml
@@ -23,6 +23,8 @@ jobs:
     name: TLS check (${{ matrix.mode }})
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           cache: false

--- a/.github/workflows/verify-config.yaml
+++ b/.github/workflows/verify-config.yaml
@@ -19,18 +19,18 @@ jobs:
     name: Verify Config Files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Install go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
           go-version: 1.25.x
       - name: Cache go dependencies
         id: cache-go-dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: |
             ~/go/pkg/mod

--- a/.github/workflows/verify-config.yaml
+++ b/.github/workflows/verify-config.yaml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Install go
         uses: actions/setup-go@v6
         with:

--- a/.github/workflows/web-scan.yaml
+++ b/.github/workflows/web-scan.yaml
@@ -29,6 +29,8 @@ jobs:
           go-version: 1.25.x
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Build zot
         run: |
           echo "Building $FLAVOR"

--- a/.github/workflows/web-scan.yaml
+++ b/.github/workflows/web-scan.yaml
@@ -22,13 +22,13 @@ jobs:
         flavor: [zot-linux-amd64-minimal, zot-linux-amd64]
     steps:
       - name: Install go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           cache: false
           check-latest: true
           go-version: 1.25.x
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - name: Build zot
@@ -59,7 +59,7 @@ jobs:
         env:
           FLAVOR: ${{ matrix.flavor }}
       - name: ZAP Scan Rest API
-        uses: zaproxy/action-baseline@v0.15.0
+        uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25 # v0.15.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           docker_name: 'ghcr.io/zaproxy/zaproxy:stable'


### PR DESCRIPTION
**What type of PR is this?**

cleanup

**Which issue does this PR fix**:

N/A. Proactive security hardening based on zizmor static analysis.

We still have area of improvement. See https://github.com/zizmorcore/zizmor/issues/1775#issue-4112001655

**What does this PR do / Why do we need it**:

You can review commit by commit.

- Addresses all fixable findings from [zizmor](https://docs.zizmor.sh), a static analysis tool for GitHub Actions security, and tightens Dependabot configuration.
- `artipacked` added `persist-credentials: false` to every `actions/checkout` call across 22 workflow files. Without it, the GitHub token is written to `.git/config` and accessible to all subsequent steps and uploaded artifacts.
- `template-injection` moved `${{ github.* }}` expressions out of `run:` blocks and yq `cmd:` inputs into `env:` variables. Direct interpolation lets a crafted value (e.g. a release tag containing shell metacharacters) execute arbitrary code.
- `unpinned-uses` pinned all 24 unique action references to their full 40-char commit SHA using `pinact`, with the version tag preserved as an inline comment. Branch-based refs (`@main`, `@master`, partial SHAs) resolved via GitHub API.

Dependabot grouped Go and GitHub Actions updates into one PR per ecosystem, 14-day cooldown on action updates, fixed Monday schedule. What do you think ? I find it much more digest to handle.

**If an issue # is not available please add repro steps and logs showing the issue**:

```
zizmor .
346 findings: 172 high, 9 medium, 45 low
```

After this PR: 7 findings remain (5 `excessive-permissions`, 2 `secrets-outside-env`) both require out-of-band repo configuration (GitHub Environments, per-job permission auditing) and are tracked separately.

**Testing done on this change**:

Re-ran `zizmor .` after each commit to verify findings resolved. 

**Automation added to e2e**:

No, zizmor can be added to CI as a follow-up. 🤷 

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:

No
