### PR TITLE
feat(events): include actor and request metadata in webhook payloads

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -42,6 +42,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/debug/pprof"
 	debug "zotregistry.dev/zot/v2/pkg/debug/swagger"
 	ext "zotregistry.dev/zot/v2/pkg/extensions"
+	"zotregistry.dev/zot/v2/pkg/extensions/events"
 	"zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/meta"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
@@ -756,6 +757,8 @@ func (rh *RouteHandler) UpdateManifest(response http.ResponseWriter, request *ht
 		return
 	}
 
+	ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
+
 	if len(digestQueryTags) > 0 && !zcommon.IsDigest(reference) {
 		err := apiErr.NewError(apiErr.MANIFEST_INVALID).AddDetail(map[string]string{
 			"reason": "tag query parameters are only valid when pushing a manifest by digest",
@@ -765,7 +768,7 @@ func (rh *RouteHandler) UpdateManifest(response http.ResponseWriter, request *ht
 		return
 	}
 
-	digest, subjectDigest, err := imgStore.PutImageManifest(name, reference, mediaType, body, digestQueryTags)
+	digest, subjectDigest, err := imgStore.PutImageManifest(ctx, name, reference, mediaType, body, digestQueryTags)
 	if err != nil {
 		details := zerr.GetDetails(err)
 		if errors.Is(err, zerr.ErrRepoNotFound) { //nolint:gocritic // errorslint conflicts with gocritic:IfElseChain
@@ -792,7 +795,7 @@ func (rh *RouteHandler) UpdateManifest(response http.ResponseWriter, request *ht
 			// could be syscall.EMFILE (Err:0x18 too many opened files), etc
 			rh.c.Log.Error().Err(err).Msg("unexpected error, performing cleanup")
 
-			if err = imgStore.DeleteImageManifest(name, reference, false); err != nil {
+			if err = imgStore.DeleteImageManifest(ctx, name, reference, false); err != nil {
 				// deletion of image manifest is important, but not critical for image repo consistency
 				// in the worst scenario a partial manifest file written to disk will not affect the repo because
 				// the new manifest was not added to "index.json" file (it is possible that GC will take care of it)
@@ -937,7 +940,9 @@ func (rh *RouteHandler) DeleteManifest(response http.ResponseWriter, request *ht
 		return
 	}
 
-	err = imgStore.DeleteImageManifest(name, reference, detectCollision)
+	ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
+
+	err = imgStore.DeleteImageManifest(ctx, name, reference, detectCollision)
 	if err != nil { //nolint: dupl
 		details := zerr.GetDetails(err)
 		if errors.Is(err, zerr.ErrRepoNotFound) { //nolint:gocritic // errorslint conflicts with gocritic:IfElseChain
@@ -2499,4 +2504,24 @@ func isSyncOnDemandEnabled(ctlr *Controller) bool {
 	}
 
 	return false
+}
+
+func eventContextFromRequest(r *http.Request) *events.EventContext {
+	ectx := &events.EventContext{
+		Request: &events.RequestInfo{
+			Addr:      r.RemoteAddr,
+			Method:    r.Method,
+			UserAgent: r.UserAgent(),
+		},
+	}
+
+	userAc, err := reqCtx.UserAcFromContext(r.Context())
+	if err == nil && userAc != nil {
+		username := userAc.GetUsername()
+		if username != "" {
+			ectx.Actor = &events.ActorInfo{Name: username}
+		}
+	}
+
+	return ectx
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1112,7 +1112,8 @@ func (rh *RouteHandler) CheckBlob(response http.ResponseWriter, request *http.Re
 	var blen int64
 
 	if userCanMount {
-		ok, blen, err = imgStore.CheckBlob(name, digest)
+		ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
+		ok, blen, err = imgStore.CheckBlob(ctx, name, digest)
 	} else {
 		var lockLatency time.Time
 
@@ -1536,7 +1537,8 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 	}
 
 	if rangeHeaderPresent {
-		ok, bsize, err := imgStore.CheckBlob(name, digest)
+		ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
+		ok, bsize, err := imgStore.CheckBlob(ctx, name, digest)
 		if err != nil {
 			writeBlobError(err)
 
@@ -1724,6 +1726,8 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 
 	imgStore := rh.getImageStore(name)
 
+	ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
+
 	// currently zot does not support cross-repository mounting, following dist-spec and returning 202
 	if mountDigests, ok := request.URL.Query()["mount"]; ok {
 		if len(mountDigests) != 1 {
@@ -1755,11 +1759,11 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 		// check blob looks for actual path (name+mountDigests[0]) first then look for cache and
 		// if found in cache, will do hard link and if fails we will start new upload.
 		if userCanMount {
-			_, _, err = imgStore.CheckBlob(name, mountDigest)
+			_, _, err = imgStore.CheckBlob(ctx, name, mountDigest)
 		}
 
 		if err != nil || !userCanMount {
-			upload, err := imgStore.NewBlobUpload(name)
+			upload, err := imgStore.NewBlobUpload(ctx, name)
 			if err != nil {
 				details := zerr.GetDetails(err)
 				if errors.Is(err, zerr.ErrRepoNotFound) {
@@ -1833,7 +1837,7 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 			return
 		}
 
-		sessionID, size, err := imgStore.FullBlobUpload(name, request.Body, digest)
+		sessionID, size, err := imgStore.FullBlobUpload(ctx, name, request.Body, digest)
 		if err != nil {
 			rh.c.Log.Error().Err(err).Int64("actual", size).Int64("expected", contentLength).
 				Msg("failed to full blob upload")
@@ -1856,7 +1860,7 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 		return
 	}
 
-	upload, err := imgStore.NewBlobUpload(name)
+	upload, err := imgStore.NewBlobUpload(ctx, name)
 	if err != nil {
 		details := zerr.GetDetails(err)
 		if errors.Is(err, zerr.ErrRepoNotFound) {
@@ -1983,9 +1987,11 @@ func (rh *RouteHandler) PatchBlobUpload(response http.ResponseWriter, request *h
 
 	var err error
 
+	ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
+
 	if request.Header.Get("Content-Length") == "" || request.Header.Get("Content-Range") == "" {
 		// streamed blob upload
-		clen, err = imgStore.PutBlobChunkStreamed(name, sessionID, request.Body)
+		clen, err = imgStore.PutBlobChunkStreamed(ctx, name, sessionID, request.Body)
 	} else {
 		// chunked blob upload
 		var contentLength int64
@@ -2004,7 +2010,7 @@ func (rh *RouteHandler) PatchBlobUpload(response http.ResponseWriter, request *h
 			return
 		}
 
-		clen, err = imgStore.PutBlobChunk(name, sessionID, from, to, request.Body)
+		clen, err = imgStore.PutBlobChunk(ctx, name, sessionID, from, to, request.Body)
 	}
 
 	if err != nil { //nolint: dupl
@@ -2071,6 +2077,8 @@ func (rh *RouteHandler) UpdateBlobUpload(response http.ResponseWriter, request *
 
 	imgStore := rh.getImageStore(name)
 
+	ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
+
 	sessionID, ok := vars["session_id"]
 	if !ok || sessionID == "" {
 		response.WriteHeader(http.StatusNotFound)
@@ -2134,7 +2142,7 @@ func (rh *RouteHandler) UpdateBlobUpload(response http.ResponseWriter, request *
 			return
 		}
 
-		_, err = imgStore.PutBlobChunk(name, sessionID, from, to, request.Body)
+		_, err = imgStore.PutBlobChunk(ctx, name, sessionID, from, to, request.Body)
 		if err != nil { //nolint:dupl
 			details := zerr.GetDetails(err)
 			if errors.Is(err, zerr.ErrBadUploadRange) { //nolint:gocritic // errorslint conflicts with gocritic:IfElseChain

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -43,6 +43,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/debug/pprof"
 	debug "zotregistry.dev/zot/v2/pkg/debug/swagger"
 	ext "zotregistry.dev/zot/v2/pkg/extensions"
+	"zotregistry.dev/zot/v2/pkg/extensions/events"
 	"zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/meta"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
@@ -779,7 +780,9 @@ func (rh *RouteHandler) UpdateManifest(response http.ResponseWriter, request *ht
 		return
 	}
 
-	digest, subjectDigest, err := imgStore.PutImageManifest(name, reference, mediaType, body, digestQueryTags)
+	ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
+
+	digest, subjectDigest, err := imgStore.PutImageManifest(ctx, name, reference, mediaType, body, digestQueryTags)
 	if err != nil {
 		details := zerr.GetDetails(err)
 		if errors.Is(err, zerr.ErrRepoNotFound) { //nolint:gocritic // errorslint conflicts with gocritic:IfElseChain
@@ -806,7 +809,7 @@ func (rh *RouteHandler) UpdateManifest(response http.ResponseWriter, request *ht
 			// could be syscall.EMFILE (Err:0x18 too many opened files), etc
 			rh.c.Log.Error().Err(err).Msg("unexpected error, performing cleanup")
 
-			if err = imgStore.DeleteImageManifest(name, reference, false); err != nil {
+			if err = imgStore.DeleteImageManifest(ctx, name, reference, false); err != nil {
 				// deletion of image manifest is important, but not critical for image repo consistency
 				// in the worst scenario a partial manifest file written to disk will not affect the repo because
 				// the new manifest was not added to "index.json" file (it is possible that GC will take care of it)
@@ -951,7 +954,9 @@ func (rh *RouteHandler) DeleteManifest(response http.ResponseWriter, request *ht
 		return
 	}
 
-	err = imgStore.DeleteImageManifest(name, reference, detectCollision)
+	ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
+
+	err = imgStore.DeleteImageManifest(ctx, name, reference, detectCollision)
 	if err != nil { //nolint: dupl
 		details := zerr.GetDetails(err)
 		if errors.Is(err, zerr.ErrRepoNotFound) { //nolint:gocritic // errorslint conflicts with gocritic:IfElseChain
@@ -2938,4 +2943,23 @@ func isSyncOnDemandEnabled(ctlr *Controller) bool {
 	}
 
 	return false
+}
+
+func eventContextFromRequest(r *http.Request) *events.EventContext {
+	ectx := &events.EventContext{
+		Request: &events.RequestInfo{
+			Addr:      r.RemoteAddr,
+			Method:    r.Method,
+			UserAgent: r.UserAgent(),
+		},
+	}
+
+	userAc, err := reqCtx.UserAcFromContext(r.Context())
+	if err == nil {
+		if username := userAc.GetUsername(); username != "" {
+			ectx.Actor = &events.ActorInfo{Name: username}
+		}
+	}
+
+	return ectx
 }

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -503,9 +503,9 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", zerr.ErrRepoNotFound
 					},
 				})
@@ -518,9 +518,9 @@ func TestRoutes(t *testing.T) {
 				},
 
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", zerr.ErrManifestNotFound
 					},
 				})
@@ -532,9 +532,9 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", zerr.ErrBadManifest
 					},
 				})
@@ -546,9 +546,9 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", zerr.ErrBlobNotFound
 					},
 				})
@@ -561,9 +561,9 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", zerr.ErrRepoBadVersion
 					},
 				})
@@ -595,9 +595,9 @@ func TestRoutes(t *testing.T) {
 			digestRef := manifestDigest.String()
 
 			ism := &mocks.MockedImageStore{
-				PutImageManifestFn: func(repo, reference, mediaType string, body []byte, extraTags []string) (
-					godigest.Digest, godigest.Digest, error,
-				) {
+				PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+					body []byte, extraTags []string,
+				) (godigest.Digest, godigest.Digest, error) {
 					So(extraTags, ShouldResemble, []string{"meta-a", "meta-b"})
 					So(string(body), ShouldEqual, string(mcontent))
 
@@ -692,7 +692,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					DeleteImageManifestFn: func(repo, reference string, detectCollision bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error {
 						return zerr.ErrRepoNotFound
 					},
 				},
@@ -707,7 +707,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					DeleteImageManifestFn: func(repo, reference string, detectCollision bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error {
 						return zerr.ErrManifestNotFound
 					},
 				},
@@ -722,7 +722,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					DeleteImageManifestFn: func(repo, reference string, detectCollision bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error {
 						return ErrUnexpectedError
 					},
 				},
@@ -737,7 +737,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					DeleteImageManifestFn: func(repo, reference string, detectCollision bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error {
 						return zerr.ErrBadManifest
 					},
 				},

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -266,9 +266,9 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", zerr.ErrRepoNotFound
 					},
 				})
@@ -281,9 +281,9 @@ func TestRoutes(t *testing.T) {
 				},
 
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", zerr.ErrManifestNotFound
 					},
 				})
@@ -295,9 +295,9 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", zerr.ErrBadManifest
 					},
 				})
@@ -309,9 +309,9 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", zerr.ErrBlobNotFound
 					},
 				})
@@ -324,9 +324,9 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", zerr.ErrRepoBadVersion
 					},
 				})
@@ -358,9 +358,9 @@ func TestRoutes(t *testing.T) {
 			digestRef := manifestDigest.String()
 
 			ism := &mocks.MockedImageStore{
-				PutImageManifestFn: func(repo, reference, mediaType string, body []byte, extraTags []string) (
-					godigest.Digest, godigest.Digest, error,
-				) {
+				PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+					body []byte, extraTags []string,
+				) (godigest.Digest, godigest.Digest, error) {
 					So(extraTags, ShouldResemble, []string{"meta-a", "meta-b"})
 					So(string(body), ShouldEqual, string(mcontent))
 
@@ -455,7 +455,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					DeleteImageManifestFn: func(repo, reference string, detectCollision bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error {
 						return zerr.ErrRepoNotFound
 					},
 				},
@@ -470,7 +470,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					DeleteImageManifestFn: func(repo, reference string, detectCollision bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error {
 						return zerr.ErrManifestNotFound
 					},
 				},
@@ -485,7 +485,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					DeleteImageManifestFn: func(repo, reference string, detectCollision bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error {
 						return ErrUnexpectedError
 					},
 				},
@@ -500,7 +500,7 @@ func TestRoutes(t *testing.T) {
 					"reference": "reference",
 				},
 				&mocks.MockedImageStore{
-					DeleteImageManifestFn: func(repo, reference string, detectCollision bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error {
 						return zerr.ErrBadManifest
 					},
 				},

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -1307,7 +1307,9 @@ func TestRoutes(t *testing.T) {
 					"Content-Length": "100",
 				},
 				&mocks.MockedImageStore{
-					FullBlobUploadFn: func(ctx context.Context, repo string, body io.Reader, digest godigest.Digest) (string, int64, error) {
+					FullBlobUploadFn: func(ctx context.Context, repo string, body io.Reader,
+						digest godigest.Digest,
+					) (string, int64, error) {
 						return sessionStr, 0, zerr.ErrBadBlobDigest
 					},
 				})
@@ -1323,7 +1325,9 @@ func TestRoutes(t *testing.T) {
 					"Content-Length": "100",
 				},
 				&mocks.MockedImageStore{
-					FullBlobUploadFn: func(ctx context.Context, repo string, body io.Reader, digest godigest.Digest) (string, int64, error) {
+					FullBlobUploadFn: func(ctx context.Context, repo string, body io.Reader,
+						digest godigest.Digest,
+					) (string, int64, error) {
 						return sessionStr, 20, nil
 					},
 				})

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -835,7 +835,7 @@ func TestRoutes(t *testing.T) {
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrBadBlobDigest
 					},
 				})
@@ -848,7 +848,7 @@ func TestRoutes(t *testing.T) {
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -861,7 +861,7 @@ func TestRoutes(t *testing.T) {
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrBlobNotFound
 					},
 				})
@@ -874,7 +874,7 @@ func TestRoutes(t *testing.T) {
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, ErrUnexpectedError
 					},
 				})
@@ -887,7 +887,7 @@ func TestRoutes(t *testing.T) {
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 						return false, 0, nil
 					},
 				})
@@ -1025,7 +1025,7 @@ func TestRoutes(t *testing.T) {
 
 						return "https://storage.example.com/zot/repo/blobs/sha256/layer", nil
 					},
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 4, nil
 					},
 					GetBlobPartialFn: func(repo string, digest godigest.Digest, mediaType string,
@@ -1253,10 +1253,10 @@ func TestRoutes(t *testing.T) {
 				},
 				map[string]string{},
 				&mocks.MockedImageStore{
-					NewBlobUploadFn: func(repo string) (string, error) {
+					NewBlobUploadFn: func(ctx context.Context, repo string) (string, error) {
 						return "", zerr.ErrRepoNotFound
 					},
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -1270,10 +1270,10 @@ func TestRoutes(t *testing.T) {
 				},
 				map[string]string{},
 				&mocks.MockedImageStore{
-					NewBlobUploadFn: func(repo string) (string, error) {
+					NewBlobUploadFn: func(ctx context.Context, repo string) (string, error) {
 						return "", zerr.ErrRepoNotFound
 					},
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -1288,10 +1288,10 @@ func TestRoutes(t *testing.T) {
 					"Content-Type": "badContentType",
 				},
 				&mocks.MockedImageStore{
-					NewBlobUploadFn: func(repo string) (string, error) {
+					NewBlobUploadFn: func(ctx context.Context, repo string) (string, error) {
 						return "", zerr.ErrRepoNotFound
 					},
-					CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 						return true, 0, zerr.ErrRepoNotFound
 					},
 				})
@@ -1307,7 +1307,7 @@ func TestRoutes(t *testing.T) {
 					"Content-Length": "100",
 				},
 				&mocks.MockedImageStore{
-					FullBlobUploadFn: func(repo string, body io.Reader, digest godigest.Digest) (string, int64, error) {
+					FullBlobUploadFn: func(ctx context.Context, repo string, body io.Reader, digest godigest.Digest) (string, int64, error) {
 						return sessionStr, 0, zerr.ErrBadBlobDigest
 					},
 				})
@@ -1323,7 +1323,7 @@ func TestRoutes(t *testing.T) {
 					"Content-Length": "100",
 				},
 				&mocks.MockedImageStore{
-					FullBlobUploadFn: func(repo string, body io.Reader, digest godigest.Digest) (string, int64, error) {
+					FullBlobUploadFn: func(ctx context.Context, repo string, body io.Reader, digest godigest.Digest) (string, int64, error) {
 						return sessionStr, 20, nil
 					},
 				})
@@ -1337,7 +1337,7 @@ func TestRoutes(t *testing.T) {
 					"Content-Length": "100",
 				},
 				&mocks.MockedImageStore{
-					NewBlobUploadFn: func(repo string) (string, error) {
+					NewBlobUploadFn: func(ctx context.Context, repo string) (string, error) {
 						return "", zerr.ErrRepoNotFound
 					},
 				})
@@ -1351,7 +1351,7 @@ func TestRoutes(t *testing.T) {
 					"Content-Length": "100",
 				},
 				&mocks.MockedImageStore{
-					NewBlobUploadFn: func(repo string) (string, error) {
+					NewBlobUploadFn: func(ctx context.Context, repo string) (string, error) {
 						return "", ErrUnexpectedError
 					},
 				})
@@ -1529,7 +1529,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					PutBlobChunkFn: func(repo, uuid string, from, to int64, body io.Reader) (int64, error) {
+					PutBlobChunkFn: func(ctx context.Context, repo, uuid string, from, to int64, body io.Reader) (int64, error) {
 						return 100, zerr.ErrRepoNotFound
 					},
 				},
@@ -1547,7 +1547,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					PutBlobChunkFn: func(repo, uuid string, from, to int64, body io.Reader) (int64, error) {
+					PutBlobChunkFn: func(ctx context.Context, repo, uuid string, from, to int64, body io.Reader) (int64, error) {
 						return 100, zerr.ErrUploadNotFound
 					},
 				},
@@ -1565,7 +1565,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					PutBlobChunkFn: func(repo, uuid string, from, to int64, body io.Reader) (int64, error) {
+					PutBlobChunkFn: func(ctx context.Context, repo, uuid string, from, to int64, body io.Reader) (int64, error) {
 						return 100, ErrUnexpectedError
 					},
 					DeleteBlobUploadFn: func(repo, uuid string) error {
@@ -1670,7 +1670,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					PutBlobChunkFn: func(repo, uuid string, from, to int64, body io.Reader) (int64, error) {
+					PutBlobChunkFn: func(ctx context.Context, repo, uuid string, from, to int64, body io.Reader) (int64, error) {
 						return 0, zerr.ErrBadUploadRange
 					},
 				},
@@ -1690,7 +1690,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					PutBlobChunkFn: func(repo, uuid string, from, to int64, body io.Reader) (int64, error) {
+					PutBlobChunkFn: func(ctx context.Context, repo, uuid string, from, to int64, body io.Reader) (int64, error) {
 						return 0, zerr.ErrRepoNotFound
 					},
 				},
@@ -1710,7 +1710,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					PutBlobChunkFn: func(repo, uuid string, from, to int64, body io.Reader) (int64, error) {
+					PutBlobChunkFn: func(ctx context.Context, repo, uuid string, from, to int64, body io.Reader) (int64, error) {
 						return 0, zerr.ErrUploadNotFound
 					},
 				},
@@ -1730,7 +1730,7 @@ func TestRoutes(t *testing.T) {
 					"session_id": "test",
 				},
 				&mocks.MockedImageStore{
-					PutBlobChunkFn: func(repo, uuid string, from, to int64, body io.Reader) (int64, error) {
+					PutBlobChunkFn: func(ctx context.Context, repo, uuid string, from, to int64, body io.Reader) (int64, error) {
 						return 0, ErrUnexpectedError
 					},
 					DeleteBlobUploadFn: func(repo, uuid string) error {
@@ -2384,7 +2384,7 @@ func descriptorStore(t *testing.T) mocks.MockedImageStore {
 
 	return mocks.MockedImageStore{
 		RootDirFn: func() string { return t.TempDir() },
-		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 			if digest == layerDigest {
 				return true, 4, nil
 			}
@@ -2404,7 +2404,7 @@ func descriptorStore(t *testing.T) mocks.MockedImageStore {
 
 func TestCheckBlobUsesDescriptorContentType(t *testing.T) {
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(repo string, digest godigest.Digest) (bool, int64, error) {
+	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 		return true, 42, nil
 	}
 
@@ -2441,7 +2441,7 @@ func TestCheckBlobFallsBackToBinaryContentType(t *testing.T) {
 	// must fall back to application/octet-stream so OCI clients get a
 	// well-formed Content-Type.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 			return true, 1024, nil
 		},
 		GetIndexContentFn: func(repo string) ([]byte, error) {
@@ -2649,7 +2649,7 @@ func TestGetBlobPartialFallsBackToBinaryContentType(t *testing.T) {
 	// Single-range request for a blob whose repo has no index — same
 	// fallback behaviour as the full-GET case.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 			return true, 4, nil
 		},
 		GetBlobPartialFn: func(
@@ -2698,7 +2698,7 @@ func TestGetBlobMultipartPartHasDescriptorContentType(t *testing.T) {
 	const blobBody = "0123456789"
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(repo string, digest godigest.Digest) (bool, int64, error) {
+	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 		return true, int64(len(blobBody)), nil
 	}
 	store.GetBlobPartialFn = func(
@@ -2859,7 +2859,7 @@ func TestGetBlobMultipartContentLengthMatchesBody(t *testing.T) {
 	const blobBody = "0123456789abcdef" // 16 bytes
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(repo string, digest godigest.Digest) (bool, int64, error) {
+	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 		return true, int64(len(blobBody)), nil
 	}
 	store.GetBlobPartialFn = func(
@@ -2932,7 +2932,7 @@ func TestGetBlobMultipartOpensOneReaderAtATime(t *testing.T) {
 	var opens partialReaderOpenTracker
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(repo string, digest godigest.Digest) (bool, int64, error) {
+	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 		return true, int64(len(blobBody)), nil
 	}
 	store.GetBlobPartialFn = func(
@@ -2990,7 +2990,7 @@ func TestGetBlobMultipartTruncatesOnReaderError(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(repo string, digest godigest.Digest) (bool, int64, error) {
+	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 		return true, int64(len(blobBody)), nil
 	}
 	store.GetBlobPartialFn = func(
@@ -3051,7 +3051,7 @@ func TestGetBlobRangeUnsatisfiable(t *testing.T) {
 	// retry with a valid range. parseRangeHeader rejects the header
 	// before the handler reaches GetBlobPartial.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 			return true, 4, nil
 		},
 		GetIndexContentFn: func(repo string) ([]byte, error) {
@@ -3085,7 +3085,7 @@ func TestGetBlobRangeCheckBlobError(t *testing.T) {
 	// CheckBlob returning a non-zerr error must surface as 500 via
 	// writeBlobError's default branch.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 			return false, 0, ErrUnexpectedError
 		},
 	})
@@ -3116,7 +3116,7 @@ func TestGetBlobRangeCheckBlobMissing(t *testing.T) {
 	// repo still exists) must short-circuit to 404 BLOB_UNKNOWN before
 	// any range parsing or descriptor lookup.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 			return false, 0, nil
 		},
 	})
@@ -3156,7 +3156,7 @@ func TestGetBlobSingleRangePartialBlobNotFound(t *testing.T) {
 	// the response is still recoverable because no body bytes have
 	// been written yet.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 			return true, 4, nil
 		},
 		GetBlobPartialFn: func(
@@ -3204,7 +3204,7 @@ func TestGetBlobSingleRangePartialUnexpectedError(t *testing.T) {
 	// Single-range path: GetBlobPartial returning a non-zerr error
 	// hits writeBlobError's default branch and produces a 500.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 			return true, 4, nil
 		},
 		GetBlobPartialFn: func(
@@ -3251,7 +3251,7 @@ func TestGetBlobSingleRangeLengthMismatch(t *testing.T) {
 	// since on the single-range path the headers haven't been flushed
 	// yet and 5xx is still possible.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 			return true, 4, nil
 		},
 		GetBlobPartialFn: func(
@@ -3304,7 +3304,7 @@ func TestGetBlobMultipartShortReaderTruncates(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(repo string, digest godigest.Digest) (bool, int64, error) {
+	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 		return true, int64(len(blobBody)), nil
 	}
 	store.GetBlobPartialFn = func(
@@ -3388,7 +3388,7 @@ func TestGetBlobRangeCheckBlobNamedErrors(t *testing.T) {
 	for name, testCase := range cases {
 		t.Run(name, func(t *testing.T) {
 			handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-				CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+				CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 					return false, 0, testCase.err
 				},
 			})
@@ -3444,7 +3444,7 @@ func TestGetBlobMultipartReaderCloseError(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(repo string, digest godigest.Digest) (bool, int64, error) {
+	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 		return true, int64(len(blobBody)), nil
 	}
 	store.GetBlobPartialFn = func(

--- a/pkg/extensions/events/builder.go
+++ b/pkg/extensions/events/builder.go
@@ -34,6 +34,22 @@ func (b *eventBuilder) WithEventType(eventType EventType) *eventBuilder {
 	return b
 }
 
+func (b *eventBuilder) WithEventContext(ectx *EventContext) *eventBuilder {
+	if ectx == nil {
+		return b
+	}
+
+	if ectx.Actor != nil {
+		b.data["actor"] = ectx.Actor
+	}
+
+	if ectx.Request != nil {
+		b.data["request"] = ectx.Request
+	}
+
+	return b
+}
+
 func (b *eventBuilder) Build() (*cloudevents.Event, error) {
 	if b.eventType == "" {
 		return nil, zerr.ErrEventTypeEmpty

--- a/pkg/extensions/events/common.go
+++ b/pkg/extensions/events/common.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"time"
 )
 
@@ -22,11 +23,43 @@ func (e EventType) String() string {
 	return string(e)
 }
 
+// ActorInfo describes who triggered an event.
+type ActorInfo struct {
+	Name string `json:"name"`
+}
+
+// RequestInfo describes the HTTP request that triggered an event.
+type RequestInfo struct {
+	Addr      string `json:"addr"`
+	Method    string `json:"method"`
+	UserAgent string `json:"useragent"`
+}
+
+// EventContext carries actor and request metadata for events.
+type EventContext struct {
+	Actor   *ActorInfo   `json:"actor,omitempty"`
+	Request *RequestInfo `json:"request,omitempty"`
+}
+
+type eventContextKey struct{}
+
+// WithEventContext attaches an EventContext to a context.Context.
+func WithEventContext(ctx context.Context, ec *EventContext) context.Context {
+	return context.WithValue(ctx, eventContextKey{}, ec)
+}
+
+// EventContextFromContext retrieves the EventContext from a context.Context.
+func EventContextFromContext(ctx context.Context) *EventContext {
+	ec, _ := ctx.Value(eventContextKey{}).(*EventContext)
+
+	return ec
+}
+
 type Recorder interface {
 	Close()
 
-	RepositoryCreated(name string)
-	ImageUpdated(name, reference, digest, mediaType, manifest string)
-	ImageDeleted(name, reference, digest, mediaType string)
-	ImageLintFailed(name, reference, digest, mediaType, manifest string)
+	RepositoryCreated(name string, ectx *EventContext)
+	ImageUpdated(name, reference, digest, mediaType, manifest string, ectx *EventContext)
+	ImageDeleted(name, reference, digest, mediaType string, ectx *EventContext)
+	ImageLintFailed(name, reference, digest, mediaType, manifest string, ectx *EventContext)
 }

--- a/pkg/extensions/events/common.go
+++ b/pkg/extensions/events/common.go
@@ -50,6 +50,10 @@ func WithEventContext(ctx context.Context, ec *EventContext) context.Context {
 
 // EventContextFromContext retrieves the EventContext from a context.Context.
 func EventContextFromContext(ctx context.Context) *EventContext {
+	if ctx == nil {
+		return nil
+	}
+
 	ec, _ := ctx.Value(eventContextKey{}).(*EventContext)
 
 	return ec

--- a/pkg/extensions/events/events.go
+++ b/pkg/extensions/events/events.go
@@ -52,10 +52,11 @@ func (r eventRecorder) publish(event *cloudevents.Event) {
 	}()
 }
 
-func (r eventRecorder) RepositoryCreated(name string) {
+func (r eventRecorder) RepositoryCreated(name string, ectx *EventContext) {
 	event, err := newEventBuilder().
 		WithEventType(RepositoryCreatedEventType).
 		WithDataField("name", name).
+		WithEventContext(ectx).
 		Build()
 	if err != nil {
 		r.log.Warn().Err(err).Msg("failed to create event")
@@ -66,7 +67,7 @@ func (r eventRecorder) RepositoryCreated(name string) {
 	r.publish(event)
 }
 
-func (r eventRecorder) ImageUpdated(name, reference, digest, mediaType, manifest string) {
+func (r eventRecorder) ImageUpdated(name, reference, digest, mediaType, manifest string, ectx *EventContext) {
 	event, err := newEventBuilder().
 		WithEventType(ImageUpdatedEventType).
 		WithDataField("name", name).
@@ -74,6 +75,7 @@ func (r eventRecorder) ImageUpdated(name, reference, digest, mediaType, manifest
 		WithDataField("digest", digest).
 		WithDataField("mediaType", mediaType).
 		WithDataField("manifest", manifest).
+		WithEventContext(ectx).
 		Build()
 	if err != nil {
 		r.log.Warn().Err(err).Msg("failed to create event")
@@ -84,13 +86,14 @@ func (r eventRecorder) ImageUpdated(name, reference, digest, mediaType, manifest
 	r.publish(event)
 }
 
-func (r eventRecorder) ImageDeleted(name, reference, digest, mediaType string) {
+func (r eventRecorder) ImageDeleted(name, reference, digest, mediaType string, ectx *EventContext) {
 	event, err := newEventBuilder().
 		WithEventType(ImageDeletedEventType).
 		WithDataField("name", name).
 		WithDataField("reference", reference).
 		WithDataField("digest", digest).
 		WithDataField("mediaType", mediaType).
+		WithEventContext(ectx).
 		Build()
 	if err != nil {
 		r.log.Warn().Err(err).Msg("failed to create event")
@@ -101,7 +104,7 @@ func (r eventRecorder) ImageDeleted(name, reference, digest, mediaType string) {
 	r.publish(event)
 }
 
-func (r eventRecorder) ImageLintFailed(name, reference, digest, mediaType, manifest string) {
+func (r eventRecorder) ImageLintFailed(name, reference, digest, mediaType, manifest string, ectx *EventContext) {
 	event, err := newEventBuilder().
 		WithEventType(ImageLintFailedEventType).
 		WithDataField("name", name).
@@ -109,6 +112,7 @@ func (r eventRecorder) ImageLintFailed(name, reference, digest, mediaType, manif
 		WithDataField("digest", digest).
 		WithDataField("mediaType", mediaType).
 		WithDataField("manifest", manifest).
+		WithEventContext(ectx).
 		Build()
 	if err != nil {
 		r.log.Warn().Err(err).Msg("failed to create event")

--- a/pkg/extensions/events/events_test.go
+++ b/pkg/extensions/events/events_test.go
@@ -3,6 +3,7 @@
 package events_test
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -59,24 +60,112 @@ func TestEvents(t *testing.T) {
 		recorder, err := events.NewRecorder(log.NewTestLogger(), sink)
 		So(err, ShouldBeNil)
 		Convey("repository created", func() {
-			recorder.RepositoryCreated("test")
+			recorder.RepositoryCreated("test", nil)
 			ev := <-sink.store
 			So(ev.Type(), ShouldEqual, events.RepositoryCreatedEventType.String())
 		})
 		Convey("image updated", func() {
-			recorder.ImageUpdated("test", "v1", "", string(types.OCIManifestSchema1), "")
+			recorder.ImageUpdated("test", "v1", "", string(types.OCIManifestSchema1), "", nil)
 			ev := <-sink.store
 			So(ev.Type(), ShouldEqual, events.ImageUpdatedEventType.String())
 		})
 		Convey("image deleted", func() {
-			recorder.ImageDeleted("test", "v1", "", string(types.OCIManifestSchema1))
+			recorder.ImageDeleted("test", "v1", "", string(types.OCIManifestSchema1), nil)
 			ev := <-sink.store
 			So(ev.Type(), ShouldEqual, events.ImageDeletedEventType.String())
 		})
 		Convey("image lint failed", func() {
-			recorder.ImageLintFailed("test", "v1", "", string(types.OCIManifestSchema1), "")
+			recorder.ImageLintFailed("test", "v1", "", string(types.OCIManifestSchema1), "", nil)
 			ev := <-sink.store
 			So(ev.Type(), ShouldEqual, events.ImageLintFailedEventType.String())
+		})
+	})
+}
+
+func TestEventsWithContext(t *testing.T) {
+	Convey("emits events with actor and request metadata", t, func() {
+		sink := newMockSink()
+		recorder, err := events.NewRecorder(log.NewTestLogger(), sink)
+		So(err, ShouldBeNil)
+
+		ectx := &events.EventContext{
+			Actor: &events.ActorInfo{Name: "testuser"},
+			Request: &events.RequestInfo{
+				Addr:      "192.168.1.1:12345",
+				Method:    "PUT",
+				UserAgent: "docker/24.0.5",
+			},
+		}
+
+		Convey("image updated includes actor and request", func() {
+			recorder.ImageUpdated("test", "v1", "sha256:abc", string(types.OCIManifestSchema1), "{}", ectx)
+			ev := <-sink.store
+			So(ev.Type(), ShouldEqual, events.ImageUpdatedEventType.String())
+
+			var data map[string]any
+			err := ev.DataAs(&data)
+			So(err, ShouldBeNil)
+
+			actor, ok := data["actor"].(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(actor["name"], ShouldEqual, "testuser")
+
+			req, ok := data["request"].(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(req["addr"], ShouldEqual, "192.168.1.1:12345")
+			So(req["method"], ShouldEqual, "PUT")
+			So(req["useragent"], ShouldEqual, "docker/24.0.5")
+		})
+
+		Convey("image deleted includes actor and request", func() {
+			recorder.ImageDeleted("test", "v1", "sha256:abc", string(types.OCIManifestSchema1), ectx)
+			ev := <-sink.store
+			So(ev.Type(), ShouldEqual, events.ImageDeletedEventType.String())
+
+			var data map[string]any
+			err := ev.DataAs(&data)
+			So(err, ShouldBeNil)
+
+			actor, ok := data["actor"].(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(actor["name"], ShouldEqual, "testuser")
+		})
+
+		Convey("nil event context omits actor and request", func() {
+			recorder.ImageUpdated("test", "v1", "sha256:abc", string(types.OCIManifestSchema1), "{}", nil)
+			ev := <-sink.store
+
+			var data map[string]any
+			err := ev.DataAs(&data)
+			So(err, ShouldBeNil)
+
+			_, hasActor := data["actor"]
+			So(hasActor, ShouldBeFalse)
+
+			_, hasRequest := data["request"]
+			So(hasRequest, ShouldBeFalse)
+		})
+	})
+}
+
+func TestEventContextHelpers(t *testing.T) {
+	Convey("EventContext context helpers", t, func() {
+		Convey("round-trips through context", func() {
+			ectx := &events.EventContext{
+				Actor:   &events.ActorInfo{Name: "user1"},
+				Request: &events.RequestInfo{Addr: "1.2.3.4", Method: "PUT", UserAgent: "test/1.0"},
+			}
+
+			ctx := events.WithEventContext(context.Background(), ectx)
+			got := events.EventContextFromContext(ctx)
+			So(got, ShouldNotBeNil)
+			So(got.Actor.Name, ShouldEqual, "user1")
+			So(got.Request.Addr, ShouldEqual, "1.2.3.4")
+		})
+
+		Convey("returns nil from empty context", func() {
+			got := events.EventContextFromContext(context.Background())
+			So(got, ShouldBeNil)
 		})
 	})
 }
@@ -111,31 +200,150 @@ func TestHTTPSinkEvents(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		Convey("repository created", func() {
-			recorder.RepositoryCreated("test")
+			recorder.RepositoryCreated("test", nil)
 			e := getEvent(t, eventChan)
 			So(e, ShouldNotBeNil)
 			So(e.Type(), ShouldEqual, events.RepositoryCreatedEventType.String())
 		})
 
 		Convey("image updated", func() {
-			recorder.ImageUpdated("test", "v1", "", string(types.OCIManifestSchema1), "")
+			recorder.ImageUpdated("test", "v1", "", string(types.OCIManifestSchema1), "", nil)
 			e := getEvent(t, eventChan)
 			So(e, ShouldNotBeNil)
 			So(e.Type(), ShouldEqual, events.ImageUpdatedEventType.String())
 		})
 
 		Convey("image deleted", func() {
-			recorder.ImageDeleted("test", "v1", "", string(types.OCIManifestSchema1))
+			recorder.ImageDeleted("test", "v1", "", string(types.OCIManifestSchema1), nil)
 			e := getEvent(t, eventChan)
 			So(e, ShouldNotBeNil)
 			So(e.Type(), ShouldEqual, events.ImageDeletedEventType.String())
 		})
 
 		Convey("image lint failed", func() {
-			recorder.ImageLintFailed("test", "v1", "", string(types.OCIManifestSchema1), "")
+			recorder.ImageLintFailed("test", "v1", "", string(types.OCIManifestSchema1), "", nil)
 			e := getEvent(t, eventChan)
 			So(e, ShouldNotBeNil)
 			So(e.Type(), ShouldEqual, events.ImageLintFailedEventType.String())
+		})
+	})
+}
+
+func TestHTTPSinkEventsWithMetadata(t *testing.T) {
+	Convey("emits events with actor and request metadata to http sink", t, func() {
+		eventChan := make(chan *cloudevents.Event, 1)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			event, err := cehttp.NewEventFromHTTPRequest(r)
+			if err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+
+				return
+			}
+
+			eventChan <- event
+
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		defer server.Close()
+
+		config := eventsconf.SinkConfig{
+			Type:    eventsconf.HTTP,
+			Address: server.URL,
+			Timeout: 5 * time.Second,
+		}
+		sink, err := events.NewHTTPSink(config)
+		So(err, ShouldBeNil)
+
+		recorder, err := events.NewRecorder(log.NewTestLogger(), sink)
+		So(err, ShouldBeNil)
+
+		ectx := &events.EventContext{
+			Actor: &events.ActorInfo{Name: "admin"},
+			Request: &events.RequestInfo{
+				Addr:      "10.0.0.1:54321",
+				Method:    "PUT",
+				UserAgent: "skopeo/1.14.0",
+			},
+		}
+
+		Convey("image updated carries actor and request over HTTP", func() {
+			recorder.ImageUpdated("myrepo", "v2.0",
+				"sha256:abcdef", string(types.OCIManifestSchema1), "{}", ectx)
+			ev := getEvent(t, eventChan)
+			So(ev, ShouldNotBeNil)
+			So(ev.Type(), ShouldEqual, events.ImageUpdatedEventType.String())
+
+			var data map[string]any
+			err := ev.DataAs(&data)
+			So(err, ShouldBeNil)
+
+			So(data["name"], ShouldEqual, "myrepo")
+			So(data["reference"], ShouldEqual, "v2.0")
+
+			actor, ok := data["actor"].(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(actor["name"], ShouldEqual, "admin")
+
+			req, ok := data["request"].(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(req["addr"], ShouldEqual, "10.0.0.1:54321")
+			So(req["method"], ShouldEqual, "PUT")
+			So(req["useragent"], ShouldEqual, "skopeo/1.14.0")
+		})
+
+		Convey("image deleted carries actor over HTTP", func() {
+			recorder.ImageDeleted("myrepo", "v1.0",
+				"sha256:123456", string(types.OCIManifestSchema1), ectx)
+			ev := getEvent(t, eventChan)
+			So(ev, ShouldNotBeNil)
+			So(ev.Type(), ShouldEqual, events.ImageDeletedEventType.String())
+
+			var data map[string]any
+			err := ev.DataAs(&data)
+			So(err, ShouldBeNil)
+
+			actor, ok := data["actor"].(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(actor["name"], ShouldEqual, "admin")
+
+			req, ok := data["request"].(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(req["method"], ShouldEqual, "PUT")
+		})
+
+		Convey("repository created carries actor over HTTP", func() {
+			recorder.RepositoryCreated("newrepo", ectx)
+			ev := getEvent(t, eventChan)
+			So(ev, ShouldNotBeNil)
+			So(ev.Type(), ShouldEqual, events.RepositoryCreatedEventType.String())
+
+			var data map[string]any
+			err := ev.DataAs(&data)
+			So(err, ShouldBeNil)
+
+			So(data["name"], ShouldEqual, "newrepo")
+
+			actor, ok := data["actor"].(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(actor["name"], ShouldEqual, "admin")
+		})
+
+		Convey("nil context omits actor and request over HTTP", func() {
+			recorder.ImageUpdated("myrepo", "v3.0",
+				"sha256:fedcba", string(types.OCIManifestSchema1), "{}", nil)
+			ev := getEvent(t, eventChan)
+			So(ev, ShouldNotBeNil)
+
+			var data map[string]any
+			err := ev.DataAs(&data)
+			So(err, ShouldBeNil)
+
+			_, hasActor := data["actor"]
+			So(hasActor, ShouldBeFalse)
+
+			_, hasRequest := data["request"]
+			So(hasRequest, ShouldBeFalse)
 		})
 	})
 }
@@ -158,7 +366,7 @@ func TestNATSSinkEvents(t *testing.T) {
 			defer nc.Close()
 			So(err, ShouldBeNil)
 
-			recorder.RepositoryCreated("test")
+			recorder.RepositoryCreated("test", nil)
 
 			e := getEvent(t, eventChan)
 			So(e, ShouldNotBeNil)
@@ -181,7 +389,7 @@ func TestNATSSinkEvents(t *testing.T) {
 			defer nc.Close()
 			So(err, ShouldBeNil)
 
-			recorder.ImageUpdated("test", "v1", "", string(types.OCIManifestSchema1), "")
+			recorder.ImageUpdated("test", "v1", "", string(types.OCIManifestSchema1), "", nil)
 
 			e := getEvent(t, eventChan)
 			So(e, ShouldNotBeNil)
@@ -204,7 +412,7 @@ func TestNATSSinkEvents(t *testing.T) {
 			defer recorder.Close()
 			So(err, ShouldBeNil)
 
-			recorder.ImageDeleted("test", "v1", "", string(types.OCIManifestSchema1))
+			recorder.ImageDeleted("test", "v1", "", string(types.OCIManifestSchema1), nil)
 
 			e := getEvent(t, eventChan)
 			So(e, ShouldNotBeNil)
@@ -227,7 +435,7 @@ func TestNATSSinkEvents(t *testing.T) {
 			defer nc.Close()
 			So(err, ShouldBeNil)
 
-			recorder.ImageLintFailed("test", "v1", "", string(types.OCIManifestSchema1), "")
+			recorder.ImageLintFailed("test", "v1", "", string(types.OCIManifestSchema1), "", nil)
 
 			e := getEvent(t, eventChan)
 			So(e, ShouldNotBeNil)

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -770,7 +770,8 @@ func TestGCMetrics(t *testing.T) {
 		imgStore := ctlr.StoreController.DefaultStore
 
 		orphanBlob := []byte("orphaned-blob-content")
-		_, _, err = imgStore.FullBlobUpload("gc-metrics-test", bytes.NewReader(orphanBlob), godigest.FromBytes(orphanBlob))
+		_, _, err = imgStore.FullBlobUpload(context.Background(), "gc-metrics-test",
+			bytes.NewReader(orphanBlob), godigest.FromBytes(orphanBlob))
 		So(err, ShouldBeNil)
 
 		audit := log.NewAuditLogger("debug", "/dev/null")

--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -740,7 +740,7 @@ func (scanner Scanner) storeSBOMAsOCIArtifact(ctx context.Context,
 		return nil
 	}
 
-	sbomExists, _, err := imgStore.CheckBlob(repo, sbom.digest)
+	sbomExists, _, err := imgStore.CheckBlob(ctx, repo, sbom.digest)
 	if err != nil && !errors.Is(err, zerr.ErrBlobNotFound) {
 		return err
 	}
@@ -753,7 +753,7 @@ func (scanner Scanner) storeSBOMAsOCIArtifact(ctx context.Context,
 
 		defer sbomFile.Close()
 
-		if _, _, err = imgStore.FullBlobUpload(repo, sbomFile, sbom.digest); err != nil {
+		if _, _, err = imgStore.FullBlobUpload(ctx, repo, sbomFile, sbom.digest); err != nil {
 			return err
 		}
 
@@ -761,13 +761,13 @@ func (scanner Scanner) storeSBOMAsOCIArtifact(ctx context.Context,
 			Msg("uploaded sbom blob")
 	}
 
-	emptyConfigExists, _, err := imgStore.CheckBlob(repo, ispec.DescriptorEmptyJSON.Digest)
+	emptyConfigExists, _, err := imgStore.CheckBlob(ctx, repo, ispec.DescriptorEmptyJSON.Digest)
 	if err != nil && !errors.Is(err, zerr.ErrBlobNotFound) {
 		return err
 	}
 
 	if !emptyConfigExists {
-		if _, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
+		if _, _, err = imgStore.FullBlobUpload(ctx, repo, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
 			ispec.DescriptorEmptyJSON.Digest); err != nil {
 			return err
 		}
@@ -805,7 +805,7 @@ func (scanner Scanner) storeSBOMAsOCIArtifact(ctx context.Context,
 	}
 
 	sbomManifestDigest := godigest.FromBytes(sbomManifestBlob)
-	_, _, err = imgStore.PutImageManifest(repo, sbomManifestDigest.String(), ispec.MediaTypeImageManifest,
+	_, _, err = imgStore.PutImageManifest(ctx, repo, sbomManifestDigest.String(), ispec.MediaTypeImageManifest,
 		sbomManifestBlob, nil)
 	if err != nil {
 		return err

--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -4272,8 +4272,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		indexMultiArchMiddle1Blob, err := json.Marshal(indexMultiArchMiddle1)
 		So(err, ShouldBeNil)
 
-		indexMultiArchMiddle1Digest, _, err := storeCtlr.GetDefaultImageStore().PutImageManifest(repoName,
-			"multiArchMiddle1", ispec.MediaTypeImageIndex, indexMultiArchMiddle1Blob, nil)
+		indexMultiArchMiddle1Digest, _, err := storeCtlr.GetDefaultImageStore().PutImageManifest(
+			context.Background(), repoName, "multiArchMiddle1", ispec.MediaTypeImageIndex, indexMultiArchMiddle1Blob, nil)
 		So(err, ShouldBeNil)
 
 		image211 := CreateRandomImage()
@@ -4297,8 +4297,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		indexMultiArchMiddle2Blob, err := json.Marshal(indexMultiArchMiddle2)
 		So(err, ShouldBeNil)
 
-		indexMultiArchMiddle2Digest, _, err := storeCtlr.GetDefaultImageStore().PutImageManifest(repoName,
-			"multiArchMiddle2", ispec.MediaTypeImageIndex, indexMultiArchMiddle2Blob, nil)
+		indexMultiArchMiddle2Digest, _, err := storeCtlr.GetDefaultImageStore().PutImageManifest(
+			context.Background(), repoName, "multiArchMiddle2", ispec.MediaTypeImageIndex, indexMultiArchMiddle2Blob, nil)
 		So(err, ShouldBeNil)
 
 		image31 := CreateRandomImage()
@@ -4332,8 +4332,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		indexMultiArchTopBlob, err := json.Marshal(indexMultiArchTop)
 		So(err, ShouldBeNil)
 
-		_, _, err = storeCtlr.GetDefaultImageStore().PutImageManifest(repoName, "multiArchTop", ispec.MediaTypeImageIndex,
-			indexMultiArchTopBlob, nil)
+		_, _, err = storeCtlr.GetDefaultImageStore().PutImageManifest(
+			context.Background(), repoName, "multiArchTop", ispec.MediaTypeImageIndex, indexMultiArchTopBlob, nil)
 		So(err, ShouldBeNil)
 
 		ctlrManager.StartAndWait(port)
@@ -4444,8 +4444,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		indexMultiArchMiddle1Blob, err := json.Marshal(indexMultiArchMiddle1)
 		So(err, ShouldBeNil)
 
-		indexMultiArchMiddle1Digest, _, err := storeCtlr.GetDefaultImageStore().PutImageManifest(repoName,
-			"multiArchMiddle1", ispec.MediaTypeImageIndex, indexMultiArchMiddle1Blob, nil)
+		indexMultiArchMiddle1Digest, _, err := storeCtlr.GetDefaultImageStore().PutImageManifest(
+			context.Background(), repoName, "multiArchMiddle1", ispec.MediaTypeImageIndex, indexMultiArchMiddle1Blob, nil)
 		So(err, ShouldBeNil)
 
 		image211 := CreateRandomImage()
@@ -4469,8 +4469,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		indexMultiArchMiddle2Blob, err := json.Marshal(indexMultiArchMiddle2)
 		So(err, ShouldBeNil)
 
-		indexMultiArchMiddle2Digest, _, err := storeCtlr.GetDefaultImageStore().PutImageManifest(repoName,
-			"multiArchMiddle2", ispec.MediaTypeImageIndex, indexMultiArchMiddle2Blob, nil)
+		indexMultiArchMiddle2Digest, _, err := storeCtlr.GetDefaultImageStore().PutImageManifest(
+			context.Background(), repoName, "multiArchMiddle2", ispec.MediaTypeImageIndex, indexMultiArchMiddle2Blob, nil)
 		So(err, ShouldBeNil)
 
 		image31 := CreateRandomImage()
@@ -4504,8 +4504,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		indexMultiArchTopBlob, err := json.Marshal(indexMultiArchTop)
 		So(err, ShouldBeNil)
 
-		_, _, err = storeCtlr.GetDefaultImageStore().PutImageManifest(repoName, "multiArchTop", ispec.MediaTypeImageIndex,
-			indexMultiArchTopBlob, nil)
+		_, _, err = storeCtlr.GetDefaultImageStore().PutImageManifest(
+			context.Background(), repoName, "multiArchTop", ispec.MediaTypeImageIndex, indexMultiArchTopBlob, nil)
 		So(err, ShouldBeNil)
 
 		ctlr := api.NewController(conf)
@@ -5231,12 +5231,12 @@ func TestMetaDBWhenSigningImages(t *testing.T) {
 			Convey("imageIsSignature fails", func() {
 				// make image store ignore the wrong format of the input
 				ctlr.StoreController.DefaultStore = mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", nil
 					},
-					DeleteImageManifestFn: func(repo, reference string, dc bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, dc bool) error {
 						return ErrTestError
 					},
 				}
@@ -6628,12 +6628,12 @@ func TestMetaDBWhenDeletingImages(t *testing.T) {
 
 			Convey("imageIsSignature fails", func() {
 				ctlr.StoreController.DefaultStore = mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", nil
 					},
-					DeleteImageManifestFn: func(repo, reference string, dc bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, dc bool) error {
 						return nil
 					},
 				}
@@ -6654,12 +6654,13 @@ func TestMetaDBWhenDeletingImages(t *testing.T) {
 
 						return configBlob, nil
 					},
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", nil
 					},
-					DeleteImageManifestFn: func(repo, reference string, dc bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, dc bool) error {
 						return nil
 					},
 					GetImageManifestFn: func(repo, reference string) ([]byte, godigest.Digest, string, error) {
@@ -6684,12 +6685,13 @@ func TestMetaDBWhenDeletingImages(t *testing.T) {
 
 						return configBlob, nil
 					},
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string) (godigest.Digest,
-						godigest.Digest, error,
-					) {
+
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
+					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", ErrTestError
 					},
-					DeleteImageManifestFn: func(repo, reference string, dc bool) error {
+					DeleteImageManifestFn: func(ctx context.Context, repo, reference string, dc bool) error {
 						return nil
 					},
 					GetImageManifestFn: func(repo, reference string) ([]byte, godigest.Digest, string, error) {

--- a/pkg/extensions/sync/destination.go
+++ b/pkg/extensions/sync/destination.go
@@ -217,7 +217,7 @@ func (registry *DestinationRegistry) copyManifest(repo string, desc ispec.Descri
 			return err
 		}
 
-		digest, _, err := imageStore.PutImageManifest(repo, reference,
+		digest, _, err := imageStore.PutImageManifest(context.Background(), repo, reference,
 			desc.MediaType, manifestContent, nil)
 		if err != nil {
 			registry.log.Error().Str("errorType", common.TypeOf(err)).
@@ -299,7 +299,7 @@ func (registry *DestinationRegistry) copyManifest(repo string, desc ispec.Descri
 			return firstMissingErr
 		}
 
-		_, _, err := imageStore.PutImageManifest(repo, reference, desc.MediaType, manifestContent, nil)
+		_, _, err := imageStore.PutImageManifest(context.Background(), repo, reference, desc.MediaType, manifestContent, nil)
 		if err != nil {
 			registry.log.Error().Str("errorType", common.TypeOf(err)).Str("repo", repo).Str("reference", reference).
 				Err(err).Msg("failed to upload manifest")

--- a/pkg/extensions/sync/destination.go
+++ b/pkg/extensions/sync/destination.go
@@ -327,7 +327,8 @@ func (registry *DestinationRegistry) copyBlob(repo string, blobDigest godigest.D
 	tempImageStore storageTypes.ImageStore,
 ) error {
 	imageStore := registry.storeController.GetImageStore(repo)
-	if found, _, _ := imageStore.CheckBlob(repo, blobDigest); found {
+	ctx := context.Background()
+	if found, _, _ := imageStore.CheckBlob(ctx, repo, blobDigest); found {
 		// Blob is already at destination, nothing to do
 		return nil
 	}
@@ -343,7 +344,7 @@ func (registry *DestinationRegistry) copyBlob(repo string, blobDigest godigest.D
 	}
 	defer blobReadCloser.Close()
 
-	_, _, err = imageStore.FullBlobUpload(repo, blobReadCloser, blobDigest)
+	_, _, err = imageStore.FullBlobUpload(ctx, repo, blobReadCloser, blobDigest)
 	if err != nil {
 		registry.log.Error().Str("errorType", common.TypeOf(err)).Err(err).
 			Str("blob digest", blobDigest.String()).Str("media type", blobMediaType).

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -864,8 +864,10 @@ func TestDestinationRegistry(t *testing.T) {
 			So(err, ShouldBeNil)
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
-			_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
-			So(err, ShouldBeNil)
+
+			_, _, err = imgStore.PutImageManifest(
+				context.Background(), repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+				So(err, ShouldBeNil)
 
 			index.Manifests = append(index.Manifests, ispec.Descriptor{
 				Digest:    digest,
@@ -880,7 +882,8 @@ func TestDestinationRegistry(t *testing.T) {
 		indexDigest := godigest.FromBytes(indexContent)
 		So(indexDigest, ShouldNotBeNil)
 
-		_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
 		So(err, ShouldBeNil)
 
 		Convey("sync index image", func() {
@@ -1067,7 +1070,9 @@ func TestDestinationRegistry(t *testing.T) {
 				So(manifestDigest, ShouldNotBeNil)
 
 				// Store the manifest in the temp image store
-				_, _, err = tempImgStore.PutImageManifest(repoName, manifestDigest.String(), ispec.MediaTypeImageManifest, manifestContent, nil)
+
+				_, _, err = tempImgStore.PutImageManifest(
+					context.Background(), repoName, manifestDigest.String(), ispec.MediaTypeImageManifest, manifestContent, nil)
 				So(err, ShouldBeNil)
 
 				// Add to index
@@ -1085,7 +1090,9 @@ func TestDestinationRegistry(t *testing.T) {
 			So(indexDigest, ShouldNotBeNil)
 
 			// Store the index manifest in the temp image store
-			_, _, err = tempImgStore.PutImageManifest(repoName, indexDigest.String(), ispec.MediaTypeImageIndex, indexContent, nil)
+
+			_, _, err = tempImgStore.PutImageManifest(
+				context.Background(), repoName, indexDigest.String(), ispec.MediaTypeImageIndex, indexContent, nil)
 			So(err, ShouldBeNil)
 
 			// Now remove one of the child manifest blobs to trigger the error
@@ -1178,8 +1185,9 @@ func TestDestinationRegistry(t *testing.T) {
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
 
-			_, _, err = imgStore.PutImageManifest(repoName, "2.0", ispec.MediaTypeImageManifest, content, nil)
-			So(err, ShouldBeNil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "2.0", ispec.MediaTypeImageManifest, content, nil)
+				So(err, ShouldBeNil)
 
 			Convey("sync image", func() {
 				ok, err := registry.CanSkipImage(repoName, "2.0", digest)

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -803,7 +803,7 @@ func TestDestinationRegistry(t *testing.T) {
 		imgStore := getImageStoreFromImageReference(repoName, imageReference, log)
 
 		// create a blob/layer
-		upload, err := imgStore.NewBlobUpload(repoName)
+		upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -812,7 +812,7 @@ func TestDestinationRegistry(t *testing.T) {
 		buflen := buf.Len()
 		digest := godigest.FromBytes(content)
 		So(digest, ShouldNotBeNil)
-		blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+		blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 		bdgst1 := digest
@@ -829,14 +829,14 @@ func TestDestinationRegistry(t *testing.T) {
 
 		for i := 0; i < 4; i++ {
 			// upload image config blob
-			upload, err := imgStore.NewBlobUpload(repoName)
+			upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
 			cblob, cdigest := GetRandomImageConfig()
 			buf := bytes.NewBuffer(cblob)
 			buflen := buf.Len()
-			blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+			blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -867,7 +867,7 @@ func TestDestinationRegistry(t *testing.T) {
 
 			_, _, err = imgStore.PutImageManifest(
 				context.Background(), repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
-				So(err, ShouldBeNil)
+			So(err, ShouldBeNil)
 
 			index.Manifests = append(index.Manifests, ispec.Descriptor{
 				Digest:    digest,
@@ -881,7 +881,6 @@ func TestDestinationRegistry(t *testing.T) {
 		So(err, ShouldBeNil)
 		indexDigest := godigest.FromBytes(indexContent)
 		So(indexDigest, ShouldNotBeNil)
-
 
 		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
 		So(err, ShouldBeNil)
@@ -1019,11 +1018,11 @@ func TestDestinationRegistry(t *testing.T) {
 				So(digest, ShouldNotBeNil)
 
 				// Upload blob
-				upload, err := tempImgStore.NewBlobUpload(repoName)
+				upload, err := tempImgStore.NewBlobUpload(context.Background(), repoName)
 				So(err, ShouldBeNil)
 				So(upload, ShouldNotBeEmpty)
 
-				blob, err := tempImgStore.PutBlobChunkStreamed(repoName, upload, buf)
+				blob, err := tempImgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 				So(err, ShouldBeNil)
 				So(blob, ShouldEqual, buflen)
 
@@ -1035,12 +1034,12 @@ func TestDestinationRegistry(t *testing.T) {
 				cdigest := godigest.FromBytes(cblob)
 				So(cdigest, ShouldNotBeNil)
 
-				upload, err = tempImgStore.NewBlobUpload(repoName)
+				upload, err = tempImgStore.NewBlobUpload(context.Background(), repoName)
 				So(err, ShouldBeNil)
 				So(upload, ShouldNotBeEmpty)
 
 				cbuf := bytes.NewBuffer(cblob)
-				blob, err = tempImgStore.PutBlobChunkStreamed(repoName, upload, cbuf)
+				blob, err = tempImgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, cbuf)
 				So(err, ShouldBeNil)
 				So(blob, ShouldEqual, len(cblob))
 
@@ -1129,7 +1128,7 @@ func TestDestinationRegistry(t *testing.T) {
 			// upload image
 
 			// create a blob/layer
-			upload, err := imgStore.NewBlobUpload(repoName)
+			upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -1138,7 +1137,7 @@ func TestDestinationRegistry(t *testing.T) {
 			buflen := buf.Len()
 			digest := godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
-			blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+			blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 			bdgst1 := digest
@@ -1149,14 +1148,14 @@ func TestDestinationRegistry(t *testing.T) {
 			So(blob, ShouldEqual, buflen)
 
 			// upload image config blob
-			upload, err = imgStore.NewBlobUpload(repoName)
+			upload, err = imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
 			cblob, cdigest := GetRandomImageConfig()
 			buf = bytes.NewBuffer(cblob)
 			buflen = buf.Len()
-			blob, err = imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+			blob, err = imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -1185,9 +1184,8 @@ func TestDestinationRegistry(t *testing.T) {
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
 
-
 			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "2.0", ispec.MediaTypeImageManifest, content, nil)
-				So(err, ShouldBeNil)
+			So(err, ShouldBeNil)
 
 			Convey("sync image", func() {
 				ok, err := registry.CanSkipImage(repoName, "2.0", digest)

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -3348,7 +3348,7 @@ func TestBasicAuth(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 
-			err = dctlr.StoreController.DefaultStore.DeleteImageManifest(testImage, testImageTag, false)
+			err = dctlr.StoreController.DefaultStore.DeleteImageManifest(context.Background(), testImage, testImageTag, false)
 			So(err, ShouldBeNil)
 
 			resp, err = destClient.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + "1.1.1")

--- a/pkg/meta/hooks.go
+++ b/pkg/meta/hooks.go
@@ -90,7 +90,7 @@ func rollbackDigestManifestTags(ctx context.Context, repo string, tags, appliedM
 
 	for i := len(tags) - 1; i >= 0; i-- {
 		refTag := tags[i]
-		if delErr := imgStore.DeleteImageManifest(repo, refTag, false); delErr != nil &&
+		if delErr := imgStore.DeleteImageManifest(context.Background(), repo, refTag, false); delErr != nil &&
 			!errors.Is(delErr, zerr.ErrManifestNotFound) {
 			log.Error().Err(delErr).Str("repository", repo).Str("tag", refTag).
 				Msg("multi-tag digest push: rollback DeleteImageManifest failed")
@@ -125,8 +125,8 @@ func rollbackDigestManifestTags(ctx context.Context, repo string, tags, appliedM
 			continue
 		}
 
-		if _, _, putErr := imgStore.PutImageManifest(repo, prior.digest.String(), prior.mediaType, restoreBody,
-			[]string{refTag}); putErr != nil {
+		if _, _, putErr := imgStore.PutImageManifest(context.Background(), repo, prior.digest.String(), prior.mediaType,
+			restoreBody, []string{refTag}); putErr != nil {
 			log.Error().Err(putErr).Str("repository", repo).Str("tag", refTag).
 				Msg("multi-tag digest push: rollback restore prior manifest in store failed")
 
@@ -158,7 +158,7 @@ func OnUpdateManifest(ctx context.Context, repo, reference, mediaType string, di
 	if err != nil {
 		log.Info().Str("tag", reference).Str("repository", repo).Msg("uploading image meta was unsuccessful for tag in repo")
 
-		if err := imgStore.DeleteImageManifest(repo, reference, false); err != nil {
+		if err := imgStore.DeleteImageManifest(ctx, repo, reference, false); err != nil {
 			log.Error().Err(err).Str("reference", reference).Str("repository", repo).
 				Msg("failed to remove image manifest in repo")
 
@@ -250,7 +250,7 @@ func OnDeleteManifest(repo, reference, mediaType string, digest godigest.Digest,
 			log.Info().Str("component", "metadb").Msg("restoring image store")
 
 			// restore image store
-			_, _, err := imgStore.PutImageManifest(repo, reference, mediaType, manifestBlob, nil)
+			_, _, err := imgStore.PutImageManifest(context.Background(), repo, reference, mediaType, manifestBlob, nil)
 			if err != nil {
 				log.Error().Err(err).Str("component", "metadb").
 					Msg("failed to restore manifest to image store, database is not consistent")

--- a/pkg/meta/hooks.go
+++ b/pkg/meta/hooks.go
@@ -91,7 +91,7 @@ func rollbackDigestManifestTags(ctx context.Context, repo string, tags, appliedM
 
 	for i := range slices.Backward(tags) {
 		refTag := tags[i]
-		if delErr := imgStore.DeleteImageManifest(repo, refTag, false); delErr != nil &&
+		if delErr := imgStore.DeleteImageManifest(context.Background(), repo, refTag, false); delErr != nil &&
 			!errors.Is(delErr, zerr.ErrManifestNotFound) {
 			log.Error().Err(delErr).Str("repository", repo).Str("tag", refTag).
 				Msg("multi-tag digest push: rollback DeleteImageManifest failed")
@@ -126,8 +126,8 @@ func rollbackDigestManifestTags(ctx context.Context, repo string, tags, appliedM
 			continue
 		}
 
-		if _, _, putErr := imgStore.PutImageManifest(repo, prior.digest.String(), prior.mediaType, restoreBody,
-			[]string{refTag}); putErr != nil {
+		if _, _, putErr := imgStore.PutImageManifest(context.Background(), repo, prior.digest.String(), prior.mediaType,
+			restoreBody, []string{refTag}); putErr != nil {
 			log.Error().Err(putErr).Str("repository", repo).Str("tag", refTag).
 				Msg("multi-tag digest push: rollback restore prior manifest in store failed")
 
@@ -159,7 +159,7 @@ func OnUpdateManifest(ctx context.Context, repo, reference, mediaType string, di
 	if err != nil {
 		log.Info().Str("tag", reference).Str("repository", repo).Msg("uploading image meta was unsuccessful for tag in repo")
 
-		if err := imgStore.DeleteImageManifest(repo, reference, false); err != nil {
+		if err := imgStore.DeleteImageManifest(ctx, repo, reference, false); err != nil {
 			log.Error().Err(err).Str("reference", reference).Str("repository", repo).
 				Msg("failed to remove image manifest in repo")
 
@@ -251,7 +251,7 @@ func OnDeleteManifest(repo, reference, mediaType string, digest godigest.Digest,
 			log.Info().Str("component", "metadb").Msg("restoring image store")
 
 			// restore image store
-			_, _, err := imgStore.PutImageManifest(repo, reference, mediaType, manifestBlob, nil)
+			_, _, err := imgStore.PutImageManifest(context.Background(), repo, reference, mediaType, manifestBlob, nil)
 			if err != nil {
 				log.Error().Err(err).Str("component", "metadb").
 					Msg("failed to restore manifest to image store, database is not consistent")

--- a/pkg/meta/hooks.go
+++ b/pkg/meta/hooks.go
@@ -91,7 +91,7 @@ func rollbackDigestManifestTags(ctx context.Context, repo string, tags, appliedM
 
 	for i := range slices.Backward(tags) {
 		refTag := tags[i]
-		if delErr := imgStore.DeleteImageManifest(context.Background(), repo, refTag, false); delErr != nil &&
+		if delErr := imgStore.DeleteImageManifest(ctx, repo, refTag, false); delErr != nil &&
 			!errors.Is(delErr, zerr.ErrManifestNotFound) {
 			log.Error().Err(delErr).Str("repository", repo).Str("tag", refTag).
 				Msg("multi-tag digest push: rollback DeleteImageManifest failed")
@@ -126,7 +126,7 @@ func rollbackDigestManifestTags(ctx context.Context, repo string, tags, appliedM
 			continue
 		}
 
-		if _, _, putErr := imgStore.PutImageManifest(context.Background(), repo, prior.digest.String(), prior.mediaType,
+		if _, _, putErr := imgStore.PutImageManifest(ctx, repo, prior.digest.String(), prior.mediaType,
 			restoreBody, []string{refTag}); putErr != nil {
 			log.Error().Err(putErr).Str("repository", repo).Str("tag", refTag).
 				Msg("multi-tag digest push: rollback restore prior manifest in store failed")

--- a/pkg/meta/hooks_internal_test.go
+++ b/pkg/meta/hooks_internal_test.go
@@ -129,7 +129,7 @@ func TestRollbackDigestManifestTags(t *testing.T) {
 			var deleteCalls int
 
 			is := mocks.MockedImageStore{
-				DeleteImageManifestFn: func(repo, reference string, detectCollision bool) error {
+				DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error {
 					deleteCalls++
 
 					return errors.New("delete failed")
@@ -145,7 +145,7 @@ func TestRollbackDigestManifestTags(t *testing.T) {
 
 		Convey("delete manifest not found is ignored", func() {
 			is := mocks.MockedImageStore{
-				DeleteImageManifestFn: func(repo, reference string, detectCollision bool) error {
+				DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error {
 					return zerr.ErrManifestNotFound
 				},
 			}
@@ -177,7 +177,7 @@ func TestRollbackDigestManifestTags(t *testing.T) {
 			}
 
 			is := mocks.MockedImageStore{
-				DeleteImageManifestFn: func(string, string, bool) error { return nil },
+				DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error { return nil },
 				GetBlobContentFn: func(string, godigest.Digest) ([]byte, error) {
 					return nil, errors.New("blob missing")
 				},
@@ -196,13 +196,13 @@ func TestRollbackDigestManifestTags(t *testing.T) {
 			}
 
 			is := mocks.MockedImageStore{
-				DeleteImageManifestFn: func(string, string, bool) error { return nil },
+				DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error { return nil },
 				GetBlobContentFn: func(_ string, blobDigest godigest.Digest) ([]byte, error) {
 					So(blobDigest, ShouldResemble, priorD)
 
 					return priorBody, nil
 				},
-				PutImageManifestFn: func(string, string, string, []byte, []string) (godigest.Digest, godigest.Digest, error) {
+				PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string, body []byte, extraTags []string) (godigest.Digest, godigest.Digest, error) {
 					return "", "", errors.New("put failed")
 				},
 			}
@@ -233,7 +233,7 @@ func TestRollbackDigestManifestTags(t *testing.T) {
 			}
 
 			is := mocks.MockedImageStore{
-				DeleteImageManifestFn: func(string, string, bool) error { return nil },
+				DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error { return nil },
 				GetBlobContentFn: func(_ string, blobDigest godigest.Digest) ([]byte, error) {
 					switch {
 					case blobDigest == priorD:
@@ -247,7 +247,7 @@ func TestRollbackDigestManifestTags(t *testing.T) {
 
 					return nil, nil
 				},
-				PutImageManifestFn: func(_, _, _ string, blob []byte, _ []string) (godigest.Digest, godigest.Digest, error) {
+				PutImageManifestFn: func(ctx context.Context, _, _, _ string, blob []byte, _ []string) (godigest.Digest, godigest.Digest, error) {
 					d := godigest.FromBytes(blob)
 
 					return d, d, nil

--- a/pkg/meta/hooks_test.go
+++ b/pkg/meta/hooks_test.go
@@ -54,7 +54,9 @@ type failDeleteImageStore struct {
 	deleteErr error
 }
 
-func (f *failDeleteImageStore) DeleteImageManifest(repo, reference string, detectCollision bool) error {
+func (f *failDeleteImageStore) DeleteImageManifest(ctx context.Context, repo, reference string,
+	detectCollision bool,
+) error {
 	return f.deleteErr
 }
 
@@ -103,7 +105,7 @@ func TestOnUpdateManifestDigestTags_success(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		imgStore := storeController.GetImageStore("repo")
-		_, _, err = imgStore.PutImageManifest("repo", manifestDigest.String(), mediaType, manifestBody,
+		_, _, err = imgStore.PutImageManifest(context.Background(), "repo", manifestDigest.String(), mediaType, manifestBody,
 			[]string{"ta", "tb"})
 		So(err, ShouldBeNil)
 
@@ -159,7 +161,7 @@ func TestOnUpdateManifestDigestTags_rollbackPartialMeta(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			imgStore := storeController.GetImageStore("repo")
-			_, _, err = imgStore.PutImageManifest("repo", manifestDigest.String(), mediaType, manifestBody,
+			_, _, err = imgStore.PutImageManifest(context.Background(), "repo", manifestDigest.String(), mediaType, manifestBody,
 				[]string{"ta", "tb"})
 			So(err, ShouldBeNil)
 
@@ -245,7 +247,7 @@ func TestOnUpdateManifestDigestTags_rollbackRestoresMovedTag(t *testing.T) {
 
 			imgStore := storeController.GetImageStore("repo")
 
-			_, _, err = imgStore.PutImageManifest("repo", digestB.String(), mediaTypeB, bodyB,
+			_, _, err = imgStore.PutImageManifest(context.Background(), "repo", digestB.String(), mediaTypeB, bodyB,
 				[]string{"movable", "onlyB"})
 			So(err, ShouldBeNil)
 
@@ -321,7 +323,7 @@ func TestOnUpdateManifestDigestTags_whenRepoMetaMissing(t *testing.T) {
 		So(errors.Is(err, zerr.ErrRepoMetaNotFound), ShouldBeTrue)
 
 		imgStore := storeController.GetImageStore("repo")
-		_, _, err = imgStore.PutImageManifest("repo", manifestDigest.String(), mediaType, manifestBody,
+		_, _, err = imgStore.PutImageManifest(context.Background(), "repo", manifestDigest.String(), mediaType, manifestBody,
 			[]string{"ta", "tb"})
 		So(err, ShouldBeNil)
 

--- a/pkg/meta/parse_test.go
+++ b/pkg/meta/parse_test.go
@@ -734,7 +734,8 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 		err = WriteImageToFileSystem(image, modifiedAddImageRepo, newTag, storeController)
 		So(err, ShouldBeNil)
 
-		err = storeController.GetDefaultImageStore().DeleteImageManifest(modifiedRemoveImageRepo, tag2, false)
+		err = storeController.GetDefaultImageStore().DeleteImageManifest(
+			context.Background(), modifiedRemoveImageRepo, tag2, false)
 		So(err, ShouldBeNil)
 
 		err = os.RemoveAll(filepath.Join(rootDir, deletedRepo))

--- a/pkg/meta/parse_test.go
+++ b/pkg/meta/parse_test.go
@@ -763,7 +763,8 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 		err = WriteImageToFileSystem(image, modifiedAddImageRepo, newTag, storeController)
 		So(err, ShouldBeNil)
 
-		err = storeController.GetDefaultImageStore().DeleteImageManifest(modifiedRemoveImageRepo, tag2, false)
+		err = storeController.GetDefaultImageStore().DeleteImageManifest(
+			context.Background(), modifiedRemoveImageRepo, tag2, false)
 		So(err, ShouldBeNil)
 
 		err = os.RemoveAll(filepath.Join(rootDir, deletedRepo))

--- a/pkg/storage/common/common_test.go
+++ b/pkg/storage/common/common_test.go
@@ -2,6 +2,7 @@ package storage_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -59,19 +60,21 @@ func TestValidateManifest(t *testing.T) {
 			body, err := json.Marshal(manifest)
 			So(err, ShouldBeNil)
 
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageConfig, body, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0", ispec.MediaTypeImageConfig, body, nil)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, zerr.ErrBadManifest)
 		})
 
 		Convey("empty manifest with bad media type", func() {
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageConfig, []byte(""), nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0",
+				ispec.MediaTypeImageConfig, []byte(""), nil)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, zerr.ErrBadManifest)
 		})
 
 		Convey("empty manifest with correct media type", func() {
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, []byte(""), nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0",
+				ispec.MediaTypeImageManifest, []byte(""), nil)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, zerr.ErrBadManifest)
 		})
@@ -97,7 +100,7 @@ func TestValidateManifest(t *testing.T) {
 			body, err := json.Marshal(manifest)
 			So(err, ShouldBeNil)
 
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, body, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, body, nil)
 			So(err, ShouldNotBeNil)
 
 			var internalErr *zerr.Error
@@ -134,7 +137,8 @@ func TestValidateManifest(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// this was actually an umoci error on config blob
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, body, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, body, nil)
 			So(err, ShouldBeNil)
 		})
 
@@ -163,7 +167,7 @@ func TestValidateManifest(t *testing.T) {
 			body, err := json.Marshal(manifest)
 			So(err, ShouldBeNil)
 
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, body, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, body, nil)
 			So(err, ShouldBeNil)
 		})
 
@@ -182,7 +186,7 @@ func TestValidateManifest(t *testing.T) {
 			body, err := json.Marshal(manifest)
 			So(err, ShouldBeNil)
 
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, body, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, body, nil)
 			So(err, ShouldBeNil)
 		})
 	})

--- a/pkg/storage/common/common_test.go
+++ b/pkg/storage/common/common_test.go
@@ -49,12 +49,12 @@ func TestValidateManifest(t *testing.T) {
 		digest := godigest.FromBytes(content)
 		So(digest, ShouldNotBeNil)
 
-		_, blen, err := imgStore.FullBlobUpload("test", bytes.NewReader(content), digest)
+		_, blen, err := imgStore.FullBlobUpload(context.Background(), "test", bytes.NewReader(content), digest)
 		So(err, ShouldBeNil)
 		So(blen, ShouldEqual, len(content))
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest)
+		_, clen, err := imgStore.FullBlobUpload(context.Background(), "test", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 

--- a/pkg/storage/common/common_test.go
+++ b/pkg/storage/common/common_test.go
@@ -64,19 +64,21 @@ func TestValidateManifest(t *testing.T) {
 			body, err := json.Marshal(manifest)
 			So(err, ShouldBeNil)
 
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageConfig, body, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0", ispec.MediaTypeImageConfig, body, nil)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, zerr.ErrBadManifest)
 		})
 
 		Convey("empty manifest with bad media type", func() {
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageConfig, []byte(""), nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0",
+				ispec.MediaTypeImageConfig, []byte(""), nil)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, zerr.ErrBadManifest)
 		})
 
 		Convey("empty manifest with correct media type", func() {
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, []byte(""), nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0",
+				ispec.MediaTypeImageManifest, []byte(""), nil)
 			So(err, ShouldNotBeNil)
 			So(err, ShouldEqual, zerr.ErrBadManifest)
 		})
@@ -102,7 +104,7 @@ func TestValidateManifest(t *testing.T) {
 			body, err := json.Marshal(manifest)
 			So(err, ShouldBeNil)
 
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, body, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, body, nil)
 			So(err, ShouldNotBeNil)
 
 			var internalErr *zerr.Error
@@ -139,7 +141,8 @@ func TestValidateManifest(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// this was actually an umoci error on config blob
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, body, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, body, nil)
 			So(err, ShouldBeNil)
 		})
 
@@ -168,7 +171,7 @@ func TestValidateManifest(t *testing.T) {
 			body, err := json.Marshal(manifest)
 			So(err, ShouldBeNil)
 
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, body, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, body, nil)
 			So(err, ShouldBeNil)
 		})
 
@@ -187,7 +190,7 @@ func TestValidateManifest(t *testing.T) {
 			body, err := json.Marshal(manifest)
 			So(err, ShouldBeNil)
 
-			_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, body, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, body, nil)
 			So(err, ShouldBeNil)
 		})
 	})

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -125,7 +125,8 @@ func TestGarbageCollectManifestErrors(t *testing.T) {
 
 		manifestDigest := godigest.FromBytes(body)
 
-		_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, body, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0", ispec.MediaTypeImageManifest, body, nil)
 		So(err, ShouldBeNil)
 
 		Convey("trigger GetIndex error in GetReferencedBlobs", func() {
@@ -247,8 +248,10 @@ func TestGarbageCollectIndexErrors(t *testing.T) {
 
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
-			_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
-			So(err, ShouldBeNil)
+
+			_, _, err = imgStore.PutImageManifest(
+				context.Background(), repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+				So(err, ShouldBeNil)
 
 			index.Manifests = append(index.Manifests, ispec.Descriptor{
 				Digest:    digest,
@@ -264,7 +267,8 @@ func TestGarbageCollectIndexErrors(t *testing.T) {
 		indexDigest := godigest.FromBytes(indexContent)
 		So(indexDigest, ShouldNotBeNil)
 
-		_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
 		So(err, ShouldBeNil)
 
 		index, err = common.GetIndex(imgStore, repoName, log)

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -126,7 +126,8 @@ func TestGarbageCollectManifestErrors(t *testing.T) {
 
 		manifestDigest := godigest.FromBytes(body)
 
-		_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, body, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0", ispec.MediaTypeImageManifest, body, nil)
 		So(err, ShouldBeNil)
 
 		Convey("trigger GetIndex error in GetReferencedBlobs", func() {
@@ -248,8 +249,10 @@ func TestGarbageCollectIndexErrors(t *testing.T) {
 
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
-			_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
-			So(err, ShouldBeNil)
+
+			_, _, err = imgStore.PutImageManifest(
+				context.Background(), repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+				So(err, ShouldBeNil)
 
 			index.Manifests = append(index.Manifests, ispec.Descriptor{
 				Digest:    digest,
@@ -265,7 +268,8 @@ func TestGarbageCollectIndexErrors(t *testing.T) {
 		indexDigest := godigest.FromBytes(indexContent)
 		So(indexDigest, ShouldNotBeNil)
 
-		_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
 		So(err, ShouldBeNil)
 
 		index, err = common.GetIndex(imgStore, repoName, log)

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -95,12 +95,12 @@ func TestGarbageCollectManifestErrors(t *testing.T) {
 		digest := godigest.FromBytes(content)
 		So(digest, ShouldNotBeNil)
 
-		_, blen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(content), digest)
+		_, blen, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(content), digest)
 		So(err, ShouldBeNil)
 		So(blen, ShouldEqual, len(content))
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
+		_, clen, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
@@ -125,7 +125,6 @@ func TestGarbageCollectManifestErrors(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest := godigest.FromBytes(body)
-
 
 		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0", ispec.MediaTypeImageManifest, body, nil)
 		So(err, ShouldBeNil)
@@ -201,7 +200,7 @@ func TestGarbageCollectIndexErrors(t *testing.T) {
 		bdgst := godigest.FromBytes(content)
 		So(bdgst, ShouldNotBeNil)
 
-		_, bsize, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(content), bdgst)
+		_, bsize, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(content), bdgst)
 		So(err, ShouldBeNil)
 		So(bsize, ShouldEqual, len(content))
 
@@ -213,14 +212,14 @@ func TestGarbageCollectIndexErrors(t *testing.T) {
 
 		for i := 0; i < 4; i++ {
 			// upload image config blob
-			upload, err := imgStore.NewBlobUpload(repoName)
+			upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
 			cblob, cdigest := GetRandomImageConfig()
 			buf := bytes.NewBuffer(cblob)
 			buflen := buf.Len()
-			blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+			blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -252,7 +251,7 @@ func TestGarbageCollectIndexErrors(t *testing.T) {
 
 			_, _, err = imgStore.PutImageManifest(
 				context.Background(), repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
-				So(err, ShouldBeNil)
+			So(err, ShouldBeNil)
 
 			index.Manifests = append(index.Manifests, ispec.Descriptor{
 				Digest:    digest,
@@ -267,7 +266,6 @@ func TestGarbageCollectIndexErrors(t *testing.T) {
 
 		indexDigest := godigest.FromBytes(indexContent)
 		So(indexDigest, ShouldNotBeNil)
-
 
 		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
 		So(err, ShouldBeNil)

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -1383,8 +1383,8 @@ func TestGarbageCollectDeletion(t *testing.T) {
 			topIndexBlob, err := json.Marshal(topIndex)
 			So(err, ShouldBeNil)
 
-			rootIndexDigest, _, err := imgStore.PutImageManifest(repoName, "topindex", ispec.MediaTypeImageIndex,
-				topIndexBlob, nil)
+			rootIndexDigest, _, err := imgStore.PutImageManifest(context.Background(),
+				repoName, "topindex", ispec.MediaTypeImageIndex, topIndexBlob, nil)
 			So(err, ShouldBeNil)
 
 			bottomIndex1Digest := bottomIndex1.IndexDescriptor.Digest

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -1237,12 +1237,12 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 						},
 					}, audit, log, metrics)
 
-					blobUploadID, err := imgStore.NewBlobUpload(repoName)
+					blobUploadID, err := imgStore.NewBlobUpload(context.Background(), repoName)
 					So(err, ShouldBeNil)
 
 					content := []byte("test-data3")
 					buf := bytes.NewBuffer(content)
-					_, err = imgStore.PutBlobChunkStreamed(repoName, blobUploadID, buf)
+					_, err = imgStore.PutBlobChunkStreamed(context.Background(), repoName, blobUploadID, buf)
 					So(err, ShouldBeNil)
 
 					// Blob upload should be there
@@ -2559,12 +2559,12 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 						},
 					}, audit, log, metrics)
 
-					blobUploadID, err := imgStore.NewBlobUpload(repoName)
+					blobUploadID, err := imgStore.NewBlobUpload(context.Background(), repoName)
 					So(err, ShouldBeNil)
 
 					content := []byte("test-data3")
 					buf := bytes.NewBuffer(content)
-					_, err = imgStore.PutBlobChunkStreamed(repoName, blobUploadID, buf)
+					_, err = imgStore.PutBlobChunkStreamed(context.Background(), repoName, blobUploadID, buf)
 					So(err, ShouldBeNil)
 
 					// Blob upload should be there

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -1390,8 +1390,8 @@ func TestGarbageCollectDeletion(t *testing.T) {
 			topIndexBlob, err := json.Marshal(topIndex)
 			So(err, ShouldBeNil)
 
-			rootIndexDigest, _, err := imgStore.PutImageManifest(repoName, "topindex", ispec.MediaTypeImageIndex,
-				topIndexBlob, nil)
+			rootIndexDigest, _, err := imgStore.PutImageManifest(context.Background(),
+				repoName, "topindex", ispec.MediaTypeImageIndex, topIndexBlob, nil)
 			So(err, ShouldBeNil)
 
 			bottomIndex1Digest := bottomIndex1.IndexDescriptor.Digest

--- a/pkg/storage/gcs/gcs_test.go
+++ b/pkg/storage/gcs/gcs_test.go
@@ -204,12 +204,9 @@ func newHTTPSProxyServer(target string) (*httpsProxyServer, error) {
 }
 
 func (p *httpsProxyServer) Start() {
-	p.wg.Add(1) //nolint:modernize // standard sync.WaitGroup usage
-
-	go func() {
-		defer p.wg.Done()
+	p.wg.Go(func() {
 		_ = p.server.Serve(p.listener)
-	}()
+	})
 }
 
 func (p *httpsProxyServer) Stop() {
@@ -453,7 +450,7 @@ func TestGCSDriver(t *testing.T) {
 
 		Convey("Init Repo", func() {
 			repoName := "test-repo-init"
-			err := imgStore.InitRepo(repoName)
+			err := imgStore.InitRepo(context.Background(), repoName)
 			So(err, ShouldBeNil)
 
 			isValid, err := imgStore.ValidateRepo(repoName)
@@ -492,7 +489,9 @@ func TestGCSDriver(t *testing.T) {
 			// Upload manifest
 			mblob, err := json.Marshal(image.Manifest)
 			So(err, ShouldBeNil)
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, mblob, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+				ispec.MediaTypeImageManifest, mblob, nil)
 			So(err, ShouldBeNil)
 
 			// Verify manifest
@@ -540,10 +539,12 @@ func TestGCSDriver(t *testing.T) {
 			// Upload manifest
 			mblob, err := json.Marshal(image.Manifest)
 			So(err, ShouldBeNil)
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, mblob, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+				ispec.MediaTypeImageManifest, mblob, nil)
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest(repoName, "1.0", false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, "1.0", false)
 			So(err, ShouldBeNil)
 
 			_, _, _, err = imgStore.GetImageManifest(repoName, "1.0")
@@ -637,7 +638,8 @@ func TestGCSDedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest := godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe1", manifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe1", manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -711,7 +713,8 @@ func TestGCSDedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest = godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe2", manifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe2", manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -905,7 +908,8 @@ func TestGCSDeleteBlobsInUse(t *testing.T) {
 		manifestBuf, err := json.Marshal(manifest)
 		So(err, ShouldBeNil)
 
-		manifestDigest, _, err := imgStore.PutImageManifest("repo", tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+		manifestDigest, _, err := imgStore.PutImageManifest(
+			context.Background(), "repo", tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
 		Convey("Try to delete blob currently in use", func() {
@@ -928,7 +932,7 @@ func TestGCSDeleteBlobsInUse(t *testing.T) {
 		})
 
 		Convey("Delete manifest first, then blob", func() {
-			err := imgStore.DeleteImageManifest("repo", manifestDigest.String(), false)
+			err := imgStore.DeleteImageManifest(context.Background(), "repo", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			err = imgStore.DeleteBlob("repo", digest)
@@ -982,7 +986,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 		})
 
 		Convey("Initialize repo", func() {
-			err := imgStore.InitRepo(repoName)
+			err := imgStore.InitRepo(context.Background(), repoName)
 			So(err, ShouldBeNil)
 
 			ok := imgStore.DirExists(path.Join(imgStore.RootDir(), repoName))
@@ -1188,19 +1192,19 @@ func TestGCSStorageAPIs(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				Convey("Bad image manifest", func() {
-					_, _, err = imgStore.PutImageManifest("test", digest.String(), "application/json",
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(), "application/json",
 						manifestBuf, nil)
 					So(err, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(), ispec.MediaTypeImageManifest,
 						[]byte{}, nil)
 					So(err, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(), ispec.MediaTypeImageManifest,
 						[]byte(`{"test":true}`), nil)
 					So(err, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(), ispec.MediaTypeImageManifest,
 						manifestBuf, nil)
 					So(err, ShouldNotBeNil)
 
@@ -1250,20 +1254,25 @@ func TestGCSStorageAPIs(t *testing.T) {
 					badMb, err := json.Marshal(manifest)
 					So(err, ShouldBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, badMb, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0",
+						ispec.MediaTypeImageManifest, badMb, nil)
 					So(err, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(
+						context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					// same manifest for coverage
-					_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(
+						context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(
+						context.Background(), "test", "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", "3.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(
+						context.Background(), "test", "3.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					_, err = imgStore.GetImageTags("inexistent")
@@ -1280,7 +1289,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 					_, _, _, err = imgStore.GetImageManifest("test", "3.0")
 					So(err, ShouldBeNil)
 
-					err = imgStore.DeleteImageManifest("test", "1.0", false)
+					err = imgStore.DeleteImageManifest(context.Background(), "test", "1.0", false)
 					So(err, ShouldBeNil)
 
 					tags, err = imgStore.GetImageTags("test")
@@ -1313,11 +1322,11 @@ func TestGCSStorageAPIs(t *testing.T) {
 					So(hasBlob, ShouldEqual, true)
 
 					// with detectManifestCollision should get error
-					err = imgStore.DeleteImageManifest("test", digest.String(), true)
+					err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), true)
 					So(err, ShouldNotBeNil)
 
 					// If we pass reference all manifest with input reference should be deleted.
-					err = imgStore.DeleteImageManifest("test", digest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), false)
 					So(err, ShouldBeNil)
 
 					tags, err = imgStore.GetImageTags("test")
@@ -1433,11 +1442,11 @@ func TestGCSStorageAPIs(t *testing.T) {
 				})
 
 				Convey("Bad image manifest", func() {
-					_, _, err = imgStore.PutImageManifest("test", digest.String(),
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 						ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", digest.String(),
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 						ispec.MediaTypeImageManifest, []byte("bad json"), nil)
 					So(err, ShouldNotBeNil)
 
@@ -1474,12 +1483,13 @@ func TestGCSStorageAPIs(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					digest := godigest.FromBytes(manifestBuf)
-					_, _, err = imgStore.PutImageManifest("test", digest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 						ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					// same manifest for coverage
-					_, _, err = imgStore.PutImageManifest("test", digest.String(),
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 						ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -1499,13 +1509,13 @@ func TestGCSStorageAPIs(t *testing.T) {
 
 					So(len(index.Manifests), ShouldEqual, 1)
 
-					err = imgStore.DeleteImageManifest("test", "1.0", false)
+					err = imgStore.DeleteImageManifest(context.Background(), "test", "1.0", false)
 					So(err, ShouldNotBeNil)
 
-					err = imgStore.DeleteImageManifest("inexistent", "1.0", false)
+					err = imgStore.DeleteImageManifest(context.Background(), "inexistent", "1.0", false)
 					So(err, ShouldNotBeNil)
 
-					err = imgStore.DeleteImageManifest("test", digest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), false)
 					So(err, ShouldBeNil)
 
 					_, _, _, err = imgStore.GetImageManifest("test", digest.String())
@@ -1566,7 +1576,9 @@ func TestGCSStorageAPIs(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			digest = godigest.FromBytes(manifestBuf)
-			_, _, err = imgStore.PutImageManifest("replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+
+			_, _, err = imgStore.PutImageManifest(
+				context.Background(), "replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldBeNil)
 
 			_, _, _, err = imgStore.GetImageManifest("replace", digest.String())
@@ -1620,7 +1632,9 @@ func TestGCSStorageAPIs(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			_ = godigest.FromBytes(manifestBuf)
-			_, _, err = imgStore.PutImageManifest("replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+
+			_, _, err = imgStore.PutImageManifest(
+				context.Background(), "replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldBeNil)
 		})
 
@@ -1893,7 +1907,8 @@ func TestGCSMandatoryAnnotations(t *testing.T) {
 					},
 				}, storeDriver, cacheDriver, nil, nil)
 
-			_, _, err = imgStoreWithLinter.PutImageManifest("test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+			_, _, err = imgStoreWithLinter.PutImageManifest(
+				context.Background(), "test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -1913,7 +1928,8 @@ func TestGCSMandatoryAnnotations(t *testing.T) {
 					},
 				}, storeDriver, nil, nil, nil)
 
-			_, _, err = imgStoreWithLinter.PutImageManifest("test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+			_, _, err = imgStoreWithLinter.PutImageManifest(
+				context.Background(), "test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -1974,7 +1990,9 @@ func pushRandomImageIndexGCS(imgStore storageTypes.ImageStore, repoName string,
 
 		digest = godigest.FromBytes(content)
 		So(digest, ShouldNotBeNil)
-		_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+		_, _, err = imgStore.PutImageManifest(
+			context.Background(), repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -1991,7 +2009,8 @@ func pushRandomImageIndexGCS(imgStore storageTypes.ImageStore, repoName string,
 	indexDigest := godigest.FromBytes(indexContent)
 	So(indexDigest, ShouldNotBeNil)
 
-	_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+	_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+		ispec.MediaTypeImageIndex, indexContent, nil)
 	So(err, ShouldBeNil)
 
 	return bdgst, digest, indexDigest, int64(len(indexContent))
@@ -2109,7 +2128,8 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 
 		digest := godigest.FromBytes(manifestBuf)
 
-		_, _, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, tag,
+			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
 		// put artifact referencing above image
@@ -2149,7 +2169,8 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 		// push artifact manifest
-		_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2167,7 +2188,8 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		orphanArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 		// push orphan artifact manifest
-		_, _, err = imgStore.PutImageManifest(repoName, orphanArtifactManifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, orphanArtifactManifestDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2186,7 +2208,7 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		Convey("Garbage collect blobs after manifest is removed", func() {
-			err = imgStore.DeleteImageManifest(repoName, digest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, digest.String(), false)
 			So(err, ShouldBeNil)
 
 			err = garbageCollect.CleanRepo(ctx, repoName)
@@ -2314,7 +2336,8 @@ func TestGCSGarbageCollectImageIndex(t *testing.T) {
 		artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 		// push artifact manifest
-		_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2328,7 +2351,7 @@ func TestGCSGarbageCollectImageIndex(t *testing.T) {
 			err = garbageCollect.CleanRepo(ctx, repoName)
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest(repoName, indexDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, indexDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			err = garbageCollect.CleanRepo(ctx, repoName)
@@ -2489,7 +2512,9 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
-			_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+			_, _, err = imgStore.PutImageManifest(
+				context.Background(), repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -2524,7 +2549,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 			artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 			// push artifact manifest
-			_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 				ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 			So(err, ShouldBeNil)
 		}
@@ -2572,7 +2598,9 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 
 			digest := godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
-			_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+			_, _, err = imgStore.PutImageManifest(
+				context.Background(), repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			innerIndex.Manifests = append(innerIndex.Manifests, ispec.Descriptor{
@@ -2589,7 +2617,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		innerIndexDigest := godigest.FromBytes(innerIndexContent)
 		So(innerIndexDigest, ShouldNotBeNil)
 
-		_, _, err = imgStore.PutImageManifest(repoName, innerIndexDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, innerIndexDigest.String(),
 			ispec.MediaTypeImageIndex, innerIndexContent, nil)
 		So(err, ShouldBeNil)
 
@@ -2608,7 +2636,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		indexDigest := godigest.FromBytes(indexContent)
 		So(indexDigest, ShouldNotBeNil)
 
-		_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+			ispec.MediaTypeImageIndex, indexContent, nil)
 		So(err, ShouldBeNil)
 
 		artifactManifest := ispec.Manifest{
@@ -2636,7 +2665,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 		// push artifact manifest
-		_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2653,7 +2683,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		artifactManifestIndexDigest := godigest.FromBytes(artifactManifestIndexBuf)
 
 		// push artifact manifest referencing a manifest from index image
-		_, _, err = imgStore.PutImageManifest(repoName, artifactManifestIndexDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestIndexDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestIndexBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2670,7 +2701,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		artifactManifestInnerIndexDigest := godigest.FromBytes(artifactManifestInnerIndexBuf)
 
 		// push artifact manifest referencing a manifest from index image
-		_, _, err = imgStore.PutImageManifest(repoName, artifactManifestInnerIndexDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestInnerIndexDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestInnerIndexBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2687,7 +2719,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		artifactOfArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
-		_, _, err = imgStore.PutImageManifest(repoName, artifactOfArtifactManifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactOfArtifactManifestDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2705,7 +2738,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		orphanArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 		// push orphan artifact manifest
-		_, _, err = imgStore.PutImageManifest(repoName, orphanArtifactManifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, orphanArtifactManifestDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2740,7 +2774,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 			_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest(repoName, artifactDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, artifactDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			err = garbageCollect.CleanRepo(ctx, repoName)
@@ -2770,7 +2804,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 			_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest(repoName, indexDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, indexDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			err = garbageCollect.CleanRepo(ctx, repoName)
@@ -2849,7 +2883,7 @@ func RunGCSCheckAllBlobsIntegrityTests( //nolint: thelper
 ) {
 	Convey("Scrub only one repo", func() {
 		// initialize repo
-		err := imgStore.InitRepo(repoName)
+		err := imgStore.InitRepo(context.Background(), repoName)
 		So(err, ShouldBeNil)
 
 		ok := imgStore.DirExists(path.Join(imgStore.RootDir(), repoName))
@@ -3225,7 +3259,9 @@ func RunGCSCheckAllBlobsIntegrityTests( //nolint: thelper
 
 			indexBlob, err := json.Marshal(index)
 			So(err, ShouldBeNil)
-			indexDigest, _, err := imgStore.PutImageManifest(repoName, "", ispec.MediaTypeImageIndex, indexBlob, nil)
+
+			indexDigest, _, err := imgStore.PutImageManifest(
+				context.Background(), repoName, "", ispec.MediaTypeImageIndex, indexBlob, nil)
 			So(err, ShouldBeNil)
 
 			buff := bytes.NewBufferString("")

--- a/pkg/storage/gcs/gcs_test.go
+++ b/pkg/storage/gcs/gcs_test.go
@@ -463,7 +463,7 @@ func TestGCSDriver(t *testing.T) {
 
 		Convey("Init Repo", func() {
 			repoName := "test-repo-init"
-			err := imgStore.InitRepo(repoName)
+			err := imgStore.InitRepo(context.Background(), repoName)
 			So(err, ShouldBeNil)
 
 			isValid, err := imgStore.ValidateRepo(repoName)
@@ -502,7 +502,9 @@ func TestGCSDriver(t *testing.T) {
 			// Upload manifest
 			mblob, err := json.Marshal(image.Manifest)
 			So(err, ShouldBeNil)
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, mblob, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+				ispec.MediaTypeImageManifest, mblob, nil)
 			So(err, ShouldBeNil)
 
 			// Verify manifest
@@ -550,10 +552,12 @@ func TestGCSDriver(t *testing.T) {
 			// Upload manifest
 			mblob, err := json.Marshal(image.Manifest)
 			So(err, ShouldBeNil)
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, mblob, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+				ispec.MediaTypeImageManifest, mblob, nil)
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest(repoName, "1.0", false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, "1.0", false)
 			So(err, ShouldBeNil)
 
 			_, _, _, err = imgStore.GetImageManifest(repoName, "1.0")
@@ -647,7 +651,8 @@ func TestGCSDedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest := godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe1", manifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe1", manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -721,7 +726,8 @@ func TestGCSDedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest = godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe2", manifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe2", manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -915,7 +921,8 @@ func TestGCSDeleteBlobsInUse(t *testing.T) {
 		manifestBuf, err := json.Marshal(manifest)
 		So(err, ShouldBeNil)
 
-		manifestDigest, _, err := imgStore.PutImageManifest("repo", tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+		manifestDigest, _, err := imgStore.PutImageManifest(
+			context.Background(), "repo", tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
 		Convey("Try to delete blob currently in use", func() {
@@ -938,7 +945,7 @@ func TestGCSDeleteBlobsInUse(t *testing.T) {
 		})
 
 		Convey("Delete manifest first, then blob", func() {
-			err := imgStore.DeleteImageManifest("repo", manifestDigest.String(), false)
+			err := imgStore.DeleteImageManifest(context.Background(), "repo", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			err = imgStore.DeleteBlob("repo", digest)
@@ -992,7 +999,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 		})
 
 		Convey("Initialize repo", func() {
-			err := imgStore.InitRepo(repoName)
+			err := imgStore.InitRepo(context.Background(), repoName)
 			So(err, ShouldBeNil)
 
 			ok := imgStore.DirExists(path.Join(imgStore.RootDir(), repoName))
@@ -1198,19 +1205,19 @@ func TestGCSStorageAPIs(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				Convey("Bad image manifest", func() {
-					_, _, err = imgStore.PutImageManifest("test", digest.String(), "application/json",
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(), "application/json",
 						manifestBuf, nil)
 					So(err, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(), ispec.MediaTypeImageManifest,
 						[]byte{}, nil)
 					So(err, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(), ispec.MediaTypeImageManifest,
 						[]byte(`{"test":true}`), nil)
 					So(err, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(), ispec.MediaTypeImageManifest,
 						manifestBuf, nil)
 					So(err, ShouldNotBeNil)
 
@@ -1260,20 +1267,25 @@ func TestGCSStorageAPIs(t *testing.T) {
 					badMb, err := json.Marshal(manifest)
 					So(err, ShouldBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, badMb, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0",
+						ispec.MediaTypeImageManifest, badMb, nil)
 					So(err, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(
+						context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					// same manifest for coverage
-					_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(
+						context.Background(), "test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(
+						context.Background(), "test", "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", "3.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(
+						context.Background(), "test", "3.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					_, err = imgStore.GetImageTags("inexistent")
@@ -1290,7 +1302,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 					_, _, _, err = imgStore.GetImageManifest("test", "3.0")
 					So(err, ShouldBeNil)
 
-					err = imgStore.DeleteImageManifest("test", "1.0", false)
+					err = imgStore.DeleteImageManifest(context.Background(), "test", "1.0", false)
 					So(err, ShouldBeNil)
 
 					tags, err = imgStore.GetImageTags("test")
@@ -1323,11 +1335,11 @@ func TestGCSStorageAPIs(t *testing.T) {
 					So(hasBlob, ShouldEqual, true)
 
 					// with detectManifestCollision should get error
-					err = imgStore.DeleteImageManifest("test", digest.String(), true)
+					err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), true)
 					So(err, ShouldNotBeNil)
 
 					// If we pass reference all manifest with input reference should be deleted.
-					err = imgStore.DeleteImageManifest("test", digest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), false)
 					So(err, ShouldBeNil)
 
 					tags, err = imgStore.GetImageTags("test")
@@ -1443,11 +1455,11 @@ func TestGCSStorageAPIs(t *testing.T) {
 				})
 
 				Convey("Bad image manifest", func() {
-					_, _, err = imgStore.PutImageManifest("test", digest.String(),
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 						ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("test", digest.String(),
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 						ispec.MediaTypeImageManifest, []byte("bad json"), nil)
 					So(err, ShouldNotBeNil)
 
@@ -1484,12 +1496,13 @@ func TestGCSStorageAPIs(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					digest := godigest.FromBytes(manifestBuf)
-					_, _, err = imgStore.PutImageManifest("test", digest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 						ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					// same manifest for coverage
-					_, _, err = imgStore.PutImageManifest("test", digest.String(),
+					_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 						ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -1509,13 +1522,13 @@ func TestGCSStorageAPIs(t *testing.T) {
 
 					So(len(index.Manifests), ShouldEqual, 1)
 
-					err = imgStore.DeleteImageManifest("test", "1.0", false)
+					err = imgStore.DeleteImageManifest(context.Background(), "test", "1.0", false)
 					So(err, ShouldNotBeNil)
 
-					err = imgStore.DeleteImageManifest("inexistent", "1.0", false)
+					err = imgStore.DeleteImageManifest(context.Background(), "inexistent", "1.0", false)
 					So(err, ShouldNotBeNil)
 
-					err = imgStore.DeleteImageManifest("test", digest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), false)
 					So(err, ShouldBeNil)
 
 					_, _, _, err = imgStore.GetImageManifest("test", digest.String())
@@ -1576,7 +1589,9 @@ func TestGCSStorageAPIs(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			digest = godigest.FromBytes(manifestBuf)
-			_, _, err = imgStore.PutImageManifest("replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+
+			_, _, err = imgStore.PutImageManifest(
+				context.Background(), "replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldBeNil)
 
 			_, _, _, err = imgStore.GetImageManifest("replace", digest.String())
@@ -1630,7 +1645,9 @@ func TestGCSStorageAPIs(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			_ = godigest.FromBytes(manifestBuf)
-			_, _, err = imgStore.PutImageManifest("replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+
+			_, _, err = imgStore.PutImageManifest(
+				context.Background(), "replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldBeNil)
 		})
 
@@ -1904,7 +1921,8 @@ func TestGCSMandatoryAnnotations(t *testing.T) {
 					},
 				}, storeDriver, cacheDriver, nil, nil)
 
-			_, _, err = imgStoreWithLinter.PutImageManifest("test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+			_, _, err = imgStoreWithLinter.PutImageManifest(
+				context.Background(), "test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -1924,7 +1942,8 @@ func TestGCSMandatoryAnnotations(t *testing.T) {
 					},
 				}, storeDriver, nil, nil, nil)
 
-			_, _, err = imgStoreWithLinter.PutImageManifest("test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+			_, _, err = imgStoreWithLinter.PutImageManifest(
+				context.Background(), "test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldNotBeNil)
 		})
 	})
@@ -1985,7 +2004,9 @@ func pushRandomImageIndexGCS(imgStore storageTypes.ImageStore, repoName string,
 
 		digest = godigest.FromBytes(content)
 		So(digest, ShouldNotBeNil)
-		_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+		_, _, err = imgStore.PutImageManifest(
+			context.Background(), repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -2002,7 +2023,8 @@ func pushRandomImageIndexGCS(imgStore storageTypes.ImageStore, repoName string,
 	indexDigest := godigest.FromBytes(indexContent)
 	So(indexDigest, ShouldNotBeNil)
 
-	_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+	_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+		ispec.MediaTypeImageIndex, indexContent, nil)
 	So(err, ShouldBeNil)
 
 	return bdgst, digest, indexDigest, int64(len(indexContent))
@@ -2122,7 +2144,8 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 
 		digest := godigest.FromBytes(manifestBuf)
 
-		_, _, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, tag,
+			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
 		// put artifact referencing above image
@@ -2162,7 +2185,8 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 		// push artifact manifest
-		_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2180,7 +2204,8 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		orphanArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 		// push orphan artifact manifest
-		_, _, err = imgStore.PutImageManifest(repoName, orphanArtifactManifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, orphanArtifactManifestDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2199,7 +2224,7 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		Convey("Garbage collect blobs after manifest is removed", func() {
-			err = imgStore.DeleteImageManifest(repoName, digest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, digest.String(), false)
 			So(err, ShouldBeNil)
 
 			err = garbageCollect.CleanRepo(ctx, repoName)
@@ -2329,7 +2354,8 @@ func TestGCSGarbageCollectImageIndex(t *testing.T) {
 		artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 		// push artifact manifest
-		_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2343,7 +2369,7 @@ func TestGCSGarbageCollectImageIndex(t *testing.T) {
 			err = garbageCollect.CleanRepo(ctx, repoName)
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest(repoName, indexDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, indexDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			err = garbageCollect.CleanRepo(ctx, repoName)
@@ -2506,7 +2532,9 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
-			_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+			_, _, err = imgStore.PutImageManifest(
+				context.Background(), repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -2541,7 +2569,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 			artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 			// push artifact manifest
-			_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 				ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 			So(err, ShouldBeNil)
 		}
@@ -2589,7 +2618,9 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 
 			digest := godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
-			_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+			_, _, err = imgStore.PutImageManifest(
+				context.Background(), repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			innerIndex.Manifests = append(innerIndex.Manifests, ispec.Descriptor{
@@ -2606,7 +2637,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		innerIndexDigest := godigest.FromBytes(innerIndexContent)
 		So(innerIndexDigest, ShouldNotBeNil)
 
-		_, _, err = imgStore.PutImageManifest(repoName, innerIndexDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, innerIndexDigest.String(),
 			ispec.MediaTypeImageIndex, innerIndexContent, nil)
 		So(err, ShouldBeNil)
 
@@ -2625,7 +2656,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		indexDigest := godigest.FromBytes(indexContent)
 		So(indexDigest, ShouldNotBeNil)
 
-		_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+			ispec.MediaTypeImageIndex, indexContent, nil)
 		So(err, ShouldBeNil)
 
 		artifactManifest := ispec.Manifest{
@@ -2653,7 +2685,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 		// push artifact manifest
-		_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2670,7 +2703,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		artifactManifestIndexDigest := godigest.FromBytes(artifactManifestIndexBuf)
 
 		// push artifact manifest referencing a manifest from index image
-		_, _, err = imgStore.PutImageManifest(repoName, artifactManifestIndexDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestIndexDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestIndexBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2687,7 +2721,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		artifactManifestInnerIndexDigest := godigest.FromBytes(artifactManifestInnerIndexBuf)
 
 		// push artifact manifest referencing a manifest from index image
-		_, _, err = imgStore.PutImageManifest(repoName, artifactManifestInnerIndexDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestInnerIndexDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestInnerIndexBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2704,7 +2739,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		artifactOfArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
-		_, _, err = imgStore.PutImageManifest(repoName, artifactOfArtifactManifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactOfArtifactManifestDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2722,7 +2758,8 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		orphanArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 		// push orphan artifact manifest
-		_, _, err = imgStore.PutImageManifest(repoName, orphanArtifactManifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repoName, orphanArtifactManifestDigest.String(),
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2757,7 +2794,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 			_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest(repoName, artifactDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, artifactDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			err = garbageCollect.CleanRepo(ctx, repoName)
@@ -2787,7 +2824,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 			_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest(repoName, indexDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, indexDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			err = garbageCollect.CleanRepo(ctx, repoName)
@@ -2866,7 +2903,7 @@ func RunGCSCheckAllBlobsIntegrityTests( //nolint: thelper
 ) {
 	Convey("Scrub only one repo", func() {
 		// initialize repo
-		err := imgStore.InitRepo(repoName)
+		err := imgStore.InitRepo(context.Background(), repoName)
 		So(err, ShouldBeNil)
 
 		ok := imgStore.DirExists(path.Join(imgStore.RootDir(), repoName))
@@ -3242,7 +3279,9 @@ func RunGCSCheckAllBlobsIntegrityTests( //nolint: thelper
 
 			indexBlob, err := json.Marshal(index)
 			So(err, ShouldBeNil)
-			indexDigest, _, err := imgStore.PutImageManifest(repoName, "", ispec.MediaTypeImageIndex, indexBlob, nil)
+
+			indexDigest, _, err := imgStore.PutImageManifest(
+				context.Background(), repoName, "", ispec.MediaTypeImageIndex, indexBlob, nil)
 			So(err, ShouldBeNil)
 
 			buff := bytes.NewBufferString("")

--- a/pkg/storage/gcs/gcs_test.go
+++ b/pkg/storage/gcs/gcs_test.go
@@ -1168,7 +1168,8 @@ func TestGCSStorageAPIs(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(bupload, ShouldEqual, int64(firstChunkLen))
 
-				bupload, err = imgStore.PutBlobChunk(context.Background(), "test", upload, int64(firstChunkLen), int64(buflen), secondChunkBuf)
+				bupload, err = imgStore.PutBlobChunk(context.Background(), "test", upload,
+					int64(firstChunkLen), int64(buflen), secondChunkBuf)
 				So(err, ShouldBeNil)
 				So(bupload, ShouldEqual, int64(firstChunkLen+secondChunkLen))
 

--- a/pkg/storage/gcs/gcs_test.go
+++ b/pkg/storage/gcs/gcs_test.go
@@ -477,14 +477,14 @@ func TestGCSDriver(t *testing.T) {
 
 			// Upload layers
 			for _, content := range image.Layers {
-				upload, err := imgStore.NewBlobUpload(repoName)
+				upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 				So(err, ShouldBeNil)
 
 				buf := bytes.NewBuffer(content)
 				buflen := buf.Len()
 				digest := godigest.FromBytes(content)
 
-				blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+				blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 				So(err, ShouldBeNil)
 				So(blob, ShouldEqual, buflen)
 
@@ -496,7 +496,7 @@ func TestGCSDriver(t *testing.T) {
 			cblob, err := json.Marshal(image.Config)
 			So(err, ShouldBeNil)
 			cdigest := godigest.FromBytes(cblob)
-			_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewBuffer(cblob), cdigest)
+			_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewBuffer(cblob), cdigest)
 			So(err, ShouldBeNil)
 
 			// Upload manifest
@@ -527,14 +527,14 @@ func TestGCSDriver(t *testing.T) {
 
 			// Upload layers first (required for manifest validation)
 			for _, content := range image.Layers {
-				upload, err := imgStore.NewBlobUpload(repoName)
+				upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 				So(err, ShouldBeNil)
 
 				buf := bytes.NewBuffer(content)
 				buflen := buf.Len()
 				digest := godigest.FromBytes(content)
 
-				blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+				blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 				So(err, ShouldBeNil)
 				So(blob, ShouldEqual, buflen)
 
@@ -546,7 +546,7 @@ func TestGCSDriver(t *testing.T) {
 			cblob, err := json.Marshal(image.Config)
 			So(err, ShouldBeNil)
 			cdigest := godigest.FromBytes(cblob)
-			_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewBuffer(cblob), cdigest)
+			_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewBuffer(cblob), cdigest)
 			So(err, ShouldBeNil)
 
 			// Upload manifest
@@ -586,7 +586,7 @@ func TestGCSDedupe(t *testing.T) {
 		defer cleanupStorage(storeDriver, testDir)
 
 		// manifest1
-		upload, err := imgStore.NewBlobUpload("dedupe1")
+		upload, err := imgStore.NewBlobUpload(context.Background(), "dedupe1")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -594,7 +594,7 @@ func TestGCSDedupe(t *testing.T) {
 		buf := bytes.NewBuffer(content)
 		buflen := buf.Len()
 		digest := godigest.FromBytes(content)
-		blob, err := imgStore.PutBlobChunkStreamed("dedupe1", upload, buf)
+		blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "dedupe1", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -605,7 +605,7 @@ func TestGCSDedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		ok, checkBlobSize1, err := imgStore.CheckBlob("dedupe1", digest)
+		ok, checkBlobSize1, err := imgStore.CheckBlob(context.Background(), "dedupe1", digest)
 		So(ok, ShouldBeTrue)
 		So(checkBlobSize1, ShouldBeGreaterThan, 0)
 		So(err, ShouldBeNil)
@@ -623,11 +623,11 @@ func TestGCSDedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, clen, err := imgStore.FullBlobUpload("dedupe1", bytes.NewReader(cblob), cdigest)
+		_, clen, err := imgStore.FullBlobUpload(context.Background(), "dedupe1", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
-		hasBlob, _, err := imgStore.CheckBlob("dedupe1", cdigest)
+		hasBlob, _, err := imgStore.CheckBlob(context.Background(), "dedupe1", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -660,7 +660,7 @@ func TestGCSDedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// manifest2
-		upload, err = imgStore.NewBlobUpload("dedupe2")
+		upload, err = imgStore.NewBlobUpload(context.Background(), "dedupe2")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -669,7 +669,7 @@ func TestGCSDedupe(t *testing.T) {
 		buflen = buf.Len()
 		digest = godigest.FromBytes(content)
 
-		blob, err = imgStore.PutBlobChunkStreamed("dedupe2", upload, buf)
+		blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "dedupe2", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -680,7 +680,7 @@ func TestGCSDedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		ok, checkBlobSize2, err := imgStore.CheckBlob("dedupe2", digest)
+		ok, checkBlobSize2, err := imgStore.CheckBlob(context.Background(), "dedupe2", digest)
 		So(ok, ShouldBeTrue)
 		So(checkBlobSize2, ShouldBeGreaterThan, 0)
 		So(err, ShouldBeNil)
@@ -698,11 +698,11 @@ func TestGCSDedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cblob, cdigest = GetRandomImageConfig()
-		_, clen, err = imgStore.FullBlobUpload("dedupe2", bytes.NewReader(cblob), cdigest)
+		_, clen, err = imgStore.FullBlobUpload(context.Background(), "dedupe2", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
-		hasBlob, _, err = imgStore.CheckBlob("dedupe2", cdigest)
+		hasBlob, _, err = imgStore.CheckBlob(context.Background(), "dedupe2", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -758,7 +758,7 @@ func TestGCSPullRange(t *testing.T) {
 		So(err, ShouldBeNil)
 		defer cleanupStorage(storeDriver, testDir)
 
-		upload, err := imgStore.NewBlobUpload("test")
+		upload, err := imgStore.NewBlobUpload(context.Background(), "test")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -766,7 +766,7 @@ func TestGCSPullRange(t *testing.T) {
 		buf := bytes.NewBuffer(content)
 		buflen := buf.Len()
 		digest := godigest.FromBytes(content)
-		blob, err := imgStore.PutBlobChunkStreamed("test", upload, buf)
+		blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "test", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -880,7 +880,7 @@ func TestGCSDeleteBlobsInUse(t *testing.T) {
 		buf := bytes.NewBuffer(content)
 		unusedDigest := godigest.FromBytes(content)
 
-		_, _, err = imgStore.FullBlobUpload("repo", bytes.NewReader(buf.Bytes()), unusedDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), "repo", bytes.NewReader(buf.Bytes()), unusedDigest)
 		So(err, ShouldBeNil)
 
 		content = []byte("test-data1")
@@ -888,13 +888,13 @@ func TestGCSDeleteBlobsInUse(t *testing.T) {
 		buflen := buf.Len()
 		digest := godigest.FromBytes(content)
 
-		_, _, err = imgStore.FullBlobUpload("repo", bytes.NewReader(buf.Bytes()), digest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), "repo", bytes.NewReader(buf.Bytes()), digest)
 		So(err, ShouldBeNil)
 
 		cblob, cdigest := GetRandomImageConfig()
 
 		var clen int64
-		_, clen, err = imgStore.FullBlobUpload("repo", bytes.NewReader(cblob), cdigest)
+		_, clen, err = imgStore.FullBlobUpload(context.Background(), "repo", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
@@ -1040,7 +1040,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 			body := []byte("this blob will be hashed using an unavailable hashing algorithm")
 			buf := bytes.NewBuffer(body)
 			digest := godigest.Digest("md5:8114c3f59ef9dcf737410e0f4b00a154")
-			upload, n, err := imgStore.FullBlobUpload("test", buf, digest)
+			upload, n, err := imgStore.FullBlobUpload(context.Background(), "test", buf, digest)
 			So(err, ShouldEqual, godigest.ErrDigestUnsupported)
 			So(n, ShouldEqual, -1)
 			So(upload, ShouldEqual, "")
@@ -1056,7 +1056,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 			body := []byte("this is a blob")
 			buf := bytes.NewBuffer(body)
 			digest := godigest.FromBytes(body)
-			upload, n, err := imgStore.FullBlobUpload("test", buf, digest)
+			upload, n, err := imgStore.FullBlobUpload(context.Background(), "test", buf, digest)
 			So(err, ShouldBeNil)
 			So(n, ShouldEqual, len(body))
 			So(upload, ShouldNotBeEmpty)
@@ -1076,7 +1076,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 			body := []byte("this blob will be hashed using sha512")
 			buf := bytes.NewBuffer(body)
 			digest := godigest.SHA512.FromBytes(body)
-			upload, n, err := imgStore.FullBlobUpload("test", buf, digest)
+			upload, n, err := imgStore.FullBlobUpload(context.Background(), "test", buf, digest)
 			So(err, ShouldBeNil)
 			So(n, ShouldEqual, len(body))
 			So(upload, ShouldNotBeEmpty)
@@ -1095,7 +1095,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 			body := []byte("this blob will be hashed using sha384")
 			buf := bytes.NewBuffer(body)
 			digest := godigest.SHA384.FromBytes(body)
-			upload, n, err := imgStore.FullBlobUpload("test", buf, digest)
+			upload, n, err := imgStore.FullBlobUpload(context.Background(), "test", buf, digest)
 			So(err, ShouldBeNil)
 			So(n, ShouldEqual, len(body))
 			So(upload, ShouldNotBeEmpty)
@@ -1111,14 +1111,14 @@ func TestGCSStorageAPIs(t *testing.T) {
 		})
 
 		Convey("New blob upload", func() {
-			upload, err := imgStore.NewBlobUpload("test")
+			upload, err := imgStore.NewBlobUpload(context.Background(), "test")
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
 			err = imgStore.DeleteBlobUpload("test", upload)
 			So(err, ShouldBeNil)
 
-			upload, err = imgStore.NewBlobUpload("test")
+			upload, err = imgStore.NewBlobUpload(context.Background(), "test")
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -1153,10 +1153,10 @@ func TestGCSStorageAPIs(t *testing.T) {
 				blobDigest := digest
 
 				// invalid chunk range
-				_, err = imgStore.PutBlobChunk("test", upload, 10, int64(buflen), buf)
+				_, err = imgStore.PutBlobChunk(context.Background(), "test", upload, 10, int64(buflen), buf)
 				So(err, ShouldNotBeNil)
 
-				bupload, err = imgStore.PutBlobChunk("test", upload, 0, int64(firstChunkLen), firstChunkBuf)
+				bupload, err = imgStore.PutBlobChunk(context.Background(), "test", upload, 0, int64(firstChunkLen), firstChunkBuf)
 				So(err, ShouldBeNil)
 				So(bupload, ShouldEqual, firstChunkLen)
 
@@ -1168,14 +1168,14 @@ func TestGCSStorageAPIs(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(bupload, ShouldEqual, int64(firstChunkLen))
 
-				bupload, err = imgStore.PutBlobChunk("test", upload, int64(firstChunkLen), int64(buflen), secondChunkBuf)
+				bupload, err = imgStore.PutBlobChunk(context.Background(), "test", upload, int64(firstChunkLen), int64(buflen), secondChunkBuf)
 				So(err, ShouldBeNil)
 				So(bupload, ShouldEqual, int64(firstChunkLen+secondChunkLen))
 
 				err = imgStore.FinishBlobUpload("test", upload, buf, digest)
 				So(err, ShouldBeNil)
 
-				_, _, err = imgStore.CheckBlob("test", digest)
+				_, _, err = imgStore.CheckBlob(context.Background(), "test", digest)
 				So(err, ShouldBeNil)
 
 				ok, _, _, err := imgStore.StatBlob("test", digest)
@@ -1230,11 +1230,11 @@ func TestGCSStorageAPIs(t *testing.T) {
 
 				Convey("Good image manifest", func() {
 					cblob, cdigest := GetRandomImageConfig()
-					_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest)
+					_, clen, err := imgStore.FullBlobUpload(context.Background(), "test", bytes.NewReader(cblob), cdigest)
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
 
-					hasBlob, _, err := imgStore.CheckBlob("test", cdigest)
+					hasBlob, _, err := imgStore.CheckBlob(context.Background(), "test", cdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -1330,7 +1330,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 					So(len(repos), ShouldEqual, 0)
 
 					// We deleted only one tag, make sure blob should not be removed.
-					hasBlob, _, err = imgStore.CheckBlob("test", digest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), "test", digest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -1347,7 +1347,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 					So(len(tags), ShouldEqual, 0)
 
 					// All tags/references are deleted, blob should not be present in disk.
-					hasBlob, _, err = imgStore.CheckBlob("test", digest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), "test", digest)
 					So(err, ShouldNotBeNil)
 					So(hasBlob, ShouldEqual, false)
 
@@ -1374,7 +1374,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 		})
 
 		Convey("New blob upload streamed", func() {
-			bupload, err := imgStore.NewBlobUpload("test")
+			bupload, err := imgStore.NewBlobUpload(context.Background(), "test")
 			So(err, ShouldBeNil)
 			So(bupload, ShouldNotBeEmpty)
 
@@ -1398,11 +1398,11 @@ func TestGCSStorageAPIs(t *testing.T) {
 				buf := bytes.NewBuffer(content)
 				buflen := buf.Len()
 				digest := godigest.FromBytes(content)
-				upload, err = imgStore.PutBlobChunkStreamed("test", bupload, buf)
+				upload, err = imgStore.PutBlobChunkStreamed(context.Background(), "test", bupload, buf)
 				So(err, ShouldBeNil)
 				So(upload, ShouldEqual, buflen)
 
-				_, err = imgStore.PutBlobChunkStreamed("test", "inexistent", buf)
+				_, err = imgStore.PutBlobChunkStreamed(context.Background(), "test", "inexistent", buf)
 				So(err, ShouldNotBeNil)
 
 				err = imgStore.FinishBlobUpload("test", "inexistent", buf, digest)
@@ -1415,7 +1415,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 				err = imgStore.FinishBlobUpload("test", bupload, buf, digest)
 				So(err, ShouldBeNil)
 
-				ok, _, err := imgStore.CheckBlob("test", digest)
+				ok, _, err := imgStore.CheckBlob(context.Background(), "test", digest)
 				So(ok, ShouldBeTrue)
 				So(err, ShouldBeNil)
 
@@ -1444,10 +1444,10 @@ func TestGCSStorageAPIs(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				Convey("Bad digests", func() {
-					_, _, err := imgStore.FullBlobUpload("test", bytes.NewBuffer([]byte{}), "inexistent")
+					_, _, err := imgStore.FullBlobUpload(context.Background(), "test", bytes.NewBuffer([]byte{}), "inexistent")
 					So(err, ShouldNotBeNil)
 
-					_, _, err = imgStore.CheckBlob("test", "inexistent")
+					_, _, err = imgStore.CheckBlob(context.Background(), "test", "inexistent")
 					So(err, ShouldNotBeNil)
 
 					_, _, _, err = imgStore.StatBlob("test", "inexistent")
@@ -1469,11 +1469,11 @@ func TestGCSStorageAPIs(t *testing.T) {
 
 				Convey("Good image manifest", func() {
 					cblob, cdigest := GetRandomImageConfig()
-					_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest)
+					_, clen, err := imgStore.FullBlobUpload(context.Background(), "test", bytes.NewReader(cblob), cdigest)
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
 
-					hasBlob, _, err := imgStore.CheckBlob("test", cdigest)
+					hasBlob, _, err := imgStore.CheckBlob(context.Background(), "test", cdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -1542,7 +1542,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 
 		Convey("Modify manifest in-place", func() {
 			// original blob
-			upload, err := imgStore.NewBlobUpload("replace")
+			upload, err := imgStore.NewBlobUpload(context.Background(), "replace")
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -1550,7 +1550,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 			buf := bytes.NewBuffer(content)
 			buflen := buf.Len()
 			digest := godigest.FromBytes(content)
-			blob, err := imgStore.PutBlobChunkStreamed("replace", upload, buf)
+			blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "replace", upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -1562,11 +1562,11 @@ func TestGCSStorageAPIs(t *testing.T) {
 			So(blob, ShouldEqual, buflen)
 
 			cblob, cdigest := GetRandomImageConfig()
-			_, clen, err := imgStore.FullBlobUpload("replace", bytes.NewReader(cblob), cdigest)
+			_, clen, err := imgStore.FullBlobUpload(context.Background(), "replace", bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
 
-			hasBlob, _, err := imgStore.CheckBlob("replace", cdigest)
+			hasBlob, _, err := imgStore.CheckBlob(context.Background(), "replace", cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1598,7 +1598,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// new blob to replace
-			upload, err = imgStore.NewBlobUpload("replace")
+			upload, err = imgStore.NewBlobUpload(context.Background(), "replace")
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -1606,7 +1606,7 @@ func TestGCSStorageAPIs(t *testing.T) {
 			buf = bytes.NewBuffer(content)
 			buflen = buf.Len()
 			digest = godigest.FromBytes(content)
-			blob, err = imgStore.PutBlobChunkStreamed("replace", upload, buf)
+			blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "replace", upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -1618,11 +1618,11 @@ func TestGCSStorageAPIs(t *testing.T) {
 			So(blob, ShouldEqual, buflen)
 
 			cblob, cdigest = GetRandomImageConfig()
-			_, clen, err = imgStore.FullBlobUpload("replace", bytes.NewReader(cblob), cdigest)
+			_, clen, err = imgStore.FullBlobUpload(context.Background(), "replace", bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
 
-			hasBlob, _, err = imgStore.CheckBlob("replace", cdigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), "replace", cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1724,7 +1724,7 @@ func TestGCSReuploadCorruptedBlob(t *testing.T) {
 		blobSize := len(blob)
 		blobPath := imgStore.BlobPath(repoName, blobDigest)
 
-		ok, size, err := imgStore.CheckBlob(repoName, blobDigest)
+		ok, size, err := imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 		So(ok, ShouldBeTrue)
 		So(size, ShouldEqual, blobSize)
 		So(err, ShouldBeNil)
@@ -1732,7 +1732,7 @@ func TestGCSReuploadCorruptedBlob(t *testing.T) {
 		_, err = gcsDriver.WriteFile(blobPath, []byte("corrupted"))
 		So(err, ShouldBeNil)
 
-		ok, size, err = imgStore.CheckBlob(repoName, blobDigest)
+		ok, size, err = imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 		So(ok, ShouldBeFalse)
 		So(size, ShouldNotEqual, blobSize)
 		So(err, ShouldEqual, zerr.ErrBlobNotFound)
@@ -1745,7 +1745,7 @@ func TestGCSReuploadCorruptedBlob(t *testing.T) {
 		So(blobSize, ShouldEqual, size)
 		So(err, ShouldBeNil)
 
-		ok, size, err = imgStore.CheckBlob(repoName, blobDigest)
+		ok, size, err = imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 		So(ok, ShouldBeTrue)
 		So(size, ShouldEqual, blobSize)
 		So(err, ShouldBeNil)
@@ -1766,7 +1766,7 @@ func TestGCSReuploadCorruptedBlob(t *testing.T) {
 		blobSize := len(blob)
 		blobPath := imgStore.BlobPath(repoName, blobDigest)
 
-		ok, size, err := imgStore.CheckBlob(repoName, blobDigest)
+		ok, size, err := imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 		So(ok, ShouldBeTrue)
 		So(size, ShouldEqual, blobSize)
 		So(err, ShouldBeNil)
@@ -1774,7 +1774,7 @@ func TestGCSReuploadCorruptedBlob(t *testing.T) {
 		_, err = gcsDriver.WriteFile(blobPath, []byte("corrupted"))
 		So(err, ShouldBeNil)
 
-		ok, size, err = imgStore.CheckBlob(repoName, blobDigest)
+		ok, size, err = imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 		So(ok, ShouldBeFalse)
 		So(size, ShouldNotEqual, blobSize)
 		So(err, ShouldEqual, zerr.ErrBlobNotFound)
@@ -1787,7 +1787,7 @@ func TestGCSReuploadCorruptedBlob(t *testing.T) {
 		So(blobSize, ShouldEqual, size)
 		So(err, ShouldBeNil)
 
-		ok, size, err = imgStore.CheckBlob(repoName, blobDigest)
+		ok, size, err = imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 		So(ok, ShouldBeTrue)
 		So(size, ShouldEqual, blobSize)
 		So(err, ShouldBeNil)
@@ -1873,13 +1873,13 @@ func TestGCSMandatoryAnnotations(t *testing.T) {
 		buflen := buf.Len()
 		digest := godigest.FromBytes(content)
 
-		_, _, err = imgStore.FullBlobUpload("test", bytes.NewReader(buf.Bytes()), digest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), "test", bytes.NewReader(buf.Bytes()), digest)
 		So(err, ShouldBeNil)
 
 		cblob, cdigest := GetRandomImageConfig()
 
 		var clen int64
-		_, clen, err = imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest)
+		_, clen, err = imgStore.FullBlobUpload(context.Background(), "test", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
@@ -1956,7 +1956,7 @@ func pushRandomImageIndexGCS(imgStore storageTypes.ImageStore, repoName string,
 	bdgst := godigest.FromBytes(content)
 	So(bdgst, ShouldNotBeNil)
 
-	_, bsize, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(content), bdgst)
+	_, bsize, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(content), bdgst)
 	So(err, ShouldBeNil)
 	So(bsize, ShouldEqual, len(content))
 
@@ -1968,14 +1968,14 @@ func pushRandomImageIndexGCS(imgStore storageTypes.ImageStore, repoName string,
 
 	for range 4 {
 		// upload image config blob
-		upload, err := imgStore.NewBlobUpload(repoName)
+		upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
 		cblob, cdigest := GetRandomImageConfig()
 		buf := bytes.NewBuffer(cblob)
 		buflen := buf.Len()
-		blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+		blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -2074,7 +2074,7 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		}, audit, testLog, metrics)
 
 		// upload orphan blob
-		upload, err := imgStore.NewBlobUpload(repoName)
+		upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -2083,7 +2083,7 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		buflen := buf.Len()
 		odigest := godigest.FromBytes(content)
 
-		blob, err := imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+		blob, err := imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -2094,7 +2094,7 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		time.Sleep(1 * time.Second)
 
 		// upload blob
-		upload, err = imgStore.NewBlobUpload(repoName)
+		upload, err = imgStore.NewBlobUpload(context.Background(), repoName)
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -2103,7 +2103,7 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		buflen = buf.Len()
 		bdigest := godigest.FromBytes(content)
 
-		blob, err = imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+		blob, err = imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -2114,11 +2114,11 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		annotationsMap[ispec.AnnotationRefName] = tag
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
+		_, clen, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
-		hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest)
+		hasBlob, _, err := imgStore.CheckBlob(context.Background(), repoName, cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -2153,11 +2153,11 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 		// push layer
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
 		So(err, ShouldBeNil)
 
 		// push config
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
 			ispec.DescriptorEmptyJSON.Digest)
 		So(err, ShouldBeNil)
 
@@ -2212,11 +2212,11 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 		err = garbageCollect.CleanRepo(ctx, repoName)
 		So(err, ShouldBeNil)
 
-		hasBlob, _, err = imgStore.CheckBlob(repoName, odigest)
+		hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, odigest)
 		So(err, ShouldNotBeNil)
 		So(hasBlob, ShouldEqual, false)
 
-		hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
+		hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -2230,11 +2230,11 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 			err = garbageCollect.CleanRepo(ctx, repoName)
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
@@ -2297,7 +2297,7 @@ func TestGCSGarbageCollectImageIndex(t *testing.T) {
 		}, audit, testLog, metrics)
 
 		// upload orphan blob
-		upload, err := imgStore.NewBlobUpload(repoName)
+		upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -2306,7 +2306,7 @@ func TestGCSGarbageCollectImageIndex(t *testing.T) {
 		buflen := buf.Len()
 		odigest := godigest.FromBytes(content)
 
-		blob, err := imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+		blob, err := imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -2320,11 +2320,11 @@ func TestGCSGarbageCollectImageIndex(t *testing.T) {
 		artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 		// push layer
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
 		So(err, ShouldBeNil)
 
 		// push config
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
 			ispec.DescriptorEmptyJSON.Digest)
 		So(err, ShouldBeNil)
 
@@ -2359,7 +2359,7 @@ func TestGCSGarbageCollectImageIndex(t *testing.T) {
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
-		hasBlob, _, err := imgStore.CheckBlob(repoName, bdgst)
+		hasBlob, _, err := imgStore.CheckBlob(context.Background(), repoName, bdgst)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -2379,16 +2379,16 @@ func TestGCSGarbageCollectImageIndex(t *testing.T) {
 			So(err, ShouldNotBeNil)
 
 			// orphan blob
-			hasBlob, _, err = imgStore.CheckBlob(repoName, odigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, odigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, bdgst)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdgst)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
 			// check last manifest from index image
-			hasBlob, _, err = imgStore.CheckBlob(repoName, digest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, digest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
@@ -2396,7 +2396,7 @@ func TestGCSGarbageCollectImageIndex(t *testing.T) {
 			_, _, _, err := imgStore.GetImageManifest(repoName, artifactDigest.String())
 			So(err, ShouldNotBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
@@ -2452,7 +2452,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		}, audit, testLog, metrics)
 
 		// upload orphan blob
-		upload, err := imgStore.NewBlobUpload(repoName)
+		upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -2461,7 +2461,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		buflen := buf.Len()
 		odigest := godigest.FromBytes(content)
 
-		blob, err := imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+		blob, err := imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -2472,7 +2472,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		bdgst := godigest.FromBytes(content)
 		So(bdgst, ShouldNotBeNil)
 
-		_, bsize, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(content), bdgst)
+		_, bsize, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(content), bdgst)
 		So(err, ShouldBeNil)
 		So(bsize, ShouldEqual, len(content))
 
@@ -2480,11 +2480,11 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 		// push layer
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
 		So(err, ShouldBeNil)
 
 		// push config
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
 			ispec.DescriptorEmptyJSON.Digest)
 		So(err, ShouldBeNil)
 
@@ -2496,14 +2496,14 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 
 		for range 4 {
 			// upload image config blob
-			upload, err := imgStore.NewBlobUpload(repoName)
+			upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
 			cblob, cdigest := GetRandomImageConfig()
 			buf := bytes.NewBuffer(cblob)
 			buflen := buf.Len()
-			blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+			blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -2582,14 +2582,14 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 
 		for range 3 {
 			// upload image config blob
-			upload, err := imgStore.NewBlobUpload(repoName)
+			upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
 			cblob, cdigest := GetRandomImageConfig()
 			buf := bytes.NewBuffer(cblob)
 			buflen := buf.Len()
-			blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+			blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -2763,7 +2763,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 			ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 		So(err, ShouldBeNil)
 
-		hasBlob, _, err := imgStore.CheckBlob(repoName, bdgst)
+		hasBlob, _, err := imgStore.CheckBlob(context.Background(), repoName, bdgst)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -2771,7 +2771,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
-		hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+		hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -2837,7 +2837,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 			So(err, ShouldNotBeNil)
 
 			// orphan blob
-			hasBlob, _, err = imgStore.CheckBlob(repoName, odigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, odigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
@@ -2854,18 +2854,18 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 			So(err, ShouldNotBeNil)
 
 			// check last manifest from index image
-			hasBlob, _, err = imgStore.CheckBlob(repoName, digest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, digest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
 			_, _, _, err = imgStore.GetImageManifest(repoName, artifactManifestIndexDigest.String())
 			So(err, ShouldNotBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, bdgst)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdgst)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -131,7 +131,7 @@ func (is *ImageStore) Unlock(lockStart *time.Time) {
 	monitoring.ObserveStorageLockLatency(is.metrics, latency, is.RootDir(), storageConstants.RWLOCK) // histogram
 }
 
-func (is *ImageStore) initRepo(name string) error {
+func (is *ImageStore) initRepo(ctx context.Context, name string) error {
 	repoDir := path.Join(is.rootDir, name)
 
 	if !utf8.ValidString(name) {
@@ -200,7 +200,7 @@ func (is *ImageStore) initRepo(name string) error {
 		}
 
 		if is.events != nil {
-			is.events.RepositoryCreated(name)
+			is.events.RepositoryCreated(name, events.EventContextFromContext(ctx))
 		}
 	}
 
@@ -208,13 +208,13 @@ func (is *ImageStore) initRepo(name string) error {
 }
 
 // InitRepo creates an image repository under this store.
-func (is *ImageStore) InitRepo(name string) error {
+func (is *ImageStore) InitRepo(ctx context.Context, name string) error {
 	var lockLatency time.Time
 
 	is.Lock(&lockLatency)
 	defer is.Unlock(&lockLatency)
 
-	return is.initRepo(name)
+	return is.initRepo(ctx, name)
 }
 
 // ValidateRepo validates that the repository layout is complaint with the OCI repo layout.
@@ -539,10 +539,10 @@ func (is *ImageStore) GetImageManifest(repo, reference string) ([]byte, godigest
 // When extraTags is non-empty, the reference must be a digest; each entry becomes an
 // org.opencontainers.image.ref.name on a separate index descriptor (distribution-spec
 // digest push with tag query params).
-func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //nolint: gocyclo,cyclop
+func (is *ImageStore) PutImageManifest(ctx context.Context, repo, reference, mediaType string, //nolint: gocyclo,cyclop
 	body []byte, extraTags []string,
 ) (godigest.Digest, godigest.Digest, error) {
-	if err := is.InitRepo(repo); err != nil {
+	if err := is.InitRepo(ctx, repo); err != nil {
 		is.log.Debug().Err(err).Msg("init repo")
 
 		return "", "", err
@@ -648,8 +648,8 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 	}
 
 	var (
-		lintDesc        ispec.Descriptor
-		commitEventRefs []string
+		lintDesc    ispec.Descriptor
+		changedTags []string
 	)
 
 	if len(extraTags) > 0 {
@@ -667,7 +667,7 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 
 		anyIndexChange := false
 
-		changedTags := make([]string, 0, len(extraTags))
+		changedTags = make([]string, 0, len(extraTags))
 
 		var (
 			updateIndex bool
@@ -716,8 +716,6 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 				ispec.AnnotationRefName: changedTags[0],
 			},
 		}
-
-		commitEventRefs = changedTags
 	} else {
 		updateIndex, oldDgst, err := common.CheckIfIndexNeedsUpdate(&index, &desc, is.log)
 		if err != nil {
@@ -753,7 +751,6 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 		desc.ArtifactType = artifactType
 
 		lintDesc = desc
-		commitEventRefs = []string{reference}
 	}
 
 	pass, err := common.ApplyLinter(is, is.linter, repo, lintDesc)
@@ -762,7 +759,14 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 			Msg("linter didn't pass")
 
 		if is.events != nil {
-			is.events.ImageLintFailed(repo, reference, mDigest.String(), mediaType, string(body))
+			evCtx := events.EventContextFromContext(ctx)
+			if len(changedTags) > 0 {
+				for _, tag := range changedTags {
+					is.events.ImageLintFailed(repo, tag, mDigest.String(), mediaType, string(body), evCtx)
+				}
+			} else {
+				is.events.ImageLintFailed(repo, reference, mDigest.String(), mediaType, string(body), evCtx)
+			}
 		}
 
 		return "", "", err
@@ -773,8 +777,13 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 	}
 
 	if is.events != nil {
-		for _, ref := range commitEventRefs {
-			is.events.ImageUpdated(repo, ref, mDigest.String(), mediaType, string(body))
+		evCtx := events.EventContextFromContext(ctx)
+		if len(changedTags) > 0 {
+			for _, tag := range changedTags {
+				is.events.ImageUpdated(repo, tag, mDigest.String(), mediaType, string(body), evCtx)
+			}
+		} else {
+			is.events.ImageUpdated(repo, reference, mDigest.String(), mediaType, string(body), evCtx)
 		}
 	}
 
@@ -782,7 +791,7 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 }
 
 // DeleteImageManifest deletes the image manifest from the repository.
-func (is *ImageStore) DeleteImageManifest(repo, reference string, detectCollisions bool) error {
+func (is *ImageStore) DeleteImageManifest(ctx context.Context, repo, reference string, detectCollisions bool) error {
 	dir := path.Join(is.rootDir, repo)
 	if fi, err := is.storeDriver.Stat(dir); err != nil || !fi.IsDir() {
 		return zerr.ErrRepoNotFound
@@ -793,7 +802,7 @@ func (is *ImageStore) DeleteImageManifest(repo, reference string, detectCollisio
 	is.Lock(&lockLatency)
 	defer is.Unlock(&lockLatency)
 
-	err := is.deleteImageManifest(repo, reference, detectCollisions)
+	err := is.deleteImageManifest(ctx, repo, reference, detectCollisions)
 	if err != nil {
 		return err
 	}
@@ -801,7 +810,7 @@ func (is *ImageStore) DeleteImageManifest(repo, reference string, detectCollisio
 	return nil
 }
 
-func (is *ImageStore) deleteImageManifest(repo, reference string, detectCollisions bool) error {
+func (is *ImageStore) deleteImageManifest(ctx context.Context, repo, reference string, detectCollisions bool) error {
 	defer func() {
 		if is.storeDriver.Name() == storageConstants.LocalStorageDriverName {
 			monitoring.SetStorageUsage(is.metrics, is.rootDir, repo)
@@ -876,7 +885,8 @@ func (is *ImageStore) deleteImageManifest(repo, reference string, detectCollisio
 	}
 
 	if is.events != nil {
-		is.events.ImageDeleted(repo, reference, manifestDesc.Digest.String(), manifestDesc.MediaType)
+		is.events.ImageDeleted(repo, reference, manifestDesc.Digest.String(), manifestDesc.MediaType,
+			events.EventContextFromContext(ctx))
 	}
 
 	return nil
@@ -928,7 +938,7 @@ func (is *ImageStore) StatBlobUpload(repo, uuid string) (bool, int64, time.Time,
 
 // NewBlobUpload returns the unique ID for an upload in progress.
 func (is *ImageStore) NewBlobUpload(repo string) (string, error) {
-	if err := is.InitRepo(repo); err != nil {
+	if err := is.InitRepo(context.Background(), repo); err != nil {
 		is.log.Error().Err(err).Msg("failed to initialize repo")
 
 		return "", err
@@ -983,7 +993,7 @@ func (is *ImageStore) GetBlobUpload(repo, uuid string) (int64, error) {
 // PutBlobChunkStreamed appends another chunk of data to the specified blob. It returns
 // the number of actual bytes to the blob.
 func (is *ImageStore) PutBlobChunkStreamed(repo, uuid string, body io.Reader) (int64, error) {
-	if err := is.InitRepo(repo); err != nil {
+	if err := is.InitRepo(context.Background(), repo); err != nil {
 		return -1, err
 	}
 
@@ -1016,7 +1026,7 @@ func (is *ImageStore) PutBlobChunkStreamed(repo, uuid string, body io.Reader) (i
 func (is *ImageStore) PutBlobChunk(repo, uuid string, from, to int64,
 	body io.Reader,
 ) (int64, error) {
-	if err := is.InitRepo(repo); err != nil {
+	if err := is.InitRepo(context.Background(), repo); err != nil {
 		return -1, err
 	}
 
@@ -1151,7 +1161,7 @@ func (is *ImageStore) FullBlobUpload(repo string, body io.Reader, dstDigest godi
 		return "", -1, err
 	}
 
-	if err := is.InitRepo(repo); err != nil {
+	if err := is.InitRepo(context.Background(), repo); err != nil {
 		return "", -1, err
 	}
 
@@ -1527,7 +1537,7 @@ func (is *ImageStore) checkCacheBlob(digest godigest.Digest) (string, error) {
 }
 
 func (is *ImageStore) copyBlob(repo string, blobPath, dstRecord string) (int64, error) {
-	if err := is.initRepo(repo); err != nil {
+	if err := is.initRepo(context.Background(), repo); err != nil {
 		is.log.Error().Err(err).Str("repository", repo).Msg("failed to initialize an empty repo")
 
 		return -1, err
@@ -1831,7 +1841,7 @@ func (is *ImageStore) CleanupRepo(repo string, blobs []godigest.Digest, removeRe
 
 		if err := is.deleteBlob(repo, digest); err != nil {
 			if errors.Is(err, zerr.ErrBlobReferenced) {
-				if err := is.deleteImageManifest(repo, digest.String(), true); err != nil {
+				if err := is.deleteImageManifest(context.Background(), repo, digest.String(), true); err != nil {
 					if errors.Is(err, zerr.ErrManifestConflict) || errors.Is(err, zerr.ErrManifestReferenced) {
 						continue
 					}

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -132,7 +132,7 @@ func (is *ImageStore) Unlock(lockStart *time.Time) {
 	monitoring.ObserveStorageLockLatency(is.metrics, latency, is.RootDir(), storageConstants.RWLOCK) // histogram
 }
 
-func (is *ImageStore) initRepo(name string) error {
+func (is *ImageStore) initRepo(ctx context.Context, name string) error {
 	repoDir := path.Join(is.rootDir, name)
 
 	if !utf8.ValidString(name) {
@@ -201,7 +201,7 @@ func (is *ImageStore) initRepo(name string) error {
 		}
 
 		if is.events != nil {
-			is.events.RepositoryCreated(name)
+			is.events.RepositoryCreated(name, events.EventContextFromContext(ctx))
 		}
 	}
 
@@ -209,13 +209,13 @@ func (is *ImageStore) initRepo(name string) error {
 }
 
 // InitRepo creates an image repository under this store.
-func (is *ImageStore) InitRepo(name string) error {
+func (is *ImageStore) InitRepo(ctx context.Context, name string) error {
 	var lockLatency time.Time
 
 	is.Lock(&lockLatency)
 	defer is.Unlock(&lockLatency)
 
-	return is.initRepo(name)
+	return is.initRepo(ctx, name)
 }
 
 // ValidateRepo validates that the repository layout is complaint with the OCI repo layout.
@@ -540,10 +540,10 @@ func (is *ImageStore) GetImageManifest(repo, reference string) ([]byte, godigest
 // When extraTags is non-empty, the reference must be a digest; each entry becomes an
 // org.opencontainers.image.ref.name on a separate index descriptor (distribution-spec
 // digest push with tag query params).
-func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //nolint: gocyclo,cyclop
+func (is *ImageStore) PutImageManifest(ctx context.Context, repo, reference, mediaType string, //nolint: gocyclo,cyclop
 	body []byte, extraTags []string,
 ) (godigest.Digest, godigest.Digest, error) {
-	if err := is.InitRepo(repo); err != nil {
+	if err := is.InitRepo(ctx, repo); err != nil {
 		is.log.Debug().Err(err).Msg("init repo")
 
 		return "", "", err
@@ -649,8 +649,8 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 	}
 
 	var (
-		lintDesc        ispec.Descriptor
-		commitEventRefs []string
+		lintDesc    ispec.Descriptor
+		changedTags []string
 	)
 
 	if len(extraTags) > 0 {
@@ -668,7 +668,7 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 
 		anyIndexChange := false
 
-		changedTags := make([]string, 0, len(extraTags))
+		changedTags = make([]string, 0, len(extraTags))
 
 		var (
 			updateIndex bool
@@ -717,8 +717,6 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 				ispec.AnnotationRefName: changedTags[0],
 			},
 		}
-
-		commitEventRefs = changedTags
 	} else {
 		updateIndex, oldDgst, err := common.CheckIfIndexNeedsUpdate(&index, &desc, is.log)
 		if err != nil {
@@ -754,7 +752,6 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 		desc.ArtifactType = artifactType
 
 		lintDesc = desc
-		commitEventRefs = []string{reference}
 	}
 
 	pass, err := common.ApplyLinter(is, is.linter, repo, lintDesc)
@@ -763,7 +760,14 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 			Msg("linter didn't pass")
 
 		if is.events != nil {
-			is.events.ImageLintFailed(repo, reference, mDigest.String(), mediaType, string(body))
+			evCtx := events.EventContextFromContext(ctx)
+			if len(changedTags) > 0 {
+				for _, tag := range changedTags {
+					is.events.ImageLintFailed(repo, tag, mDigest.String(), mediaType, string(body), evCtx)
+				}
+			} else {
+				is.events.ImageLintFailed(repo, reference, mDigest.String(), mediaType, string(body), evCtx)
+			}
 		}
 
 		return "", "", err
@@ -774,8 +778,13 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 	}
 
 	if is.events != nil {
-		for _, ref := range commitEventRefs {
-			is.events.ImageUpdated(repo, ref, mDigest.String(), mediaType, string(body))
+		evCtx := events.EventContextFromContext(ctx)
+		if len(changedTags) > 0 {
+			for _, tag := range changedTags {
+				is.events.ImageUpdated(repo, tag, mDigest.String(), mediaType, string(body), evCtx)
+			}
+		} else {
+			is.events.ImageUpdated(repo, reference, mDigest.String(), mediaType, string(body), evCtx)
 		}
 	}
 
@@ -783,7 +792,7 @@ func (is *ImageStore) PutImageManifest(repo, reference, mediaType string, //noli
 }
 
 // DeleteImageManifest deletes the image manifest from the repository.
-func (is *ImageStore) DeleteImageManifest(repo, reference string, detectCollisions bool) error {
+func (is *ImageStore) DeleteImageManifest(ctx context.Context, repo, reference string, detectCollisions bool) error {
 	dir := path.Join(is.rootDir, repo)
 	if fi, err := is.storeDriver.Stat(dir); err != nil || !fi.IsDir() {
 		return zerr.ErrRepoNotFound
@@ -794,7 +803,7 @@ func (is *ImageStore) DeleteImageManifest(repo, reference string, detectCollisio
 	is.Lock(&lockLatency)
 	defer is.Unlock(&lockLatency)
 
-	err := is.deleteImageManifest(repo, reference, detectCollisions)
+	err := is.deleteImageManifest(ctx, repo, reference, detectCollisions)
 	if err != nil {
 		return err
 	}
@@ -802,7 +811,7 @@ func (is *ImageStore) DeleteImageManifest(repo, reference string, detectCollisio
 	return nil
 }
 
-func (is *ImageStore) deleteImageManifest(repo, reference string, detectCollisions bool) error {
+func (is *ImageStore) deleteImageManifest(ctx context.Context, repo, reference string, detectCollisions bool) error {
 	defer func() {
 		if is.storeDriver.Name() == storageConstants.LocalStorageDriverName {
 			monitoring.SetStorageUsage(is.metrics, is.rootDir, repo)
@@ -877,7 +886,8 @@ func (is *ImageStore) deleteImageManifest(repo, reference string, detectCollisio
 	}
 
 	if is.events != nil {
-		is.events.ImageDeleted(repo, reference, manifestDesc.Digest.String(), manifestDesc.MediaType)
+		is.events.ImageDeleted(repo, reference, manifestDesc.Digest.String(), manifestDesc.MediaType,
+			events.EventContextFromContext(ctx))
 	}
 
 	return nil
@@ -929,7 +939,7 @@ func (is *ImageStore) StatBlobUpload(repo, uuid string) (bool, int64, time.Time,
 
 // NewBlobUpload returns the unique ID for an upload in progress.
 func (is *ImageStore) NewBlobUpload(repo string) (string, error) {
-	if err := is.InitRepo(repo); err != nil {
+	if err := is.InitRepo(context.Background(), repo); err != nil {
 		is.log.Error().Err(err).Msg("failed to initialize repo")
 
 		return "", err
@@ -984,7 +994,7 @@ func (is *ImageStore) GetBlobUpload(repo, uuid string) (int64, error) {
 // PutBlobChunkStreamed appends another chunk of data to the specified blob. It returns
 // the number of actual bytes to the blob.
 func (is *ImageStore) PutBlobChunkStreamed(repo, uuid string, body io.Reader) (int64, error) {
-	if err := is.InitRepo(repo); err != nil {
+	if err := is.InitRepo(context.Background(), repo); err != nil {
 		return -1, err
 	}
 
@@ -1017,7 +1027,7 @@ func (is *ImageStore) PutBlobChunkStreamed(repo, uuid string, body io.Reader) (i
 func (is *ImageStore) PutBlobChunk(repo, uuid string, from, to int64,
 	body io.Reader,
 ) (int64, error) {
-	if err := is.InitRepo(repo); err != nil {
+	if err := is.InitRepo(context.Background(), repo); err != nil {
 		return -1, err
 	}
 
@@ -1152,7 +1162,7 @@ func (is *ImageStore) FullBlobUpload(repo string, body io.Reader, dstDigest godi
 		return "", -1, err
 	}
 
-	if err := is.InitRepo(repo); err != nil {
+	if err := is.InitRepo(context.Background(), repo); err != nil {
 		return "", -1, err
 	}
 
@@ -1538,7 +1548,7 @@ func (is *ImageStore) checkCacheBlob(digest godigest.Digest) (string, error) {
 }
 
 func (is *ImageStore) copyBlob(repo string, blobPath, dstRecord string) (int64, error) {
-	if err := is.initRepo(repo); err != nil {
+	if err := is.initRepo(context.Background(), repo); err != nil {
 		is.log.Error().Err(err).Str("repository", repo).Msg("failed to initialize an empty repo")
 
 		return -1, err
@@ -1871,7 +1881,7 @@ func (is *ImageStore) CleanupRepo(repo string, blobs []godigest.Digest, removeRe
 
 		if err := is.deleteBlob(repo, digest); err != nil {
 			if errors.Is(err, zerr.ErrBlobReferenced) {
-				if err := is.deleteImageManifest(repo, digest.String(), true); err != nil {
+				if err := is.deleteImageManifest(context.Background(), repo, digest.String(), true); err != nil {
 					if errors.Is(err, zerr.ErrManifestConflict) || errors.Is(err, zerr.ErrManifestReferenced) {
 						continue
 					}

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -752,6 +752,7 @@ func (is *ImageStore) PutImageManifest(ctx context.Context, repo, reference, med
 		desc.ArtifactType = artifactType
 
 		lintDesc = desc
+		changedTags = []string{reference}
 	}
 
 	pass, err := common.ApplyLinter(is, is.linter, repo, lintDesc)
@@ -760,14 +761,10 @@ func (is *ImageStore) PutImageManifest(ctx context.Context, repo, reference, med
 			Msg("linter didn't pass")
 
 		if is.events != nil {
-			evCtx := events.EventContextFromContext(ctx)
-			if len(changedTags) > 0 {
-				for _, tag := range changedTags {
-					is.events.ImageLintFailed(repo, tag, mDigest.String(), mediaType, string(body), evCtx)
-				}
-			} else {
-				is.events.ImageLintFailed(repo, reference, mDigest.String(), mediaType, string(body), evCtx)
-			}
+			// lint is a property of the manifest, not of the tag(s) it is applied under,
+			// so a single event is emitted per manifest regardless of how many tags changed.
+			is.events.ImageLintFailed(repo, changedTags[0], mDigest.String(), mediaType, string(body),
+				events.EventContextFromContext(ctx))
 		}
 
 		return "", "", err
@@ -779,12 +776,8 @@ func (is *ImageStore) PutImageManifest(ctx context.Context, repo, reference, med
 
 	if is.events != nil {
 		evCtx := events.EventContextFromContext(ctx)
-		if len(changedTags) > 0 {
-			for _, tag := range changedTags {
-				is.events.ImageUpdated(repo, tag, mDigest.String(), mediaType, string(body), evCtx)
-			}
-		} else {
-			is.events.ImageUpdated(repo, reference, mDigest.String(), mediaType, string(body), evCtx)
+		for _, ref := range changedTags {
+			is.events.ImageUpdated(repo, ref, mDigest.String(), mediaType, string(body), evCtx)
 		}
 	}
 

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -938,8 +938,8 @@ func (is *ImageStore) StatBlobUpload(repo, uuid string) (bool, int64, time.Time,
 }
 
 // NewBlobUpload returns the unique ID for an upload in progress.
-func (is *ImageStore) NewBlobUpload(repo string) (string, error) {
-	if err := is.InitRepo(context.Background(), repo); err != nil {
+func (is *ImageStore) NewBlobUpload(ctx context.Context, repo string) (string, error) {
+	if err := is.InitRepo(ctx, repo); err != nil {
 		is.log.Error().Err(err).Msg("failed to initialize repo")
 
 		return "", err
@@ -993,8 +993,8 @@ func (is *ImageStore) GetBlobUpload(repo, uuid string) (int64, error) {
 
 // PutBlobChunkStreamed appends another chunk of data to the specified blob. It returns
 // the number of actual bytes to the blob.
-func (is *ImageStore) PutBlobChunkStreamed(repo, uuid string, body io.Reader) (int64, error) {
-	if err := is.InitRepo(context.Background(), repo); err != nil {
+func (is *ImageStore) PutBlobChunkStreamed(ctx context.Context, repo, uuid string, body io.Reader) (int64, error) {
+	if err := is.InitRepo(ctx, repo); err != nil {
 		return -1, err
 	}
 
@@ -1024,10 +1024,10 @@ func (is *ImageStore) PutBlobChunkStreamed(repo, uuid string, body io.Reader) (i
 
 // PutBlobChunk writes another chunk of data to the specified blob. It returns
 // the number of actual bytes to the blob.
-func (is *ImageStore) PutBlobChunk(repo, uuid string, from, to int64,
+func (is *ImageStore) PutBlobChunk(ctx context.Context, repo, uuid string, from, to int64,
 	body io.Reader,
 ) (int64, error) {
-	if err := is.InitRepo(context.Background(), repo); err != nil {
+	if err := is.InitRepo(ctx, repo); err != nil {
 		return -1, err
 	}
 
@@ -1157,12 +1157,14 @@ func (is *ImageStore) FinishBlobUpload(repo, uuid string, body io.Reader, dstDig
 }
 
 // FullBlobUpload handles a full blob upload, and no partial session is created.
-func (is *ImageStore) FullBlobUpload(repo string, body io.Reader, dstDigest godigest.Digest) (string, int64, error) {
+func (is *ImageStore) FullBlobUpload(ctx context.Context, repo string, body io.Reader,
+	dstDigest godigest.Digest,
+) (string, int64, error) {
 	if err := dstDigest.Validate(); err != nil {
 		return "", -1, err
 	}
 
-	if err := is.InitRepo(context.Background(), repo); err != nil {
+	if err := is.InitRepo(ctx, repo); err != nil {
 		return "", -1, err
 	}
 
@@ -1431,7 +1433,7 @@ func (is *ImageStore) GetAllDedupeReposCandidates(digest godigest.Digest) ([]str
 
 // CheckBlob verifies a blob and returns true if the blob is correct.
 // If the blob is not found but it's found in cache then it will be copied over.
-func (is *ImageStore) CheckBlob(repo string, digest godigest.Digest) (bool, int64, error) {
+func (is *ImageStore) CheckBlob(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 	var lockLatency time.Time
 
 	if err := digest.Validate(); err != nil {
@@ -1480,7 +1482,7 @@ func (is *ImageStore) CheckBlob(repo string, digest godigest.Digest) (bool, int6
 		return false, -1, zerr.ErrBlobNotFound
 	}
 
-	blobSize, err := is.copyBlob(repo, blobPath, dstRecord)
+	blobSize, err := is.copyBlob(ctx, repo, blobPath, dstRecord)
 	if err != nil {
 		return false, -1, zerr.ErrBlobNotFound
 	}
@@ -1547,8 +1549,8 @@ func (is *ImageStore) checkCacheBlob(digest godigest.Digest) (string, error) {
 	return dstRecord, nil
 }
 
-func (is *ImageStore) copyBlob(repo string, blobPath, dstRecord string) (int64, error) {
-	if err := is.initRepo(context.Background(), repo); err != nil {
+func (is *ImageStore) copyBlob(ctx context.Context, repo string, blobPath, dstRecord string) (int64, error) {
+	if err := is.initRepo(ctx, repo); err != nil {
 		is.log.Error().Err(err).Str("repository", repo).Msg("failed to initialize an empty repo")
 
 		return -1, err

--- a/pkg/storage/local/local_elevated_test.go
+++ b/pkg/storage/local/local_elevated_test.go
@@ -4,6 +4,7 @@ package local_test
 
 import (
 	"bytes"
+	"context"
 	_ "crypto/sha256"
 	"os"
 	"os/exec"
@@ -55,7 +56,7 @@ func TestElevatedPrivilegesInvalidDedupe(t *testing.T) {
 		So(blob, ShouldEqual, buflen)
 
 		// Create a file at the same place where FinishBlobUpload will create
-		err = imgStore.InitRepo("dedupe2")
+		err = imgStore.InitRepo(context.Background(), "dedupe2")
 		So(err, ShouldBeNil)
 
 		err = os.MkdirAll(path.Join(dir, "dedupe2", "blobs/sha256"), 0o755)

--- a/pkg/storage/local/local_elevated_test.go
+++ b/pkg/storage/local/local_elevated_test.go
@@ -36,7 +36,7 @@ func TestElevatedPrivilegesInvalidDedupe(t *testing.T) {
 		}, log)
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
-		upload, err := imgStore.NewBlobUpload("dedupe1")
+		upload, err := imgStore.NewBlobUpload(context.Background(), "dedupe1")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -44,7 +44,7 @@ func TestElevatedPrivilegesInvalidDedupe(t *testing.T) {
 		buf := bytes.NewBuffer(content)
 		buflen := buf.Len()
 		digest := godigest.FromBytes(content)
-		blob, err := imgStore.PutBlobChunkStreamed("dedupe1", upload, buf)
+		blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "dedupe1", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -69,7 +69,7 @@ func TestElevatedPrivilegesInvalidDedupe(t *testing.T) {
 			panic(err)
 		}
 
-		upload, err = imgStore.NewBlobUpload("dedupe2")
+		upload, err = imgStore.NewBlobUpload(context.Background(), "dedupe2")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -77,7 +77,7 @@ func TestElevatedPrivilegesInvalidDedupe(t *testing.T) {
 		buf = bytes.NewBuffer(content)
 		buflen = buf.Len()
 		digest = godigest.FromBytes(content)
-		blob, err = imgStore.PutBlobChunkStreamed("dedupe2", upload, buf)
+		blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "dedupe2", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -142,7 +142,8 @@ func TestStorageFSAPIs(t *testing.T) {
 				panic(err)
 			}
 
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repoName, "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldNotBeNil)
 
 			err = os.Chmod(path.Join(imgStore.RootDir(), repoName, "index.json"), 0o755)
@@ -150,7 +151,8 @@ func TestStorageFSAPIs(t *testing.T) {
 				panic(err)
 			}
 
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repoName, "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldBeNil)
 
 			manifestPath := path.Join(imgStore.RootDir(), repoName, "blobs", digest.Algorithm().String(), digest.Encoded())
@@ -176,7 +178,8 @@ func TestStorageFSAPIs(t *testing.T) {
 				panic(err)
 			}
 
-			_, _, err = imgStore.PutImageManifest(repoName, "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repoName, "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldNotBeNil)
 
 			err = os.Chmod(path.Join(imgStore.RootDir(), repoName), 0o755)
@@ -192,7 +195,7 @@ func TestStorageFSAPIs(t *testing.T) {
 				panic(err)
 			}
 
-			err = imgStore.DeleteImageManifest(repoName, digest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, digest.String(), false)
 			So(err, ShouldNotBeNil)
 
 			err = os.RemoveAll(path.Join(imgStore.RootDir(), repoName))
@@ -371,7 +374,8 @@ func FuzzTestPutGetImageManifest(f *testing.F) {
 
 		mdigest := godigest.FromBytes(manifestBuf)
 
-		_, _, err = imgStore.PutImageManifest(repoName, mdigest.String(), ispec.MediaTypeImageManifest, manifestBuf, nil)
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			repoName, mdigest.String(), ispec.MediaTypeImageManifest, manifestBuf, nil)
 		if err != nil && errors.Is(err, zerr.ErrBadManifest) {
 			t.Errorf("the error that occurred is %v \n", err)
 		}
@@ -427,12 +431,13 @@ func FuzzTestPutDeleteImageManifest(f *testing.F) {
 
 		mdigest := godigest.FromBytes(manifestBuf)
 
-		_, _, err = imgStore.PutImageManifest(repoName, mdigest.String(), ispec.MediaTypeImageManifest, manifestBuf, nil)
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			repoName, mdigest.String(), ispec.MediaTypeImageManifest, manifestBuf, nil)
 		if err != nil && errors.Is(err, zerr.ErrBadManifest) {
 			t.Errorf("the error that occurred is %v \n", err)
 		}
 
-		err = imgStore.DeleteImageManifest(repoName, mdigest.String(), false)
+		err = imgStore.DeleteImageManifest(context.Background(), repoName, mdigest.String(), false)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -464,7 +469,7 @@ func FuzzTestDeleteImageManifest(f *testing.F) {
 			return
 		}
 
-		err = imgStore.DeleteImageManifest(string(data), digest.String(), false)
+		err = imgStore.DeleteImageManifest(context.Background(), string(data), digest.String(), false)
 		if err != nil {
 			if errors.Is(err, zerr.ErrRepoNotFound) || isKnownErr(err) {
 				return
@@ -496,7 +501,7 @@ func FuzzInitRepo(f *testing.F) {
 		}, *log)
 		imgStore := local.NewImageStore(dir, true, true, *log, metrics, nil, cacheDriver, nil, nil)
 
-		err := imgStore.InitRepo(data)
+		err := imgStore.InitRepo(context.Background(), data)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -522,7 +527,7 @@ func FuzzInitValidateRepo(f *testing.F) {
 		}, *log)
 		imgStore := local.NewImageStore(dir, true, true, *log, metrics, nil, cacheDriver, nil, nil)
 
-		err := imgStore.InitRepo(data)
+		err := imgStore.InitRepo(context.Background(), data)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -752,10 +757,10 @@ func TestStorageCacheErrors(t *testing.T) {
 			},
 		}, nil, nil)
 
-		err := imgStore.InitRepo(originRepo)
+		err := imgStore.InitRepo(context.Background(), originRepo)
 		So(err, ShouldBeNil)
 
-		err = imgStore.InitRepo(dedupedRepo)
+		err = imgStore.InitRepo(context.Background(), dedupedRepo)
 		So(err, ShouldBeNil)
 
 		_, _, err = imgStore.FullBlobUpload(originRepo, bytes.NewReader(cblob), cdigest)
@@ -1177,7 +1182,8 @@ func TestDedupeLinks(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			manifestDigest := godigest.FromBytes(manifestBuf)
-			_, _, err = imgStore.PutImageManifest("dedupe1", manifestDigest.String(),
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe1", manifestDigest.String(),
 				ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldBeNil)
 
@@ -1240,7 +1246,9 @@ func TestDedupeLinks(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			manifestDigest2 := godigest.FromBytes(manifestBuf)
-			_, _, err = imgStore.PutImageManifest("dedupe2", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				"dedupe2", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldBeNil)
 
 			_, _, _, err = imgStore.GetImageManifest("dedupe2", manifestDigest2.String())
@@ -1258,10 +1266,10 @@ func TestDedupeLinks(t *testing.T) {
 					So(blobDigest1, ShouldEqual, blobDigest2)
 
 					// to not trigger BlobInUse err, delete manifest first
-					err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 					So(err, ShouldBeNil)
 
-					err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+					err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", "1.0", false)
 					So(err, ShouldBeNil)
 
 					err = imgStore.DeleteBlob("dedupe1", godigest.NewDigestFromEncoded(godigest.SHA256, blobDigest1))
@@ -1272,7 +1280,7 @@ func TestDedupeLinks(t *testing.T) {
 					So(err, ShouldNotBeNil)
 
 					// Delete the manifest
-					err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 					So(err, ShouldBeNil)
 
 					// The call should succeed
@@ -1420,10 +1428,10 @@ func TestDedupeLinks(t *testing.T) {
 				So(blobDigest1, ShouldEqual, blobDigest2)
 
 				// to not trigger BlobInUse err, delete manifest first
-				err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 				So(err, ShouldBeNil)
 
-				err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", "1.0", false)
 				So(err, ShouldBeNil)
 
 				err = imgStore.DeleteBlob("dedupe1", godigest.NewDigestFromEncoded(godigest.SHA256, blobDigest1))
@@ -1434,7 +1442,7 @@ func TestDedupeLinks(t *testing.T) {
 				So(err, ShouldNotBeNil)
 
 				// Delete the manifest
-				err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 				So(err, ShouldBeNil)
 
 				// The call should succeed
@@ -1545,7 +1553,7 @@ func TestNegativeCases(t *testing.T) {
 		}
 
 		if os.Geteuid() != 0 {
-			err = imgStore.InitRepo("test")
+			err = imgStore.InitRepo(context.Background(), "test")
 			So(err, ShouldNotBeNil)
 		}
 
@@ -1557,21 +1565,21 @@ func TestNegativeCases(t *testing.T) {
 		// Init repo should fail if repo is a file.
 		err = os.WriteFile(path.Join(dir, "file-test"), []byte("this is test file"), 0o755) //nolint:gosec
 		So(err, ShouldBeNil)
-		err = imgStore.InitRepo("file-test")
+		err = imgStore.InitRepo(context.Background(), "file-test")
 		So(err, ShouldNotBeNil)
 
 		err = os.Mkdir(path.Join(dir, "test-dir"), 0o755)
 		So(err, ShouldBeNil)
 
-		err = imgStore.InitRepo("test-dir")
+		err = imgStore.InitRepo(context.Background(), "test-dir")
 		So(err, ShouldBeNil)
 
 		// Init repo should fail if repo is invalid UTF-8
-		err = imgStore.InitRepo("hi \255")
+		err = imgStore.InitRepo(context.Background(), "hi \255")
 		So(err, ShouldNotBeNil)
 
 		// Init repo should fail if repo name does not match spec
-		err = imgStore.InitRepo("_trivy")
+		err = imgStore.InitRepo(context.Background(), "_trivy")
 		So(err, ShouldNotBeNil)
 		So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 	})
@@ -1590,7 +1598,7 @@ func TestNegativeCases(t *testing.T) {
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
 		So(imgStore, ShouldNotBeNil)
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 
 		err := os.MkdirAll(path.Join(dir, "invalid-test"), 0o755)
 		So(err, ShouldBeNil)
@@ -1704,13 +1712,13 @@ func TestNegativeCases(t *testing.T) {
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
 		So(imgStore, ShouldNotBeNil)
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 		So(os.Remove(path.Join(dir, "test", "index.json")), ShouldBeNil)
 
 		_, err := imgStore.GetImageTags("test")
 		So(err, ShouldNotBeNil)
 		So(os.RemoveAll(path.Join(dir, "test")), ShouldBeNil)
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 		So(os.WriteFile(path.Join(dir, "test", "index.json"), []byte{}, 0o600), ShouldBeNil)
 
 		_, err = imgStore.GetImageTags("test")
@@ -1731,7 +1739,7 @@ func TestNegativeCases(t *testing.T) {
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
 		So(imgStore, ShouldNotBeNil)
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 
 		err := os.Chmod(path.Join(dir, "test", "index.json"), 0o000)
 		if err != nil {
@@ -1754,7 +1762,7 @@ func TestNegativeCases(t *testing.T) {
 			panic(err)
 		}
 
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 
 		err = os.WriteFile(path.Join(dir, "test", "index.json"), []byte{}, 0o600)
 		if err != nil {
@@ -1779,7 +1787,7 @@ func TestNegativeCases(t *testing.T) {
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
 		So(imgStore, ShouldNotBeNil)
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 
 		err := os.Chmod(path.Join(dir, "test", ".uploads"), 0o000)
 		if err != nil {
@@ -1802,7 +1810,7 @@ func TestNegativeCases(t *testing.T) {
 			panic(err)
 		}
 
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 
 		_, err = imgStore.NewBlobUpload("test")
 		So(err, ShouldNotBeNil)
@@ -1957,7 +1965,7 @@ func TestInjectWriteFile(t *testing.T) {
 		imgStore := local.NewImageStore(dir, true, false, log, metrics, nil, cacheDriver, nil, nil)
 
 		Convey("Failure path not reached", func() {
-			err := imgStore.InitRepo("repo1")
+			err := imgStore.InitRepo(context.Background(), "repo1")
 			So(err, ShouldBeNil)
 		})
 	})
@@ -2350,7 +2358,7 @@ func TestGarbageCollectImageUnknownManifest(t *testing.T) {
 		})
 
 		Convey("Garbage collect - gc repo after manifest delete", func() {
-			err = imgStore.DeleteImageManifest(repoName, img.DigestStr(), true)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, img.DigestStr(), true)
 			So(err, ShouldBeNil)
 
 			err = gc.CleanRepo(ctx, repoName)
@@ -2477,7 +2485,9 @@ func TestGarbageCollectErrors(t *testing.T) {
 
 				digest = godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
-				_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 				So(err, ShouldBeNil)
 
 				index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -2494,7 +2504,8 @@ func TestGarbageCollectErrors(t *testing.T) {
 			indexDigest := godigest.FromBytes(indexContent)
 			So(indexDigest, ShouldNotBeNil)
 
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+				ispec.MediaTypeImageIndex, indexContent, nil)
 			So(err, ShouldBeNil)
 
 			err = os.Chmod(imgStore.BlobPath(repoName, indexDigest), 0o000)
@@ -2545,7 +2556,8 @@ func TestGarbageCollectErrors(t *testing.T) {
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
 
-			_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			// trigger GetBlobContent error
@@ -2604,10 +2616,12 @@ func TestGarbageCollectErrors(t *testing.T) {
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
 
-			_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 			// upload again same manifest so that we trigger manifest conflict
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, content, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+				ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			time.Sleep(500 * time.Millisecond)
@@ -2656,7 +2670,7 @@ func TestInitRepo(t *testing.T) {
 		err := os.Mkdir(path.Join(dir, "test-dir"), 0o000)
 		So(err, ShouldBeNil)
 
-		err = imgStore.InitRepo("test-dir")
+		err = imgStore.InitRepo(context.Background(), "test-dir")
 		So(err, ShouldNotBeNil)
 	})
 }
@@ -3099,7 +3113,7 @@ func TestStorageDriverErr(t *testing.T) {
 	imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
 	Convey("Init repo", t, func() {
-		err := imgStore.InitRepo(repoName)
+		err := imgStore.InitRepo(context.Background(), repoName)
 		So(err, ShouldBeNil)
 
 		Convey("New blob upload error", func() {

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -150,7 +150,8 @@ func TestStorageFSAPIs(t *testing.T) {
 				panic(err)
 			}
 
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repoName, "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldNotBeNil)
 
 			err = os.Chmod(path.Join(imgStore.RootDir(), repoName, "index.json"), 0o755)
@@ -158,7 +159,8 @@ func TestStorageFSAPIs(t *testing.T) {
 				panic(err)
 			}
 
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repoName, "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldBeNil)
 
 			manifestPath := path.Join(imgStore.RootDir(), repoName, "blobs", digest.Algorithm().String(), digest.Encoded())
@@ -184,7 +186,8 @@ func TestStorageFSAPIs(t *testing.T) {
 				panic(err)
 			}
 
-			_, _, err = imgStore.PutImageManifest(repoName, "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repoName, "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldNotBeNil)
 
 			err = os.Chmod(path.Join(imgStore.RootDir(), repoName), 0o755)
@@ -200,7 +203,7 @@ func TestStorageFSAPIs(t *testing.T) {
 				panic(err)
 			}
 
-			err = imgStore.DeleteImageManifest(repoName, digest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, digest.String(), false)
 			So(err, ShouldNotBeNil)
 
 			err = os.RemoveAll(path.Join(imgStore.RootDir(), repoName))
@@ -379,7 +382,8 @@ func FuzzTestPutGetImageManifest(f *testing.F) {
 
 		mdigest := godigest.FromBytes(manifestBuf)
 
-		_, _, err = imgStore.PutImageManifest(repoName, mdigest.String(), ispec.MediaTypeImageManifest, manifestBuf, nil)
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			repoName, mdigest.String(), ispec.MediaTypeImageManifest, manifestBuf, nil)
 		if err != nil && errors.Is(err, zerr.ErrBadManifest) {
 			t.Errorf("the error that occurred is %v \n", err)
 		}
@@ -435,12 +439,13 @@ func FuzzTestPutDeleteImageManifest(f *testing.F) {
 
 		mdigest := godigest.FromBytes(manifestBuf)
 
-		_, _, err = imgStore.PutImageManifest(repoName, mdigest.String(), ispec.MediaTypeImageManifest, manifestBuf, nil)
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			repoName, mdigest.String(), ispec.MediaTypeImageManifest, manifestBuf, nil)
 		if err != nil && errors.Is(err, zerr.ErrBadManifest) {
 			t.Errorf("the error that occurred is %v \n", err)
 		}
 
-		err = imgStore.DeleteImageManifest(repoName, mdigest.String(), false)
+		err = imgStore.DeleteImageManifest(context.Background(), repoName, mdigest.String(), false)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -472,7 +477,7 @@ func FuzzTestDeleteImageManifest(f *testing.F) {
 			return
 		}
 
-		err = imgStore.DeleteImageManifest(string(data), digest.String(), false)
+		err = imgStore.DeleteImageManifest(context.Background(), string(data), digest.String(), false)
 		if err != nil {
 			if errors.Is(err, zerr.ErrRepoNotFound) || isKnownErr(err) {
 				return
@@ -504,7 +509,7 @@ func FuzzInitRepo(f *testing.F) {
 		}, *log)
 		imgStore := local.NewImageStore(dir, true, true, *log, metrics, nil, cacheDriver, nil, nil)
 
-		err := imgStore.InitRepo(data)
+		err := imgStore.InitRepo(context.Background(), data)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -530,7 +535,7 @@ func FuzzInitValidateRepo(f *testing.F) {
 		}, *log)
 		imgStore := local.NewImageStore(dir, true, true, *log, metrics, nil, cacheDriver, nil, nil)
 
-		err := imgStore.InitRepo(data)
+		err := imgStore.InitRepo(context.Background(), data)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -760,10 +765,10 @@ func TestStorageCacheErrors(t *testing.T) {
 			},
 		}, nil, nil)
 
-		err := imgStore.InitRepo(originRepo)
+		err := imgStore.InitRepo(context.Background(), originRepo)
 		So(err, ShouldBeNil)
 
-		err = imgStore.InitRepo(dedupedRepo)
+		err = imgStore.InitRepo(context.Background(), dedupedRepo)
 		So(err, ShouldBeNil)
 
 		_, _, err = imgStore.FullBlobUpload(originRepo, bytes.NewReader(cblob), cdigest)
@@ -1271,7 +1276,8 @@ func TestDedupeLinks(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			manifestDigest := godigest.FromBytes(manifestBuf)
-			_, _, err = imgStore.PutImageManifest("dedupe1", manifestDigest.String(),
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe1", manifestDigest.String(),
 				ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldBeNil)
 
@@ -1334,7 +1340,9 @@ func TestDedupeLinks(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			manifestDigest2 := godigest.FromBytes(manifestBuf)
-			_, _, err = imgStore.PutImageManifest("dedupe2", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				"dedupe2", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 			So(err, ShouldBeNil)
 
 			_, _, _, err = imgStore.GetImageManifest("dedupe2", manifestDigest2.String())
@@ -1352,10 +1360,10 @@ func TestDedupeLinks(t *testing.T) {
 					So(blobDigest1, ShouldEqual, blobDigest2)
 
 					// to not trigger BlobInUse err, delete manifest first
-					err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 					So(err, ShouldBeNil)
 
-					err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+					err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", "1.0", false)
 					So(err, ShouldBeNil)
 
 					err = imgStore.DeleteBlob("dedupe1", godigest.NewDigestFromEncoded(godigest.SHA256, blobDigest1))
@@ -1366,7 +1374,7 @@ func TestDedupeLinks(t *testing.T) {
 					So(err, ShouldNotBeNil)
 
 					// Delete the manifest
-					err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 					So(err, ShouldBeNil)
 
 					// The call should succeed
@@ -1514,10 +1522,10 @@ func TestDedupeLinks(t *testing.T) {
 				So(blobDigest1, ShouldEqual, blobDigest2)
 
 				// to not trigger BlobInUse err, delete manifest first
-				err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 				So(err, ShouldBeNil)
 
-				err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", "1.0", false)
 				So(err, ShouldBeNil)
 
 				err = imgStore.DeleteBlob("dedupe1", godigest.NewDigestFromEncoded(godigest.SHA256, blobDigest1))
@@ -1528,7 +1536,7 @@ func TestDedupeLinks(t *testing.T) {
 				So(err, ShouldNotBeNil)
 
 				// Delete the manifest
-				err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 				So(err, ShouldBeNil)
 
 				// The call should succeed
@@ -1932,7 +1940,7 @@ func TestNegativeCases(t *testing.T) {
 		}
 
 		if os.Geteuid() != 0 {
-			err = imgStore.InitRepo("test")
+			err = imgStore.InitRepo(context.Background(), "test")
 			So(err, ShouldNotBeNil)
 		}
 
@@ -1944,21 +1952,21 @@ func TestNegativeCases(t *testing.T) {
 		// Init repo should fail if repo is a file.
 		err = os.WriteFile(path.Join(dir, "file-test"), []byte("this is test file"), 0o755) //nolint:gosec
 		So(err, ShouldBeNil)
-		err = imgStore.InitRepo("file-test")
+		err = imgStore.InitRepo(context.Background(), "file-test")
 		So(err, ShouldNotBeNil)
 
 		err = os.Mkdir(path.Join(dir, "test-dir"), 0o755)
 		So(err, ShouldBeNil)
 
-		err = imgStore.InitRepo("test-dir")
+		err = imgStore.InitRepo(context.Background(), "test-dir")
 		So(err, ShouldBeNil)
 
 		// Init repo should fail if repo is invalid UTF-8
-		err = imgStore.InitRepo("hi \255")
+		err = imgStore.InitRepo(context.Background(), "hi \255")
 		So(err, ShouldNotBeNil)
 
 		// Init repo should fail if repo name does not match spec
-		err = imgStore.InitRepo("_trivy")
+		err = imgStore.InitRepo(context.Background(), "_trivy")
 		So(err, ShouldNotBeNil)
 		So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 	})
@@ -1977,7 +1985,7 @@ func TestNegativeCases(t *testing.T) {
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
 		So(imgStore, ShouldNotBeNil)
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 
 		err := os.MkdirAll(path.Join(dir, "invalid-test"), 0o755)
 		So(err, ShouldBeNil)
@@ -2091,13 +2099,13 @@ func TestNegativeCases(t *testing.T) {
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
 		So(imgStore, ShouldNotBeNil)
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 		So(os.Remove(path.Join(dir, "test", "index.json")), ShouldBeNil)
 
 		_, err := imgStore.GetImageTags("test")
 		So(err, ShouldNotBeNil)
 		So(os.RemoveAll(path.Join(dir, "test")), ShouldBeNil)
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 		So(os.WriteFile(path.Join(dir, "test", "index.json"), []byte{}, 0o600), ShouldBeNil)
 
 		_, err = imgStore.GetImageTags("test")
@@ -2118,7 +2126,7 @@ func TestNegativeCases(t *testing.T) {
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
 		So(imgStore, ShouldNotBeNil)
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 
 		err := os.Chmod(path.Join(dir, "test", "index.json"), 0o000)
 		if err != nil {
@@ -2141,7 +2149,7 @@ func TestNegativeCases(t *testing.T) {
 			panic(err)
 		}
 
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 
 		err = os.WriteFile(path.Join(dir, "test", "index.json"), []byte{}, 0o600)
 		if err != nil {
@@ -2166,7 +2174,7 @@ func TestNegativeCases(t *testing.T) {
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
 		So(imgStore, ShouldNotBeNil)
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 
 		err := os.Chmod(path.Join(dir, "test", ".uploads"), 0o000)
 		if err != nil {
@@ -2189,7 +2197,7 @@ func TestNegativeCases(t *testing.T) {
 			panic(err)
 		}
 
-		So(imgStore.InitRepo("test"), ShouldBeNil)
+		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 
 		_, err = imgStore.NewBlobUpload("test")
 		So(err, ShouldNotBeNil)
@@ -2344,7 +2352,7 @@ func TestInjectWriteFile(t *testing.T) {
 		imgStore := local.NewImageStore(dir, true, false, log, metrics, nil, cacheDriver, nil, nil)
 
 		Convey("Failure path not reached", func() {
-			err := imgStore.InitRepo("repo1")
+			err := imgStore.InitRepo(context.Background(), "repo1")
 			So(err, ShouldBeNil)
 		})
 	})
@@ -2737,7 +2745,7 @@ func TestGarbageCollectImageUnknownManifest(t *testing.T) {
 		})
 
 		Convey("Garbage collect - gc repo after manifest delete", func() {
-			err = imgStore.DeleteImageManifest(repoName, img.DigestStr(), true)
+			err = imgStore.DeleteImageManifest(context.Background(), repoName, img.DigestStr(), true)
 			So(err, ShouldBeNil)
 
 			err = gc.CleanRepo(ctx, repoName)
@@ -2864,7 +2872,9 @@ func TestGarbageCollectErrors(t *testing.T) {
 
 				digest = godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
-				_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 				So(err, ShouldBeNil)
 
 				index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -2881,7 +2891,8 @@ func TestGarbageCollectErrors(t *testing.T) {
 			indexDigest := godigest.FromBytes(indexContent)
 			So(indexDigest, ShouldNotBeNil)
 
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+				ispec.MediaTypeImageIndex, indexContent, nil)
 			So(err, ShouldBeNil)
 
 			err = os.Chmod(imgStore.BlobPath(repoName, indexDigest), 0o000)
@@ -2932,7 +2943,8 @@ func TestGarbageCollectErrors(t *testing.T) {
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
 
-			_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			// trigger GetBlobContent error
@@ -2991,10 +3003,12 @@ func TestGarbageCollectErrors(t *testing.T) {
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
 
-			_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 			// upload again same manifest so that we trigger manifest conflict
-			_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageManifest, content, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+				ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			time.Sleep(500 * time.Millisecond)
@@ -3043,7 +3057,7 @@ func TestInitRepo(t *testing.T) {
 		err := os.Mkdir(path.Join(dir, "test-dir"), 0o000)
 		So(err, ShouldBeNil)
 
-		err = imgStore.InitRepo("test-dir")
+		err = imgStore.InitRepo(context.Background(), "test-dir")
 		So(err, ShouldNotBeNil)
 	})
 }
@@ -3486,7 +3500,7 @@ func TestStorageDriverErr(t *testing.T) {
 	imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
 	Convey("Init repo", t, func() {
-		err := imgStore.InitRepo(repoName)
+		err := imgStore.InitRepo(context.Background(), repoName)
 		So(err, ShouldBeNil)
 
 		Convey("New blob upload error", func() {

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -95,7 +95,7 @@ func TestStorageFSAPIs(t *testing.T) {
 
 	Convey("Repo layout", t, func(c C) {
 		Convey("Bad image manifest", func() {
-			upload, err := imgStore.NewBlobUpload(repoName)
+			upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -104,7 +104,7 @@ func TestStorageFSAPIs(t *testing.T) {
 			buflen := buf.Len()
 			digest := godigest.FromBytes(content)
 
-			blob, err := imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+			blob, err := imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -115,11 +115,11 @@ func TestStorageFSAPIs(t *testing.T) {
 			annotationsMap[ispec.AnnotationRefName] = tag
 
 			cblob, cdigest := GetRandomImageConfig()
-			_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
+			_, clen, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
 
-			hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest)
+			hasBlob, _, err := imgStore.CheckBlob(context.Background(), repoName, cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -230,7 +230,7 @@ func FuzzNewBlobUpload(f *testing.F) {
 
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
-		_, err := imgStore.NewBlobUpload(data)
+		_, err := imgStore.NewBlobUpload(context.Background(), data)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -259,7 +259,7 @@ func FuzzPutBlobChunk(f *testing.F) {
 
 		repoName := data
 
-		uuid, err := imgStore.NewBlobUpload(repoName)
+		uuid, err := imgStore.NewBlobUpload(context.Background(), repoName)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -271,7 +271,7 @@ func FuzzPutBlobChunk(f *testing.F) {
 		buf := bytes.NewBufferString(data)
 		buflen := buf.Len()
 
-		_, err = imgStore.PutBlobChunk(repoName, uuid, 0, int64(buflen), buf)
+		_, err = imgStore.PutBlobChunk(context.Background(), repoName, uuid, 0, int64(buflen), buf)
 		if err != nil {
 			t.Error(err)
 		}
@@ -295,7 +295,7 @@ func FuzzPutBlobChunkStreamed(f *testing.F) {
 
 		repoName := data
 
-		uuid, err := imgStore.NewBlobUpload(repoName)
+		uuid, err := imgStore.NewBlobUpload(context.Background(), repoName)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -306,7 +306,7 @@ func FuzzPutBlobChunkStreamed(f *testing.F) {
 
 		buf := bytes.NewBufferString(data)
 
-		_, err = imgStore.PutBlobChunkStreamed(repoName, uuid, buf)
+		_, err = imgStore.PutBlobChunkStreamed(context.Background(), repoName, uuid, buf)
 		if err != nil {
 			t.Error(err)
 		}
@@ -360,12 +360,12 @@ func FuzzTestPutGetImageManifest(f *testing.F) {
 			t.Errorf("error occurred while generating random blob, %v", err)
 		}
 
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(cblob), cdigest)
 		if err != nil {
 			t.Error(err)
 		}
 
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(lblob), ldigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(lblob), ldigest)
 		if err != nil {
 			t.Error(err)
 		}
@@ -417,12 +417,12 @@ func FuzzTestPutDeleteImageManifest(f *testing.F) {
 			t.Errorf("error occurred while generating random blob, %v", err)
 		}
 
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(cblob), cdigest)
 		if err != nil {
 			t.Error(err)
 		}
 
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(lblob), ldigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(lblob), ldigest)
 		if err != nil {
 			t.Error(err)
 		}
@@ -672,7 +672,7 @@ func FuzzFinishBlobUpload(f *testing.F) {
 
 		repoName := data
 
-		upload, err := imgStore.NewBlobUpload(repoName)
+		upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -686,7 +686,7 @@ func FuzzFinishBlobUpload(f *testing.F) {
 		buflen := buf.Len()
 		digest := godigest.FromBytes(content)
 
-		_, err = imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+		_, err = imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -727,7 +727,7 @@ func FuzzFullBlobUpload(f *testing.F) {
 			t.Errorf("error occurred while generating random blob, %v", err)
 		}
 
-		_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(lblob), ldigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(lblob), ldigest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -771,11 +771,11 @@ func TestStorageCacheErrors(t *testing.T) {
 		err = imgStore.InitRepo(context.Background(), dedupedRepo)
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.FullBlobUpload(originRepo, bytes.NewReader(cblob), cdigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), originRepo, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 
 		getBlobPath = imgStore.BlobPath(originRepo, cdigest)
-		_, _, err = imgStore.FullBlobUpload(dedupedRepo, bytes.NewReader(cblob), cdigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), dedupedRepo, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldNotBeNil)
 	})
 }
@@ -801,7 +801,7 @@ func FuzzDedupeBlob(f *testing.F) {
 		src := path.Join(imgStore.RootDir(), "src")
 		blob := bytes.NewReader([]byte(data))
 
-		_, _, err := imgStore.FullBlobUpload("repoName", blob, blobDigest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), "repoName", blob, blobDigest)
 		if err != nil {
 			t.Error(err)
 		}
@@ -836,7 +836,7 @@ func FuzzDeleteBlobUpload(f *testing.F) {
 		}, *log)
 		imgStore := local.NewImageStore(dir, true, true, *log, metrics, nil, cacheDriver, nil, nil)
 
-		uuid, err := imgStore.NewBlobUpload(repoName)
+		uuid, err := imgStore.NewBlobUpload(context.Background(), repoName)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -890,7 +890,7 @@ func FuzzCheckBlob(f *testing.F) {
 		imgStore := local.NewImageStore(dir, true, true, *log, metrics, nil, cacheDriver, nil, nil)
 		digest := godigest.FromString(data)
 
-		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader([]byte(data)), digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -899,7 +899,7 @@ func FuzzCheckBlob(f *testing.F) {
 			t.Error(err)
 		}
 
-		_, _, err = imgStore.CheckBlob(repoName, digest)
+		_, _, err = imgStore.CheckBlob(context.Background(), repoName, digest)
 		if err != nil {
 			t.Error(err)
 		}
@@ -940,7 +940,7 @@ func TestMissingBlobChecksDoNotLogErrors(t *testing.T) {
 
 		imgStore, buf := newImageStore(t)
 
-		found, size, err := imgStore.CheckBlob("repo", digest)
+		found, size, err := imgStore.CheckBlob(context.Background(), "repo", digest)
 		if !errors.Is(err, zerr.ErrBlobNotFound) {
 			t.Fatalf("expected ErrBlobNotFound, got %v", err)
 		}
@@ -1009,7 +1009,7 @@ func FuzzGetBlob(f *testing.F) {
 		imgStore := local.NewImageStore(dir, true, true, *log, metrics, nil, cacheDriver, nil, nil)
 		digest := godigest.FromString(data)
 
-		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader([]byte(data)), digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -1050,7 +1050,7 @@ func FuzzDeleteBlob(f *testing.F) {
 		imgStore := local.NewImageStore(dir, true, true, *log, metrics, nil, cacheDriver, nil, nil)
 		digest := godigest.FromString(data)
 
-		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader([]byte(data)), digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -1087,7 +1087,7 @@ func FuzzGetIndexContent(f *testing.F) {
 		imgStore := local.NewImageStore(dir, true, true, *log, metrics, nil, cacheDriver, nil, nil)
 		digest := godigest.FromString(data)
 
-		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader([]byte(data)), digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -1124,7 +1124,7 @@ func FuzzGetBlobContent(f *testing.F) {
 		imgStore := local.NewImageStore(dir, true, true, *log, metrics, nil, cacheDriver, nil, nil)
 		digest := godigest.FromString(data)
 
-		_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader([]byte(data)), digest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader([]byte(data)), digest)
 		if err != nil {
 			if isKnownErr(err) {
 				return
@@ -1221,7 +1221,7 @@ func TestDedupeLinks(t *testing.T) {
 			taskScheduler.Shutdown()
 
 			// manifest1
-			upload, err := imgStore.NewBlobUpload("dedupe1")
+			upload, err := imgStore.NewBlobUpload(context.Background(), "dedupe1")
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -1229,7 +1229,7 @@ func TestDedupeLinks(t *testing.T) {
 			buf := bytes.NewBuffer(content)
 			buflen := buf.Len()
 			digest := godigest.FromBytes(content)
-			blob, err := imgStore.PutBlobChunkStreamed("dedupe1", upload, buf)
+			blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "dedupe1", upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -1240,7 +1240,7 @@ func TestDedupeLinks(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			_, _, err = imgStore.CheckBlob("dedupe1", digest)
+			_, _, err = imgStore.CheckBlob(context.Background(), "dedupe1", digest)
 			So(err, ShouldBeNil)
 
 			blobrc, _, err := imgStore.GetBlob("dedupe1", digest, "application/vnd.oci.image.layer.v1.tar+gzip")
@@ -1249,11 +1249,11 @@ func TestDedupeLinks(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			cblob, cdigest := GetRandomImageConfig()
-			_, clen, err := imgStore.FullBlobUpload("dedupe1", bytes.NewReader(cblob), cdigest)
+			_, clen, err := imgStore.FullBlobUpload(context.Background(), "dedupe1", bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
 
-			hasBlob, _, err := imgStore.CheckBlob("dedupe1", cdigest)
+			hasBlob, _, err := imgStore.CheckBlob(context.Background(), "dedupe1", cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1285,7 +1285,7 @@ func TestDedupeLinks(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// manifest2
-			upload, err = imgStore.NewBlobUpload("dedupe2")
+			upload, err = imgStore.NewBlobUpload(context.Background(), "dedupe2")
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -1293,7 +1293,7 @@ func TestDedupeLinks(t *testing.T) {
 			buf = bytes.NewBuffer(content)
 			buflen = buf.Len()
 			digest = godigest.FromBytes(content)
-			blob, err = imgStore.PutBlobChunkStreamed("dedupe2", upload, buf)
+			blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "dedupe2", upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -1304,7 +1304,7 @@ func TestDedupeLinks(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			_, _, err = imgStore.CheckBlob("dedupe2", digest)
+			_, _, err = imgStore.CheckBlob(context.Background(), "dedupe2", digest)
 			So(err, ShouldBeNil)
 
 			blobrc, _, err = imgStore.GetBlob("dedupe2", digest, "application/vnd.oci.image.layer.v1.tar+gzip")
@@ -1313,11 +1313,11 @@ func TestDedupeLinks(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			cblob, cdigest = GetRandomImageConfig()
-			_, clen, err = imgStore.FullBlobUpload("dedupe2", bytes.NewReader(cblob), cdigest)
+			_, clen, err = imgStore.FullBlobUpload(context.Background(), "dedupe2", bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
 
-			hasBlob, _, err = imgStore.CheckBlob("dedupe2", cdigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), "dedupe2", cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1553,7 +1553,7 @@ func TestDedupeLinks(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				// now cache is inconsistent with storage (blobs present in cache but not in storage)
-				upload, err = imgStore.NewBlobUpload("dedupe3")
+				upload, err = imgStore.NewBlobUpload(context.Background(), "dedupe3")
 				So(err, ShouldBeNil)
 				So(upload, ShouldNotBeEmpty)
 
@@ -1561,7 +1561,7 @@ func TestDedupeLinks(t *testing.T) {
 				buf = bytes.NewBuffer(content)
 				buflen = buf.Len()
 				digest = godigest.FromBytes(content)
-				blob, err = imgStore.PutBlobChunkStreamed("dedupe3", upload, buf)
+				blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "dedupe3", upload, buf)
 				So(err, ShouldBeNil)
 				So(blob, ShouldEqual, buflen)
 
@@ -2181,7 +2181,7 @@ func TestNegativeCases(t *testing.T) {
 			panic(err)
 		}
 
-		_, err = imgStore.NewBlobUpload("test")
+		_, err = imgStore.NewBlobUpload(context.Background(), "test")
 		So(err, ShouldNotBeNil)
 
 		err = os.Chmod(path.Join(dir, "test"), 0o000)
@@ -2189,7 +2189,7 @@ func TestNegativeCases(t *testing.T) {
 			panic(err)
 		}
 
-		_, err = imgStore.NewBlobUpload("test")
+		_, err = imgStore.NewBlobUpload(context.Background(), "test")
 		So(err, ShouldNotBeNil)
 
 		err = os.Chmod(path.Join(dir, "test"), 0o755)
@@ -2199,7 +2199,7 @@ func TestNegativeCases(t *testing.T) {
 
 		So(imgStore.InitRepo(context.Background(), "test"), ShouldBeNil)
 
-		_, err = imgStore.NewBlobUpload("test")
+		_, err = imgStore.NewBlobUpload(context.Background(), "test")
 		So(err, ShouldNotBeNil)
 
 		err = os.Chmod(path.Join(dir, "test", ".uploads"), 0o755)
@@ -2207,7 +2207,7 @@ func TestNegativeCases(t *testing.T) {
 			panic(err)
 		}
 
-		upload, err := imgStore.NewBlobUpload("test")
+		upload, err := imgStore.NewBlobUpload(context.Background(), "test")
 		So(err, ShouldBeNil)
 
 		err = os.Chmod(path.Join(dir, "test", ".uploads"), 0o000)
@@ -2225,10 +2225,10 @@ func TestNegativeCases(t *testing.T) {
 		content := []byte("test-data3")
 		buf := bytes.NewBuffer(content)
 		l := buf.Len()
-		_, err = imgStore.PutBlobChunkStreamed("test", upload, buf)
+		_, err = imgStore.PutBlobChunkStreamed(context.Background(), "test", upload, buf)
 		So(err, ShouldNotBeNil)
 
-		_, err = imgStore.PutBlobChunk("test", upload, 0, int64(l), buf)
+		_, err = imgStore.PutBlobChunk(context.Background(), "test", upload, 0, int64(l), buf)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -2549,7 +2549,7 @@ func TestGarbageCollectForImageStore(t *testing.T) {
 				ImageRetention: DeleteReferrers,
 			}, audit, log, metrics)
 
-			blobUploadID, err := imgStore.NewBlobUpload(repoName)
+			blobUploadID, err := imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 
 			err = gc.CleanRepo(ctx, repoName)
@@ -2717,7 +2717,7 @@ func TestGarbageCollectImageUnknownManifest(t *testing.T) {
 			_, _, _, err = imgStore.GetImageManifest(repoName, img.DigestStr())
 			So(err, ShouldBeNil)
 
-			hasBlob, _, err := imgStore.CheckBlob(repoName, img.ConfigDescriptor.Digest)
+			hasBlob, _, err := imgStore.CheckBlob(context.Background(), repoName, img.ConfigDescriptor.Digest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -2727,19 +2727,19 @@ func TestGarbageCollectImageUnknownManifest(t *testing.T) {
 			_, _, _, err = imgStore.GetImageManifest(repoName, referrerDigest.String())
 			So(err, ShouldNotBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, artifactDigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactDigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, referrerDigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, referrerDigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, artifact.ConfigDescriptor.Digest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifact.ConfigDescriptor.Digest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, referrer.ConfigDescriptor.Digest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, referrer.ConfigDescriptor.Digest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 		})
@@ -2754,7 +2754,7 @@ func TestGarbageCollectImageUnknownManifest(t *testing.T) {
 			_, _, _, err = imgStore.GetImageManifest(repoName, img.DigestStr())
 			So(err, ShouldNotBeNil)
 
-			hasBlob, _, err := imgStore.CheckBlob(repoName, img.ConfigDescriptor.Digest)
+			hasBlob, _, err := imgStore.CheckBlob(context.Background(), repoName, img.ConfigDescriptor.Digest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
@@ -2764,19 +2764,19 @@ func TestGarbageCollectImageUnknownManifest(t *testing.T) {
 			_, _, _, err = imgStore.GetImageManifest(repoName, referrerDigest.String())
 			So(err, ShouldNotBeNil)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, artifactDigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactDigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, referrerDigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, referrerDigest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, artifact.ConfigDescriptor.Digest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifact.ConfigDescriptor.Digest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 
-			hasBlob, _, err = imgStore.CheckBlob(repoName, referrer.ConfigDescriptor.Digest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, referrer.ConfigDescriptor.Digest)
 			So(err, ShouldNotBeNil)
 			So(hasBlob, ShouldEqual, false)
 		})
@@ -2808,7 +2808,7 @@ func TestGarbageCollectErrors(t *testing.T) {
 		}, audit, log, metrics)
 
 		// create a blob/layer
-		upload, err := imgStore.NewBlobUpload(repoName)
+		upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -2818,7 +2818,7 @@ func TestGarbageCollectErrors(t *testing.T) {
 		digest := godigest.FromBytes(content)
 		So(digest, ShouldNotBeNil)
 
-		blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+		blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -2836,14 +2836,14 @@ func TestGarbageCollectErrors(t *testing.T) {
 
 			for range 4 {
 				// upload image config blob
-				upload, err = imgStore.NewBlobUpload(repoName)
+				upload, err = imgStore.NewBlobUpload(context.Background(), repoName)
 				So(err, ShouldBeNil)
 				So(upload, ShouldNotBeEmpty)
 
 				cblob, cdigest := GetRandomImageConfig()
 				buf = bytes.NewBuffer(cblob)
 				buflen = buf.Len()
-				blob, err = imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+				blob, err = imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 				So(err, ShouldBeNil)
 				So(blob, ShouldEqual, buflen)
 
@@ -2906,14 +2906,14 @@ func TestGarbageCollectErrors(t *testing.T) {
 
 		Convey("Trigger error on GetBlobContent and Unmarshal for untagged manifest", func() {
 			// upload image config blob
-			upload, err = imgStore.NewBlobUpload(repoName)
+			upload, err = imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
 			cblob, cdigest := GetRandomImageConfig()
 			buf = bytes.NewBuffer(cblob)
 			buflen = buf.Len()
-			blob, err = imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+			blob, err = imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -2966,14 +2966,14 @@ func TestGarbageCollectErrors(t *testing.T) {
 
 		Convey("Trigger manifest conflict error", func() {
 			// upload image config blob
-			upload, err = imgStore.NewBlobUpload(repoName)
+			upload, err = imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
 			cblob, cdigest := GetRandomImageConfig()
 			buf = bytes.NewBuffer(cblob)
 			buflen = buf.Len()
-			blob, err = imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+			blob, err = imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -3017,7 +3017,7 @@ func TestGarbageCollectErrors(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// blob shouldn't be gc'ed //TODO check this one
-			found, _, err := imgStore.CheckBlob(repoName, digest)
+			found, _, err := imgStore.CheckBlob(context.Background(), repoName, digest)
 			So(err, ShouldBeNil)
 			So(found, ShouldEqual, true)
 		})
@@ -3403,7 +3403,7 @@ func TestPutBlobChunkStreamed(t *testing.T) {
 
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
-		uuid, err := imgStore.NewBlobUpload("test")
+		uuid, err := imgStore.NewBlobUpload(context.Background(), "test")
 		So(err, ShouldBeNil)
 
 		var reader io.Reader
@@ -3412,7 +3412,7 @@ func TestPutBlobChunkStreamed(t *testing.T) {
 		err = os.Chmod(blobPath, 0o000)
 		So(err, ShouldBeNil)
 
-		_, err = imgStore.PutBlobChunkStreamed("test", uuid, reader)
+		_, err = imgStore.PutBlobChunkStreamed(context.Background(), "test", uuid, reader)
 		So(err, ShouldNotBeNil)
 	})
 }
@@ -3434,7 +3434,7 @@ func TestPullRange(t *testing.T) {
 			imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 			repoName := "pull-range"
 
-			upload, err := imgStore.NewBlobUpload(repoName)
+			upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -3443,7 +3443,7 @@ func TestPullRange(t *testing.T) {
 			buflen := buf.Len()
 			bdigest := godigest.FromBytes(content)
 
-			blob, err := imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+			blob, err := imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -3507,14 +3507,14 @@ func TestStorageDriverErr(t *testing.T) {
 			err := os.Chmod(path.Join(imgStore.RootDir(), repoName, storageConstants.BlobUploadDir), 0o000)
 			So(err, ShouldBeNil)
 
-			_, err = imgStore.NewBlobUpload(repoName)
+			_, err = imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldNotBeNil)
 
 			err = os.Chmod(path.Join(imgStore.RootDir(), repoName, storageConstants.BlobUploadDir),
 				storageConstants.DefaultDirPerms)
 			So(err, ShouldBeNil)
 
-			uuid, err := imgStore.NewBlobUpload(repoName)
+			uuid, err := imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 
 			size, err := imgStore.GetBlobUpload(repoName, uuid)
@@ -3526,7 +3526,7 @@ func TestStorageDriverErr(t *testing.T) {
 			bufLen := buf.Len()
 			digest := godigest.FromBytes(content)
 
-			size, err = imgStore.PutBlobChunkStreamed(repoName, uuid, buf)
+			size, err = imgStore.PutBlobChunkStreamed(context.Background(), repoName, uuid, buf)
 			So(err, ShouldBeNil)
 			So(size, ShouldEqual, bufLen)
 
@@ -3546,10 +3546,10 @@ func TestStorageDriverErr(t *testing.T) {
 			// push again
 			buf = bytes.NewBuffer(content)
 
-			uuid, err = imgStore.NewBlobUpload(repoName)
+			uuid, err = imgStore.NewBlobUpload(context.Background(), repoName)
 			So(err, ShouldBeNil)
 
-			size, err = imgStore.PutBlobChunkStreamed(repoName, uuid, buf)
+			size, err = imgStore.PutBlobChunkStreamed(context.Background(), repoName, uuid, buf)
 			So(err, ShouldBeNil)
 			So(size, ShouldEqual, bufLen)
 

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -220,14 +220,14 @@ func TestStorageDriverStatFunction(t *testing.T) {
 
 		So(imgStore, ShouldNotBeNil)
 
-		err = imgStore.InitRepo(repo1)
+		err = imgStore.InitRepo(context.Background(), repo1)
 		So(err, ShouldBeNil)
 
 		isValid, err := imgStore.ValidateRepo(repo1)
 		So(err, ShouldBeNil)
 		So(isValid, ShouldBeTrue)
 
-		err = imgStore.InitRepo(repo2)
+		err = imgStore.InitRepo(context.Background(), repo2)
 		So(err, ShouldBeNil)
 
 		isValid, err = imgStore.ValidateRepo(repo2)
@@ -337,7 +337,8 @@ func TestGetOCIReferrers(t *testing.T) {
 		mbuflen := mbuf.Len()
 		mdigest := godigest.FromBytes(mblob)
 
-		d, _, err := imgStore.PutImageManifest(repo, "1.0", ispec.MediaTypeImageManifest, mbuf.Bytes(), nil)
+		d, _, err := imgStore.PutImageManifest(context.Background(), repo, "1.0",
+			ispec.MediaTypeImageManifest, mbuf.Bytes(), nil)
 		So(d, ShouldEqual, mdigest)
 		So(err, ShouldBeNil)
 
@@ -391,7 +392,8 @@ func TestGetOCIReferrers(t *testing.T) {
 			manBufLen := len(manBuf)
 			manDigest := godigest.FromBytes(manBuf)
 
-			_, _, err = imgStore.PutImageManifest(repo, manDigest.Encoded(), ispec.MediaTypeImageManifest, manBuf, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repo, manDigest.Encoded(), ispec.MediaTypeImageManifest, manBuf, nil)
 			So(err, ShouldBeNil)
 
 			index, err := imgStore.GetReferrers(repo, mdigest, []string{artifactType})
@@ -443,29 +445,29 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 
 			// Init repo should fail if repo name does not match spec
-			err = imgStore.InitRepo(".")
+			err = imgStore.InitRepo(context.Background(), ".")
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 
-			err = imgStore.InitRepo("..")
+			err = imgStore.InitRepo(context.Background(), "..")
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 
-			err = imgStore.InitRepo("_test-dir")
+			err = imgStore.InitRepo(context.Background(), "_test-dir")
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 
-			err = imgStore.InitRepo(".test-dir")
+			err = imgStore.InitRepo(context.Background(), ".test-dir")
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 
-			err = imgStore.InitRepo("-test-dir")
+			err = imgStore.InitRepo(context.Background(), "-test-dir")
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 		})
 
 		Convey("Invalid validate repo", func(c C) {
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			objects, err := storeDriver.List(context.Background(), path.Join(imgStore.RootDir(), testImage))
 			So(err, ShouldBeNil)
 
@@ -520,7 +522,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 		})
 
 		Convey("Invalid get image tags", func(c C) {
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 
 			So(storeDriver.Move(context.Background(), path.Join(testDir, testImage, "index.json"),
 				path.Join(testDir, testImage, "blobs")), ShouldBeNil)
@@ -533,7 +535,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 
 			So(storeDriver.Delete(context.Background(), path.Join(testDir, testImage)), ShouldBeNil)
 
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			So(storeDriver.PutContent(context.Background(), path.Join(testDir, testImage, "index.json"), []byte{}), ShouldBeNil)
 			_, err = imgStore.GetImageTags(testImage)
 			So(err, ShouldNotBeNil)
@@ -547,12 +549,12 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 		defer cleanupStorage(storeDriver, testDir)
 
 		Convey("Invalid get image manifest", func(c C) {
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			So(storeDriver.Delete(context.Background(), path.Join(testDir, testImage, "index.json")), ShouldBeNil)
 			_, _, _, err = imgStore.GetImageManifest(testImage, "")
 			So(err, ShouldNotBeNil)
 			So(storeDriver.Delete(context.Background(), path.Join(testDir, testImage)), ShouldBeNil)
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			So(storeDriver.PutContent(context.Background(), path.Join(testDir, testImage, "index.json"), []byte{}), ShouldBeNil)
 			_, _, _, err = imgStore.GetImageManifest(testImage, "")
 			So(err, ShouldNotBeNil)
@@ -561,12 +563,12 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 		Convey("Invalid validate repo", func(c C) {
 			So(imgStore, ShouldNotBeNil)
 
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			So(storeDriver.Delete(context.Background(), path.Join(testDir, testImage, "index.json")), ShouldBeNil)
 			_, err = imgStore.ValidateRepo(testImage)
 			So(err, ShouldNotBeNil)
 			So(storeDriver.Delete(context.Background(), path.Join(testDir, testImage)), ShouldBeNil)
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			So(storeDriver.Move(context.Background(), path.Join(testDir, testImage, "index.json"),
 				path.Join(testDir, testImage, "_index.json")), ShouldBeNil)
 
@@ -578,7 +580,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 		Convey("Invalid finish blob upload", func(c C) {
 			So(imgStore, ShouldNotBeNil)
 
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			upload, err := imgStore.NewBlobUpload(testImage)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
@@ -638,7 +640,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			})
 			So(imgStore, ShouldNotBeNil)
 
-			So(imgStore.InitRepo(testImage), ShouldNotBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldNotBeNil)
 			_, err := imgStore.ValidateRepo(testImage)
 			So(err, ShouldNotBeNil)
 
@@ -662,10 +664,10 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			err = imgStore.DeleteBlobUpload(testImage, upload)
 			So(err, ShouldNotBeNil)
 
-			err = imgStore.DeleteImageManifest(testImage, "1.0", false)
+			err = imgStore.DeleteImageManifest(context.Background(), testImage, "1.0", false)
 			So(err, ShouldNotBeNil)
 
-			_, _, err = imgStore.PutImageManifest(testImage, "1.0", "application/json", []byte{}, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), testImage, "1.0", "application/json", []byte{}, nil)
 			So(err, ShouldNotBeNil)
 
 			_, err = imgStore.PutBlobChunkStreamed(testImage, upload, bytes.NewBufferString(testImage))
@@ -711,7 +713,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 					return []byte{}, errS3
 				},
 			})
-			err := imgStore.DeleteImageManifest(testImage, "1.0", false)
+			err := imgStore.DeleteImageManifest(context.Background(), testImage, "1.0", false)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -727,7 +729,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 
 		Convey("Test DeleteImageManifest2", func(c C) {
 			imgStore = createMockStorage(testDir, tdir, false, &mocks.StorageDriverMock{})
-			err := imgStore.DeleteImageManifest(testImage, "1.0", false)
+			err := imgStore.DeleteImageManifest(context.Background(), testImage, "1.0", false)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -1041,7 +1043,8 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest := godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe1", manifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe1", manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -1120,7 +1123,8 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest2 := godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe2", "1.0", ispec.MediaTypeImageManifest,
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe2", "1.0", ispec.MediaTypeImageManifest,
 			manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -1145,11 +1149,11 @@ func TestS3Dedupe(t *testing.T) {
 			So(blobDigest1, ShouldEqual, blobDigest2)
 
 			// to not trigger BlobInUse err, delete manifest first
-			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			// delete tag, but not manifest
-			err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", "1.0", false)
 			So(err, ShouldBeNil)
 
 			// delete should succeed as the manifest was deleted
@@ -1160,7 +1164,7 @@ func TestS3Dedupe(t *testing.T) {
 			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
 			So(err, ShouldEqual, zerr.ErrBlobReferenced)
 
-			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
@@ -1169,10 +1173,10 @@ func TestS3Dedupe(t *testing.T) {
 
 		Convey("Check that delete blobs moves the real content to the next contenders", func() {
 			// to not trigger BlobInUse err, delete manifest first
-			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			// if we delete blob1, the content should be moved to blob2
@@ -1292,7 +1296,8 @@ func TestS3Dedupe(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			manifestDigest3 := godigest.FromBytes(manifestBuf)
-			_, _, err = imgStore.PutImageManifest("dedupe3", "1.0", ispec.MediaTypeImageManifest,
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe3", "1.0", ispec.MediaTypeImageManifest,
 				manifestBuf, nil)
 			So(err, ShouldBeNil)
 
@@ -1318,13 +1323,13 @@ func TestS3Dedupe(t *testing.T) {
 			Convey("delete blobs from storage/cache should work when dedupe is false", func() {
 				So(blobDigest1, ShouldEqual, blobDigest2)
 				// to not trigger BlobInUse err, delete manifest first
-				err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 				So(err, ShouldBeNil)
 
-				err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 				So(err, ShouldBeNil)
 
-				err = imgStore.DeleteImageManifest("dedupe3", manifestDigest3.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe3", manifestDigest3.String(), false)
 				So(err, ShouldBeNil)
 
 				err = imgStore.DeleteBlob("dedupe1", blobDigest1)
@@ -1467,7 +1472,8 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest := godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe1", manifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe1", manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -1537,7 +1543,8 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest2 := godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe2", "1.0", ispec.MediaTypeImageManifest,
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe2", "1.0", ispec.MediaTypeImageManifest,
 			manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -1562,11 +1569,11 @@ func TestS3Dedupe(t *testing.T) {
 			So(blobDigest1, ShouldEqual, blobDigest2)
 
 			// to not trigger BlobInUse err, delete manifest first
-			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			// delete tag, but not manifest
-			err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", "1.0", false)
 			So(err, ShouldBeNil)
 
 			// Delete should succeed as the manifest was deleted
@@ -1577,7 +1584,7 @@ func TestS3Dedupe(t *testing.T) {
 			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
 			So(err, ShouldEqual, zerr.ErrBlobReferenced)
 
-			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
@@ -1617,11 +1624,11 @@ func TestS3Dedupe(t *testing.T) {
 				So(blobDigest1, ShouldEqual, blobDigest2)
 
 				// to not trigger BlobInUse err, delete manifest first
-				err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 				So(err, ShouldBeNil)
 
 				// delete tag, but not manifest
-				err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", "1.0", false)
 				So(err, ShouldBeNil)
 
 				// delete should succeed as the manifest was deleted
@@ -1632,7 +1639,7 @@ func TestS3Dedupe(t *testing.T) {
 				err = imgStore.DeleteBlob("dedupe2", blobDigest2)
 				So(err, ShouldEqual, zerr.ErrBlobReferenced)
 
-				err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 				So(err, ShouldBeNil)
 
 				err = imgStore.DeleteBlob("dedupe2", blobDigest2)
@@ -1668,10 +1675,10 @@ func TestS3Dedupe(t *testing.T) {
 		Convey("Check that delete blobs moves the real content to the next contenders", func() {
 			// if we delete blob1, the content should be moved to blob2
 			// to not trigger BlobInUse err, delete manifest first
-			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			err = imgStore.DeleteBlob("dedupe1", blobDigest1)
@@ -1762,7 +1769,8 @@ func TestRebuildDedupeIndex(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		digest = godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe1", digest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe1", digest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -1795,7 +1803,8 @@ func TestRebuildDedupeIndex(t *testing.T) {
 		So(clen, ShouldEqual, len(cblob))
 
 		digest = godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe2", digest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe2", digest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2893,7 +2902,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		So(digest, ShouldNotBeNil)
 
 		m1content := content
-		_, _, err = imgStore.PutImageManifest("index", "test:1.0", ispec.MediaTypeImageManifest, content, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			"index", "test:1.0", ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		// create another manifest but upload using its sha256 reference
@@ -2937,7 +2948,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		So(digest, ShouldNotBeNil)
 		m2dgst := digest
 		m2size := len(content)
-		_, _, err = imgStore.PutImageManifest("index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			"index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		Convey("Image index", func() {
@@ -2978,7 +2991,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
-			_, _, err = imgStore.PutImageManifest("index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				"index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			var index ispec.Index
@@ -3002,7 +3017,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
 			index1dgst := digest
-			_, _, err = imgStore.PutImageManifest("index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				"index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
 			So(err, ShouldBeNil)
 			_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 			So(err, ShouldBeNil)
@@ -3046,7 +3063,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 			So(digest, ShouldNotBeNil)
 			m4dgst := digest
 			m4size := len(content)
-			_, _, err = imgStore.PutImageManifest("index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				"index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			index.SchemaVersion = 2
@@ -3069,7 +3088,8 @@ func TestS3ManifestImageIndex(t *testing.T) {
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
 
-			_, _, err = imgStore.PutImageManifest("index", "test:index2", ispec.MediaTypeImageIndex, content, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				"index", "test:index2", ispec.MediaTypeImageIndex, content, nil)
 			So(err, ShouldBeNil)
 			_, _, _, err = imgStore.GetImageManifest("index", "test:index2")
 			So(err, ShouldBeNil)
@@ -3100,7 +3120,8 @@ func TestS3ManifestImageIndex(t *testing.T) {
 				digest = godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
 
-				_, _, err = imgStore.PutImageManifest("index", "test:index3", ispec.MediaTypeImageIndex, content, nil)
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					"index", "test:index3", ispec.MediaTypeImageIndex, content, nil)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index3")
 				So(err, ShouldBeNil)
@@ -3122,7 +3143,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 				digest = godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
-				_, _, err = imgStore.PutImageManifest("index", digest.String(), ispec.MediaTypeImageIndex, content, nil)
+
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					"index", digest.String(), ispec.MediaTypeImageIndex, content, nil)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", digest.String())
 				So(err, ShouldBeNil)
@@ -3130,12 +3153,12 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 			Convey("Deleting an image index", func() {
 				// delete manifest by tag should pass
-				err := imgStore.DeleteImageManifest("index", "test:index3", false)
+				err := imgStore.DeleteImageManifest(context.Background(), "index", "test:index3", false)
 				So(err, ShouldNotBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index3")
 				So(err, ShouldNotBeNil)
 
-				err = imgStore.DeleteImageManifest("index", "test:index1", false)
+				err = imgStore.DeleteImageManifest(context.Background(), "index", "test:index1", false)
 				So(err, ShouldBeNil)
 
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
@@ -3147,12 +3170,12 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 			Convey("Deleting an image index by digest", func() {
 				// delete manifest by tag should pass
-				err := imgStore.DeleteImageManifest("index", "test:index3", false)
+				err := imgStore.DeleteImageManifest(context.Background(), "index", "test:index3", false)
 				So(err, ShouldNotBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index3")
 				So(err, ShouldNotBeNil)
 
-				err = imgStore.DeleteImageManifest("index", index1dgst.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "index", index1dgst.String(), false)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 				So(err, ShouldNotBeNil)
@@ -3202,7 +3225,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 				digest = godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
-				_, _, err = imgStore.PutImageManifest("index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					"index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", digest.String())
 				So(err, ShouldBeNil)
@@ -3222,12 +3247,13 @@ func TestS3ManifestImageIndex(t *testing.T) {
 				digest = godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
 
-				_, _, err = imgStore.PutImageManifest("index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					"index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 				So(err, ShouldBeNil)
 
-				err = imgStore.DeleteImageManifest("index", "test:index1", false)
+				err = imgStore.DeleteImageManifest(context.Background(), "index", "test:index1", false)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 				So(err, ShouldNotBeNil)
@@ -3238,7 +3264,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 					cleanupStorage(storeDriver, path.Join(testDir, "index", "blobs",
 						index1dgst.Algorithm().String(), index1dgst.Encoded()))
 
-					err = imgStore.DeleteImageManifest("index", index1dgst.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "index", index1dgst.String(), false)
 					So(err, ShouldNotBeNil)
 					_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 					So(err, ShouldNotBeNil)
@@ -3254,7 +3280,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 					So(err, ShouldBeNil)
 					wrtr.Close()
 
-					err = imgStore.DeleteImageManifest("index", index1dgst.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "index", index1dgst.String(), false)
 					So(err, ShouldBeNil)
 					_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 					So(err, ShouldNotBeNil)
@@ -3278,11 +3304,13 @@ func TestS3ManifestImageIndex(t *testing.T) {
 					digest = godigest.FromBytes(content)
 					So(digest, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("index", "test:1.0", ispec.MediaTypeImageIndex, content, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"index", "test:1.0", ispec.MediaTypeImageIndex, content, nil)
 					So(err, ShouldBeNil)
 
 					// previously an image index, try writing a manifest
-					_, _, err = imgStore.PutImageManifest("index", "test:index1", ispec.MediaTypeImageManifest, m1content, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"index", "test:index1", ispec.MediaTypeImageManifest, m1content, nil)
 					So(err, ShouldBeNil)
 				})
 			})
@@ -3351,7 +3379,8 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 		m1size := len(content)
 
-		_, _, err = imgStore.PutImageManifest("index", "test:1.0", ispec.MediaTypeImageManifest, content, nil)
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			"index", "test:1.0", ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		// second config
@@ -3386,7 +3415,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		So(m2digest, ShouldNotBeNil)
 
 		m2size := len(content)
-		_, _, err = imgStore.PutImageManifest("index", m2digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			"index", m2digest.String(), ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		Convey("Put image index with valid subject", func() {
@@ -3412,7 +3443,8 @@ func TestS3ManifestImageIndex(t *testing.T) {
 			idigest := godigest.FromBytes(content)
 			So(idigest, ShouldNotBeNil)
 
-			digest1, digest2, err := imgStore.PutImageManifest("index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
+			digest1, digest2, err := imgStore.PutImageManifest(context.Background(),
+				"index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
 			So(err, ShouldBeNil)
 			So(digest1.String(), ShouldEqual, idigest.String())
 			So(digest2.String(), ShouldEqual, m1digest.String())

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -220,14 +220,14 @@ func TestStorageDriverStatFunction(t *testing.T) {
 
 		So(imgStore, ShouldNotBeNil)
 
-		err = imgStore.InitRepo(repo1)
+		err = imgStore.InitRepo(context.Background(), repo1)
 		So(err, ShouldBeNil)
 
 		isValid, err := imgStore.ValidateRepo(repo1)
 		So(err, ShouldBeNil)
 		So(isValid, ShouldBeTrue)
 
-		err = imgStore.InitRepo(repo2)
+		err = imgStore.InitRepo(context.Background(), repo2)
 		So(err, ShouldBeNil)
 
 		isValid, err = imgStore.ValidateRepo(repo2)
@@ -337,7 +337,8 @@ func TestGetOCIReferrers(t *testing.T) {
 		mbuflen := mbuf.Len()
 		mdigest := godigest.FromBytes(mblob)
 
-		d, _, err := imgStore.PutImageManifest(repo, "1.0", ispec.MediaTypeImageManifest, mbuf.Bytes(), nil)
+		d, _, err := imgStore.PutImageManifest(context.Background(), repo, "1.0",
+			ispec.MediaTypeImageManifest, mbuf.Bytes(), nil)
 		So(d, ShouldEqual, mdigest)
 		So(err, ShouldBeNil)
 
@@ -391,7 +392,8 @@ func TestGetOCIReferrers(t *testing.T) {
 			manBufLen := len(manBuf)
 			manDigest := godigest.FromBytes(manBuf)
 
-			_, _, err = imgStore.PutImageManifest(repo, manDigest.Encoded(), ispec.MediaTypeImageManifest, manBuf, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				repo, manDigest.Encoded(), ispec.MediaTypeImageManifest, manBuf, nil)
 			So(err, ShouldBeNil)
 
 			index, err := imgStore.GetReferrers(repo, mdigest, []string{artifactType})
@@ -443,29 +445,29 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 
 			// Init repo should fail if repo name does not match spec
-			err = imgStore.InitRepo(".")
+			err = imgStore.InitRepo(context.Background(), ".")
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 
-			err = imgStore.InitRepo("..")
+			err = imgStore.InitRepo(context.Background(), "..")
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 
-			err = imgStore.InitRepo("_test-dir")
+			err = imgStore.InitRepo(context.Background(), "_test-dir")
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 
-			err = imgStore.InitRepo(".test-dir")
+			err = imgStore.InitRepo(context.Background(), ".test-dir")
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 
-			err = imgStore.InitRepo("-test-dir")
+			err = imgStore.InitRepo(context.Background(), "-test-dir")
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
 		})
 
 		Convey("Invalid validate repo", func(c C) {
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			objects, err := storeDriver.List(context.Background(), path.Join(imgStore.RootDir(), testImage))
 			So(err, ShouldBeNil)
 
@@ -520,7 +522,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 		})
 
 		Convey("Invalid get image tags", func(c C) {
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 
 			So(storeDriver.Move(context.Background(), path.Join(testDir, testImage, "index.json"),
 				path.Join(testDir, testImage, "blobs")), ShouldBeNil)
@@ -533,7 +535,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 
 			So(storeDriver.Delete(context.Background(), path.Join(testDir, testImage)), ShouldBeNil)
 
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			So(storeDriver.PutContent(context.Background(), path.Join(testDir, testImage, "index.json"), []byte{}), ShouldBeNil)
 			_, err = imgStore.GetImageTags(testImage)
 			So(err, ShouldNotBeNil)
@@ -547,12 +549,12 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 		defer cleanupStorage(storeDriver, testDir)
 
 		Convey("Invalid get image manifest", func(c C) {
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			So(storeDriver.Delete(context.Background(), path.Join(testDir, testImage, "index.json")), ShouldBeNil)
 			_, _, _, err = imgStore.GetImageManifest(testImage, "")
 			So(err, ShouldNotBeNil)
 			So(storeDriver.Delete(context.Background(), path.Join(testDir, testImage)), ShouldBeNil)
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			So(storeDriver.PutContent(context.Background(), path.Join(testDir, testImage, "index.json"), []byte{}), ShouldBeNil)
 			_, _, _, err = imgStore.GetImageManifest(testImage, "")
 			So(err, ShouldNotBeNil)
@@ -561,12 +563,12 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 		Convey("Invalid validate repo", func(c C) {
 			So(imgStore, ShouldNotBeNil)
 
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			So(storeDriver.Delete(context.Background(), path.Join(testDir, testImage, "index.json")), ShouldBeNil)
 			_, err = imgStore.ValidateRepo(testImage)
 			So(err, ShouldNotBeNil)
 			So(storeDriver.Delete(context.Background(), path.Join(testDir, testImage)), ShouldBeNil)
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			So(storeDriver.Move(context.Background(), path.Join(testDir, testImage, "index.json"),
 				path.Join(testDir, testImage, "_index.json")), ShouldBeNil)
 
@@ -578,7 +580,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 		Convey("Invalid finish blob upload", func(c C) {
 			So(imgStore, ShouldNotBeNil)
 
-			So(imgStore.InitRepo(testImage), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
 			upload, err := imgStore.NewBlobUpload(testImage)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
@@ -638,7 +640,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			})
 			So(imgStore, ShouldNotBeNil)
 
-			So(imgStore.InitRepo(testImage), ShouldNotBeNil)
+			So(imgStore.InitRepo(context.Background(), testImage), ShouldNotBeNil)
 			_, err := imgStore.ValidateRepo(testImage)
 			So(err, ShouldNotBeNil)
 
@@ -662,10 +664,10 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			err = imgStore.DeleteBlobUpload(testImage, upload)
 			So(err, ShouldNotBeNil)
 
-			err = imgStore.DeleteImageManifest(testImage, "1.0", false)
+			err = imgStore.DeleteImageManifest(context.Background(), testImage, "1.0", false)
 			So(err, ShouldNotBeNil)
 
-			_, _, err = imgStore.PutImageManifest(testImage, "1.0", "application/json", []byte{}, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(), testImage, "1.0", "application/json", []byte{}, nil)
 			So(err, ShouldNotBeNil)
 
 			_, err = imgStore.PutBlobChunkStreamed(testImage, upload, bytes.NewBufferString(testImage))
@@ -711,7 +713,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 					return []byte{}, errS3
 				},
 			})
-			err := imgStore.DeleteImageManifest(testImage, "1.0", false)
+			err := imgStore.DeleteImageManifest(context.Background(), testImage, "1.0", false)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -727,7 +729,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 
 		Convey("Test DeleteImageManifest2", func(c C) {
 			imgStore = createMockStorage(testDir, tdir, false, &mocks.StorageDriverMock{})
-			err := imgStore.DeleteImageManifest(testImage, "1.0", false)
+			err := imgStore.DeleteImageManifest(context.Background(), testImage, "1.0", false)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -1041,7 +1043,8 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest := godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe1", manifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe1", manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -1120,7 +1123,8 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest2 := godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe2", "1.0", ispec.MediaTypeImageManifest,
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe2", "1.0", ispec.MediaTypeImageManifest,
 			manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -1145,11 +1149,11 @@ func TestS3Dedupe(t *testing.T) {
 			So(blobDigest1, ShouldEqual, blobDigest2)
 
 			// to not trigger BlobInUse err, delete manifest first
-			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			// delete tag, but not manifest
-			err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", "1.0", false)
 			So(err, ShouldBeNil)
 
 			// delete should succeed as the manifest was deleted
@@ -1160,7 +1164,7 @@ func TestS3Dedupe(t *testing.T) {
 			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
 			So(err, ShouldEqual, zerr.ErrBlobReferenced)
 
-			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
@@ -1169,10 +1173,10 @@ func TestS3Dedupe(t *testing.T) {
 
 		Convey("Check that delete blobs moves the real content to the next contenders", func() {
 			// to not trigger BlobInUse err, delete manifest first
-			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			// if we delete blob1, the content should be moved to blob2
@@ -1300,7 +1304,8 @@ func TestS3Dedupe(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			manifestDigest3 := godigest.FromBytes(manifestBuf)
-			_, _, err = imgStore.PutImageManifest("dedupe3", "1.0", ispec.MediaTypeImageManifest,
+
+			_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe3", "1.0", ispec.MediaTypeImageManifest,
 				manifestBuf, nil)
 			So(err, ShouldBeNil)
 
@@ -1326,13 +1331,13 @@ func TestS3Dedupe(t *testing.T) {
 			Convey("delete blobs from storage/cache should work when dedupe is false", func() {
 				So(blobDigest1, ShouldEqual, blobDigest2)
 				// to not trigger BlobInUse err, delete manifest first
-				err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 				So(err, ShouldBeNil)
 
-				err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 				So(err, ShouldBeNil)
 
-				err = imgStore.DeleteImageManifest("dedupe3", manifestDigest3.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe3", manifestDigest3.String(), false)
 				So(err, ShouldBeNil)
 
 				err = imgStore.DeleteBlob("dedupe1", blobDigest1)
@@ -1475,7 +1480,8 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest := godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe1", manifestDigest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe1", manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -1545,7 +1551,8 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		manifestDigest2 := godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe2", "1.0", ispec.MediaTypeImageManifest,
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe2", "1.0", ispec.MediaTypeImageManifest,
 			manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -1570,11 +1577,11 @@ func TestS3Dedupe(t *testing.T) {
 			So(blobDigest1, ShouldEqual, blobDigest2)
 
 			// to not trigger BlobInUse err, delete manifest first
-			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
 			// delete tag, but not manifest
-			err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", "1.0", false)
 			So(err, ShouldBeNil)
 
 			// Delete should succeed as the manifest was deleted
@@ -1585,7 +1592,7 @@ func TestS3Dedupe(t *testing.T) {
 			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
 			So(err, ShouldEqual, zerr.ErrBlobReferenced)
 
-			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			err = imgStore.DeleteBlob("dedupe2", blobDigest2)
@@ -1625,11 +1632,11 @@ func TestS3Dedupe(t *testing.T) {
 				So(blobDigest1, ShouldEqual, blobDigest2)
 
 				// to not trigger BlobInUse err, delete manifest first
-				err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 				So(err, ShouldBeNil)
 
 				// delete tag, but not manifest
-				err = imgStore.DeleteImageManifest("dedupe2", "1.0", false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", "1.0", false)
 				So(err, ShouldBeNil)
 
 				// delete should succeed as the manifest was deleted
@@ -1640,7 +1647,7 @@ func TestS3Dedupe(t *testing.T) {
 				err = imgStore.DeleteBlob("dedupe2", blobDigest2)
 				So(err, ShouldEqual, zerr.ErrBlobReferenced)
 
-				err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 				So(err, ShouldBeNil)
 
 				err = imgStore.DeleteBlob("dedupe2", blobDigest2)
@@ -1676,10 +1683,10 @@ func TestS3Dedupe(t *testing.T) {
 		Convey("Check that delete blobs moves the real content to the next contenders", func() {
 			// if we delete blob1, the content should be moved to blob2
 			// to not trigger BlobInUse err, delete manifest first
-			err = imgStore.DeleteImageManifest("dedupe1", manifestDigest.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe1", manifestDigest.String(), false)
 			So(err, ShouldBeNil)
 
-			err = imgStore.DeleteImageManifest("dedupe2", manifestDigest2.String(), false)
+			err = imgStore.DeleteImageManifest(context.Background(), "dedupe2", manifestDigest2.String(), false)
 			So(err, ShouldBeNil)
 
 			err = imgStore.DeleteBlob("dedupe1", blobDigest1)
@@ -1770,7 +1777,8 @@ func TestRebuildDedupeIndex(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		digest = godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe1", digest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe1", digest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -1803,7 +1811,8 @@ func TestRebuildDedupeIndex(t *testing.T) {
 		So(clen, ShouldEqual, len(cblob))
 
 		digest = godigest.FromBytes(manifestBuf)
-		_, _, err = imgStore.PutImageManifest("dedupe2", digest.String(),
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), "dedupe2", digest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -2901,7 +2910,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		So(digest, ShouldNotBeNil)
 
 		m1content := content
-		_, _, err = imgStore.PutImageManifest("index", "test:1.0", ispec.MediaTypeImageManifest, content, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			"index", "test:1.0", ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		// create another manifest but upload using its sha256 reference
@@ -2945,7 +2956,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		So(digest, ShouldNotBeNil)
 		m2dgst := digest
 		m2size := len(content)
-		_, _, err = imgStore.PutImageManifest("index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			"index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		Convey("Image index", func() {
@@ -2986,7 +2999,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
-			_, _, err = imgStore.PutImageManifest("index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				"index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			var index ispec.Index
@@ -3010,7 +3025,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
 			index1dgst := digest
-			_, _, err = imgStore.PutImageManifest("index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				"index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
 			So(err, ShouldBeNil)
 			_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 			So(err, ShouldBeNil)
@@ -3054,7 +3071,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 			So(digest, ShouldNotBeNil)
 			m4dgst := digest
 			m4size := len(content)
-			_, _, err = imgStore.PutImageManifest("index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				"index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
 			So(err, ShouldBeNil)
 
 			index.SchemaVersion = 2
@@ -3077,7 +3096,8 @@ func TestS3ManifestImageIndex(t *testing.T) {
 			digest = godigest.FromBytes(content)
 			So(digest, ShouldNotBeNil)
 
-			_, _, err = imgStore.PutImageManifest("index", "test:index2", ispec.MediaTypeImageIndex, content, nil)
+			_, _, err = imgStore.PutImageManifest(context.Background(),
+				"index", "test:index2", ispec.MediaTypeImageIndex, content, nil)
 			So(err, ShouldBeNil)
 			_, _, _, err = imgStore.GetImageManifest("index", "test:index2")
 			So(err, ShouldBeNil)
@@ -3108,7 +3128,8 @@ func TestS3ManifestImageIndex(t *testing.T) {
 				digest = godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
 
-				_, _, err = imgStore.PutImageManifest("index", "test:index3", ispec.MediaTypeImageIndex, content, nil)
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					"index", "test:index3", ispec.MediaTypeImageIndex, content, nil)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index3")
 				So(err, ShouldBeNil)
@@ -3130,7 +3151,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 				digest = godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
-				_, _, err = imgStore.PutImageManifest("index", digest.String(), ispec.MediaTypeImageIndex, content, nil)
+
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					"index", digest.String(), ispec.MediaTypeImageIndex, content, nil)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", digest.String())
 				So(err, ShouldBeNil)
@@ -3138,12 +3161,12 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 			Convey("Deleting an image index", func() {
 				// delete manifest by tag should pass
-				err := imgStore.DeleteImageManifest("index", "test:index3", false)
+				err := imgStore.DeleteImageManifest(context.Background(), "index", "test:index3", false)
 				So(err, ShouldNotBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index3")
 				So(err, ShouldNotBeNil)
 
-				err = imgStore.DeleteImageManifest("index", "test:index1", false)
+				err = imgStore.DeleteImageManifest(context.Background(), "index", "test:index1", false)
 				So(err, ShouldBeNil)
 
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
@@ -3155,12 +3178,12 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 			Convey("Deleting an image index by digest", func() {
 				// delete manifest by tag should pass
-				err := imgStore.DeleteImageManifest("index", "test:index3", false)
+				err := imgStore.DeleteImageManifest(context.Background(), "index", "test:index3", false)
 				So(err, ShouldNotBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index3")
 				So(err, ShouldNotBeNil)
 
-				err = imgStore.DeleteImageManifest("index", index1dgst.String(), false)
+				err = imgStore.DeleteImageManifest(context.Background(), "index", index1dgst.String(), false)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 				So(err, ShouldNotBeNil)
@@ -3210,7 +3233,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 				digest = godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
-				_, _, err = imgStore.PutImageManifest("index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					"index", digest.String(), ispec.MediaTypeImageManifest, content, nil)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", digest.String())
 				So(err, ShouldBeNil)
@@ -3230,12 +3255,13 @@ func TestS3ManifestImageIndex(t *testing.T) {
 				digest = godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
 
-				_, _, err = imgStore.PutImageManifest("index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					"index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 				So(err, ShouldBeNil)
 
-				err = imgStore.DeleteImageManifest("index", "test:index1", false)
+				err = imgStore.DeleteImageManifest(context.Background(), "index", "test:index1", false)
 				So(err, ShouldBeNil)
 				_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 				So(err, ShouldNotBeNil)
@@ -3246,7 +3272,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 					cleanupStorage(storeDriver, path.Join(testDir, "index", "blobs",
 						index1dgst.Algorithm().String(), index1dgst.Encoded()))
 
-					err = imgStore.DeleteImageManifest("index", index1dgst.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "index", index1dgst.String(), false)
 					So(err, ShouldNotBeNil)
 					_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 					So(err, ShouldNotBeNil)
@@ -3262,7 +3288,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 					So(err, ShouldBeNil)
 					wrtr.Close()
 
-					err = imgStore.DeleteImageManifest("index", index1dgst.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), "index", index1dgst.String(), false)
 					So(err, ShouldBeNil)
 					_, _, _, err = imgStore.GetImageManifest("index", "test:index1")
 					So(err, ShouldNotBeNil)
@@ -3286,11 +3312,13 @@ func TestS3ManifestImageIndex(t *testing.T) {
 					digest = godigest.FromBytes(content)
 					So(digest, ShouldNotBeNil)
 
-					_, _, err = imgStore.PutImageManifest("index", "test:1.0", ispec.MediaTypeImageIndex, content, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"index", "test:1.0", ispec.MediaTypeImageIndex, content, nil)
 					So(err, ShouldBeNil)
 
 					// previously an image index, try writing a manifest
-					_, _, err = imgStore.PutImageManifest("index", "test:index1", ispec.MediaTypeImageManifest, m1content, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"index", "test:index1", ispec.MediaTypeImageManifest, m1content, nil)
 					So(err, ShouldBeNil)
 				})
 			})
@@ -3359,7 +3387,8 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 		m1size := len(content)
 
-		_, _, err = imgStore.PutImageManifest("index", "test:1.0", ispec.MediaTypeImageManifest, content, nil)
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			"index", "test:1.0", ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		// second config
@@ -3394,7 +3423,9 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		So(m2digest, ShouldNotBeNil)
 
 		m2size := len(content)
-		_, _, err = imgStore.PutImageManifest("index", m2digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			"index", m2digest.String(), ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		Convey("Put image index with valid subject", func() {
@@ -3420,7 +3451,8 @@ func TestS3ManifestImageIndex(t *testing.T) {
 			idigest := godigest.FromBytes(content)
 			So(idigest, ShouldNotBeNil)
 
-			digest1, digest2, err := imgStore.PutImageManifest("index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
+			digest1, digest2, err := imgStore.PutImageManifest(context.Background(),
+				"index", "test:index1", ispec.MediaTypeImageIndex, content, nil)
 			So(err, ShouldBeNil)
 			So(digest1.String(), ShouldEqual, idigest.String())
 			So(digest2.String(), ShouldEqual, m1digest.String())

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -822,7 +822,8 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 					}, errS3
 				},
 			})
-			_, err := imgStore.PutBlobChunk(context.Background(), testImage, "uuid", 12, 100, io.NopCloser(strings.NewReader("")))
+			_, err := imgStore.PutBlobChunk(context.Background(), testImage, "uuid", 12, 100,
+				io.NopCloser(strings.NewReader("")))
 			So(err, ShouldNotBeNil)
 		})
 

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -297,7 +297,7 @@ func TestGetOCIReferrers(t *testing.T) {
 		layers := image.Layers
 
 		for _, content := range layers {
-			upload, err := imgStore.NewBlobUpload(repo)
+			upload, err := imgStore.NewBlobUpload(context.Background(), repo)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -305,7 +305,7 @@ func TestGetOCIReferrers(t *testing.T) {
 			buflen := buf.Len()
 			digest := godigest.FromBytes(content)
 
-			blob, err := imgStore.PutBlobChunkStreamed(repo, upload, buf)
+			blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repo, upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -325,7 +325,7 @@ func TestGetOCIReferrers(t *testing.T) {
 		buflen := buf.Len()
 		digest := godigest.FromBytes(cblob)
 
-		_, clen, err := imgStore.FullBlobUpload(repo, buf, digest)
+		_, clen, err := imgStore.FullBlobUpload(context.Background(), repo, buf, digest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, buflen)
 
@@ -347,7 +347,7 @@ func TestGetOCIReferrers(t *testing.T) {
 		buf = bytes.NewBuffer(body)
 		buflen = buf.Len()
 
-		_, n, err := imgStore.FullBlobUpload(repo, buf, digest)
+		_, n, err := imgStore.FullBlobUpload(context.Background(), repo, buf, digest)
 		So(err, ShouldBeNil)
 		So(n, ShouldEqual, buflen)
 
@@ -359,7 +359,7 @@ func TestGetOCIReferrers(t *testing.T) {
 			configBuf := bytes.NewBuffer(configBody)
 			configBufLen := configBuf.Len()
 
-			_, n, err := imgStore.FullBlobUpload(repo, configBuf, configDigest)
+			_, n, err := imgStore.FullBlobUpload(context.Background(), repo, configBuf, configDigest)
 			So(err, ShouldBeNil)
 			So(n, ShouldEqual, configBufLen)
 
@@ -581,7 +581,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			So(imgStore, ShouldNotBeNil)
 
 			So(imgStore.InitRepo(context.Background(), testImage), ShouldBeNil)
-			upload, err := imgStore.NewBlobUpload(testImage)
+			upload, err := imgStore.NewBlobUpload(context.Background(), testImage)
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -590,7 +590,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			buflen := buf.Len()
 			digest := godigest.FromBytes(content)
 
-			blob, err := imgStore.PutBlobChunk(testImage, upload, 0, int64(buflen), buf)
+			blob, err := imgStore.PutBlobChunk(context.Background(), testImage, upload, 0, int64(buflen), buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -644,7 +644,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			_, err := imgStore.ValidateRepo(testImage)
 			So(err, ShouldNotBeNil)
 
-			upload, err := imgStore.NewBlobUpload(testImage)
+			upload, err := imgStore.NewBlobUpload(context.Background(), testImage)
 			So(err, ShouldNotBeNil)
 
 			content := []byte("test-data1")
@@ -652,7 +652,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			buflen := buf.Len()
 			digest := godigest.FromBytes(content)
 
-			_, err = imgStore.PutBlobChunk(testImage, upload, 0, int64(buflen), buf)
+			_, err = imgStore.PutBlobChunk(context.Background(), testImage, upload, 0, int64(buflen), buf)
 			So(err, ShouldNotBeNil)
 
 			err = imgStore.FinishBlobUpload(testImage, upload, buf, digest)
@@ -670,13 +670,13 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 			_, _, err = imgStore.PutImageManifest(context.Background(), testImage, "1.0", "application/json", []byte{}, nil)
 			So(err, ShouldNotBeNil)
 
-			_, err = imgStore.PutBlobChunkStreamed(testImage, upload, bytes.NewBufferString(testImage))
+			_, err = imgStore.PutBlobChunkStreamed(context.Background(), testImage, upload, bytes.NewBufferString(testImage))
 			So(err, ShouldNotBeNil)
 
-			_, _, err = imgStore.FullBlobUpload(testImage, bytes.NewBuffer([]byte{}), "inexistent")
+			_, _, err = imgStore.FullBlobUpload(context.Background(), testImage, bytes.NewBuffer([]byte{}), "inexistent")
 			So(err, ShouldNotBeNil)
 
-			_, _, err = imgStore.CheckBlob(testImage, digest)
+			_, _, err = imgStore.CheckBlob(context.Background(), testImage, digest)
 			So(err, ShouldNotBeNil)
 
 			_, _, _, err = imgStore.StatBlob(testImage, digest)
@@ -739,7 +739,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 					return nil, errS3
 				},
 			})
-			_, err := imgStore.NewBlobUpload(testImage)
+			_, err := imgStore.NewBlobUpload(context.Background(), testImage)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -769,7 +769,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 					return &mocks.FileWriterMock{}, errS3
 				},
 			})
-			_, err := imgStore.PutBlobChunkStreamed(testImage, "uuid", io.NopCloser(strings.NewReader("")))
+			_, err := imgStore.PutBlobChunkStreamed(context.Background(), testImage, "uuid", io.NopCloser(strings.NewReader("")))
 			So(err, ShouldNotBeNil)
 		})
 
@@ -781,7 +781,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 					}}, errS3
 				},
 			})
-			_, err := imgStore.PutBlobChunkStreamed(testImage, "uuid", io.NopCloser(strings.NewReader("")))
+			_, err := imgStore.PutBlobChunkStreamed(context.Background(), testImage, "uuid", io.NopCloser(strings.NewReader("")))
 			So(err, ShouldNotBeNil)
 		})
 
@@ -791,7 +791,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 					return &mocks.FileWriterMock{}, errS3
 				},
 			})
-			_, err := imgStore.PutBlobChunk(testImage, "uuid", 0, 100, io.NopCloser(strings.NewReader("")))
+			_, err := imgStore.PutBlobChunk(context.Background(), testImage, "uuid", 0, 100, io.NopCloser(strings.NewReader("")))
 			So(err, ShouldNotBeNil)
 		})
 
@@ -808,7 +808,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 					}, nil
 				},
 			})
-			_, err := imgStore.PutBlobChunk(testImage, "uuid", 0, 100, io.NopCloser(strings.NewReader("")))
+			_, err := imgStore.PutBlobChunk(context.Background(), testImage, "uuid", 0, 100, io.NopCloser(strings.NewReader("")))
 			So(err, ShouldNotBeNil)
 		})
 
@@ -822,7 +822,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 					}, errS3
 				},
 			})
-			_, err := imgStore.PutBlobChunk(testImage, "uuid", 12, 100, io.NopCloser(strings.NewReader("")))
+			_, err := imgStore.PutBlobChunk(context.Background(), testImage, "uuid", 12, 100, io.NopCloser(strings.NewReader("")))
 			So(err, ShouldNotBeNil)
 		})
 
@@ -832,7 +832,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 					return &mocks.FileWriterMock{}, driver.PathNotFoundError{}
 				},
 			})
-			_, err := imgStore.PutBlobChunk(testImage, "uuid", 0, 100, io.NopCloser(strings.NewReader("")))
+			_, err := imgStore.PutBlobChunk(context.Background(), testImage, "uuid", 0, 100, io.NopCloser(strings.NewReader("")))
 			So(err, ShouldNotBeNil)
 		})
 
@@ -895,14 +895,14 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			d := godigest.FromBytes([]byte(""))
-			_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d)
+			_, _, err := imgStore.FullBlobUpload(context.Background(), testImage, io.NopCloser(strings.NewReader("")), d)
 			So(err, ShouldNotBeNil)
 		})
 
 		Convey("Test FullBlobUpload2", func(c C) {
 			imgStore = createMockStorage(testDir, tdir, false, &mocks.StorageDriverMock{})
 			d := godigest.FromBytes([]byte(" "))
-			_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d)
+			_, _, err := imgStore.FullBlobUpload(context.Background(), testImage, io.NopCloser(strings.NewReader("")), d)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -913,7 +913,7 @@ func TestNegativeCasesObjectsStorage(t *testing.T) {
 				},
 			})
 			d := godigest.FromBytes([]byte(""))
-			_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d)
+			_, _, err := imgStore.FullBlobUpload(context.Background(), testImage, io.NopCloser(strings.NewReader("")), d)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -978,7 +978,7 @@ func TestS3Dedupe(t *testing.T) {
 		defer cleanupStorage(storeDriver, testDir)
 
 		// manifest1
-		upload, err := imgStore.NewBlobUpload("dedupe1")
+		upload, err := imgStore.NewBlobUpload(context.Background(), "dedupe1")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -986,7 +986,7 @@ func TestS3Dedupe(t *testing.T) {
 		buf := bytes.NewBuffer(content)
 		buflen := buf.Len()
 		digest := godigest.FromBytes(content)
-		blob, err := imgStore.PutBlobChunkStreamed("dedupe1", upload, buf)
+		blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "dedupe1", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -997,7 +997,7 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		ok, checkBlobSize1, err := imgStore.CheckBlob("dedupe1", digest)
+		ok, checkBlobSize1, err := imgStore.CheckBlob(context.Background(), "dedupe1", digest)
 		So(ok, ShouldBeTrue)
 		So(checkBlobSize1, ShouldBeGreaterThan, 0)
 		So(err, ShouldBeNil)
@@ -1015,11 +1015,11 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, clen, err := imgStore.FullBlobUpload("dedupe1", bytes.NewReader(cblob), cdigest)
+		_, clen, err := imgStore.FullBlobUpload(context.Background(), "dedupe1", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
-		hasBlob, _, err := imgStore.CheckBlob("dedupe1", cdigest)
+		hasBlob, _, err := imgStore.CheckBlob(context.Background(), "dedupe1", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -1052,7 +1052,7 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// manifest2
-		upload, err = imgStore.NewBlobUpload("dedupe2")
+		upload, err = imgStore.NewBlobUpload(context.Background(), "dedupe2")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -1061,7 +1061,7 @@ func TestS3Dedupe(t *testing.T) {
 		buflen = buf.Len()
 		digest = godigest.FromBytes(content)
 
-		blob, err = imgStore.PutBlobChunkStreamed("dedupe2", upload, buf)
+		blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "dedupe2", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -1072,7 +1072,7 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		_, checkBlobSize2, err := imgStore.CheckBlob("dedupe2", digest)
+		_, checkBlobSize2, err := imgStore.CheckBlob(context.Background(), "dedupe2", digest)
 		So(err, ShouldBeNil)
 		So(checkBlobSize2, ShouldBeGreaterThan, 0)
 
@@ -1096,11 +1096,11 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cblob, cdigest = GetRandomImageConfig()
-		_, clen, err = imgStore.FullBlobUpload("dedupe2", bytes.NewReader(cblob), cdigest)
+		_, clen, err = imgStore.FullBlobUpload(context.Background(), "dedupe2", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
-		hasBlob, _, err = imgStore.CheckBlob("dedupe2", cdigest)
+		hasBlob, _, err = imgStore.CheckBlob(context.Background(), "dedupe2", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -1226,7 +1226,7 @@ func TestS3Dedupe(t *testing.T) {
 			defer cleanupStorage(storeDriver, testDir)
 
 			// manifest3 without dedupe
-			upload, err = imgStore.NewBlobUpload("dedupe3")
+			upload, err = imgStore.NewBlobUpload(context.Background(), "dedupe3")
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -1235,7 +1235,7 @@ func TestS3Dedupe(t *testing.T) {
 			buflen = buf.Len()
 			digest = godigest.FromBytes(content)
 
-			blob, err = imgStore.PutBlobChunkStreamed("dedupe3", upload, buf)
+			blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "dedupe3", upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -1246,7 +1246,7 @@ func TestS3Dedupe(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
-			_, _, err = imgStore.CheckBlob("dedupe3", digest)
+			_, _, err = imgStore.CheckBlob(context.Background(), "dedupe3", digest)
 			So(err, ShouldBeNil)
 
 			// check that we retrieve the real dedupe2/blob (which is deduped earlier - 0 size) when switching to dedupe false
@@ -1258,7 +1258,7 @@ func TestS3Dedupe(t *testing.T) {
 			err = blobReadCloser.Close()
 			So(err, ShouldBeNil)
 
-			_, checkBlobSize2, err := imgStore.CheckBlob("dedupe2", digest)
+			_, checkBlobSize2, err := imgStore.CheckBlob(context.Background(), "dedupe2", digest)
 			So(err, ShouldBeNil)
 			So(checkBlobSize2, ShouldBeGreaterThan, 0)
 			So(checkBlobSize2, ShouldEqual, getBlobSize2)
@@ -1271,17 +1271,17 @@ func TestS3Dedupe(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(getBlobSize1, ShouldEqual, len(blobContent))
 
-			_, checkBlobSize3, err := imgStore.CheckBlob("dedupe3", digest)
+			_, checkBlobSize3, err := imgStore.CheckBlob(context.Background(), "dedupe3", digest)
 			So(err, ShouldBeNil)
 			So(checkBlobSize3, ShouldBeGreaterThan, 0)
 			So(checkBlobSize3, ShouldEqual, getBlobSize3)
 
 			cblob, cdigest = GetRandomImageConfig()
-			_, clen, err = imgStore.FullBlobUpload("dedupe3", bytes.NewReader(cblob), cdigest)
+			_, clen, err = imgStore.FullBlobUpload(context.Background(), "dedupe3", bytes.NewReader(cblob), cdigest)
 			So(err, ShouldBeNil)
 			So(clen, ShouldEqual, len(cblob))
 
-			hasBlob, _, err = imgStore.CheckBlob("dedupe3", cdigest)
+			hasBlob, _, err = imgStore.CheckBlob(context.Background(), "dedupe3", cdigest)
 			So(err, ShouldBeNil)
 			So(hasBlob, ShouldEqual, true)
 
@@ -1421,7 +1421,7 @@ func TestS3Dedupe(t *testing.T) {
 		defer cleanupStorage(storeDriver, testDir)
 
 		// manifest1
-		upload, err := imgStore.NewBlobUpload("dedupe1")
+		upload, err := imgStore.NewBlobUpload(context.Background(), "dedupe1")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -1429,7 +1429,7 @@ func TestS3Dedupe(t *testing.T) {
 		buf := bytes.NewBuffer(content)
 		buflen := buf.Len()
 		digest := godigest.FromBytes(content)
-		blob, err := imgStore.PutBlobChunkStreamed("dedupe1", upload, buf)
+		blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "dedupe1", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -1440,7 +1440,7 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		_, checkBlobSize1, err := imgStore.CheckBlob("dedupe1", digest)
+		_, checkBlobSize1, err := imgStore.CheckBlob(context.Background(), "dedupe1", digest)
 		So(checkBlobSize1, ShouldBeGreaterThan, 0)
 		So(err, ShouldBeNil)
 
@@ -1452,11 +1452,11 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, clen, err := imgStore.FullBlobUpload("dedupe1", bytes.NewReader(cblob), cdigest)
+		_, clen, err := imgStore.FullBlobUpload(context.Background(), "dedupe1", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
-		hasBlob, _, err := imgStore.CheckBlob("dedupe1", cdigest)
+		hasBlob, _, err := imgStore.CheckBlob(context.Background(), "dedupe1", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -1489,7 +1489,7 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// manifest2
-		upload, err = imgStore.NewBlobUpload("dedupe2")
+		upload, err = imgStore.NewBlobUpload(context.Background(), "dedupe2")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -1498,7 +1498,7 @@ func TestS3Dedupe(t *testing.T) {
 		buflen = buf.Len()
 		digest = godigest.FromBytes(content)
 
-		blob, err = imgStore.PutBlobChunkStreamed("dedupe2", upload, buf)
+		blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "dedupe2", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -1509,7 +1509,7 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
-		_, checkBlobSize2, err := imgStore.CheckBlob("dedupe2", digest)
+		_, checkBlobSize2, err := imgStore.CheckBlob(context.Background(), "dedupe2", digest)
 		So(err, ShouldBeNil)
 		So(checkBlobSize2, ShouldBeGreaterThan, 0)
 
@@ -1524,11 +1524,11 @@ func TestS3Dedupe(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cblob, cdigest = GetRandomImageConfig()
-		_, clen, err = imgStore.FullBlobUpload("dedupe2", bytes.NewReader(cblob), cdigest)
+		_, clen, err = imgStore.FullBlobUpload(context.Background(), "dedupe2", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
-		hasBlob, _, err = imgStore.CheckBlob("dedupe2", cdigest)
+		hasBlob, _, err = imgStore.CheckBlob(context.Background(), "dedupe2", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 
@@ -1738,21 +1738,21 @@ func TestRebuildDedupeIndex(t *testing.T) {
 
 		blobDigest1 := digest
 
-		_, blen, err := imgStore.FullBlobUpload("dedupe1", buf, digest)
+		_, blen, err := imgStore.FullBlobUpload(context.Background(), "dedupe1", buf, digest)
 		So(err, ShouldBeNil)
 		So(blen, ShouldEqual, buflen)
 
-		hasBlob, blen1, err := imgStore.CheckBlob("dedupe1", digest)
+		hasBlob, blen1, err := imgStore.CheckBlob(context.Background(), "dedupe1", digest)
 		So(blen1, ShouldEqual, buflen)
 		So(hasBlob, ShouldEqual, true)
 		So(err, ShouldBeNil)
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, clen, err := imgStore.FullBlobUpload("dedupe1", bytes.NewReader(cblob), cdigest)
+		_, clen, err := imgStore.FullBlobUpload(context.Background(), "dedupe1", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
-		hasBlob, clen, err = imgStore.CheckBlob("dedupe1", cdigest)
+		hasBlob, clen, err = imgStore.CheckBlob(context.Background(), "dedupe1", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 		So(clen, ShouldEqual, len(cblob))
@@ -1792,20 +1792,20 @@ func TestRebuildDedupeIndex(t *testing.T) {
 
 		blobDigest2 := digest
 
-		_, blen, err = imgStore.FullBlobUpload("dedupe2", buf, digest)
+		_, blen, err = imgStore.FullBlobUpload(context.Background(), "dedupe2", buf, digest)
 		So(err, ShouldBeNil)
 		So(blen, ShouldEqual, buflen)
 
-		hasBlob, blen1, err = imgStore.CheckBlob("dedupe2", digest)
+		hasBlob, blen1, err = imgStore.CheckBlob(context.Background(), "dedupe2", digest)
 		So(blen1, ShouldEqual, buflen)
 		So(hasBlob, ShouldEqual, true)
 		So(err, ShouldBeNil)
 
-		_, clen, err = imgStore.FullBlobUpload("dedupe2", bytes.NewReader(cblob), cdigest)
+		_, clen, err = imgStore.FullBlobUpload(context.Background(), "dedupe2", bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, len(cblob))
 
-		hasBlob, clen, err = imgStore.CheckBlob("dedupe2", cdigest)
+		hasBlob, clen, err = imgStore.CheckBlob(context.Background(), "dedupe2", cdigest)
 		So(err, ShouldBeNil)
 		So(hasBlob, ShouldEqual, true)
 		So(clen, ShouldEqual, len(cblob))
@@ -2672,7 +2672,7 @@ func TestS3PullRange(t *testing.T) {
 		defer cleanupStorage(storeDriver, testDir)
 
 		// create a blob/layer
-		upload, err := imgStore.NewBlobUpload("index")
+		upload, err := imgStore.NewBlobUpload(context.Background(), "index")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -2682,7 +2682,7 @@ func TestS3PullRange(t *testing.T) {
 		digest := godigest.FromBytes(content)
 		So(digest, ShouldNotBeNil)
 
-		blob, err := imgStore.PutBlobChunkStreamed("index", upload, buf)
+		blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "index", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -2743,7 +2743,7 @@ func TestS3PullRange(t *testing.T) {
 
 		Convey("With Dedupe", func() {
 			// create a blob/layer with same content
-			upload, err := imgStore.NewBlobUpload("dupindex")
+			upload, err := imgStore.NewBlobUpload(context.Background(), "dupindex")
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
@@ -2753,7 +2753,7 @@ func TestS3PullRange(t *testing.T) {
 			digest := godigest.FromBytes(dupcontent)
 			So(digest, ShouldNotBeNil)
 
-			blob, err := imgStore.PutBlobChunkStreamed("dupindex", upload, buf)
+			blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "dupindex", upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -2850,7 +2850,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		defer cleanupStorage(storeDriver, testDir)
 
 		// create a blob/layer
-		upload, err := imgStore.NewBlobUpload("index")
+		upload, err := imgStore.NewBlobUpload(context.Background(), "index")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
@@ -2860,7 +2860,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		digest := godigest.FromBytes(content)
 		So(digest, ShouldNotBeNil)
 
-		blob, err := imgStore.PutBlobChunkStreamed("index", upload, buf)
+		blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "index", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -2872,14 +2872,14 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		So(blob, ShouldEqual, buflen)
 
 		// upload image config blob
-		upload, err = imgStore.NewBlobUpload("index")
+		upload, err = imgStore.NewBlobUpload(context.Background(), "index")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
 		cblob, cdigest := GetRandomImageConfig()
 		buf = bytes.NewBuffer(cblob)
 		buflen = buf.Len()
-		blob, err = imgStore.PutBlobChunkStreamed("index", upload, buf)
+		blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "index", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -2918,14 +2918,14 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		// create another manifest but upload using its sha256 reference
 
 		// upload image config blob
-		upload, err = imgStore.NewBlobUpload("index")
+		upload, err = imgStore.NewBlobUpload(context.Background(), "index")
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
 		cblob, cdigest = GetRandomImageConfig()
 		buf = bytes.NewBuffer(cblob)
 		buflen = buf.Len()
-		blob, err = imgStore.PutBlobChunkStreamed("index", upload, buf)
+		blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "index", upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 
@@ -2963,14 +2963,14 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 		Convey("Image index", func() {
 			// upload image config blob
-			upload, err = imgStore.NewBlobUpload("index")
+			upload, err = imgStore.NewBlobUpload(context.Background(), "index")
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
 			cblob, cdigest = GetRandomImageConfig()
 			buf = bytes.NewBuffer(cblob)
 			buflen = buf.Len()
-			blob, err = imgStore.PutBlobChunkStreamed("index", upload, buf)
+			blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "index", upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -3033,14 +3033,14 @@ func TestS3ManifestImageIndex(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// upload another image config blob
-			upload, err = imgStore.NewBlobUpload("index")
+			upload, err = imgStore.NewBlobUpload(context.Background(), "index")
 			So(err, ShouldBeNil)
 			So(upload, ShouldNotBeEmpty)
 
 			cblob, cdigest = GetRandomImageConfig()
 			buf = bytes.NewBuffer(cblob)
 			buflen = buf.Len()
-			blob, err = imgStore.PutBlobChunkStreamed("index", upload, buf)
+			blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "index", upload, buf)
 			So(err, ShouldBeNil)
 			So(blob, ShouldEqual, buflen)
 
@@ -3194,7 +3194,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 			Convey("Update an index tag with different manifest", func() {
 				// create a blob/layer
-				upload, err := imgStore.NewBlobUpload("index")
+				upload, err := imgStore.NewBlobUpload(context.Background(), "index")
 				So(err, ShouldBeNil)
 				So(upload, ShouldNotBeEmpty)
 
@@ -3204,7 +3204,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 				digest := godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
 
-				blob, err := imgStore.PutBlobChunkStreamed("index", upload, buf)
+				blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "index", upload, buf)
 				So(err, ShouldBeNil)
 				So(blob, ShouldEqual, buflen)
 
@@ -3350,7 +3350,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 
 		So(bdigest, ShouldNotBeNil)
 
-		_, clen, err := imgStore.FullBlobUpload("index", buf, bdigest)
+		_, clen, err := imgStore.FullBlobUpload(context.Background(), "index", buf, bdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, buflen)
 
@@ -3359,7 +3359,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		buf = bytes.NewBuffer(cblob)
 		buflen = buf.Len()
 
-		_, clen, err = imgStore.FullBlobUpload("index", buf, cdigest)
+		_, clen, err = imgStore.FullBlobUpload(context.Background(), "index", buf, cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, buflen)
 
@@ -3396,7 +3396,7 @@ func TestS3ManifestImageIndex(t *testing.T) {
 		buf = bytes.NewBuffer(cblob)
 		buflen = buf.Len()
 
-		_, clen, err = imgStore.FullBlobUpload("index", buf, cdigest)
+		_, clen, err = imgStore.FullBlobUpload(context.Background(), "index", buf, cdigest)
 		So(err, ShouldBeNil)
 		So(clen, ShouldEqual, buflen)
 
@@ -3603,7 +3603,7 @@ func TestS3DedupeErr(t *testing.T) {
 		err := imgStore.DedupeBlob("repo", digest, "", "dst")
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.CheckBlob("repo", digest)
+		_, _, err = imgStore.CheckBlob(context.Background(), "repo", digest)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -3624,7 +3624,7 @@ func TestS3DedupeErr(t *testing.T) {
 		err := imgStore.DedupeBlob("repo", digest, "", "dst")
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.CheckBlob("repo", digest)
+		_, _, err = imgStore.CheckBlob(context.Background(), "repo", digest)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -3642,7 +3642,7 @@ func TestS3DedupeErr(t *testing.T) {
 		err := imgStore.DedupeBlob("repo", digest, "", "dst")
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.CheckBlob("repo", digest)
+		_, _, err = imgStore.CheckBlob(context.Background(), "repo", digest)
 		So(err, ShouldNotBeNil)
 	})
 
@@ -3820,7 +3820,7 @@ func TestS3DedupeErr(t *testing.T) {
 		err := imgStore.DedupeBlob("repo", digest, "", blobPath)
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.CheckBlob("repo2", digest)
+		_, _, err = imgStore.CheckBlob(context.Background(), "repo2", digest)
 		So(err, ShouldBeNil)
 
 		err = imgStore.DeleteBlob("repo", digest)
@@ -3835,7 +3835,7 @@ func TestS3DedupeErr(t *testing.T) {
 			},
 		})
 		d := godigest.FromBytes([]byte(""))
-		_, _, err := imgStore.FullBlobUpload(testImage, io.NopCloser(strings.NewReader("")), d)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), testImage, io.NopCloser(strings.NewReader("")), d)
 		So(err, ShouldNotBeNil)
 	})
 

--- a/pkg/storage/scrub_test.go
+++ b/pkg/storage/scrub_test.go
@@ -114,7 +114,7 @@ func RunCheckAllBlobsIntegrityTests( //nolint: thelper
 ) {
 	Convey("Scrub only one repo", func() {
 		// initialize repo
-		err := imgStore.InitRepo(repoName)
+		err := imgStore.InitRepo(context.Background(), repoName)
 		So(err, ShouldBeNil)
 
 		ok := imgStore.DirExists(path.Join(imgStore.RootDir(), repoName))
@@ -490,7 +490,9 @@ func RunCheckAllBlobsIntegrityTests( //nolint: thelper
 
 			indexBlob, err := json.Marshal(index)
 			So(err, ShouldBeNil)
-			indexDigest, _, err := imgStore.PutImageManifest(repoName, "", ispec.MediaTypeImageIndex, indexBlob, nil)
+
+			indexDigest, _, err := imgStore.PutImageManifest(context.Background(),
+				repoName, "", ispec.MediaTypeImageIndex, indexBlob, nil)
 			So(err, ShouldBeNil)
 
 			buff := bytes.NewBufferString("")

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -263,9 +263,11 @@ type imageUpdatedCall struct {
 
 func (c *captureImageEvents) Close() {}
 
-func (c *captureImageEvents) RepositoryCreated(string) {}
+func (c *captureImageEvents) RepositoryCreated(string, *events.EventContext) {}
 
-func (c *captureImageEvents) ImageUpdated(name, reference, digest, mediaType, manifest string) {
+func (c *captureImageEvents) ImageUpdated(name, reference, digest, mediaType, manifest string,
+	ectx *events.EventContext,
+) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -274,9 +276,10 @@ func (c *captureImageEvents) ImageUpdated(name, reference, digest, mediaType, ma
 	})
 }
 
-func (c *captureImageEvents) ImageDeleted(string, string, string, string) {}
+func (c *captureImageEvents) ImageDeleted(string, string, string, string, *events.EventContext) {}
 
-func (c *captureImageEvents) ImageLintFailed(string, string, string, string, string) {}
+func (c *captureImageEvents) ImageLintFailed(string, string, string, string, string, *events.EventContext) {
+}
 
 // TestPutImageManifestExtraTagsAndEvents covers extra-tag digest pushes, index updates, and ImageUpdated events.
 // One Convey uses createObjectsStore (nil recorder); the rest use newLocalImageStoreWithEventRecorder.
@@ -348,7 +351,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		manifestBuf, err := json.Marshal(manifest)
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.PutImageManifest(repo, "1.0", ispec.MediaTypeImageManifest, manifestBuf,
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, "1.0", ispec.MediaTypeImageManifest, manifestBuf,
 			[]string{"extra"})
 		So(errors.Is(err, zerr.ErrBadManifest), ShouldBeTrue)
 	})
@@ -389,7 +392,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		manifestDigest := godigest.FromBytes(manifestBuf)
 		extraTags := []string{"v1.2.3", "v1.2", "latest"}
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, extraTags)
 		So(err, ShouldBeNil)
 
@@ -419,7 +422,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		So(len(wantRefs), ShouldEqual, 0)
 		eventCapture.mu.Unlock()
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, extraTags)
 		So(err, ShouldBeNil)
 
@@ -459,7 +462,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 
 		manifestDigest := godigest.FromBytes(manifestBuf)
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -474,7 +477,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 
 		extraTags := []string{"after-tag"}
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, extraTags)
 		So(err, ShouldBeNil)
 
@@ -523,7 +526,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		manifestDigest := godigest.FromBytes(manifestBuf)
 		firstTags := []string{"tag-a", "tag-b", "tag-c"}
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, firstTags)
 		So(err, ShouldBeNil)
 
@@ -538,7 +541,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		So(len(eventCapture.imageUpdated), ShouldEqual, 3)
 		eventCapture.mu.Unlock()
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, []string{"tag-b"})
 		So(err, ShouldBeNil)
 
@@ -553,7 +556,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		So(len(eventCapture.imageUpdated), ShouldEqual, 3)
 		eventCapture.mu.Unlock()
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, []string{"tag-d"})
 		So(err, ShouldBeNil)
 
@@ -710,7 +713,7 @@ func TestStorageAPIs(t *testing.T) {
 				})
 
 				Convey("Initialize repo", func() {
-					err := imgStore.InitRepo(repoName)
+					err := imgStore.InitRepo(context.Background(), repoName)
 					So(err, ShouldBeNil)
 
 					ok := imgStore.DirExists(path.Join(imgStore.RootDir(), repoName))
@@ -916,19 +919,22 @@ func TestStorageAPIs(t *testing.T) {
 						So(err, ShouldBeNil)
 
 						Convey("Bad image manifest", func() {
-							_, _, err = imgStore.PutImageManifest("test", digest.String(), "application/json",
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(), "application/json",
 								manifestBuf, nil)
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", digest.String(), ispec.MediaTypeImageManifest,
 								[]byte{}, nil)
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", digest.String(), ispec.MediaTypeImageManifest,
 								[]byte(`{"test":true}`), nil)
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", digest.String(), ispec.MediaTypeImageManifest,
 								manifestBuf, nil)
 							So(err, ShouldNotBeNil)
 
@@ -978,20 +984,25 @@ func TestStorageAPIs(t *testing.T) {
 							badMb, err := json.Marshal(manifest)
 							So(err, ShouldBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, badMb, nil)
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0",
+								ispec.MediaTypeImageManifest, badMb, nil)
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
 							// same manifest for coverage
-							_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", "3.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", "3.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
 							_, err = imgStore.GetImageTags("inexistent")
@@ -1008,7 +1019,7 @@ func TestStorageAPIs(t *testing.T) {
 							_, _, _, err = imgStore.GetImageManifest("test", "3.0")
 							So(err, ShouldBeNil)
 
-							err = imgStore.DeleteImageManifest("test", "1.0", false)
+							err = imgStore.DeleteImageManifest(context.Background(), "test", "1.0", false)
 							So(err, ShouldBeNil)
 
 							tags, err = imgStore.GetImageTags("test")
@@ -1041,11 +1052,11 @@ func TestStorageAPIs(t *testing.T) {
 							So(hasBlob, ShouldEqual, true)
 
 							// with detectManifestCollision should get error
-							err = imgStore.DeleteImageManifest("test", digest.String(), true)
+							err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), true)
 							So(err, ShouldNotBeNil)
 
 							// If we pass reference all manifest with input reference should be deleted.
-							err = imgStore.DeleteImageManifest("test", digest.String(), false)
+							err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), false)
 							So(err, ShouldBeNil)
 
 							tags, err = imgStore.GetImageTags("test")
@@ -1161,11 +1172,11 @@ func TestStorageAPIs(t *testing.T) {
 						})
 
 						Convey("Bad image manifest", func() {
-							_, _, err = imgStore.PutImageManifest("test", digest.String(),
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 								ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", digest.String(),
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 								ispec.MediaTypeImageManifest, []byte("bad json"), nil)
 							So(err, ShouldNotBeNil)
 
@@ -1202,12 +1213,13 @@ func TestStorageAPIs(t *testing.T) {
 							So(err, ShouldBeNil)
 
 							digest := godigest.FromBytes(manifestBuf)
-							_, _, err = imgStore.PutImageManifest("test", digest.String(),
+
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 								ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
 							// same manifest for coverage
-							_, _, err = imgStore.PutImageManifest("test", digest.String(),
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 								ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
@@ -1236,13 +1248,13 @@ func TestStorageAPIs(t *testing.T) {
 
 							So(len(index.Manifests), ShouldEqual, 1)
 
-							err = imgStore.DeleteImageManifest("test", "1.0", false)
+							err = imgStore.DeleteImageManifest(context.Background(), "test", "1.0", false)
 							So(err, ShouldNotBeNil)
 
-							err = imgStore.DeleteImageManifest("inexistent", "1.0", false)
+							err = imgStore.DeleteImageManifest(context.Background(), "inexistent", "1.0", false)
 							So(err, ShouldNotBeNil)
 
-							err = imgStore.DeleteImageManifest("test", digest.String(), false)
+							err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), false)
 							So(err, ShouldBeNil)
 
 							_, _, _, err = imgStore.GetImageManifest("test", digest.String())
@@ -1303,7 +1315,9 @@ func TestStorageAPIs(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					digest = godigest.FromBytes(manifestBuf)
-					_, _, err = imgStore.PutImageManifest("replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					_, _, _, err = imgStore.GetImageManifest("replace", digest.String())
@@ -1357,7 +1371,9 @@ func TestStorageAPIs(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					_ = godigest.FromBytes(manifestBuf)
-					_, _, err = imgStore.PutImageManifest("replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 				})
 
@@ -1494,7 +1510,8 @@ func TestMandatoryAnnotations(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				Convey("Missing mandatory annotations", func() {
-					_, _, err = imgStore.PutImageManifest("test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldNotBeNil)
 				})
 
@@ -1522,7 +1539,8 @@ func TestMandatoryAnnotations(t *testing.T) {
 							}, store, cacheDriver, nil, nil)
 					}
 
-					_, _, err = imgStore.PutImageManifest("test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldNotBeNil)
 				})
 			})
@@ -1742,7 +1760,8 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				manifestBuf, err := json.Marshal(manifest)
 				So(err, ShouldBeNil)
 
-				manifestDigest, _, err := imgStore.PutImageManifest("repo", tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+				manifestDigest, _, err := imgStore.PutImageManifest(context.Background(),
+					"repo", tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 				So(err, ShouldBeNil)
 
 				Convey("Try to delete blob currently in use", func() {
@@ -1765,7 +1784,7 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				})
 
 				Convey("Delete manifest first, then blob", func() {
-					err := imgStore.DeleteImageManifest("repo", manifestDigest.String(), false)
+					err := imgStore.DeleteImageManifest(context.Background(), "repo", manifestDigest.String(), false)
 					So(err, ShouldBeNil)
 
 					err = imgStore.DeleteBlob("repo", digest)
@@ -1868,7 +1887,9 @@ func TestDeleteBlobsInUse(t *testing.T) {
 
 					digest = godigest.FromBytes(content)
 					So(digest, ShouldNotBeNil)
-					_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 					So(err, ShouldBeNil)
 
 					index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -1885,13 +1906,13 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				indexDigest := godigest.FromBytes(indexContent)
 				So(indexDigest, ShouldNotBeNil)
 
-				indexManifestDigest, _, err := imgStore.PutImageManifest(repoName, "index",
-					ispec.MediaTypeImageIndex, indexContent, nil)
+				indexManifestDigest, _, err := imgStore.PutImageManifest(context.Background(),
+					repoName, "index", ispec.MediaTypeImageIndex, indexContent, nil)
 				So(err, ShouldBeNil)
 
 				Convey("Try to delete manifest being referenced by image index", func() {
 					// modifying multi arch images should not be allowed
-					err := imgStore.DeleteImageManifest(repoName, digest.String(), false)
+					err := imgStore.DeleteImageManifest(context.Background(), repoName, digest.String(), false)
 					So(err, ShouldEqual, zerr.ErrManifestReferenced)
 				})
 
@@ -1915,11 +1936,11 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				})
 
 				Convey("Delete manifests first, then blob", func() {
-					err := imgStore.DeleteImageManifest(repoName, indexManifestDigest.String(), false)
+					err := imgStore.DeleteImageManifest(context.Background(), repoName, indexManifestDigest.String(), false)
 					So(err, ShouldBeNil)
 
 					for _, manifestDesc := range index.Manifests {
-						err := imgStore.DeleteImageManifest(repoName, manifestDesc.Digest.String(), false)
+						err := imgStore.DeleteImageManifest(context.Background(), repoName, manifestDesc.Digest.String(), false)
 						So(err, ShouldBeNil)
 					}
 
@@ -2327,7 +2348,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 					digest := godigest.FromBytes(manifestBuf)
 
-					_, _, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repoName, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					err = gc.CleanRepo(ctx, repoName)
@@ -2370,7 +2392,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -2385,7 +2408,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
-					err = imgStore.DeleteImageManifest(repoName, digest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), repoName, digest.String(), false)
 					So(err, ShouldBeNil)
 
 					err = gc.CleanRepo(ctx, repoName)
@@ -2510,7 +2533,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 					digest := godigest.FromBytes(manifestBuf)
 
-					_, _, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repoName, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					// put artifact referencing above image
@@ -2550,7 +2574,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -2566,7 +2591,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					artifactOfArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
-					_, _, err = imgStore.PutImageManifest(repoName, artifactOfArtifactManifestDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactOfArtifactManifestDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -2584,7 +2610,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					orphanArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push orphan artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, orphanArtifactManifestDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, orphanArtifactManifestDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -2611,7 +2638,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					time.Sleep(1 * time.Second)
 
 					Convey("Garbage collect blobs after manifest is removed", func() {
-						err = imgStore.DeleteImageManifest(repoName, digest.String(), false)
+						err = imgStore.DeleteImageManifest(context.Background(), repoName, digest.String(), false)
 						So(err, ShouldBeNil)
 
 						err = gc.CleanRepo(ctx, repoName)
@@ -2642,10 +2669,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 					Convey("Garbage collect - don't gc manifests/blobs which are referenced by another image", func() {
 						// upload same image with another tag
-						_, _, err = imgStore.PutImageManifest(repoName, "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+						_, _, err = imgStore.PutImageManifest(context.Background(),
+							repoName, "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 						So(err, ShouldBeNil)
 
-						err = imgStore.DeleteImageManifest(repoName, tag, false)
+						err = imgStore.DeleteImageManifest(context.Background(), repoName, tag, false)
 						So(err, ShouldBeNil)
 
 						err = gc.CleanRepo(ctx, repoName)
@@ -2761,7 +2789,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					manifestBuf, err := json.Marshal(manifest)
 					So(err, ShouldBeNil)
 
-					_, _, err = imgStore.PutImageManifest(repo1Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repo1Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					// sleep so past GC timeout
@@ -2825,7 +2854,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					manifestBuf, err = json.Marshal(manifest)
 					So(err, ShouldBeNil)
 
-					_, _, err = imgStore.PutImageManifest(repo2Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repo2Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					hasBlob, _, err = imgStore.CheckBlob(repo2Name, bdigest)
@@ -2884,7 +2914,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 					digest := godigest.FromBytes(manifestBuf)
 
-					_, _, err = imgStore.PutImageManifest(repo2Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repo2Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					err = gc.CleanRepo(ctx, repo2Name)
@@ -2997,7 +3028,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest referencing index image
-					_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3013,7 +3045,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest referencing a manifest from index image
-					_, _, err = imgStore.PutImageManifest(repoName, artifactManifestDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3025,7 +3058,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					So(hasBlob, ShouldEqual, true)
 
 					Convey("delete index manifest, layers should be persisted", func() {
-						err = imgStore.DeleteImageManifest(repoName, indexDigest.String(), false)
+						err = imgStore.DeleteImageManifest(context.Background(), repoName, indexDigest.String(), false)
 						So(err, ShouldBeNil)
 
 						err = gc.CleanRepo(ctx, repoName)
@@ -3144,7 +3177,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3161,7 +3195,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactManifestIndexDigest := godigest.FromBytes(artifactManifestIndexBuf)
 
 					// push artifact manifest referencing a manifest from index image
-					_, _, err = imgStore.PutImageManifest(repoName, artifactManifestIndexDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestIndexDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestIndexBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3177,7 +3212,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					artifactOfArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
-					_, _, err = imgStore.PutImageManifest(repoName, artifactOfArtifactManifestDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactOfArtifactManifestDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3195,7 +3231,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					orphanArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push orphan artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, orphanArtifactManifestDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, orphanArtifactManifestDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3230,7 +3267,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 						_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 						So(err, ShouldBeNil)
 
-						err = imgStore.DeleteImageManifest(repoName, artifactDigest.String(), false)
+						err = imgStore.DeleteImageManifest(context.Background(), repoName, artifactDigest.String(), false)
 						So(err, ShouldBeNil)
 
 						err = gc.CleanRepo(ctx, repoName)
@@ -3260,7 +3297,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 						_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 						So(err, ShouldBeNil)
 
-						err = imgStore.DeleteImageManifest(repoName, indexDigest.String(), false)
+						err = imgStore.DeleteImageManifest(context.Background(), repoName, indexDigest.String(), false)
 						So(err, ShouldBeNil)
 
 						err = gc.CleanRepo(ctx, repoName)
@@ -3459,7 +3496,9 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 
 					digest = godigest.FromBytes(content)
 					So(digest, ShouldNotBeNil)
-					_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 					So(err, ShouldBeNil)
 
 					index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -3494,7 +3533,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 					artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 				}
@@ -3542,7 +3582,9 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 
 					digest := godigest.FromBytes(content)
 					So(digest, ShouldNotBeNil)
-					_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 					So(err, ShouldBeNil)
 
 					innerIndex.Manifests = append(innerIndex.Manifests, ispec.Descriptor{
@@ -3559,7 +3601,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				innerIndexDigest := godigest.FromBytes(innerIndexContent)
 				So(innerIndexDigest, ShouldNotBeNil)
 
-				_, _, err = imgStore.PutImageManifest(repoName, innerIndexDigest.String(),
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, innerIndexDigest.String(),
 					ispec.MediaTypeImageIndex, innerIndexContent, nil)
 				So(err, ShouldBeNil)
 
@@ -3578,7 +3620,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				indexDigest := godigest.FromBytes(indexContent)
 				So(indexDigest, ShouldNotBeNil)
 
-				_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
 				So(err, ShouldBeNil)
 
 				artifactManifest := ispec.Manifest{
@@ -3606,7 +3649,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 				// push artifact manifest
-				_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 					ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 				So(err, ShouldBeNil)
 
@@ -3623,7 +3667,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				artifactManifestIndexDigest := godigest.FromBytes(artifactManifestIndexBuf)
 
 				// push artifact manifest referencing a manifest from index image
-				_, _, err = imgStore.PutImageManifest(repoName, artifactManifestIndexDigest.String(),
+
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestIndexDigest.String(),
 					ispec.MediaTypeImageManifest, artifactManifestIndexBuf, nil)
 				So(err, ShouldBeNil)
 
@@ -3640,7 +3685,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				artifactManifestInnerIndexDigest := godigest.FromBytes(artifactManifestInnerIndexBuf)
 
 				// push artifact manifest referencing a manifest from index image
-				_, _, err = imgStore.PutImageManifest(repoName, artifactManifestInnerIndexDigest.String(),
+
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestInnerIndexDigest.String(),
 					ispec.MediaTypeImageManifest, artifactManifestInnerIndexBuf, nil)
 				So(err, ShouldBeNil)
 
@@ -3657,7 +3703,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				artifactOfArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
-				_, _, err = imgStore.PutImageManifest(repoName, artifactOfArtifactManifestDigest.String(),
+
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactOfArtifactManifestDigest.String(),
 					ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 				So(err, ShouldBeNil)
 
@@ -3675,7 +3722,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				orphanArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 				// push orphan artifact manifest
-				_, _, err = imgStore.PutImageManifest(repoName, orphanArtifactManifestDigest.String(),
+
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, orphanArtifactManifestDigest.String(),
 					ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 				So(err, ShouldBeNil)
 
@@ -3710,7 +3758,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 					_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 					So(err, ShouldBeNil)
 
-					err = imgStore.DeleteImageManifest(repoName, artifactDigest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), repoName, artifactDigest.String(), false)
 					So(err, ShouldBeNil)
 
 					err = gc.CleanRepo(ctx, repoName)
@@ -3740,7 +3788,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 					_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 					So(err, ShouldBeNil)
 
-					err = imgStore.DeleteImageManifest(repoName, indexDigest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), repoName, indexDigest.String(), false)
 					So(err, ShouldBeNil)
 
 					err = gc.CleanRepo(ctx, repoName)
@@ -3848,7 +3896,9 @@ func pushRandomImageIndex(imgStore storageTypes.ImageStore, repoName string,
 
 		digest = godigest.FromBytes(content)
 		So(digest, ShouldNotBeNil)
-		_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -3865,7 +3915,8 @@ func pushRandomImageIndex(imgStore storageTypes.ImageStore, repoName string,
 	indexDigest := godigest.FromBytes(indexContent)
 	So(indexDigest, ShouldNotBeNil)
 
-	_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+	_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+		ispec.MediaTypeImageIndex, indexContent, nil)
 	So(err, ShouldBeNil)
 
 	return bdgst, digest, indexDigest, int64(len(indexContent))
@@ -3985,7 +4036,7 @@ func TestPutIndexContent_atomicReplace(t *testing.T) {
 			root, imgStore, cleanup := newLocalImageStoreWithDriver(t, hookDriver)
 			defer cleanup()
 
-			So(imgStore.InitRepo(repo), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), repo), ShouldBeNil)
 
 			before, err := os.ReadFile(path.Join(root, repo, ispec.ImageIndexFile))
 			So(err, ShouldBeNil)
@@ -4022,7 +4073,7 @@ func TestPutIndexContent_atomicReplace(t *testing.T) {
 			root, imgStore, cleanup := newLocalImageStoreWithDriver(t, hookDriver)
 			defer cleanup()
 
-			So(imgStore.InitRepo(repo), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), repo), ShouldBeNil)
 
 			before, err := os.ReadFile(path.Join(root, repo, ispec.ImageIndexFile))
 			So(err, ShouldBeNil)
@@ -4046,7 +4097,7 @@ func TestPutIndexContent_atomicReplace(t *testing.T) {
 			root, imgStore, cleanup := newLocalImageStoreWithDriver(t, nil)
 			defer cleanup()
 
-			So(imgStore.InitRepo(repo), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), repo), ShouldBeNil)
 
 			var idx ispec.Index
 			buf, err := os.ReadFile(path.Join(root, repo, ispec.ImageIndexFile))

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1154,7 +1154,8 @@ func TestStorageAPIs(t *testing.T) {
 						So(err, ShouldBeNil)
 						So(bupload, ShouldEqual, int64(firstChunkLen))
 
-						bupload, err = imgStore.PutBlobChunk(context.Background(), "test", upload, int64(firstChunkLen), int64(buflen), secondChunkBuf)
+						bupload, err = imgStore.PutBlobChunk(context.Background(), "test", upload,
+							int64(firstChunkLen), int64(buflen), secondChunkBuf)
 						So(err, ShouldBeNil)
 						So(bupload, ShouldEqual, int64(firstChunkLen+secondChunkLen))
 
@@ -2634,12 +2635,13 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 					// push layer
-					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName,
+						bytes.NewReader(artifactBlob), artifactBlobDigest)
 					So(err, ShouldBeNil)
 
 					// push config
-					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
-						ispec.DescriptorEmptyJSON.Digest)
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName,
+						bytes.NewReader(ispec.DescriptorEmptyJSON.Data), ispec.DescriptorEmptyJSON.Digest)
 					So(err, ShouldBeNil)
 
 					artifactManifest := ispec.Manifest{
@@ -2816,12 +2818,13 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 					// push layer
-					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName,
+						bytes.NewReader(artifactBlob), artifactBlobDigest)
 					So(err, ShouldBeNil)
 
 					// push config
-					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
-						ispec.DescriptorEmptyJSON.Digest)
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName,
+						bytes.NewReader(ispec.DescriptorEmptyJSON.Data), ispec.DescriptorEmptyJSON.Digest)
 					So(err, ShouldBeNil)
 
 					artifactManifest := ispec.Manifest{
@@ -3272,12 +3275,13 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 					// push layer
-					_, _, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+					_, _, err := imgStore.FullBlobUpload(context.Background(), repoName,
+						bytes.NewReader(artifactBlob), artifactBlobDigest)
 					So(err, ShouldBeNil)
 
 					// push config
-					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
-						ispec.DescriptorEmptyJSON.Digest)
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName,
+						bytes.NewReader(ispec.DescriptorEmptyJSON.Data), ispec.DescriptorEmptyJSON.Digest)
 					So(err, ShouldBeNil)
 
 					artifactManifest := ispec.Manifest{
@@ -3419,12 +3423,13 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 					// push layer
-					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName,
+						bytes.NewReader(artifactBlob), artifactBlobDigest)
 					So(err, ShouldBeNil)
 
 					// push config
-					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
-						ispec.DescriptorEmptyJSON.Digest)
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName,
+						bytes.NewReader(ispec.DescriptorEmptyJSON.Data), ispec.DescriptorEmptyJSON.Digest)
 					So(err, ShouldBeNil)
 
 					// push artifact manifest pointing to index
@@ -3722,12 +3727,13 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 				// push layer
-				_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+				_, _, err = imgStore.FullBlobUpload(context.Background(), repoName,
+					bytes.NewReader(artifactBlob), artifactBlobDigest)
 				So(err, ShouldBeNil)
 
 				// push config
-				_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
-					ispec.DescriptorEmptyJSON.Digest)
+				_, _, err = imgStore.FullBlobUpload(context.Background(), repoName,
+					bytes.NewReader(ispec.DescriptorEmptyJSON.Data), ispec.DescriptorEmptyJSON.Digest)
 				So(err, ShouldBeNil)
 
 				var index ispec.Index

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -364,12 +364,12 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		repo := "badtagquery"
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 
 		layerBytes := []byte("layer")
 		layerDigest := godigest.FromBytes(layerBytes)
-		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(layerBytes), layerDigest)
 		So(err, ShouldBeNil)
 
 		manifest := ispec.Manifest{}
@@ -398,12 +398,12 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		repo := "mquery"
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, _, err := imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 
 		layerBytes := []byte("layer-bytes")
 		layerDigest := godigest.FromBytes(layerBytes)
-		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(layerBytes), layerDigest)
 		So(err, ShouldBeNil)
 
 		manifest := ispec.Manifest{}
@@ -473,12 +473,12 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		repo := "strip-untagged"
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, _, err := imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 
 		layerBytes := []byte("layer-strip")
 		layerDigest := godigest.FromBytes(layerBytes)
-		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(layerBytes), layerDigest)
 		So(err, ShouldBeNil)
 
 		manifest := ispec.Manifest{}
@@ -536,12 +536,12 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		repo := "tag-subset"
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, _, err := imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 
 		layerBytes := []byte("layer-subset")
 		layerDigest := godigest.FromBytes(layerBytes)
-		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(layerBytes), layerDigest)
 		So(err, ShouldBeNil)
 
 		manifest := ispec.Manifest{}
@@ -621,12 +621,12 @@ func TestDeleteImageManifestEvents(t *testing.T) {
 		tag := "v1"
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, _, err := imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 
 		layerBytes := []byte("layer-del")
 		layerDigest := godigest.FromBytes(layerBytes)
-		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(layerBytes), layerDigest)
 		So(err, ShouldBeNil)
 
 		manifest := ispec.Manifest{}
@@ -667,12 +667,12 @@ func TestDeleteImageManifestEvents(t *testing.T) {
 		repo := "delrepo-digest"
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, _, err := imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 
 		layerBytes := []byte("layer-del-d")
 		layerDigest := godigest.FromBytes(layerBytes)
-		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(layerBytes), layerDigest)
 		So(err, ShouldBeNil)
 
 		manifest := ispec.Manifest{}
@@ -712,12 +712,12 @@ func TestDeleteImageManifestEvents(t *testing.T) {
 		repo := "delrepo-missing"
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, _, err := imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 
 		layerBytes := []byte("layer-missing")
 		layerDigest := godigest.FromBytes(layerBytes)
-		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(layerBytes), layerDigest)
 		So(err, ShouldBeNil)
 
 		manifest := ispec.Manifest{}
@@ -758,12 +758,12 @@ func TestImageLintFailedEvents(t *testing.T) {
 		t.Helper()
 
 		cblob, cdigest := GetRandomImageConfig()
-		_, _, err := imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(cblob), cdigest)
 		So(err, ShouldBeNil)
 
 		layerBytes := []byte("layer-lint")
 		layerDigest := godigest.FromBytes(layerBytes)
-		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		_, _, err = imgStore.FullBlobUpload(context.Background(), repo, bytes.NewReader(layerBytes), layerDigest)
 		So(err, ShouldBeNil)
 
 		manifest := ispec.Manifest{}
@@ -1026,7 +1026,7 @@ func TestStorageAPIs(t *testing.T) {
 					body := []byte("this blob will be hashed using an unavailable hashing algorithm")
 					buf := bytes.NewBuffer(body)
 					digest := godigest.Digest("md5:8114c3f59ef9dcf737410e0f4b00a154")
-					upload, n, err := imgStore.FullBlobUpload("test", buf, digest)
+					upload, n, err := imgStore.FullBlobUpload(context.Background(), "test", buf, digest)
 					So(err, ShouldEqual, godigest.ErrDigestUnsupported)
 					So(n, ShouldEqual, -1)
 					So(upload, ShouldEqual, "")
@@ -1042,7 +1042,7 @@ func TestStorageAPIs(t *testing.T) {
 					body := []byte("this is a blob")
 					buf := bytes.NewBuffer(body)
 					digest := godigest.FromBytes(body)
-					upload, n, err := imgStore.FullBlobUpload("test", buf, digest)
+					upload, n, err := imgStore.FullBlobUpload(context.Background(), "test", buf, digest)
 					So(err, ShouldBeNil)
 					So(n, ShouldEqual, len(body))
 					So(upload, ShouldNotBeEmpty)
@@ -1062,7 +1062,7 @@ func TestStorageAPIs(t *testing.T) {
 					body := []byte("this blob will be hashed using sha512")
 					buf := bytes.NewBuffer(body)
 					digest := godigest.SHA512.FromBytes(body)
-					upload, n, err := imgStore.FullBlobUpload("test", buf, digest)
+					upload, n, err := imgStore.FullBlobUpload(context.Background(), "test", buf, digest)
 					So(err, ShouldBeNil)
 					So(n, ShouldEqual, len(body))
 					So(upload, ShouldNotBeEmpty)
@@ -1081,7 +1081,7 @@ func TestStorageAPIs(t *testing.T) {
 					body := []byte("this blob will be hashed using sha384")
 					buf := bytes.NewBuffer(body)
 					digest := godigest.SHA384.FromBytes(body)
-					upload, n, err := imgStore.FullBlobUpload("test", buf, digest)
+					upload, n, err := imgStore.FullBlobUpload(context.Background(), "test", buf, digest)
 					So(err, ShouldBeNil)
 					So(n, ShouldEqual, len(body))
 					So(upload, ShouldNotBeEmpty)
@@ -1097,14 +1097,14 @@ func TestStorageAPIs(t *testing.T) {
 				})
 
 				Convey("New blob upload", func() {
-					upload, err := imgStore.NewBlobUpload("test")
+					upload, err := imgStore.NewBlobUpload(context.Background(), "test")
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
 					err = imgStore.DeleteBlobUpload("test", upload)
 					So(err, ShouldBeNil)
 
-					upload, err = imgStore.NewBlobUpload("test")
+					upload, err = imgStore.NewBlobUpload(context.Background(), "test")
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
@@ -1139,10 +1139,10 @@ func TestStorageAPIs(t *testing.T) {
 						blobDigest := digest
 
 						// invalid chunk range
-						_, err = imgStore.PutBlobChunk("test", upload, 10, int64(buflen), buf)
+						_, err = imgStore.PutBlobChunk(context.Background(), "test", upload, 10, int64(buflen), buf)
 						So(err, ShouldNotBeNil)
 
-						bupload, err = imgStore.PutBlobChunk("test", upload, 0, int64(firstChunkLen), firstChunkBuf)
+						bupload, err = imgStore.PutBlobChunk(context.Background(), "test", upload, 0, int64(firstChunkLen), firstChunkBuf)
 						So(err, ShouldBeNil)
 						So(bupload, ShouldEqual, firstChunkLen)
 
@@ -1154,14 +1154,14 @@ func TestStorageAPIs(t *testing.T) {
 						So(err, ShouldBeNil)
 						So(bupload, ShouldEqual, int64(firstChunkLen))
 
-						bupload, err = imgStore.PutBlobChunk("test", upload, int64(firstChunkLen), int64(buflen), secondChunkBuf)
+						bupload, err = imgStore.PutBlobChunk(context.Background(), "test", upload, int64(firstChunkLen), int64(buflen), secondChunkBuf)
 						So(err, ShouldBeNil)
 						So(bupload, ShouldEqual, int64(firstChunkLen+secondChunkLen))
 
 						err = imgStore.FinishBlobUpload("test", upload, buf, digest)
 						So(err, ShouldBeNil)
 
-						_, _, err = imgStore.CheckBlob("test", digest)
+						_, _, err = imgStore.CheckBlob(context.Background(), "test", digest)
 						So(err, ShouldBeNil)
 
 						ok, _, _, err := imgStore.StatBlob("test", digest)
@@ -1219,11 +1219,11 @@ func TestStorageAPIs(t *testing.T) {
 
 						Convey("Good image manifest", func() {
 							cblob, cdigest := GetRandomImageConfig()
-							_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest)
+							_, clen, err := imgStore.FullBlobUpload(context.Background(), "test", bytes.NewReader(cblob), cdigest)
 							So(err, ShouldBeNil)
 							So(clen, ShouldEqual, len(cblob))
 
-							hasBlob, _, err := imgStore.CheckBlob("test", cdigest)
+							hasBlob, _, err := imgStore.CheckBlob(context.Background(), "test", cdigest)
 							So(err, ShouldBeNil)
 							So(hasBlob, ShouldEqual, true)
 
@@ -1319,7 +1319,7 @@ func TestStorageAPIs(t *testing.T) {
 							So(len(repos), ShouldEqual, 0)
 
 							// We deleted only one tag, make sure blob should not be removed.
-							hasBlob, _, err = imgStore.CheckBlob("test", digest)
+							hasBlob, _, err = imgStore.CheckBlob(context.Background(), "test", digest)
 							So(err, ShouldBeNil)
 							So(hasBlob, ShouldEqual, true)
 
@@ -1336,7 +1336,7 @@ func TestStorageAPIs(t *testing.T) {
 							So(len(tags), ShouldEqual, 0)
 
 							// All tags/references are deleted, blob should not be present in disk.
-							hasBlob, _, err = imgStore.CheckBlob("test", digest)
+							hasBlob, _, err = imgStore.CheckBlob(context.Background(), "test", digest)
 							So(err, ShouldNotBeNil)
 							So(hasBlob, ShouldEqual, false)
 
@@ -1363,7 +1363,7 @@ func TestStorageAPIs(t *testing.T) {
 				})
 
 				Convey("New blob upload streamed", func() {
-					bupload, err := imgStore.NewBlobUpload("test")
+					bupload, err := imgStore.NewBlobUpload(context.Background(), "test")
 					So(err, ShouldBeNil)
 					So(bupload, ShouldNotBeEmpty)
 
@@ -1387,11 +1387,11 @@ func TestStorageAPIs(t *testing.T) {
 						buf := bytes.NewBuffer(content)
 						buflen := buf.Len()
 						digest := godigest.FromBytes(content)
-						upload, err = imgStore.PutBlobChunkStreamed("test", bupload, buf)
+						upload, err = imgStore.PutBlobChunkStreamed(context.Background(), "test", bupload, buf)
 						So(err, ShouldBeNil)
 						So(upload, ShouldEqual, buflen)
 
-						_, err = imgStore.PutBlobChunkStreamed("test", "inexistent", buf)
+						_, err = imgStore.PutBlobChunkStreamed(context.Background(), "test", "inexistent", buf)
 						So(err, ShouldNotBeNil)
 
 						err = imgStore.FinishBlobUpload("test", "inexistent", buf, digest)
@@ -1404,7 +1404,7 @@ func TestStorageAPIs(t *testing.T) {
 						err = imgStore.FinishBlobUpload("test", bupload, buf, digest)
 						So(err, ShouldBeNil)
 
-						ok, _, err := imgStore.CheckBlob("test", digest)
+						ok, _, err := imgStore.CheckBlob(context.Background(), "test", digest)
 						So(ok, ShouldBeTrue)
 						So(err, ShouldBeNil)
 
@@ -1433,10 +1433,10 @@ func TestStorageAPIs(t *testing.T) {
 						So(err, ShouldBeNil)
 
 						Convey("Bad digests", func() {
-							_, _, err := imgStore.FullBlobUpload("test", bytes.NewBuffer([]byte{}), "inexistent")
+							_, _, err := imgStore.FullBlobUpload(context.Background(), "test", bytes.NewBuffer([]byte{}), "inexistent")
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.CheckBlob("test", "inexistent")
+							_, _, err = imgStore.CheckBlob(context.Background(), "test", "inexistent")
 							So(err, ShouldNotBeNil)
 
 							_, _, _, err = imgStore.StatBlob("test", "inexistent")
@@ -1458,11 +1458,11 @@ func TestStorageAPIs(t *testing.T) {
 
 						Convey("Good image manifest", func() {
 							cblob, cdigest := GetRandomImageConfig()
-							_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest)
+							_, clen, err := imgStore.FullBlobUpload(context.Background(), "test", bytes.NewReader(cblob), cdigest)
 							So(err, ShouldBeNil)
 							So(clen, ShouldEqual, len(cblob))
 
-							hasBlob, _, err := imgStore.CheckBlob("test", cdigest)
+							hasBlob, _, err := imgStore.CheckBlob(context.Background(), "test", cdigest)
 							So(err, ShouldBeNil)
 							So(hasBlob, ShouldEqual, true)
 
@@ -1540,7 +1540,7 @@ func TestStorageAPIs(t *testing.T) {
 
 				Convey("Modify manifest in-place", func() {
 					// original blob
-					upload, err := imgStore.NewBlobUpload("replace")
+					upload, err := imgStore.NewBlobUpload(context.Background(), "replace")
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
@@ -1548,7 +1548,7 @@ func TestStorageAPIs(t *testing.T) {
 					buf := bytes.NewBuffer(content)
 					buflen := buf.Len()
 					digest := godigest.FromBytes(content)
-					blob, err := imgStore.PutBlobChunkStreamed("replace", upload, buf)
+					blob, err := imgStore.PutBlobChunkStreamed(context.Background(), "replace", upload, buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -1560,11 +1560,11 @@ func TestStorageAPIs(t *testing.T) {
 					So(blob, ShouldEqual, buflen)
 
 					cblob, cdigest := GetRandomImageConfig()
-					_, clen, err := imgStore.FullBlobUpload("replace", bytes.NewReader(cblob), cdigest)
+					_, clen, err := imgStore.FullBlobUpload(context.Background(), "replace", bytes.NewReader(cblob), cdigest)
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
 
-					hasBlob, _, err := imgStore.CheckBlob("replace", cdigest)
+					hasBlob, _, err := imgStore.CheckBlob(context.Background(), "replace", cdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -1596,7 +1596,7 @@ func TestStorageAPIs(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					// new blob to replace
-					upload, err = imgStore.NewBlobUpload("replace")
+					upload, err = imgStore.NewBlobUpload(context.Background(), "replace")
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
@@ -1604,7 +1604,7 @@ func TestStorageAPIs(t *testing.T) {
 					buf = bytes.NewBuffer(content)
 					buflen = buf.Len()
 					digest = godigest.FromBytes(content)
-					blob, err = imgStore.PutBlobChunkStreamed("replace", upload, buf)
+					blob, err = imgStore.PutBlobChunkStreamed(context.Background(), "replace", upload, buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -1616,11 +1616,11 @@ func TestStorageAPIs(t *testing.T) {
 					So(blob, ShouldEqual, buflen)
 
 					cblob, cdigest = GetRandomImageConfig()
-					_, clen, err = imgStore.FullBlobUpload("replace", bytes.NewReader(cblob), cdigest)
+					_, clen, err = imgStore.FullBlobUpload(context.Background(), "replace", bytes.NewReader(cblob), cdigest)
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
 
-					hasBlob, _, err = imgStore.CheckBlob("replace", cdigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), "replace", cdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -1750,11 +1750,11 @@ func TestMandatoryAnnotations(t *testing.T) {
 				buflen := buf.Len()
 				digest := godigest.FromBytes(content)
 
-				_, _, err := imgStore.FullBlobUpload("test", bytes.NewReader(buf.Bytes()), digest)
+				_, _, err := imgStore.FullBlobUpload(context.Background(), "test", bytes.NewReader(buf.Bytes()), digest)
 				So(err, ShouldBeNil)
 
 				cblob, cdigest := GetRandomImageConfig()
-				_, clen, err := imgStore.FullBlobUpload("test", bytes.NewReader(cblob), cdigest)
+				_, clen, err := imgStore.FullBlobUpload(context.Background(), "test", bytes.NewReader(cblob), cdigest)
 				So(err, ShouldBeNil)
 				So(clen, ShouldEqual, len(cblob))
 
@@ -1993,7 +1993,7 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				buf := bytes.NewBuffer(content)
 				unusedDigest := godigest.FromBytes(content)
 
-				_, _, err := imgStore.FullBlobUpload("repo", bytes.NewReader(buf.Bytes()), unusedDigest)
+				_, _, err := imgStore.FullBlobUpload(context.Background(), "repo", bytes.NewReader(buf.Bytes()), unusedDigest)
 				So(err, ShouldBeNil)
 
 				content = []byte("test-data1")
@@ -2001,11 +2001,11 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				buflen := buf.Len()
 				digest := godigest.FromBytes(content)
 
-				_, _, err = imgStore.FullBlobUpload("repo", bytes.NewReader(buf.Bytes()), digest)
+				_, _, err = imgStore.FullBlobUpload(context.Background(), "repo", bytes.NewReader(buf.Bytes()), digest)
 				So(err, ShouldBeNil)
 
 				cblob, cdigest := GetRandomImageConfig()
-				_, clen, err := imgStore.FullBlobUpload("repo", bytes.NewReader(cblob), cdigest)
+				_, clen, err := imgStore.FullBlobUpload(context.Background(), "repo", bytes.NewReader(cblob), cdigest)
 				So(err, ShouldBeNil)
 				So(clen, ShouldEqual, len(cblob))
 
@@ -2087,11 +2087,11 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				buf := bytes.NewBuffer(content)
 				unusedDigest := godigest.FromBytes(content)
 
-				_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(buf.Bytes()), unusedDigest)
+				_, _, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(buf.Bytes()), unusedDigest)
 				So(err, ShouldBeNil)
 
 				// create a blob/layer
-				upload, err := imgStore.NewBlobUpload(repoName)
+				upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 				So(err, ShouldBeNil)
 				So(upload, ShouldNotBeEmpty)
 
@@ -2101,7 +2101,7 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				digest := godigest.FromBytes(content)
 				So(digest, ShouldNotBeNil)
 
-				blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+				blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 				So(err, ShouldBeNil)
 				So(blob, ShouldEqual, buflen)
 
@@ -2123,14 +2123,14 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				//nolint: dupl
 				for range 4 {
 					// upload image config blob
-					upload, err = imgStore.NewBlobUpload(repoName)
+					upload, err = imgStore.NewBlobUpload(context.Background(), repoName)
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
 					cblob, cdigest = GetRandomImageConfig()
 					buf = bytes.NewBuffer(cblob)
 					buflen = buf.Len()
-					blob, err = imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+					blob, err = imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -2321,7 +2321,7 @@ func TestReuploadCorruptedBlob(t *testing.T) {
 				blobSize := len(blob)
 				blobPath := imgStore.BlobPath(repoName, blobDigest)
 
-				ok, size, err := imgStore.CheckBlob(repoName, blobDigest)
+				ok, size, err := imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 				So(ok, ShouldBeTrue)
 				So(size, ShouldEqual, blobSize)
 				So(err, ShouldBeNil)
@@ -2329,7 +2329,7 @@ func TestReuploadCorruptedBlob(t *testing.T) {
 				_, err = driver.WriteFile(blobPath, []byte("corrupted"))
 				So(err, ShouldBeNil)
 
-				ok, size, err = imgStore.CheckBlob(repoName, blobDigest)
+				ok, size, err = imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 				So(ok, ShouldBeFalse)
 				So(size, ShouldNotEqual, blobSize)
 				So(err, ShouldEqual, zerr.ErrBlobNotFound)
@@ -2342,7 +2342,7 @@ func TestReuploadCorruptedBlob(t *testing.T) {
 				So(blobSize, ShouldEqual, size)
 				So(err, ShouldBeNil)
 
-				ok, size, err = imgStore.CheckBlob(repoName, blobDigest)
+				ok, size, err = imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 				So(ok, ShouldBeTrue)
 				So(size, ShouldEqual, blobSize)
 				So(err, ShouldBeNil)
@@ -2363,7 +2363,7 @@ func TestReuploadCorruptedBlob(t *testing.T) {
 				blobSize := len(blob)
 				blobPath := imgStore.BlobPath(repoName, blobDigest)
 
-				ok, size, err := imgStore.CheckBlob(repoName, blobDigest)
+				ok, size, err := imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 				So(ok, ShouldBeTrue)
 				So(size, ShouldEqual, blobSize)
 				So(err, ShouldBeNil)
@@ -2371,7 +2371,7 @@ func TestReuploadCorruptedBlob(t *testing.T) {
 				_, err = driver.WriteFile(blobPath, []byte("corrupted"))
 				So(err, ShouldBeNil)
 
-				ok, size, err = imgStore.CheckBlob(repoName, blobDigest)
+				ok, size, err = imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 				So(ok, ShouldBeFalse)
 				So(size, ShouldNotEqual, blobSize)
 				So(err, ShouldEqual, zerr.ErrBlobNotFound)
@@ -2384,7 +2384,7 @@ func TestReuploadCorruptedBlob(t *testing.T) {
 				So(blobSize, ShouldEqual, size)
 				So(err, ShouldBeNil)
 
-				ok, size, err = imgStore.CheckBlob(repoName, blobDigest)
+				ok, size, err = imgStore.CheckBlob(context.Background(), repoName, blobDigest)
 				So(ok, ShouldBeTrue)
 				So(size, ShouldEqual, blobSize)
 				So(err, ShouldBeNil)
@@ -2572,7 +2572,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 					repoName := "gc-long"
 
-					upload, err := imgStore.NewBlobUpload(repoName)
+					upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
@@ -2581,7 +2581,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					buflen := buf.Len()
 					bdigest := godigest.FromBytes(content)
 
-					blob, err := imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+					blob, err := imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -2592,11 +2592,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					annotationsMap[ispec.AnnotationRefName] = tag
 
 					cblob, cdigest := GetRandomImageConfig()
-					_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
+					_, clen, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(cblob), cdigest)
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
 
-					hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest)
+					hasBlob, _, err := imgStore.CheckBlob(context.Background(), repoName, cdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -2634,11 +2634,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 					// push layer
-					_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
 					So(err, ShouldBeNil)
 
 					// push config
-					_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
 						ispec.DescriptorEmptyJSON.Digest)
 					So(err, ShouldBeNil)
 
@@ -2674,11 +2674,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					err = gc.CleanRepo(ctx, repoName)
 					So(err, ShouldBeNil)
 
-					hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
-					hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -2688,11 +2688,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					err = gc.CleanRepo(ctx, repoName)
 					So(err, ShouldBeNil)
 
-					hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
-					hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 				})
@@ -2737,7 +2737,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					}, audit, log, metrics)
 
 					// upload orphan blob
-					upload, err := imgStore.NewBlobUpload(repoName)
+					upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
@@ -2746,7 +2746,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					buflen := buf.Len()
 					odigest := godigest.FromBytes(content)
 
-					blob, err := imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+					blob, err := imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -2757,7 +2757,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					time.Sleep(1 * time.Second)
 
 					// upload blob
-					upload, err = imgStore.NewBlobUpload(repoName)
+					upload, err = imgStore.NewBlobUpload(context.Background(), repoName)
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
@@ -2766,7 +2766,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					buflen = buf.Len()
 					bdigest := godigest.FromBytes(content)
 
-					blob, err = imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+					blob, err = imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -2777,11 +2777,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					annotationsMap[ispec.AnnotationRefName] = tag
 
 					cblob, cdigest := GetRandomImageConfig()
-					_, clen, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(cblob), cdigest)
+					_, clen, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(cblob), cdigest)
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
 
-					hasBlob, _, err := imgStore.CheckBlob(repoName, cdigest)
+					hasBlob, _, err := imgStore.CheckBlob(context.Background(), repoName, cdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -2816,11 +2816,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 					// push layer
-					_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
 					So(err, ShouldBeNil)
 
 					// push config
-					_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
 						ispec.DescriptorEmptyJSON.Digest)
 					So(err, ShouldBeNil)
 
@@ -2892,7 +2892,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					err = gc.CleanRepo(ctx, repoName)
 					So(err, ShouldBeNil)
 
-					hasBlob, _, err = imgStore.CheckBlob(repoName, odigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, odigest)
 					So(err, ShouldNotBeNil)
 					So(hasBlob, ShouldEqual, false)
 
@@ -2900,7 +2900,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					So(err, ShouldNotBeNil)
 					So(hasBlob, ShouldEqual, false)
 
-					hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -2918,11 +2918,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 						err = gc.CleanRepo(ctx, repoName)
 						So(err, ShouldBeNil)
 
-						hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdigest)
 						So(err, ShouldNotBeNil)
 						So(hasBlob, ShouldEqual, false)
 
-						hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 						So(err, ShouldNotBeNil)
 						So(hasBlob, ShouldEqual, false)
 
@@ -2953,15 +2953,15 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 						err = gc.CleanRepo(ctx, repoName)
 						So(err, ShouldBeNil)
 
-						hasBlob, _, err = imgStore.CheckBlob(repoName, bdigest)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdigest)
 						So(err, ShouldBeNil)
 						So(hasBlob, ShouldEqual, true)
 
-						hasBlob, _, err = imgStore.CheckBlob(repoName, digest)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, digest)
 						So(err, ShouldBeNil)
 						So(hasBlob, ShouldEqual, true)
 
-						hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 						So(err, ShouldBeNil)
 						So(hasBlob, ShouldEqual, true)
 
@@ -3014,7 +3014,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					repo1Name := "gc1"
 
 					// upload blob
-					upload, err := imgStore.NewBlobUpload(repo1Name)
+					upload, err := imgStore.NewBlobUpload(context.Background(), repo1Name)
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
@@ -3024,7 +3024,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					bdigest := godigest.FromBytes(content)
 					tdigest := bdigest
 
-					blob, err := imgStore.PutBlobChunk(repo1Name, upload, 0, int64(buflen), buf)
+					blob, err := imgStore.PutBlobChunk(context.Background(), repo1Name, upload, 0, int64(buflen), buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -3035,11 +3035,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					annotationsMap[ispec.AnnotationRefName] = tag
 
 					cblob, cdigest := GetRandomImageConfig()
-					_, clen, err := imgStore.FullBlobUpload(repo1Name, bytes.NewReader(cblob), cdigest)
+					_, clen, err := imgStore.FullBlobUpload(context.Background(), repo1Name, bytes.NewReader(cblob), cdigest)
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
 
-					hasBlob, _, err := imgStore.CheckBlob(repo1Name, cdigest)
+					hasBlob, _, err := imgStore.CheckBlob(context.Background(), repo1Name, cdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -3070,11 +3070,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					// sleep so past GC timeout
 					time.Sleep(3 * time.Second)
 
-					hasBlob, _, err = imgStore.CheckBlob(repo1Name, tdigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repo1Name, tdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
-					hasBlob, _, err = imgStore.CheckBlob(repo1Name, tdigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repo1Name, tdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -3082,14 +3082,14 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 					repo2Name := "gc2"
 
-					upload, err = imgStore.NewBlobUpload(repo2Name)
+					upload, err = imgStore.NewBlobUpload(context.Background(), repo2Name)
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
 					buf = bytes.NewBuffer(content)
 					buflen = buf.Len()
 
-					blob, err = imgStore.PutBlobChunk(repo2Name, upload, 0, int64(buflen), buf)
+					blob, err = imgStore.PutBlobChunk(context.Background(), repo2Name, upload, 0, int64(buflen), buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -3100,11 +3100,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					annotationsMap[ispec.AnnotationRefName] = tag
 
 					cblob, cdigest = GetRandomImageConfig()
-					_, clen, err = imgStore.FullBlobUpload(repo2Name, bytes.NewReader(cblob), cdigest)
+					_, clen, err = imgStore.FullBlobUpload(context.Background(), repo2Name, bytes.NewReader(cblob), cdigest)
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
 
-					hasBlob, _, err = imgStore.CheckBlob(repo2Name, cdigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repo2Name, cdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -3132,13 +3132,13 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 						repo2Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
-					hasBlob, _, err = imgStore.CheckBlob(repo2Name, bdigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repo2Name, bdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
 					// immediately upload any other image to second repo which should invoke GC inline, but expect layers to persist
 
-					upload, err = imgStore.NewBlobUpload(repo2Name)
+					upload, err = imgStore.NewBlobUpload(context.Background(), repo2Name)
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
@@ -3147,7 +3147,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					buflen = buf.Len()
 					bdigest = godigest.FromBytes(content)
 
-					blob, err = imgStore.PutBlobChunk(repo2Name, upload, 0, int64(buflen), buf)
+					blob, err = imgStore.PutBlobChunk(context.Background(), repo2Name, upload, 0, int64(buflen), buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -3158,11 +3158,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					annotationsMap[ispec.AnnotationRefName] = tag
 
 					cblob, cdigest = GetRandomImageConfig()
-					_, clen, err = imgStore.FullBlobUpload(repo2Name, bytes.NewReader(cblob), cdigest)
+					_, clen, err = imgStore.FullBlobUpload(context.Background(), repo2Name, bytes.NewReader(cblob), cdigest)
 					So(err, ShouldBeNil)
 					So(clen, ShouldEqual, len(cblob))
 
-					hasBlob, _, err = imgStore.CheckBlob(repo2Name, cdigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repo2Name, cdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -3196,7 +3196,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					// original blob should exist
-					hasBlob, _, err = imgStore.CheckBlob(repo2Name, tdigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repo2Name, tdigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -3272,11 +3272,11 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 					// push layer
-					_, _, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+					_, _, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
 					So(err, ShouldBeNil)
 
 					// push config
-					_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
 						ispec.DescriptorEmptyJSON.Digest)
 					So(err, ShouldBeNil)
 
@@ -3329,7 +3329,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					err = gc.CleanRepo(ctx, repoName)
 					So(err, ShouldBeNil)
 
-					hasBlob, _, err := imgStore.CheckBlob(repoName, bdgst)
+					hasBlob, _, err := imgStore.CheckBlob(context.Background(), repoName, bdgst)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -3340,16 +3340,16 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 						err = gc.CleanRepo(ctx, repoName)
 						So(err, ShouldBeNil)
 
-						hasBlob, _, err = imgStore.CheckBlob(repoName, bdgst)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdgst)
 						So(err, ShouldBeNil)
 						So(hasBlob, ShouldEqual, true)
 
 						// check last manifest from index image
-						hasBlob, _, err = imgStore.CheckBlob(repoName, digest)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, digest)
 						So(err, ShouldBeNil)
 						So(hasBlob, ShouldEqual, true)
 
-						hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 						So(err, ShouldBeNil)
 						So(hasBlob, ShouldEqual, true)
 					})
@@ -3396,7 +3396,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					}, audit, log, metrics)
 
 					// upload orphan blob
-					upload, err := imgStore.NewBlobUpload(repoName)
+					upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
@@ -3405,7 +3405,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					buflen := buf.Len()
 					odigest := godigest.FromBytes(content)
 
-					blob, err := imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+					blob, err := imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -3419,11 +3419,11 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 					// push layer
-					_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
 					So(err, ShouldBeNil)
 
 					// push config
-					_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
+					_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
 						ispec.DescriptorEmptyJSON.Digest)
 					So(err, ShouldBeNil)
 
@@ -3512,7 +3512,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
-					hasBlob, _, err := imgStore.CheckBlob(repoName, bdgst)
+					hasBlob, _, err := imgStore.CheckBlob(context.Background(), repoName, bdgst)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -3520,7 +3520,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
-					hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
@@ -3589,7 +3589,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 						So(err, ShouldNotBeNil)
 
 						// orphan blob
-						hasBlob, _, err = imgStore.CheckBlob(repoName, odigest)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, odigest)
 						So(err, ShouldNotBeNil)
 						So(hasBlob, ShouldEqual, false)
 
@@ -3597,12 +3597,12 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 						So(err, ShouldNotBeNil)
 						So(hasBlob, ShouldEqual, false)
 
-						hasBlob, _, err = imgStore.CheckBlob(repoName, bdgst)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdgst)
 						So(err, ShouldNotBeNil)
 						So(hasBlob, ShouldEqual, false)
 
 						// check last manifest from index image
-						hasBlob, _, err = imgStore.CheckBlob(repoName, digest)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, digest)
 						So(err, ShouldNotBeNil)
 						So(hasBlob, ShouldEqual, false)
 
@@ -3613,7 +3613,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 						_, _, _, err = imgStore.GetImageManifest(repoName, artifactManifestIndexDigest.String())
 						So(err, ShouldNotBeNil)
 
-						hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+						hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 						So(err, ShouldNotBeNil)
 						So(hasBlob, ShouldEqual, false)
 
@@ -3694,7 +3694,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				}, audit, log, metrics)
 
 				// upload orphan blob
-				upload, err := imgStore.NewBlobUpload(repoName)
+				upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 				So(err, ShouldBeNil)
 				So(upload, ShouldNotBeEmpty)
 
@@ -3703,7 +3703,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				buflen := buf.Len()
 				odigest := godigest.FromBytes(content)
 
-				blob, err := imgStore.PutBlobChunk(repoName, upload, 0, int64(buflen), buf)
+				blob, err := imgStore.PutBlobChunk(context.Background(), repoName, upload, 0, int64(buflen), buf)
 				So(err, ShouldBeNil)
 				So(blob, ShouldEqual, buflen)
 
@@ -3714,7 +3714,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				bdgst := godigest.FromBytes(content)
 				So(bdgst, ShouldNotBeNil)
 
-				_, bsize, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(content), bdgst)
+				_, bsize, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(content), bdgst)
 				So(err, ShouldBeNil)
 				So(bsize, ShouldEqual, len(content))
 
@@ -3722,11 +3722,11 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				artifactBlobDigest := godigest.FromBytes(artifactBlob)
 
 				// push layer
-				_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
+				_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(artifactBlob), artifactBlobDigest)
 				So(err, ShouldBeNil)
 
 				// push config
-				_, _, err = imgStore.FullBlobUpload(repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
+				_, _, err = imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(ispec.DescriptorEmptyJSON.Data),
 					ispec.DescriptorEmptyJSON.Digest)
 				So(err, ShouldBeNil)
 
@@ -3738,14 +3738,14 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 
 				for range 4 { //nolint: dupl
 					// upload image config blob
-					upload, err := imgStore.NewBlobUpload(repoName)
+					upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
 					cblob, cdigest := GetRandomImageConfig()
 					buf := bytes.NewBuffer(cblob)
 					buflen := buf.Len()
-					blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+					blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -3824,14 +3824,14 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 
 				for range 3 { //nolint: dupl
 					// upload image config blob
-					upload, err := imgStore.NewBlobUpload(repoName)
+					upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 					So(err, ShouldBeNil)
 					So(upload, ShouldNotBeEmpty)
 
 					cblob, cdigest := GetRandomImageConfig()
 					buf := bytes.NewBuffer(cblob)
 					buflen := buf.Len()
-					blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+					blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 					So(err, ShouldBeNil)
 					So(blob, ShouldEqual, buflen)
 
@@ -4005,7 +4005,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 					ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 				So(err, ShouldBeNil)
 
-				hasBlob, _, err := imgStore.CheckBlob(repoName, bdgst)
+				hasBlob, _, err := imgStore.CheckBlob(context.Background(), repoName, bdgst)
 				So(err, ShouldBeNil)
 				So(hasBlob, ShouldEqual, true)
 
@@ -4013,7 +4013,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(hasBlob, ShouldEqual, true)
 
-				hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+				hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 				So(err, ShouldBeNil)
 				So(hasBlob, ShouldEqual, true)
 
@@ -4079,7 +4079,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 					So(err, ShouldNotBeNil)
 
 					// orphan blob
-					hasBlob, _, err = imgStore.CheckBlob(repoName, odigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, odigest)
 					So(err, ShouldNotBeNil)
 					So(hasBlob, ShouldEqual, false)
 
@@ -4096,18 +4096,18 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 					So(err, ShouldNotBeNil)
 
 					// check last manifest from index image
-					hasBlob, _, err = imgStore.CheckBlob(repoName, digest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, digest)
 					So(err, ShouldNotBeNil)
 					So(hasBlob, ShouldEqual, false)
 
 					_, _, _, err = imgStore.GetImageManifest(repoName, artifactManifestIndexDigest.String())
 					So(err, ShouldNotBeNil)
 
-					hasBlob, _, err = imgStore.CheckBlob(repoName, artifactBlobDigest)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, artifactBlobDigest)
 					So(err, ShouldNotBeNil)
 					So(hasBlob, ShouldEqual, false)
 
-					hasBlob, _, err = imgStore.CheckBlob(repoName, bdgst)
+					hasBlob, _, err = imgStore.CheckBlob(context.Background(), repoName, bdgst)
 					So(err, ShouldNotBeNil)
 					So(hasBlob, ShouldEqual, false)
 
@@ -4126,7 +4126,7 @@ func pushRandomImageIndex(imgStore storageTypes.ImageStore, repoName string,
 	bdgst := godigest.FromBytes(content)
 	So(bdgst, ShouldNotBeNil)
 
-	_, bsize, err := imgStore.FullBlobUpload(repoName, bytes.NewReader(content), bdgst)
+	_, bsize, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(content), bdgst)
 	So(err, ShouldBeNil)
 	So(bsize, ShouldEqual, len(content))
 
@@ -4138,14 +4138,14 @@ func pushRandomImageIndex(imgStore storageTypes.ImageStore, repoName string,
 
 	for range 4 { //nolint: dupl
 		// upload image config blob
-		upload, err := imgStore.NewBlobUpload(repoName)
+		upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
 		So(err, ShouldBeNil)
 		So(upload, ShouldNotBeEmpty)
 
 		cblob, cdigest := GetRandomImageConfig()
 		buf := bytes.NewBuffer(cblob)
 		buflen := buf.Len()
-		blob, err := imgStore.PutBlobChunkStreamed(repoName, upload, buf)
+		blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
 		So(err, ShouldBeNil)
 		So(blob, ShouldEqual, buflen)
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -158,6 +158,16 @@ func createObjectsStore(options createObjectStoreOpts) (
 func newLocalImageStoreWithEventRecorder(t *testing.T, recorder events.Recorder) storageTypes.ImageStore {
 	t.Helper()
 
+	return newLocalImageStoreWithEventRecorderAndLinter(t, recorder, nil)
+}
+
+// newLocalImageStoreWithEventRecorderAndLinter builds a filesystem-backed image store with an optional
+// events.Recorder and an optional linter (nil disables linting).
+func newLocalImageStoreWithEventRecorderAndLinter(t *testing.T, recorder events.Recorder,
+	linter storageCommon.Lint,
+) storageTypes.ImageStore {
+	t.Helper()
+
 	cacheDir := t.TempDir()
 	rootDir := t.TempDir()
 	log := zlog.NewTestLogger()
@@ -174,7 +184,7 @@ func newLocalImageStoreWithEventRecorder(t *testing.T, recorder events.Recorder)
 	storeDriver := local.New(true)
 	metrics := monitoring.NewMetricsServer(false, log)
 
-	return imagestore.NewImageStore(rootDir, cacheDir, true, true, log, metrics, nil,
+	return imagestore.NewImageStore(rootDir, cacheDir, true, true, log, metrics, linter,
 		storeDriver, cacheDriver, nil, recorder)
 }
 
@@ -253,19 +263,31 @@ func TestStorageNew(t *testing.T) {
 }
 
 type captureImageEvents struct {
-	mu           sync.Mutex
-	imageUpdated []imageUpdatedCall
+	mu              sync.Mutex
+	imageUpdated    []imageUpdatedCall
+	imageDeleted    []imageDeletedCall
+	imageLintFailed []imageLintFailedCall
 }
 
 type imageUpdatedCall struct {
 	repo, reference, digest, mediaType, manifest string
 }
 
+type imageDeletedCall struct {
+	repo, reference, digest, mediaType string
+}
+
+type imageLintFailedCall struct {
+	repo, reference, digest, mediaType, manifest string
+}
+
 func (c *captureImageEvents) Close() {}
 
-func (c *captureImageEvents) RepositoryCreated(string) {}
+func (c *captureImageEvents) RepositoryCreated(string, *events.EventContext) {}
 
-func (c *captureImageEvents) ImageUpdated(name, reference, digest, mediaType, manifest string) {
+func (c *captureImageEvents) ImageUpdated(name, reference, digest, mediaType, manifest string,
+	ectx *events.EventContext,
+) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -274,9 +296,25 @@ func (c *captureImageEvents) ImageUpdated(name, reference, digest, mediaType, ma
 	})
 }
 
-func (c *captureImageEvents) ImageDeleted(string, string, string, string) {}
+func (c *captureImageEvents) ImageDeleted(name, reference, digest, mediaType string, ectx *events.EventContext) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
-func (c *captureImageEvents) ImageLintFailed(string, string, string, string, string) {}
+	c.imageDeleted = append(c.imageDeleted, imageDeletedCall{
+		repo: name, reference: reference, digest: digest, mediaType: mediaType,
+	})
+}
+
+func (c *captureImageEvents) ImageLintFailed(name, reference, digest, mediaType, manifest string,
+	ectx *events.EventContext,
+) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.imageLintFailed = append(c.imageLintFailed, imageLintFailedCall{
+		repo: name, reference: reference, digest: digest, mediaType: mediaType, manifest: manifest,
+	})
+}
 
 // TestPutImageManifestExtraTagsAndEvents covers extra-tag digest pushes, index updates, and ImageUpdated events.
 // One Convey uses createObjectsStore (nil recorder); the rest use newLocalImageStoreWithEventRecorder.
@@ -348,7 +386,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		manifestBuf, err := json.Marshal(manifest)
 		So(err, ShouldBeNil)
 
-		_, _, err = imgStore.PutImageManifest(repo, "1.0", ispec.MediaTypeImageManifest, manifestBuf,
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, "1.0", ispec.MediaTypeImageManifest, manifestBuf,
 			[]string{"extra"})
 		So(errors.Is(err, zerr.ErrBadManifest), ShouldBeTrue)
 	})
@@ -389,7 +427,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		manifestDigest := godigest.FromBytes(manifestBuf)
 		extraTags := []string{"v1.2.3", "v1.2", "latest"}
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, extraTags)
 		So(err, ShouldBeNil)
 
@@ -419,7 +457,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		So(len(wantRefs), ShouldEqual, 0)
 		eventCapture.mu.Unlock()
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, extraTags)
 		So(err, ShouldBeNil)
 
@@ -459,7 +497,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 
 		manifestDigest := godigest.FromBytes(manifestBuf)
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
@@ -474,7 +512,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 
 		extraTags := []string{"after-tag"}
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, extraTags)
 		So(err, ShouldBeNil)
 
@@ -523,7 +561,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		manifestDigest := godigest.FromBytes(manifestBuf)
 		firstTags := []string{"tag-a", "tag-b", "tag-c"}
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, firstTags)
 		So(err, ShouldBeNil)
 
@@ -538,7 +576,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		So(len(eventCapture.imageUpdated), ShouldEqual, 3)
 		eventCapture.mu.Unlock()
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, []string{"tag-b"})
 		So(err, ShouldBeNil)
 
@@ -553,7 +591,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		So(len(eventCapture.imageUpdated), ShouldEqual, 3)
 		eventCapture.mu.Unlock()
 
-		_, _, err = imgStore.PutImageManifest(repo, manifestDigest.String(),
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, []string{"tag-d"})
 		So(err, ShouldBeNil)
 
@@ -570,6 +608,231 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 		So(eventCapture.imageUpdated[3].reference, ShouldEqual, "tag-d")
 		So(eventCapture.imageUpdated[3].digest, ShouldEqual, manifestDigest.String())
 		So(eventCapture.imageUpdated[3].manifest, ShouldEqual, string(manifestBuf))
+		eventCapture.mu.Unlock()
+	})
+}
+
+func TestDeleteImageManifestEvents(t *testing.T) {
+	Convey("delete by tag emits ImageDeleted with manifest digest and tag reference", t, func() {
+		eventCapture := &captureImageEvents{}
+		imgStore := newLocalImageStoreWithEventRecorder(t, eventCapture)
+
+		repo := "delrepo"
+		tag := "v1"
+
+		cblob, cdigest := GetRandomImageConfig()
+		_, _, err := imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		So(err, ShouldBeNil)
+
+		layerBytes := []byte("layer-del")
+		layerDigest := godigest.FromBytes(layerBytes)
+		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		So(err, ShouldBeNil)
+
+		manifest := ispec.Manifest{}
+		manifest.SchemaVersion = 2
+		manifest.Config = ispec.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    cdigest,
+			Size:      int64(len(cblob)),
+		}
+		manifest.Layers = []ispec.Descriptor{
+			{MediaType: "application/vnd.oci.image.layer.v1.tar", Digest: layerDigest, Size: int64(len(layerBytes))},
+		}
+
+		manifestBuf, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+		manifestDigest := godigest.FromBytes(manifestBuf)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, tag,
+			ispec.MediaTypeImageManifest, manifestBuf, nil)
+		So(err, ShouldBeNil)
+
+		err = imgStore.DeleteImageManifest(context.Background(), repo, tag, false)
+		So(err, ShouldBeNil)
+
+		eventCapture.mu.Lock()
+		So(len(eventCapture.imageDeleted), ShouldEqual, 1)
+		So(eventCapture.imageDeleted[0].repo, ShouldEqual, repo)
+		So(eventCapture.imageDeleted[0].reference, ShouldEqual, tag)
+		So(eventCapture.imageDeleted[0].digest, ShouldEqual, manifestDigest.String())
+		So(eventCapture.imageDeleted[0].mediaType, ShouldEqual, ispec.MediaTypeImageManifest)
+		eventCapture.mu.Unlock()
+	})
+
+	Convey("delete by digest emits ImageDeleted with digest reference", t, func() {
+		eventCapture := &captureImageEvents{}
+		imgStore := newLocalImageStoreWithEventRecorder(t, eventCapture)
+
+		repo := "delrepo-digest"
+
+		cblob, cdigest := GetRandomImageConfig()
+		_, _, err := imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		So(err, ShouldBeNil)
+
+		layerBytes := []byte("layer-del-d")
+		layerDigest := godigest.FromBytes(layerBytes)
+		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		So(err, ShouldBeNil)
+
+		manifest := ispec.Manifest{}
+		manifest.SchemaVersion = 2
+		manifest.Config = ispec.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    cdigest,
+			Size:      int64(len(cblob)),
+		}
+		manifest.Layers = []ispec.Descriptor{
+			{MediaType: "application/vnd.oci.image.layer.v1.tar", Digest: layerDigest, Size: int64(len(layerBytes))},
+		}
+
+		manifestBuf, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+		manifestDigest := godigest.FromBytes(manifestBuf)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
+			ispec.MediaTypeImageManifest, manifestBuf, nil)
+		So(err, ShouldBeNil)
+
+		err = imgStore.DeleteImageManifest(context.Background(), repo, manifestDigest.String(), false)
+		So(err, ShouldBeNil)
+
+		eventCapture.mu.Lock()
+		So(len(eventCapture.imageDeleted), ShouldEqual, 1)
+		So(eventCapture.imageDeleted[0].repo, ShouldEqual, repo)
+		So(eventCapture.imageDeleted[0].reference, ShouldEqual, manifestDigest.String())
+		So(eventCapture.imageDeleted[0].digest, ShouldEqual, manifestDigest.String())
+		eventCapture.mu.Unlock()
+	})
+
+	Convey("delete of missing reference does not emit ImageDeleted", t, func() {
+		eventCapture := &captureImageEvents{}
+		imgStore := newLocalImageStoreWithEventRecorder(t, eventCapture)
+
+		repo := "delrepo-missing"
+
+		cblob, cdigest := GetRandomImageConfig()
+		_, _, err := imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		So(err, ShouldBeNil)
+
+		layerBytes := []byte("layer-missing")
+		layerDigest := godigest.FromBytes(layerBytes)
+		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		So(err, ShouldBeNil)
+
+		manifest := ispec.Manifest{}
+		manifest.SchemaVersion = 2
+		manifest.Config = ispec.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    cdigest,
+			Size:      int64(len(cblob)),
+		}
+		manifest.Layers = []ispec.Descriptor{
+			{MediaType: "application/vnd.oci.image.layer.v1.tar", Digest: layerDigest, Size: int64(len(layerBytes))},
+		}
+
+		manifestBuf, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(), repo, "real",
+			ispec.MediaTypeImageManifest, manifestBuf, nil)
+		So(err, ShouldBeNil)
+
+		err = imgStore.DeleteImageManifest(context.Background(), repo, "missing", false)
+		So(err, ShouldNotBeNil)
+
+		eventCapture.mu.Lock()
+		So(len(eventCapture.imageDeleted), ShouldEqual, 0)
+		eventCapture.mu.Unlock()
+	})
+}
+
+func TestImageLintFailedEvents(t *testing.T) {
+	failingLinter := &mocks.MockedLint{
+		LintFn: func(repo string, manifestDigest godigest.Digest, imageStore storageTypes.ImageStore) (bool, error) {
+			return false, nil
+		},
+	}
+
+	buildManifest := func(t *testing.T, imgStore storageTypes.ImageStore, repo string) ([]byte, godigest.Digest) {
+		t.Helper()
+
+		cblob, cdigest := GetRandomImageConfig()
+		_, _, err := imgStore.FullBlobUpload(repo, bytes.NewReader(cblob), cdigest)
+		So(err, ShouldBeNil)
+
+		layerBytes := []byte("layer-lint")
+		layerDigest := godigest.FromBytes(layerBytes)
+		_, _, err = imgStore.FullBlobUpload(repo, bytes.NewReader(layerBytes), layerDigest)
+		So(err, ShouldBeNil)
+
+		manifest := ispec.Manifest{}
+		manifest.SchemaVersion = 2
+		manifest.Config = ispec.Descriptor{
+			MediaType: "application/vnd.oci.image.config.v1+json",
+			Digest:    cdigest,
+			Size:      int64(len(cblob)),
+		}
+		manifest.Layers = []ispec.Descriptor{
+			{MediaType: "application/vnd.oci.image.layer.v1.tar", Digest: layerDigest, Size: int64(len(layerBytes))},
+		}
+
+		manifestBuf, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+
+		return manifestBuf, godigest.FromBytes(manifestBuf)
+	}
+
+	Convey("tag push that fails lint emits ImageLintFailed for the tag reference", t, func() {
+		eventCapture := &captureImageEvents{}
+		imgStore := newLocalImageStoreWithEventRecorderAndLinter(t, eventCapture, failingLinter)
+
+		repo := "lintrepo"
+		manifestBuf, manifestDigest := buildManifest(t, imgStore, repo)
+
+		_, _, err := imgStore.PutImageManifest(context.Background(), repo, "v1",
+			ispec.MediaTypeImageManifest, manifestBuf, nil)
+		So(err, ShouldNotBeNil)
+
+		eventCapture.mu.Lock()
+		So(len(eventCapture.imageLintFailed), ShouldEqual, 1)
+		So(eventCapture.imageLintFailed[0].repo, ShouldEqual, repo)
+		So(eventCapture.imageLintFailed[0].reference, ShouldEqual, "v1")
+		So(eventCapture.imageLintFailed[0].digest, ShouldEqual, manifestDigest.String())
+		So(eventCapture.imageLintFailed[0].mediaType, ShouldEqual, ispec.MediaTypeImageManifest)
+		eventCapture.mu.Unlock()
+	})
+
+	Convey("digest push with extra tags that fails lint emits one ImageLintFailed per tag", t, func() {
+		eventCapture := &captureImageEvents{}
+		imgStore := newLocalImageStoreWithEventRecorderAndLinter(t, eventCapture, failingLinter)
+
+		repo := "lintrepo-multi"
+		manifestBuf, manifestDigest := buildManifest(t, imgStore, repo)
+
+		extraTags := []string{"a", "b"}
+
+		_, _, err := imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
+			ispec.MediaTypeImageManifest, manifestBuf, extraTags)
+		So(err, ShouldNotBeNil)
+
+		eventCapture.mu.Lock()
+		So(len(eventCapture.imageLintFailed), ShouldEqual, len(extraTags))
+
+		seenRefs := map[string]struct{}{}
+
+		for _, call := range eventCapture.imageLintFailed {
+			So(call.repo, ShouldEqual, repo)
+			So(call.digest, ShouldEqual, manifestDigest.String())
+
+			seenRefs[call.reference] = struct{}{}
+		}
+
+		for _, tag := range extraTags {
+			_, ok := seenRefs[tag]
+			So(ok, ShouldBeTrue)
+		}
+
 		eventCapture.mu.Unlock()
 	})
 }
@@ -722,7 +985,7 @@ func TestStorageAPIs(t *testing.T) {
 				})
 
 				Convey("Initialize repo", func() {
-					err := imgStore.InitRepo(repoName)
+					err := imgStore.InitRepo(context.Background(), repoName)
 					So(err, ShouldBeNil)
 
 					ok := imgStore.DirExists(path.Join(imgStore.RootDir(), repoName))
@@ -928,19 +1191,22 @@ func TestStorageAPIs(t *testing.T) {
 						So(err, ShouldBeNil)
 
 						Convey("Bad image manifest", func() {
-							_, _, err = imgStore.PutImageManifest("test", digest.String(), "application/json",
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(), "application/json",
 								manifestBuf, nil)
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", digest.String(), ispec.MediaTypeImageManifest,
 								[]byte{}, nil)
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", digest.String(), ispec.MediaTypeImageManifest,
 								[]byte(`{"test":true}`), nil)
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", digest.String(), ispec.MediaTypeImageManifest,
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", digest.String(), ispec.MediaTypeImageManifest,
 								manifestBuf, nil)
 							So(err, ShouldNotBeNil)
 
@@ -990,20 +1256,25 @@ func TestStorageAPIs(t *testing.T) {
 							badMb, err := json.Marshal(manifest)
 							So(err, ShouldBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, badMb, nil)
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0",
+								ispec.MediaTypeImageManifest, badMb, nil)
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
 							// same manifest for coverage
-							_, _, err = imgStore.PutImageManifest("test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", "3.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+							_, _, err = imgStore.PutImageManifest(context.Background(),
+								"test", "3.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
 							_, err = imgStore.GetImageTags("inexistent")
@@ -1020,7 +1291,7 @@ func TestStorageAPIs(t *testing.T) {
 							_, _, _, err = imgStore.GetImageManifest("test", "3.0")
 							So(err, ShouldBeNil)
 
-							err = imgStore.DeleteImageManifest("test", "1.0", false)
+							err = imgStore.DeleteImageManifest(context.Background(), "test", "1.0", false)
 							So(err, ShouldBeNil)
 
 							tags, err = imgStore.GetImageTags("test")
@@ -1053,11 +1324,11 @@ func TestStorageAPIs(t *testing.T) {
 							So(hasBlob, ShouldEqual, true)
 
 							// with detectManifestCollision should get error
-							err = imgStore.DeleteImageManifest("test", digest.String(), true)
+							err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), true)
 							So(err, ShouldNotBeNil)
 
 							// If we pass reference all manifest with input reference should be deleted.
-							err = imgStore.DeleteImageManifest("test", digest.String(), false)
+							err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), false)
 							So(err, ShouldBeNil)
 
 							tags, err = imgStore.GetImageTags("test")
@@ -1173,11 +1444,11 @@ func TestStorageAPIs(t *testing.T) {
 						})
 
 						Convey("Bad image manifest", func() {
-							_, _, err = imgStore.PutImageManifest("test", digest.String(),
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 								ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldNotBeNil)
 
-							_, _, err = imgStore.PutImageManifest("test", digest.String(),
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 								ispec.MediaTypeImageManifest, []byte("bad json"), nil)
 							So(err, ShouldNotBeNil)
 
@@ -1214,12 +1485,13 @@ func TestStorageAPIs(t *testing.T) {
 							So(err, ShouldBeNil)
 
 							digest := godigest.FromBytes(manifestBuf)
-							_, _, err = imgStore.PutImageManifest("test", digest.String(),
+
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 								ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
 							// same manifest for coverage
-							_, _, err = imgStore.PutImageManifest("test", digest.String(),
+							_, _, err = imgStore.PutImageManifest(context.Background(), "test", digest.String(),
 								ispec.MediaTypeImageManifest, manifestBuf, nil)
 							So(err, ShouldBeNil)
 
@@ -1248,13 +1520,13 @@ func TestStorageAPIs(t *testing.T) {
 
 							So(len(index.Manifests), ShouldEqual, 1)
 
-							err = imgStore.DeleteImageManifest("test", "1.0", false)
+							err = imgStore.DeleteImageManifest(context.Background(), "test", "1.0", false)
 							So(err, ShouldNotBeNil)
 
-							err = imgStore.DeleteImageManifest("inexistent", "1.0", false)
+							err = imgStore.DeleteImageManifest(context.Background(), "inexistent", "1.0", false)
 							So(err, ShouldNotBeNil)
 
-							err = imgStore.DeleteImageManifest("test", digest.String(), false)
+							err = imgStore.DeleteImageManifest(context.Background(), "test", digest.String(), false)
 							So(err, ShouldBeNil)
 
 							_, _, _, err = imgStore.GetImageManifest("test", digest.String())
@@ -1315,7 +1587,9 @@ func TestStorageAPIs(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					digest = godigest.FromBytes(manifestBuf)
-					_, _, err = imgStore.PutImageManifest("replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					_, _, _, err = imgStore.GetImageManifest("replace", digest.String())
@@ -1369,7 +1643,9 @@ func TestStorageAPIs(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					_ = godigest.FromBytes(manifestBuf)
-					_, _, err = imgStore.PutImageManifest("replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"replace", "1.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 				})
 
@@ -1506,7 +1782,8 @@ func TestMandatoryAnnotations(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				Convey("Missing mandatory annotations", func() {
-					_, _, err = imgStore.PutImageManifest("test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldNotBeNil)
 				})
 
@@ -1534,7 +1811,8 @@ func TestMandatoryAnnotations(t *testing.T) {
 							}, store, cacheDriver, nil, nil)
 					}
 
-					_, _, err = imgStore.PutImageManifest("test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						"test", "1.0.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldNotBeNil)
 				})
 			})
@@ -1754,7 +2032,8 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				manifestBuf, err := json.Marshal(manifest)
 				So(err, ShouldBeNil)
 
-				manifestDigest, _, err := imgStore.PutImageManifest("repo", tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+				manifestDigest, _, err := imgStore.PutImageManifest(context.Background(),
+					"repo", tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 				So(err, ShouldBeNil)
 
 				Convey("Try to delete blob currently in use", func() {
@@ -1777,7 +2056,7 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				})
 
 				Convey("Delete manifest first, then blob", func() {
-					err := imgStore.DeleteImageManifest("repo", manifestDigest.String(), false)
+					err := imgStore.DeleteImageManifest(context.Background(), "repo", manifestDigest.String(), false)
 					So(err, ShouldBeNil)
 
 					err = imgStore.DeleteBlob("repo", digest)
@@ -1880,7 +2159,9 @@ func TestDeleteBlobsInUse(t *testing.T) {
 
 					digest = godigest.FromBytes(content)
 					So(digest, ShouldNotBeNil)
-					_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 					So(err, ShouldBeNil)
 
 					index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -1897,13 +2178,13 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				indexDigest := godigest.FromBytes(indexContent)
 				So(indexDigest, ShouldNotBeNil)
 
-				indexManifestDigest, _, err := imgStore.PutImageManifest(repoName, "index",
-					ispec.MediaTypeImageIndex, indexContent, nil)
+				indexManifestDigest, _, err := imgStore.PutImageManifest(context.Background(),
+					repoName, "index", ispec.MediaTypeImageIndex, indexContent, nil)
 				So(err, ShouldBeNil)
 
 				Convey("Try to delete manifest being referenced by image index", func() {
 					// modifying multi arch images should not be allowed
-					err := imgStore.DeleteImageManifest(repoName, digest.String(), false)
+					err := imgStore.DeleteImageManifest(context.Background(), repoName, digest.String(), false)
 					So(err, ShouldEqual, zerr.ErrManifestReferenced)
 				})
 
@@ -1927,11 +2208,11 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				})
 
 				Convey("Delete manifests first, then blob", func() {
-					err := imgStore.DeleteImageManifest(repoName, indexManifestDigest.String(), false)
+					err := imgStore.DeleteImageManifest(context.Background(), repoName, indexManifestDigest.String(), false)
 					So(err, ShouldBeNil)
 
 					for _, manifestDesc := range index.Manifests {
-						err := imgStore.DeleteImageManifest(repoName, manifestDesc.Digest.String(), false)
+						err := imgStore.DeleteImageManifest(context.Background(), repoName, manifestDesc.Digest.String(), false)
 						So(err, ShouldBeNil)
 					}
 
@@ -2341,7 +2622,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 					digest := godigest.FromBytes(manifestBuf)
 
-					_, _, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repoName, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					err = gc.CleanRepo(ctx, repoName)
@@ -2384,7 +2666,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -2399,7 +2682,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					So(err, ShouldBeNil)
 					So(hasBlob, ShouldEqual, true)
 
-					err = imgStore.DeleteImageManifest(repoName, digest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), repoName, digest.String(), false)
 					So(err, ShouldBeNil)
 
 					err = gc.CleanRepo(ctx, repoName)
@@ -2524,7 +2807,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 					digest := godigest.FromBytes(manifestBuf)
 
-					_, _, err = imgStore.PutImageManifest(repoName, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repoName, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					// put artifact referencing above image
@@ -2564,7 +2848,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -2580,7 +2865,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					artifactOfArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
-					_, _, err = imgStore.PutImageManifest(repoName, artifactOfArtifactManifestDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactOfArtifactManifestDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -2598,7 +2884,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					orphanArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push orphan artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, orphanArtifactManifestDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, orphanArtifactManifestDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -2625,7 +2912,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					time.Sleep(1 * time.Second)
 
 					Convey("Garbage collect blobs after manifest is removed", func() {
-						err = imgStore.DeleteImageManifest(repoName, digest.String(), false)
+						err = imgStore.DeleteImageManifest(context.Background(), repoName, digest.String(), false)
 						So(err, ShouldBeNil)
 
 						err = gc.CleanRepo(ctx, repoName)
@@ -2656,10 +2943,11 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 					Convey("Garbage collect - don't gc manifests/blobs which are referenced by another image", func() {
 						// upload same image with another tag
-						_, _, err = imgStore.PutImageManifest(repoName, "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
+						_, _, err = imgStore.PutImageManifest(context.Background(),
+							repoName, "2.0", ispec.MediaTypeImageManifest, manifestBuf, nil)
 						So(err, ShouldBeNil)
 
-						err = imgStore.DeleteImageManifest(repoName, tag, false)
+						err = imgStore.DeleteImageManifest(context.Background(), repoName, tag, false)
 						So(err, ShouldBeNil)
 
 						err = gc.CleanRepo(ctx, repoName)
@@ -2775,7 +3063,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					manifestBuf, err := json.Marshal(manifest)
 					So(err, ShouldBeNil)
 
-					_, _, err = imgStore.PutImageManifest(repo1Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repo1Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					// sleep so past GC timeout
@@ -2839,7 +3128,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 					manifestBuf, err = json.Marshal(manifest)
 					So(err, ShouldBeNil)
 
-					_, _, err = imgStore.PutImageManifest(repo2Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repo2Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					hasBlob, _, err = imgStore.CheckBlob(repo2Name, bdigest)
@@ -2898,7 +3188,8 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 					digest := godigest.FromBytes(manifestBuf)
 
-					_, _, err = imgStore.PutImageManifest(repo2Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repo2Name, tag, ispec.MediaTypeImageManifest, manifestBuf, nil)
 					So(err, ShouldBeNil)
 
 					err = gc.CleanRepo(ctx, repo2Name)
@@ -3013,7 +3304,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest referencing index image
-					_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3029,7 +3321,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest referencing a manifest from index image
-					_, _, err = imgStore.PutImageManifest(repoName, artifactManifestDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3041,7 +3334,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					So(hasBlob, ShouldEqual, true)
 
 					Convey("delete index manifest, layers should be persisted", func() {
-						err = imgStore.DeleteImageManifest(repoName, indexDigest.String(), false)
+						err = imgStore.DeleteImageManifest(context.Background(), repoName, indexDigest.String(), false)
 						So(err, ShouldBeNil)
 
 						err = gc.CleanRepo(ctx, repoName)
@@ -3160,7 +3453,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3177,7 +3471,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					artifactManifestIndexDigest := godigest.FromBytes(artifactManifestIndexBuf)
 
 					// push artifact manifest referencing a manifest from index image
-					_, _, err = imgStore.PutImageManifest(repoName, artifactManifestIndexDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestIndexDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestIndexBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3193,7 +3488,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					artifactOfArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
-					_, _, err = imgStore.PutImageManifest(repoName, artifactOfArtifactManifestDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactOfArtifactManifestDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3211,7 +3507,8 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 					orphanArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push orphan artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, orphanArtifactManifestDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, orphanArtifactManifestDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 
@@ -3246,7 +3543,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 						_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 						So(err, ShouldBeNil)
 
-						err = imgStore.DeleteImageManifest(repoName, artifactDigest.String(), false)
+						err = imgStore.DeleteImageManifest(context.Background(), repoName, artifactDigest.String(), false)
 						So(err, ShouldBeNil)
 
 						err = gc.CleanRepo(ctx, repoName)
@@ -3276,7 +3573,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 						_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 						So(err, ShouldBeNil)
 
-						err = imgStore.DeleteImageManifest(repoName, indexDigest.String(), false)
+						err = imgStore.DeleteImageManifest(context.Background(), repoName, indexDigest.String(), false)
 						So(err, ShouldBeNil)
 
 						err = gc.CleanRepo(ctx, repoName)
@@ -3477,7 +3774,9 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 
 					digest = godigest.FromBytes(content)
 					So(digest, ShouldNotBeNil)
-					_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 					So(err, ShouldBeNil)
 
 					index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -3512,7 +3811,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 					artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 					// push artifact manifest
-					_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+					_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 						ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 					So(err, ShouldBeNil)
 				}
@@ -3560,7 +3860,9 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 
 					digest := godigest.FromBytes(content)
 					So(digest, ShouldNotBeNil)
-					_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+					_, _, err = imgStore.PutImageManifest(context.Background(),
+						repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 					So(err, ShouldBeNil)
 
 					innerIndex.Manifests = append(innerIndex.Manifests, ispec.Descriptor{
@@ -3577,7 +3879,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				innerIndexDigest := godigest.FromBytes(innerIndexContent)
 				So(innerIndexDigest, ShouldNotBeNil)
 
-				_, _, err = imgStore.PutImageManifest(repoName, innerIndexDigest.String(),
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, innerIndexDigest.String(),
 					ispec.MediaTypeImageIndex, innerIndexContent, nil)
 				So(err, ShouldBeNil)
 
@@ -3596,7 +3898,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				indexDigest := godigest.FromBytes(indexContent)
 				So(indexDigest, ShouldNotBeNil)
 
-				_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+				_, _, err = imgStore.PutImageManifest(context.Background(),
+					repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
 				So(err, ShouldBeNil)
 
 				artifactManifest := ispec.Manifest{
@@ -3624,7 +3927,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				artifactDigest := godigest.FromBytes(artifactManifestBuf)
 
 				// push artifact manifest
-				_, _, err = imgStore.PutImageManifest(repoName, artifactDigest.String(),
+
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactDigest.String(),
 					ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 				So(err, ShouldBeNil)
 
@@ -3641,7 +3945,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				artifactManifestIndexDigest := godigest.FromBytes(artifactManifestIndexBuf)
 
 				// push artifact manifest referencing a manifest from index image
-				_, _, err = imgStore.PutImageManifest(repoName, artifactManifestIndexDigest.String(),
+
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestIndexDigest.String(),
 					ispec.MediaTypeImageManifest, artifactManifestIndexBuf, nil)
 				So(err, ShouldBeNil)
 
@@ -3658,7 +3963,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				artifactManifestInnerIndexDigest := godigest.FromBytes(artifactManifestInnerIndexBuf)
 
 				// push artifact manifest referencing a manifest from index image
-				_, _, err = imgStore.PutImageManifest(repoName, artifactManifestInnerIndexDigest.String(),
+
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactManifestInnerIndexDigest.String(),
 					ispec.MediaTypeImageManifest, artifactManifestInnerIndexBuf, nil)
 				So(err, ShouldBeNil)
 
@@ -3675,7 +3981,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				artifactOfArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
-				_, _, err = imgStore.PutImageManifest(repoName, artifactOfArtifactManifestDigest.String(),
+
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, artifactOfArtifactManifestDigest.String(),
 					ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 				So(err, ShouldBeNil)
 
@@ -3693,7 +4000,8 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 				orphanArtifactManifestDigest := godigest.FromBytes(artifactManifestBuf)
 
 				// push orphan artifact manifest
-				_, _, err = imgStore.PutImageManifest(repoName, orphanArtifactManifestDigest.String(),
+
+				_, _, err = imgStore.PutImageManifest(context.Background(), repoName, orphanArtifactManifestDigest.String(),
 					ispec.MediaTypeImageManifest, artifactManifestBuf, nil)
 				So(err, ShouldBeNil)
 
@@ -3728,7 +4036,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 					_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 					So(err, ShouldBeNil)
 
-					err = imgStore.DeleteImageManifest(repoName, artifactDigest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), repoName, artifactDigest.String(), false)
 					So(err, ShouldBeNil)
 
 					err = gc.CleanRepo(ctx, repoName)
@@ -3758,7 +4066,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 					_, _, _, err = imgStore.GetImageManifest(repoName, artifactDigest.String())
 					So(err, ShouldBeNil)
 
-					err = imgStore.DeleteImageManifest(repoName, indexDigest.String(), false)
+					err = imgStore.DeleteImageManifest(context.Background(), repoName, indexDigest.String(), false)
 					So(err, ShouldBeNil)
 
 					err = gc.CleanRepo(ctx, repoName)
@@ -3866,7 +4174,9 @@ func pushRandomImageIndex(imgStore storageTypes.ImageStore, repoName string,
 
 		digest = godigest.FromBytes(content)
 		So(digest, ShouldNotBeNil)
-		_, _, err = imgStore.PutImageManifest(repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+
+		_, _, err = imgStore.PutImageManifest(context.Background(),
+			repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
 		So(err, ShouldBeNil)
 
 		index.Manifests = append(index.Manifests, ispec.Descriptor{
@@ -3883,7 +4193,8 @@ func pushRandomImageIndex(imgStore storageTypes.ImageStore, repoName string,
 	indexDigest := godigest.FromBytes(indexContent)
 	So(indexDigest, ShouldNotBeNil)
 
-	_, _, err = imgStore.PutImageManifest(repoName, "1.0", ispec.MediaTypeImageIndex, indexContent, nil)
+	_, _, err = imgStore.PutImageManifest(context.Background(), repoName, "1.0",
+		ispec.MediaTypeImageIndex, indexContent, nil)
 	So(err, ShouldBeNil)
 
 	return bdgst, digest, indexDigest, int64(len(indexContent))
@@ -4003,7 +4314,7 @@ func TestPutIndexContent_atomicReplace(t *testing.T) {
 			root, imgStore, cleanup := newLocalImageStoreWithDriver(t, hookDriver)
 			defer cleanup()
 
-			So(imgStore.InitRepo(repo), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), repo), ShouldBeNil)
 
 			before, err := os.ReadFile(path.Join(root, repo, ispec.ImageIndexFile))
 			So(err, ShouldBeNil)
@@ -4040,7 +4351,7 @@ func TestPutIndexContent_atomicReplace(t *testing.T) {
 			root, imgStore, cleanup := newLocalImageStoreWithDriver(t, hookDriver)
 			defer cleanup()
 
-			So(imgStore.InitRepo(repo), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), repo), ShouldBeNil)
 
 			before, err := os.ReadFile(path.Join(root, repo, ispec.ImageIndexFile))
 			So(err, ShouldBeNil)
@@ -4064,7 +4375,7 @@ func TestPutIndexContent_atomicReplace(t *testing.T) {
 			root, imgStore, cleanup := newLocalImageStoreWithDriver(t, nil)
 			defer cleanup()
 
-			So(imgStore.InitRepo(repo), ShouldBeNil)
+			So(imgStore.InitRepo(context.Background(), repo), ShouldBeNil)
 
 			var idx ispec.Index
 			buf, err := os.ReadFile(path.Join(root, repo, ispec.ImageIndexFile))

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -803,7 +803,7 @@ func TestImageLintFailedEvents(t *testing.T) {
 		eventCapture.mu.Unlock()
 	})
 
-	Convey("digest push with extra tags that fails lint emits one ImageLintFailed per tag", t, func() {
+	Convey("digest push with extra tags that fails lint emits a single ImageLintFailed", t, func() {
 		eventCapture := &captureImageEvents{}
 		imgStore := newLocalImageStoreWithEventRecorderAndLinter(t, eventCapture, failingLinter)
 
@@ -817,22 +817,11 @@ func TestImageLintFailedEvents(t *testing.T) {
 		So(err, ShouldNotBeNil)
 
 		eventCapture.mu.Lock()
-		So(len(eventCapture.imageLintFailed), ShouldEqual, len(extraTags))
-
-		seenRefs := map[string]struct{}{}
-
-		for _, call := range eventCapture.imageLintFailed {
-			So(call.repo, ShouldEqual, repo)
-			So(call.digest, ShouldEqual, manifestDigest.String())
-
-			seenRefs[call.reference] = struct{}{}
-		}
-
-		for _, tag := range extraTags {
-			_, ok := seenRefs[tag]
-			So(ok, ShouldBeTrue)
-		}
-
+		// lint is a property of the manifest, not the tag(s), so only one event is emitted.
+		So(len(eventCapture.imageLintFailed), ShouldEqual, 1)
+		So(eventCapture.imageLintFailed[0].repo, ShouldEqual, repo)
+		So(eventCapture.imageLintFailed[0].digest, ShouldEqual, manifestDigest.String())
+		So(eventCapture.imageLintFailed[0].reference, ShouldEqual, extraTags[0])
 		eventCapture.mu.Unlock()
 	})
 }

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -28,16 +28,16 @@ type ImageStore interface { //nolint:interfacebloat
 	RUnlock(*time.Time)
 	Lock(*time.Time)
 	Unlock(*time.Time)
-	InitRepo(name string) error
+	InitRepo(ctx context.Context, name string) error
 	ValidateRepo(name string) (bool, error)
 	GetRepositories() ([]string, error)
 	GetNextRepository(processedRepos map[string]struct{}) (string, error)
 	GetNextRepositories(repo string, maxEntries int, fn FilterRepoFunc) ([]string, bool, error)
 	GetImageTags(repo string) ([]string, error)
 	GetImageManifest(repo, reference string) ([]byte, godigest.Digest, string, error)
-	PutImageManifest(repo, reference, mediaType string, body []byte, extraTags []string) (
+	PutImageManifest(ctx context.Context, repo, reference, mediaType string, body []byte, extraTags []string) (
 		godigest.Digest, godigest.Digest, error)
-	DeleteImageManifest(repo, reference string, detectCollision bool) error
+	DeleteImageManifest(ctx context.Context, repo, reference string, detectCollision bool) error
 	BlobUploadPath(repo, uuid string) string
 	StatBlobUpload(repo, uuid string) (bool, int64, time.Time, error)
 	ListBlobUploads(repo string) ([]string, error)

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -29,16 +29,16 @@ type ImageStore interface { //nolint:interfacebloat
 	RUnlock(*time.Time)
 	Lock(*time.Time)
 	Unlock(*time.Time)
-	InitRepo(name string) error
+	InitRepo(ctx context.Context, name string) error
 	ValidateRepo(name string) (bool, error)
 	GetRepositories() ([]string, error)
 	GetNextRepository(processedRepos map[string]struct{}) (string, error)
 	GetNextRepositories(repo string, maxEntries int, fn FilterRepoFunc) ([]string, bool, error)
 	GetImageTags(repo string) ([]string, error)
 	GetImageManifest(repo, reference string) ([]byte, godigest.Digest, string, error)
-	PutImageManifest(repo, reference, mediaType string, body []byte, extraTags []string) (
+	PutImageManifest(ctx context.Context, repo, reference, mediaType string, body []byte, extraTags []string) (
 		godigest.Digest, godigest.Digest, error)
-	DeleteImageManifest(repo, reference string, detectCollision bool) error
+	DeleteImageManifest(ctx context.Context, repo, reference string, detectCollision bool) error
 	BlobUploadPath(repo, uuid string) string
 	StatBlobUpload(repo, uuid string) (bool, int64, time.Time, error)
 	ListBlobUploads(repo string) ([]string, error)

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -42,17 +42,17 @@ type ImageStore interface { //nolint:interfacebloat
 	BlobUploadPath(repo, uuid string) string
 	StatBlobUpload(repo, uuid string) (bool, int64, time.Time, error)
 	ListBlobUploads(repo string) ([]string, error)
-	NewBlobUpload(repo string) (string, error)
+	NewBlobUpload(ctx context.Context, repo string) (string, error)
 	GetBlobUpload(repo, uuid string) (int64, error)
-	PutBlobChunkStreamed(repo, uuid string, body io.Reader) (int64, error)
-	PutBlobChunk(repo, uuid string, from, to int64, body io.Reader) (int64, error)
+	PutBlobChunkStreamed(ctx context.Context, repo, uuid string, body io.Reader) (int64, error)
+	PutBlobChunk(ctx context.Context, repo, uuid string, from, to int64, body io.Reader) (int64, error)
 	BlobUploadInfo(repo, uuid string) (int64, error)
 	FinishBlobUpload(repo, uuid string, body io.Reader, digest godigest.Digest) error
-	FullBlobUpload(repo string, body io.Reader, digest godigest.Digest) (string, int64, error)
+	FullBlobUpload(ctx context.Context, repo string, body io.Reader, digest godigest.Digest) (string, int64, error)
 	DedupeBlob(src string, dstDigest godigest.Digest, dstRepo, dst string) error
 	DeleteBlobUpload(repo, uuid string) error
 	BlobPath(repo string, digest godigest.Digest) string
-	CheckBlob(repo string, digest godigest.Digest) (bool, int64, error)
+	CheckBlob(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error)
 	StatBlob(repo string, digest godigest.Digest) (bool, int64, time.Time, error)
 	GetBlob(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error)
 	GetBlobPartial(repo string, digest godigest.Digest, mediaType string, from, to int64,

--- a/pkg/test/image-utils/write.go
+++ b/pkg/test/image-utils/write.go
@@ -2,6 +2,7 @@ package image
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 
 	godigest "github.com/opencontainers/go-digest"
@@ -12,7 +13,7 @@ import (
 func WriteImageToFileSystem(image Image, repoName, ref string, storeController stypes.StoreController) error {
 	store := storeController.GetImageStore(repoName)
 
-	err := store.InitRepo(repoName)
+	err := store.InitRepo(context.Background(), repoName)
 	if err != nil {
 		return err
 	}
@@ -51,7 +52,7 @@ func WriteImageToFileSystem(image Image, repoName, ref string, storeController s
 		return err
 	}
 
-	_, _, err = store.PutImageManifest(repoName, ref, image.Manifest.MediaType, manifestBlob, nil)
+	_, _, err = store.PutImageManifest(context.Background(), repoName, ref, image.Manifest.MediaType, manifestBlob, nil)
 	if err != nil {
 		return err
 	}
@@ -64,7 +65,7 @@ func WriteMultiArchImageToFileSystem(multiarchImage MultiarchImage, repoName, re
 ) error {
 	store := storeController.GetImageStore(repoName)
 
-	err := store.InitRepo(repoName)
+	err := store.InitRepo(context.Background(), repoName)
 	if err != nil {
 		return err
 	}
@@ -81,7 +82,7 @@ func WriteMultiArchImageToFileSystem(multiarchImage MultiarchImage, repoName, re
 		return err
 	}
 
-	_, _, err = store.PutImageManifest(repoName, ref, multiarchImage.Index.MediaType,
+	_, _, err = store.PutImageManifest(context.Background(), repoName, ref, multiarchImage.Index.MediaType,
 		indexBlob, nil)
 
 	return err

--- a/pkg/test/image-utils/write.go
+++ b/pkg/test/image-utils/write.go
@@ -28,7 +28,7 @@ func WriteImageToFileSystem(image Image, repoName, ref string, storeController s
 		layerReader := bytes.NewReader(layerBlob)
 		layerDigest := digestAlgorithm.FromBytes(layerBlob)
 
-		_, _, err = store.FullBlobUpload(repoName, layerReader, layerDigest)
+		_, _, err = store.FullBlobUpload(context.Background(), repoName, layerReader, layerDigest)
 		if err != nil {
 			return err
 		}
@@ -42,7 +42,7 @@ func WriteImageToFileSystem(image Image, repoName, ref string, storeController s
 	configReader := bytes.NewReader(configBlob)
 	configDigest := digestAlgorithm.FromBytes(configBlob)
 
-	_, _, err = store.FullBlobUpload(repoName, configReader, configDigest)
+	_, _, err = store.FullBlobUpload(context.Background(), repoName, configReader, configDigest)
 	if err != nil {
 		return err
 	}

--- a/pkg/test/image-utils/write_test.go
+++ b/pkg/test/image-utils/write_test.go
@@ -1,6 +1,7 @@
 package image_test
 
 import (
+	"context"
 	"errors"
 	"io"
 	"testing"
@@ -19,7 +20,7 @@ func TestWriteImageToFileSystem(t *testing.T) {
 	Convey("WriteImageToFileSystem errors", t, func() {
 		err := WriteImageToFileSystem(Image{}, "repo", "dig", storage.StoreController{
 			DefaultStore: mocks.MockedImageStore{
-				InitRepoFn: func(name string) error {
+				InitRepoFn: func(ctx context.Context, name string) error {
 					return ErrTestError
 				},
 			},
@@ -67,7 +68,8 @@ func TestWriteImageToFileSystem(t *testing.T) {
 			"tag",
 			storage.StoreController{
 				DefaultStore: mocks.MockedImageStore{
-					PutImageManifestFn: func(repo, reference, mediaType string, body []byte, _ []string,
+					PutImageManifestFn: func(ctx context.Context, repo, reference, mediaType string,
+						body []byte, extraTags []string,
 					) (godigest.Digest, godigest.Digest, error) {
 						return "", "", ErrTestError
 					},

--- a/pkg/test/image-utils/write_test.go
+++ b/pkg/test/image-utils/write_test.go
@@ -33,7 +33,7 @@ func TestWriteImageToFileSystem(t *testing.T) {
 			"tag",
 			storage.StoreController{
 				DefaultStore: mocks.MockedImageStore{
-					FullBlobUploadFn: func(repo string, body io.Reader, digest godigest.Digest,
+					FullBlobUploadFn: func(ctx context.Context, repo string, body io.Reader, digest godigest.Digest,
 					) (string, int64, error) {
 						return "", 0, ErrTestError
 					},
@@ -48,7 +48,7 @@ func TestWriteImageToFileSystem(t *testing.T) {
 			"tag",
 			storage.StoreController{
 				DefaultStore: mocks.MockedImageStore{
-					FullBlobUploadFn: func(repo string, body io.Reader, digest godigest.Digest,
+					FullBlobUploadFn: func(ctx context.Context, repo string, body io.Reader, digest godigest.Digest,
 					) (string, int64, error) {
 						if count == 0 {
 							count++

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -16,16 +16,16 @@ type MockedImageStore struct {
 	NameFn                func() string
 	DirExistsFn           func(d string) bool
 	RootDirFn             func() string
-	InitRepoFn            func(name string) error
+	InitRepoFn            func(ctx context.Context, name string) error
 	ValidateRepoFn        func(name string) (bool, error)
 	GetRepositoriesFn     func() ([]string, error)
 	GetNextRepositoryFn   func(processedRepos map[string]struct{}) (string, error)
 	GetNextRepositoriesFn func(lastRepo string, maxEntries int, fn storageTypes.FilterRepoFunc) ([]string, bool, error)
 	GetImageTagsFn        func(repo string) ([]string, error)
 	GetImageManifestFn    func(repo string, reference string) ([]byte, godigest.Digest, string, error)
-	PutImageManifestFn    func(repo string, reference string, mediaType string, body []byte,
+	PutImageManifestFn    func(ctx context.Context, repo string, reference string, mediaType string, body []byte,
 		extraTags []string) (godigest.Digest, godigest.Digest, error)
-	DeleteImageManifestFn  func(repo string, reference string, detectCollision bool) error
+	DeleteImageManifestFn  func(ctx context.Context, repo string, reference string, detectCollision bool) error
 	BlobUploadPathFn       func(repo string, uuid string) string
 	StatBlobUploadFn       func(repo string, uuid string) (bool, int64, time.Time, error)
 	ListBlobUploadsFn      func(repo string) ([]string, error)
@@ -108,9 +108,9 @@ func (is MockedImageStore) RootDir() string {
 	return ""
 }
 
-func (is MockedImageStore) InitRepo(name string) error {
+func (is MockedImageStore) InitRepo(ctx context.Context, name string) error {
 	if is.InitRepoFn != nil {
-		return is.InitRepoFn(name)
+		return is.InitRepoFn(ctx, name)
 	}
 
 	return nil
@@ -159,6 +159,7 @@ func (is MockedImageStore) GetImageManifest(repo string, reference string) ([]by
 }
 
 func (is MockedImageStore) PutImageManifest(
+	ctx context.Context,
 	repo string,
 	reference string,
 	mediaType string,
@@ -166,7 +167,7 @@ func (is MockedImageStore) PutImageManifest(
 	extraTags []string,
 ) (godigest.Digest, godigest.Digest, error) {
 	if is.PutImageManifestFn != nil {
-		return is.PutImageManifestFn(repo, reference, mediaType, body, extraTags)
+		return is.PutImageManifestFn(ctx, repo, reference, mediaType, body, extraTags)
 	}
 
 	return "", "", nil
@@ -188,9 +189,11 @@ func (is MockedImageStore) GetAllBlobs(repo string) ([]godigest.Digest, error) {
 	return []godigest.Digest{}, nil
 }
 
-func (is MockedImageStore) DeleteImageManifest(name string, reference string, detectCollision bool) error {
+func (is MockedImageStore) DeleteImageManifest(ctx context.Context, name string, reference string,
+	detectCollision bool,
+) error {
 	if is.DeleteImageManifestFn != nil {
-		return is.DeleteImageManifestFn(name, reference, detectCollision)
+		return is.DeleteImageManifestFn(ctx, name, reference, detectCollision)
 	}
 
 	return nil

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -30,19 +30,21 @@ type MockedImageStore struct {
 	BlobUploadPathFn       func(repo string, uuid string) string
 	StatBlobUploadFn       func(repo string, uuid string) (bool, int64, time.Time, error)
 	ListBlobUploadsFn      func(repo string) ([]string, error)
-	NewBlobUploadFn        func(repo string) (string, error)
+	NewBlobUploadFn        func(ctx context.Context, repo string) (string, error)
 	GetBlobUploadFn        func(repo string, uuid string) (int64, error)
 	BlobUploadInfoFn       func(repo string, uuid string) (int64, error)
-	PutBlobChunkStreamedFn func(repo string, uuid string, body io.Reader) (int64, error)
-	PutBlobChunkFn         func(repo string, uuid string, from int64, to int64, body io.Reader) (int64, error)
-	FinishBlobUploadFn     func(repo string, uuid string, body io.Reader, digest godigest.Digest) error
-	FullBlobUploadFn       func(repo string, body io.Reader, digest godigest.Digest) (string, int64, error)
-	DedupeBlobFn           func(src string, dstDigest godigest.Digest, dstRepo, dst string) error
-	DeleteBlobUploadFn     func(repo string, uuid string) error
-	BlobPathFn             func(repo string, digest godigest.Digest) string
-	CheckBlobFn            func(repo string, digest godigest.Digest) (bool, int64, error)
-	StatBlobFn             func(repo string, digest godigest.Digest) (bool, int64, time.Time, error)
-	GetBlobPartialFn       func(repo string, digest godigest.Digest, mediaType string, from, to int64,
+	PutBlobChunkStreamedFn func(ctx context.Context, repo string, uuid string, body io.Reader) (int64, error)
+	PutBlobChunkFn         func(ctx context.Context, repo string, uuid string, from int64, to int64,
+		body io.Reader) (int64, error)
+	FinishBlobUploadFn func(repo string, uuid string, body io.Reader, digest godigest.Digest) error
+	FullBlobUploadFn   func(ctx context.Context, repo string, body io.Reader,
+		digest godigest.Digest) (string, int64, error)
+	DedupeBlobFn       func(src string, dstDigest godigest.Digest, dstRepo, dst string) error
+	DeleteBlobUploadFn func(repo string, uuid string) error
+	BlobPathFn         func(repo string, digest godigest.Digest) string
+	CheckBlobFn        func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error)
+	StatBlobFn         func(repo string, digest godigest.Digest) (bool, int64, time.Time, error)
+	GetBlobPartialFn   func(repo string, digest godigest.Digest, mediaType string, from, to int64,
 	) (io.ReadCloser, int64, int64, error)
 	GetBlobFn            func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error)
 	DeleteBlobFn         func(repo string, digest godigest.Digest) error
@@ -217,9 +219,9 @@ func (is MockedImageStore) StatBlobUpload(repo string, uuid string) (bool, int64
 	return true, 0, time.Time{}, nil
 }
 
-func (is MockedImageStore) NewBlobUpload(repo string) (string, error) {
+func (is MockedImageStore) NewBlobUpload(ctx context.Context, repo string) (string, error) {
 	if is.NewBlobUploadFn != nil {
-		return is.NewBlobUploadFn(repo)
+		return is.NewBlobUploadFn(ctx, repo)
 	}
 
 	return "", nil
@@ -249,15 +251,18 @@ func (is MockedImageStore) BlobUploadPath(repo string, uuid string) string {
 	return ""
 }
 
-func (is MockedImageStore) PutBlobChunkStreamed(repo string, uuid string, body io.Reader) (int64, error) {
+func (is MockedImageStore) PutBlobChunkStreamed(ctx context.Context, repo string, uuid string,
+	body io.Reader,
+) (int64, error) {
 	if is.PutBlobChunkStreamedFn != nil {
-		return is.PutBlobChunkStreamedFn(repo, uuid, body)
+		return is.PutBlobChunkStreamedFn(ctx, repo, uuid, body)
 	}
 
 	return 0, nil
 }
 
 func (is MockedImageStore) PutBlobChunk(
+	ctx context.Context,
 	repo string,
 	uuid string,
 	from int64,
@@ -265,7 +270,7 @@ func (is MockedImageStore) PutBlobChunk(
 	body io.Reader,
 ) (int64, error) {
 	if is.PutBlobChunkFn != nil {
-		return is.PutBlobChunkFn(repo, uuid, from, to, body)
+		return is.PutBlobChunkFn(ctx, repo, uuid, from, to, body)
 	}
 
 	return 0, nil
@@ -279,9 +284,11 @@ func (is MockedImageStore) FinishBlobUpload(repo string, uuid string, body io.Re
 	return nil
 }
 
-func (is MockedImageStore) FullBlobUpload(repo string, body io.Reader, digest godigest.Digest) (string, int64, error) {
+func (is MockedImageStore) FullBlobUpload(ctx context.Context, repo string, body io.Reader,
+	digest godigest.Digest,
+) (string, int64, error) {
 	if is.FullBlobUploadFn != nil {
-		return is.FullBlobUploadFn(repo, body, digest)
+		return is.FullBlobUploadFn(ctx, repo, body, digest)
 	}
 
 	return "", 0, nil
@@ -311,9 +318,9 @@ func (is MockedImageStore) BlobPath(repo string, digest godigest.Digest) string 
 	return ""
 }
 
-func (is MockedImageStore) CheckBlob(repo string, digest godigest.Digest) (bool, int64, error) {
+func (is MockedImageStore) CheckBlob(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 	if is.CheckBlobFn != nil {
-		return is.CheckBlobFn(repo, digest)
+		return is.CheckBlobFn(ctx, repo, digest)
 	}
 
 	return true, 0, nil

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -17,16 +17,16 @@ type MockedImageStore struct {
 	NameFn                func() string
 	DirExistsFn           func(d string) bool
 	RootDirFn             func() string
-	InitRepoFn            func(name string) error
+	InitRepoFn            func(ctx context.Context, name string) error
 	ValidateRepoFn        func(name string) (bool, error)
 	GetRepositoriesFn     func() ([]string, error)
 	GetNextRepositoryFn   func(processedRepos map[string]struct{}) (string, error)
 	GetNextRepositoriesFn func(lastRepo string, maxEntries int, fn storageTypes.FilterRepoFunc) ([]string, bool, error)
 	GetImageTagsFn        func(repo string) ([]string, error)
 	GetImageManifestFn    func(repo string, reference string) ([]byte, godigest.Digest, string, error)
-	PutImageManifestFn    func(repo string, reference string, mediaType string, body []byte,
+	PutImageManifestFn    func(ctx context.Context, repo string, reference string, mediaType string, body []byte,
 		extraTags []string) (godigest.Digest, godigest.Digest, error)
-	DeleteImageManifestFn  func(repo string, reference string, detectCollision bool) error
+	DeleteImageManifestFn  func(ctx context.Context, repo string, reference string, detectCollision bool) error
 	BlobUploadPathFn       func(repo string, uuid string) string
 	StatBlobUploadFn       func(repo string, uuid string) (bool, int64, time.Time, error)
 	ListBlobUploadsFn      func(repo string) ([]string, error)
@@ -110,9 +110,9 @@ func (is MockedImageStore) RootDir() string {
 	return ""
 }
 
-func (is MockedImageStore) InitRepo(name string) error {
+func (is MockedImageStore) InitRepo(ctx context.Context, name string) error {
 	if is.InitRepoFn != nil {
-		return is.InitRepoFn(name)
+		return is.InitRepoFn(ctx, name)
 	}
 
 	return nil
@@ -161,6 +161,7 @@ func (is MockedImageStore) GetImageManifest(repo string, reference string) ([]by
 }
 
 func (is MockedImageStore) PutImageManifest(
+	ctx context.Context,
 	repo string,
 	reference string,
 	mediaType string,
@@ -168,7 +169,7 @@ func (is MockedImageStore) PutImageManifest(
 	extraTags []string,
 ) (godigest.Digest, godigest.Digest, error) {
 	if is.PutImageManifestFn != nil {
-		return is.PutImageManifestFn(repo, reference, mediaType, body, extraTags)
+		return is.PutImageManifestFn(ctx, repo, reference, mediaType, body, extraTags)
 	}
 
 	return "", "", nil
@@ -190,9 +191,11 @@ func (is MockedImageStore) GetAllBlobs(repo string) ([]godigest.Digest, error) {
 	return []godigest.Digest{}, nil
 }
 
-func (is MockedImageStore) DeleteImageManifest(name string, reference string, detectCollision bool) error {
+func (is MockedImageStore) DeleteImageManifest(ctx context.Context, name string, reference string,
+	detectCollision bool,
+) error {
 	if is.DeleteImageManifestFn != nil {
-		return is.DeleteImageManifestFn(name, reference, detectCollision)
+		return is.DeleteImageManifestFn(ctx, name, reference, detectCollision)
 	}
 
 	return nil

--- a/test/blackbox/helpers_pushpull.bash
+++ b/test/blackbox/helpers_pushpull.bash
@@ -473,13 +473,24 @@ function helper_pull_manifest_with_docker_client() {
     [ "${status}" -eq 0 ]
 }
 
-# Args: $1 = repository
+# Args: $1 = repository, $2 = attempts (optional, default: 3)
+# Retries crictl pull a few times: on busy runners the CRI-O image-store step
+# that follows blob download ("copying config") occasionally cancels its own
+# context even though zot has already served every blob with 200 OK. A fresh
+# pull replays from cri-o's local cache and almost always succeeds.
 function helper_pull_manifest_with_crictl() {
     local repo=${1}
+    local attempts=${2:-3}
     local zot_port
     zot_port=$(get_zot_port)
 
-    run crictl pull "localhost:${zot_port}/${repo}"
+    for (( i=1; i<=attempts; i++ )); do
+        run crictl pull "localhost:${zot_port}/${repo}"
+        [ "${status}" -eq 0 ] && return 0
+        echo "crictl pull ${repo} failed on attempt ${i}/${attempts} (status=${status}): ${output}" >&3
+        sleep 2
+    done
+
     [ "${status}" -eq 0 ]
 }
 


### PR DESCRIPTION
## Summary

Closes #3859

- Adds `actor` (username) and `request` (addr, method, useragent) fields to CloudEvents payloads for `ImageUpdated`, `ImageDeleted`, `ImageLintFailed`, and `RepositoryCreated` events
- Introduces `EventContext`, `ActorInfo`, and `RequestInfo` types in `pkg/extensions/events/common.go` (no build tag — always compiled so the storage layer can reference them unconditionally)
- The API layer (`UpdateManifest`, `DeleteManifest`) builds an `EventContext` from the live HTTP request and attaches it to the context via `events.WithEventContext` before passing it down to storage
- The storage layer (`imagestore`) extracts the context at event-fire time via `events.EventContextFromContext`; nil context (internal/GC paths) cleanly omits both fields from the payload
- Fields are omitted entirely when not present (unauthenticated requests, internal triggers), matching the issue's requested JSON shape

Example payload:
```json
{
  "name": "space/my-image",
  "reference": "latest",
  "digest": "sha256:abc...",
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "actor": { "name": "john" },
  "request": { "addr": "192.168.0.1:54321", "method": "PUT", "useragent": "docker/24.0.5" }
}
```