### PR TITLE
fixes zot to properly return media types / content types and support lazy pulls

### DIFF
--- a/pkg/api/blob_content_type_test.go
+++ b/pkg/api/blob_content_type_test.go
@@ -2,6 +2,7 @@ package api_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -14,6 +15,7 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
+	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/api"
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
@@ -109,6 +111,14 @@ func descriptorStore(t *testing.T) mocks.MockedImageStore {
 	}
 }
 
+func binaryMediaTypeFallbackStore(store mocks.MockedImageStore) mocks.MockedImageStore {
+	store.GetIndexContentFn = func(repo string) ([]byte, error) {
+		return nil, zerr.ErrRepoNotFound
+	}
+
+	return store
+}
+
 func TestCheckBlobUsesDescriptorContentType(t *testing.T) {
 	store := descriptorStore(t)
 	store.CheckBlobFn = func(repo string, digest godigest.Digest) (bool, int64, error) {
@@ -174,7 +184,7 @@ func TestGetBlobUsesDescriptorContentType(t *testing.T) {
 }
 
 func TestGetBlobPartialFallsBackToBinaryContentType(t *testing.T) {
-	handler := newBlobRouteHandler(mocks.MockedImageStore{
+	handler := newBlobRouteHandler(binaryMediaTypeFallbackStore(mocks.MockedImageStore{
 		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 			return true, 4, nil
 		},
@@ -185,7 +195,7 @@ func TestGetBlobPartialFallsBackToBinaryContentType(t *testing.T) {
 
 			return io.NopCloser(strings.NewReader("blob")), 4, nil
 		},
-	})
+	}))
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
 	req.Header.Set("Accept", "application/vnd.oci.image.layer.v1.tar+gzip, */*")
@@ -254,7 +264,7 @@ func TestGetBlobPartialUsesDescriptorContentType(t *testing.T) {
 }
 
 func TestGetBlobFallsBackToBinaryContentType(t *testing.T) {
-	handler := newBlobRouteHandler(mocks.MockedImageStore{
+	handler := newBlobRouteHandler(binaryMediaTypeFallbackStore(mocks.MockedImageStore{
 		GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
 			if mediaType != constants.BinaryMediaType {
 				t.Fatalf("mediaType = %q, want %q", mediaType, constants.BinaryMediaType)
@@ -262,7 +272,7 @@ func TestGetBlobFallsBackToBinaryContentType(t *testing.T) {
 
 			return io.NopCloser(strings.NewReader("blob")), 4, nil
 		},
-	})
+	}))
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
 	req = mux.SetURLVars(req, map[string]string{
@@ -288,7 +298,7 @@ func TestGetBlobFallsBackToBinaryContentType(t *testing.T) {
 func TestGetBlobSupportsMultipleRanges(t *testing.T) {
 	const blob = "0123456789"
 
-	handler := newBlobRouteHandler(mocks.MockedImageStore{
+	handler := newBlobRouteHandler(binaryMediaTypeFallbackStore(mocks.MockedImageStore{
 		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
 			return true, int64(len(blob)), nil
 		},
@@ -305,7 +315,7 @@ func TestGetBlobSupportsMultipleRanges(t *testing.T) {
 
 			return io.NopCloser(strings.NewReader(blob[from : to+1])), to - from + 1, int64(len(blob)), nil
 		},
-	})
+	}))
 
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
 	req.Header.Set("Range", "bytes=0-1,5-7")
@@ -381,5 +391,165 @@ func TestGetBlobSupportsMultipleRanges(t *testing.T) {
 
 	if _, err := reader.NextPart(); err != io.EOF {
 		t.Fatalf("expected EOF, got %v", err)
+	}
+}
+
+func TestGetBlobRejectsEmptyRangeList(t *testing.T) {
+	handler := newBlobRouteHandler(binaryMediaTypeFallbackStore(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return true, 10, nil
+		},
+		GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
+			t.Fatal("GetBlob should not be called for an invalid range header")
+
+			return nil, 0, nil
+		},
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
+	req.Header.Set("Range", "bytes=")
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": testLayerDigest().String(),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestedRangeNotSatisfiable)
+	}
+}
+
+func TestGetBlobSupportsSuffixRanges(t *testing.T) {
+	const blob = "0123456789"
+
+	handler := newBlobRouteHandler(binaryMediaTypeFallbackStore(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return true, int64(len(blob)), nil
+		},
+		GetBlobPartialFn: func(
+			repo string,
+			digest godigest.Digest,
+			mediaType string,
+			from,
+			to int64,
+		) (io.ReadCloser, int64, int64, error) {
+			if from != 7 || to != 9 {
+				t.Fatalf("range = %d-%d, want 7-9", from, to)
+			}
+
+			return io.NopCloser(strings.NewReader(blob[from : to+1])), to - from + 1, int64(len(blob)), nil
+		},
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
+	req.Header.Set("Range", "bytes=-3")
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": testLayerDigest().String(),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusPartialContent)
+	}
+
+	if got := resp.Header.Get("Content-Range"); got != "bytes 7-9/10" {
+		t.Fatalf("content-range = %q, want %q", got, "bytes 7-9/10")
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	if got := string(body); got != "789" {
+		t.Fatalf("body = %q, want %q", got, "789")
+	}
+}
+
+func TestGetBlobRejectsZeroLengthSuffixRange(t *testing.T) {
+	handler := newBlobRouteHandler(binaryMediaTypeFallbackStore(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return true, 10, nil
+		},
+		GetBlobPartialFn: func(
+			repo string,
+			digest godigest.Digest,
+			mediaType string,
+			from,
+			to int64,
+		) (io.ReadCloser, int64, int64, error) {
+			t.Fatal("GetBlobPartial should not be called for an invalid suffix range")
+
+			return nil, 0, 0, nil
+		},
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
+	req.Header.Set("Range", "bytes=-0")
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": testLayerDigest().String(),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestedRangeNotSatisfiable)
+	}
+}
+
+func TestGetBlobRejectsTooManyRanges(t *testing.T) {
+	rangeParts := make([]string, 0, 17)
+	for index := range 17 {
+		rangeParts = append(rangeParts, fmt.Sprintf("%d-%d", index, index))
+	}
+
+	handler := newBlobRouteHandler(binaryMediaTypeFallbackStore(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return true, 32, nil
+		},
+		GetBlobPartialFn: func(
+			repo string,
+			digest godigest.Digest,
+			mediaType string,
+			from,
+			to int64,
+		) (io.ReadCloser, int64, int64, error) {
+			t.Fatal("GetBlobPartial should not be called when too many ranges are requested")
+
+			return nil, 0, 0, nil
+		},
+	}))
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
+	req.Header.Set("Range", "bytes="+strings.Join(rangeParts, ","))
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": testLayerDigest().String(),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusRequestedRangeNotSatisfiable)
 	}
 }

--- a/pkg/api/blob_content_type_test.go
+++ b/pkg/api/blob_content_type_test.go
@@ -1,0 +1,390 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/api/constants"
+	"zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/storage"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+var (
+	testLayerDigest    = godigest.FromString("layer")
+	testManifestDigest = godigest.FromString("manifest")
+	testConfigDigest   = godigest.FromString("config")
+)
+
+func newBlobRouteHandler(store mocks.MockedImageStore) *RouteHandler {
+	return &RouteHandler{
+		c: &Controller{
+			Config: config.New(),
+			StoreController: storage.StoreController{
+				DefaultStore: store,
+			},
+			Log: log.NewLogger("debug", ""),
+		},
+	}
+}
+
+func descriptorFixture(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+
+	manifest := ispec.Manifest{
+		Config: ispec.Descriptor{
+			MediaType: ispec.MediaTypeImageConfig,
+			Digest:    testConfigDigest,
+			Size:      1,
+		},
+		Layers: []ispec.Descriptor{
+			{
+				MediaType: ispec.MediaTypeImageLayerGzip,
+				Digest:    testLayerDigest,
+				Size:      4,
+			},
+		},
+	}
+	manifest.SchemaVersion = 2
+
+	manifestJSON, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+
+	index := ispec.Index{
+		Manifests: []ispec.Descriptor{
+			{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    testManifestDigest,
+				Size:      int64(len(manifestJSON)),
+				Annotations: map[string]string{
+					ispec.AnnotationRefName: "latest",
+				},
+			},
+		},
+	}
+	index.SchemaVersion = 2
+
+	indexJSON, err := json.Marshal(index)
+	if err != nil {
+		t.Fatalf("marshal index: %v", err)
+	}
+
+	return indexJSON, manifestJSON
+}
+
+func descriptorStore(t *testing.T) mocks.MockedImageStore {
+	t.Helper()
+
+	indexJSON, manifestJSON := descriptorFixture(t)
+
+	return mocks.MockedImageStore{
+		RootDirFn: func() string { return "/tmp" },
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			if digest == testLayerDigest {
+				return true, 4, nil
+			}
+
+			return true, 0, nil
+		},
+		GetIndexContentFn: func(repo string) ([]byte, error) {
+			return indexJSON, nil
+		},
+		GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+			if digest == testManifestDigest {
+				return manifestJSON, nil
+			}
+
+			t.Fatalf("unexpected blob content lookup for %s", digest)
+
+			return nil, nil
+		},
+	}
+}
+
+func TestCheckBlobUsesDescriptorContentType(t *testing.T) {
+	store := descriptorStore(t)
+	store.CheckBlobFn = func(repo string, digest godigest.Digest) (bool, int64, error) {
+		return true, 42, nil
+	}
+
+	handler := newBlobRouteHandler(store)
+
+	req := httptest.NewRequest(http.MethodHead, "http://example.com/v2/test/blobs/sha256:test", nil)
+	req.Header.Set("Accept", "application/vnd.oci.image.layer.v1.tar+gzip, */*")
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": testLayerDigest.String(),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.CheckBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	if got := resp.Header.Get("Content-Type"); got != ispec.MediaTypeImageLayerGzip {
+		t.Fatalf("content-type = %q, want %q", got, ispec.MediaTypeImageLayerGzip)
+	}
+}
+
+func TestGetBlobUsesDescriptorContentType(t *testing.T) {
+	store := descriptorStore(t)
+	store.GetBlobFn = func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
+		if mediaType != ispec.MediaTypeImageLayerGzip {
+			t.Fatalf("mediaType = %q, want %q", mediaType, ispec.MediaTypeImageLayerGzip)
+		}
+
+		return io.NopCloser(strings.NewReader("blob")), 4, nil
+	}
+
+	handler := newBlobRouteHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
+	req.Header.Set("Accept", "application/vnd.oci.image.layer.v1.tar+gzip, */*")
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": testLayerDigest.String(),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	if got := resp.Header.Get("Content-Type"); got != ispec.MediaTypeImageLayerGzip {
+		t.Fatalf("content-type = %q, want %q", got, ispec.MediaTypeImageLayerGzip)
+	}
+}
+
+func TestGetBlobPartialFallsBackToBinaryContentType(t *testing.T) {
+	handler := newBlobRouteHandler(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return true, 4, nil
+		},
+		GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
+			if mediaType != constants.BinaryMediaType {
+				t.Fatalf("mediaType = %q, want %q", mediaType, constants.BinaryMediaType)
+			}
+
+			return io.NopCloser(strings.NewReader("blob")), 4, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
+	req.Header.Set("Accept", "application/vnd.oci.image.layer.v1.tar+gzip, */*")
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621",
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	if got := resp.Header.Get("Content-Type"); got != constants.BinaryMediaType {
+		t.Fatalf("content-type = %q, want %q", got, constants.BinaryMediaType)
+	}
+}
+
+func TestGetBlobPartialUsesDescriptorContentType(t *testing.T) {
+	store := descriptorStore(t)
+	store.GetBlobPartialFn = func(
+		repo string,
+		digest godigest.Digest,
+		mediaType string,
+		from,
+		to int64,
+	) (io.ReadCloser, int64, int64, error) {
+		if mediaType != ispec.MediaTypeImageLayerGzip {
+			t.Fatalf("mediaType = %q, want %q", mediaType, ispec.MediaTypeImageLayerGzip)
+		}
+
+		if from != 0 || to != 1 {
+			t.Fatalf("range = %d-%d, want 0-1", from, to)
+		}
+
+		return io.NopCloser(strings.NewReader("bl")), 2, 4, nil
+	}
+
+	handler := newBlobRouteHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
+	req.Header.Set("Range", "bytes=0-1")
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": testLayerDigest.String(),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusPartialContent)
+	}
+
+	if got := resp.Header.Get("Content-Type"); got != ispec.MediaTypeImageLayerGzip {
+		t.Fatalf("content-type = %q, want %q", got, ispec.MediaTypeImageLayerGzip)
+	}
+}
+
+func TestGetBlobFallsBackToBinaryContentType(t *testing.T) {
+	handler := newBlobRouteHandler(mocks.MockedImageStore{
+		GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
+			if mediaType != constants.BinaryMediaType {
+				t.Fatalf("mediaType = %q, want %q", mediaType, constants.BinaryMediaType)
+			}
+
+			return io.NopCloser(strings.NewReader("blob")), 4, nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": testLayerDigest.String(),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	if got := resp.Header.Get("Content-Type"); got != constants.BinaryMediaType {
+		t.Fatalf("content-type = %q, want %q", got, constants.BinaryMediaType)
+	}
+}
+
+func TestGetBlobSupportsMultipleRanges(t *testing.T) {
+	const blob = "0123456789"
+
+	handler := newBlobRouteHandler(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return true, int64(len(blob)), nil
+		},
+		GetBlobPartialFn: func(
+			repo string,
+			digest godigest.Digest,
+			mediaType string,
+			from,
+			to int64,
+		) (io.ReadCloser, int64, int64, error) {
+			if mediaType != constants.BinaryMediaType {
+				t.Fatalf("mediaType = %q, want %q", mediaType, constants.BinaryMediaType)
+			}
+
+			return io.NopCloser(strings.NewReader(blob[from : to+1])), to - from + 1, int64(len(blob)), nil
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
+	req.Header.Set("Range", "bytes=0-1,5-7")
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": testLayerDigest.String(),
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusPartialContent)
+	}
+
+	contentType, params, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if err != nil {
+		t.Fatalf("parse media type: %v", err)
+	}
+
+	if contentType != "multipart/byteranges" {
+		t.Fatalf("content-type = %q, want multipart/byteranges", contentType)
+	}
+
+	reader := multipart.NewReader(resp.Body, params["boundary"])
+
+	firstPart, err := reader.NextPart()
+	if err != nil {
+		t.Fatalf("read first part: %v", err)
+	}
+
+	firstBody, err := io.ReadAll(firstPart)
+	if err != nil {
+		t.Fatalf("read first body: %v", err)
+	}
+
+	if got := string(firstBody); got != "01" {
+		t.Fatalf("first body = %q, want %q", got, "01")
+	}
+
+	if got := firstPart.Header.Get("Content-Range"); got != "bytes 0-1/10" {
+		t.Fatalf("first content-range = %q, want %q", got, "bytes 0-1/10")
+	}
+
+	if got := firstPart.Header.Get("Content-Type"); got != constants.BinaryMediaType {
+		t.Fatalf("first part content-type = %q, want %q", got, constants.BinaryMediaType)
+	}
+
+	secondPart, err := reader.NextPart()
+	if err != nil {
+		t.Fatalf("read second part: %v", err)
+	}
+
+	secondBody, err := io.ReadAll(secondPart)
+	if err != nil {
+		t.Fatalf("read second body: %v", err)
+	}
+
+	if got := string(secondBody); got != "567" {
+		t.Fatalf("second body = %q, want %q", got, "567")
+	}
+
+	if got := secondPart.Header.Get("Content-Range"); got != "bytes 5-7/10" {
+		t.Fatalf("second content-range = %q, want %q", got, "bytes 5-7/10")
+	}
+
+	if got := secondPart.Header.Get("Content-Type"); got != constants.BinaryMediaType {
+		t.Fatalf("second part content-type = %q, want %q", got, constants.BinaryMediaType)
+	}
+
+	if _, err := reader.NextPart(); err != io.EOF {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}

--- a/pkg/api/blob_content_type_test.go
+++ b/pkg/api/blob_content_type_test.go
@@ -1,4 +1,4 @@
-package api
+package api_test
 
 import (
 	"encoding/json"
@@ -14,29 +14,24 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"zotregistry.dev/zot/v2/pkg/api"
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
-	"zotregistry.dev/zot/v2/pkg/log"
-	"zotregistry.dev/zot/v2/pkg/storage"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
 )
 
-var (
-	testLayerDigest    = godigest.FromString("layer")
-	testManifestDigest = godigest.FromString("manifest")
-	testConfigDigest   = godigest.FromString("config")
-)
+func testLayerDigest() godigest.Digest { return godigest.FromString("layer") }
 
-func newBlobRouteHandler(store mocks.MockedImageStore) *RouteHandler {
-	return &RouteHandler{
-		c: &Controller{
-			Config: config.New(),
-			StoreController: storage.StoreController{
-				DefaultStore: store,
-			},
-			Log: log.NewLogger("debug", ""),
-		},
-	}
+func testManifestDigest() godigest.Digest { return godigest.FromString("manifest") }
+
+func testConfigDigest() godigest.Digest { return godigest.FromString("config") }
+
+func newBlobRouteHandler(store mocks.MockedImageStore) *api.RouteHandler {
+	controller := api.NewController(config.New())
+	controller.Router = mux.NewRouter()
+	controller.StoreController.DefaultStore = store
+
+	return api.NewRouteHandler(controller)
 }
 
 func descriptorFixture(t *testing.T) ([]byte, []byte) {
@@ -45,13 +40,13 @@ func descriptorFixture(t *testing.T) ([]byte, []byte) {
 	manifest := ispec.Manifest{
 		Config: ispec.Descriptor{
 			MediaType: ispec.MediaTypeImageConfig,
-			Digest:    testConfigDigest,
+			Digest:    testConfigDigest(),
 			Size:      1,
 		},
 		Layers: []ispec.Descriptor{
 			{
 				MediaType: ispec.MediaTypeImageLayerGzip,
-				Digest:    testLayerDigest,
+				Digest:    testLayerDigest(),
 				Size:      4,
 			},
 		},
@@ -67,7 +62,7 @@ func descriptorFixture(t *testing.T) ([]byte, []byte) {
 		Manifests: []ispec.Descriptor{
 			{
 				MediaType: ispec.MediaTypeImageManifest,
-				Digest:    testManifestDigest,
+				Digest:    testManifestDigest(),
 				Size:      int64(len(manifestJSON)),
 				Annotations: map[string]string{
 					ispec.AnnotationRefName: "latest",
@@ -93,7 +88,7 @@ func descriptorStore(t *testing.T) mocks.MockedImageStore {
 	return mocks.MockedImageStore{
 		RootDirFn: func() string { return "/tmp" },
 		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
-			if digest == testLayerDigest {
+			if digest == testLayerDigest() {
 				return true, 4, nil
 			}
 
@@ -103,7 +98,7 @@ func descriptorStore(t *testing.T) mocks.MockedImageStore {
 			return indexJSON, nil
 		},
 		GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
-			if digest == testManifestDigest {
+			if digest == testManifestDigest() {
 				return manifestJSON, nil
 			}
 
@@ -126,7 +121,7 @@ func TestCheckBlobUsesDescriptorContentType(t *testing.T) {
 	req.Header.Set("Accept", "application/vnd.oci.image.layer.v1.tar+gzip, */*")
 	req = mux.SetURLVars(req, map[string]string{
 		"name":   "test",
-		"digest": testLayerDigest.String(),
+		"digest": testLayerDigest().String(),
 	})
 
 	rec := httptest.NewRecorder()
@@ -160,7 +155,7 @@ func TestGetBlobUsesDescriptorContentType(t *testing.T) {
 	req.Header.Set("Accept", "application/vnd.oci.image.layer.v1.tar+gzip, */*")
 	req = mux.SetURLVars(req, map[string]string{
 		"name":   "test",
-		"digest": testLayerDigest.String(),
+		"digest": testLayerDigest().String(),
 	})
 
 	rec := httptest.NewRecorder()
@@ -240,7 +235,7 @@ func TestGetBlobPartialUsesDescriptorContentType(t *testing.T) {
 	req.Header.Set("Range", "bytes=0-1")
 	req = mux.SetURLVars(req, map[string]string{
 		"name":   "test",
-		"digest": testLayerDigest.String(),
+		"digest": testLayerDigest().String(),
 	})
 
 	rec := httptest.NewRecorder()
@@ -272,7 +267,7 @@ func TestGetBlobFallsBackToBinaryContentType(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/sha256:test", nil)
 	req = mux.SetURLVars(req, map[string]string{
 		"name":   "test",
-		"digest": testLayerDigest.String(),
+		"digest": testLayerDigest().String(),
 	})
 
 	rec := httptest.NewRecorder()
@@ -316,7 +311,7 @@ func TestGetBlobSupportsMultipleRanges(t *testing.T) {
 	req.Header.Set("Range", "bytes=0-1,5-7")
 	req = mux.SetURLVars(req, map[string]string{
 		"name":   "test",
-		"digest": testLayerDigest.String(),
+		"digest": testLayerDigest().String(),
 	})
 
 	rec := httptest.NewRecorder()

--- a/pkg/api/blob_range_internal_test.go
+++ b/pkg/api/blob_range_internal_test.go
@@ -1,0 +1,562 @@
+package api
+
+import (
+	"context"
+	stderrors "errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+	godigest "github.com/opencontainers/go-digest"
+
+	zerr "zotregistry.dev/zot/v2/errors"
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	zlog "zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+func testBlobDigest() godigest.Digest {
+	return godigest.FromString("layer")
+}
+
+func newInternalBlobRouteHandler(store mocks.MockedImageStore) *RouteHandler {
+	controller := NewController(config.New())
+	controller.Router = mux.NewRouter()
+	controller.StoreController.DefaultStore = store
+
+	return NewRouteHandler(controller)
+}
+
+func withBinaryFallback(store mocks.MockedImageStore) mocks.MockedImageStore {
+	store.GetIndexContentFn = func(repo string) ([]byte, error) {
+		return nil, zerr.ErrRepoNotFound
+	}
+
+	return store
+}
+
+func newBlobGetRequest(rangeHeader string, forceEmptyRange bool) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/v2/test/blobs/"+testBlobDigest().String(), nil)
+	if forceEmptyRange {
+		req.Header["Range"] = []string{""}
+	} else if rangeHeader != "" {
+		req.Header.Set("Range", rangeHeader)
+	}
+
+	return mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": testBlobDigest().String(),
+	})
+}
+
+type trackedReadCloser struct {
+	reader   io.Reader
+	closeErr error
+	closed   bool
+}
+
+func (reader *trackedReadCloser) Read(p []byte) (int, error) {
+	return reader.reader.Read(p)
+}
+
+func (reader *trackedReadCloser) Close() error {
+	reader.closed = true
+
+	return reader.closeErr
+}
+
+type erroringResponseWriter struct {
+	header http.Header
+	status int
+	err    error
+}
+
+func (writer *erroringResponseWriter) Header() http.Header {
+	if writer.header == nil {
+		writer.header = make(http.Header)
+	}
+
+	return writer.header
+}
+
+func (writer *erroringResponseWriter) WriteHeader(status int) {
+	writer.status = status
+}
+
+func (writer *erroringResponseWriter) Write(p []byte) (int, error) {
+	return 0, writer.err
+}
+
+func TestParseRangeHeader(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name    string
+		header  string
+		size    int64
+		want    []blobRange
+		wantErr error
+	}{
+		{
+			name:   "empty header",
+			header: "",
+			size:   10,
+			want:   nil,
+		},
+		{
+			name:    "invalid prefix",
+			header:  "items=0-1",
+			size:    10,
+			wantErr: zerr.ErrParsingHTTPHeader,
+		},
+		{
+			name:    "missing dash",
+			header:  "bytes=1",
+			size:    10,
+			wantErr: zerr.ErrParsingHTTPHeader,
+		},
+		{
+			name:    "empty range member",
+			header:  "bytes=0-1,",
+			size:    10,
+			wantErr: zerr.ErrParsingHTTPHeader,
+		},
+		{
+			name:    "malformed suffix",
+			header:  "bytes=--1",
+			size:    10,
+			wantErr: zerr.ErrParsingHTTPHeader,
+		},
+		{
+			name:    "nonnumeric suffix",
+			header:  "bytes=-abc",
+			size:    10,
+			wantErr: zerr.ErrParsingHTTPHeader,
+		},
+		{
+			name:   "suffix larger than blob",
+			header: "bytes=-20",
+			size:   10,
+			want: []blobRange{
+				{start: 0, length: 10},
+			},
+		},
+		{
+			name:    "suffix collapses to zero on empty blob",
+			header:  "bytes=-1",
+			size:    0,
+			wantErr: zerr.ErrBadUploadRange,
+		},
+		{
+			name:    "invalid start",
+			header:  "bytes=abc-1",
+			size:    10,
+			wantErr: zerr.ErrParsingHTTPHeader,
+		},
+		{
+			name:    "non overlapping range",
+			header:  "bytes=10-11",
+			size:    10,
+			wantErr: zerr.ErrBadUploadRange,
+		},
+		{
+			name:   "open ended range",
+			header: "bytes=5-",
+			size:   10,
+			want: []blobRange{
+				{start: 5, length: 5},
+			},
+		},
+		{
+			name:    "invalid end",
+			header:  "bytes=5-4",
+			size:    10,
+			wantErr: zerr.ErrParsingHTTPHeader,
+		},
+		{
+			name:   "range end clamps to blob size",
+			header: "bytes=8-20",
+			size:   10,
+			want: []blobRange{
+				{start: 8, length: 2},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := parseRangeHeader(testCase.header, testCase.size)
+			if !stderrors.Is(err, testCase.wantErr) {
+				t.Fatalf("error = %v, want %v", err, testCase.wantErr)
+			}
+
+			if !reflect.DeepEqual(got, testCase.want) {
+				t.Fatalf("ranges = %#v, want %#v", got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestWriteMultipartByteRangesHonorsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	recorder := httptest.NewRecorder()
+	readerCalled := false
+
+	writeMultipartByteRanges(
+		ctx,
+		recorder,
+		"application/octet-stream",
+		4,
+		[]blobRange{{start: 0, length: 2}},
+		func(blobRange) (io.ReadCloser, error) {
+			readerCalled = true
+
+			return io.NopCloser(strings.NewReader("ab")), nil
+		},
+		zlog.NewTestLogger(),
+	)
+
+	if readerCalled {
+		t.Fatalf("range reader should not be called when the context is already canceled")
+	}
+
+	if recorder.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusPartialContent)
+	}
+}
+
+func TestWriteMultipartByteRangesClosesReaderOnContextCancelAfterLookup(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	reader := &trackedReadCloser{reader: strings.NewReader("ab")}
+	recorder := httptest.NewRecorder()
+
+	writeMultipartByteRanges(
+		ctx,
+		recorder,
+		"application/octet-stream",
+		4,
+		[]blobRange{{start: 0, length: 2}},
+		func(blobRange) (io.ReadCloser, error) {
+			cancel()
+
+			return reader, nil
+		},
+		zlog.NewTestLogger(),
+	)
+
+	if !reader.closed {
+		t.Fatalf("range reader was not closed after the context was canceled")
+	}
+}
+
+func TestWriteMultipartByteRangesStopsOnRangeReaderError(t *testing.T) {
+	t.Parallel()
+
+	recorder := httptest.NewRecorder()
+	readerCalled := false
+
+	writeMultipartByteRanges(
+		context.Background(),
+		recorder,
+		"application/octet-stream",
+		4,
+		[]blobRange{{start: 0, length: 2}},
+		func(blobRange) (io.ReadCloser, error) {
+			readerCalled = true
+
+			return nil, stderrors.New("boom")
+		},
+		zlog.NewTestLogger(),
+	)
+
+	if !readerCalled {
+		t.Fatalf("range reader was not called")
+	}
+
+	if recorder.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusPartialContent)
+	}
+}
+
+func TestWriteMultipartByteRangesStopsOnShortRead(t *testing.T) {
+	t.Parallel()
+
+	reader := &trackedReadCloser{reader: strings.NewReader("a")}
+	recorder := httptest.NewRecorder()
+
+	writeMultipartByteRanges(
+		context.Background(),
+		recorder,
+		"application/octet-stream",
+		4,
+		[]blobRange{{start: 0, length: 2}},
+		func(blobRange) (io.ReadCloser, error) {
+			return reader, nil
+		},
+		zlog.NewTestLogger(),
+	)
+
+	if !reader.closed {
+		t.Fatalf("range reader was not closed after a short read")
+	}
+}
+
+func TestWriteMultipartByteRangesStopsOnCloseError(t *testing.T) {
+	t.Parallel()
+
+	reader := &trackedReadCloser{
+		reader:   strings.NewReader("ab"),
+		closeErr: stderrors.New("close failed"),
+	}
+	recorder := httptest.NewRecorder()
+
+	writeMultipartByteRanges(
+		context.Background(),
+		recorder,
+		"application/octet-stream",
+		4,
+		[]blobRange{{start: 0, length: 2}},
+		func(blobRange) (io.ReadCloser, error) {
+			return reader, nil
+		},
+		zlog.NewTestLogger(),
+	)
+
+	if !reader.closed {
+		t.Fatalf("range reader was not closed when Close returned an error")
+	}
+}
+
+func TestWriteMultipartByteRangesHandlesResponseWriteError(t *testing.T) {
+	t.Parallel()
+
+	writer := &erroringResponseWriter{err: stderrors.New("response write failed")}
+
+	writeMultipartByteRanges(
+		context.Background(),
+		writer,
+		"application/octet-stream",
+		4,
+		[]blobRange{{start: 0, length: 2}},
+		func(blobRange) (io.ReadCloser, error) {
+			return io.NopCloser(strings.NewReader("ab")), nil
+		},
+		zlog.NewTestLogger(),
+	)
+
+	if writer.status != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", writer.status, http.StatusPartialContent)
+	}
+}
+
+func TestGetBlobRejectsExplicitEmptyRangeHeader(t *testing.T) {
+	t.Parallel()
+
+	handler := newInternalBlobRouteHandler(withBinaryFallback(mocks.MockedImageStore{
+		GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
+			t.Fatalf("GetBlob should not be called when Range is explicitly empty")
+
+			return nil, 0, nil
+		},
+	}))
+
+	req := newBlobGetRequest("", true)
+	recorder := httptest.NewRecorder()
+	handler.GetBlob(recorder, req)
+
+	if recorder.Code != http.StatusRequestedRangeNotSatisfiable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusRequestedRangeNotSatisfiable)
+	}
+}
+
+func TestGetBlobReturnsInternalServerErrorWhenRangePreflightFails(t *testing.T) {
+	t.Parallel()
+
+	handler := newInternalBlobRouteHandler(withBinaryFallback(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return false, 0, stderrors.New("boom")
+		},
+		GetBlobPartialFn: func(repo string, digest godigest.Digest, mediaType string, from, to int64,
+		) (io.ReadCloser, int64, int64, error) {
+			t.Fatalf("GetBlobPartial should not be called when range preflight fails")
+
+			return nil, 0, 0, nil
+		},
+	}))
+
+	req := newBlobGetRequest("bytes=0-1", false)
+	recorder := httptest.NewRecorder()
+	handler.GetBlob(recorder, req)
+
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
+	}
+}
+
+func TestGetBlobReturnsNotFoundWhenRangePreflightBlobIsMissing(t *testing.T) {
+	t.Parallel()
+
+	handler := newInternalBlobRouteHandler(withBinaryFallback(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return false, 0, nil
+		},
+		GetBlobPartialFn: func(repo string, digest godigest.Digest, mediaType string, from, to int64,
+		) (io.ReadCloser, int64, int64, error) {
+			t.Fatalf("GetBlobPartial should not be called when the blob is missing")
+
+			return nil, 0, 0, nil
+		},
+	}))
+
+	req := newBlobGetRequest("bytes=0-1", false)
+	recorder := httptest.NewRecorder()
+	handler.GetBlob(recorder, req)
+
+	if recorder.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusNotFound)
+	}
+}
+
+func TestGetBlobSupportsOpenEndedRanges(t *testing.T) {
+	t.Parallel()
+
+	const blob = "0123456789"
+
+	handler := newInternalBlobRouteHandler(withBinaryFallback(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return true, int64(len(blob)), nil
+		},
+		GetBlobPartialFn: func(repo string, digest godigest.Digest, mediaType string, from, to int64,
+		) (io.ReadCloser, int64, int64, error) {
+			if from != 7 || to != 9 {
+				t.Fatalf("range = %d-%d, want 7-9", from, to)
+			}
+
+			return io.NopCloser(strings.NewReader(blob[from : to+1])), to - from + 1, int64(len(blob)), nil
+		},
+	}))
+
+	req := newBlobGetRequest("bytes=7-", false)
+	recorder := httptest.NewRecorder()
+	handler.GetBlob(recorder, req)
+
+	resp := recorder.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusPartialContent)
+	}
+
+	if got := resp.Header.Get("Content-Range"); got != "bytes 7-9/10" {
+		t.Fatalf("content-range = %q, want %q", got, "bytes 7-9/10")
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+
+	if got := string(body); got != "789" {
+		t.Fatalf("body = %q, want %q", got, "789")
+	}
+}
+
+func TestGetBlobClampsRangeEndToBlobSize(t *testing.T) {
+	t.Parallel()
+
+	const blob = "0123456789"
+
+	handler := newInternalBlobRouteHandler(withBinaryFallback(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return true, int64(len(blob)), nil
+		},
+		GetBlobPartialFn: func(repo string, digest godigest.Digest, mediaType string, from, to int64,
+		) (io.ReadCloser, int64, int64, error) {
+			if from != 8 || to != 9 {
+				t.Fatalf("range = %d-%d, want 8-9", from, to)
+			}
+
+			return io.NopCloser(strings.NewReader(blob[from : to+1])), to - from + 1, int64(len(blob)), nil
+		},
+	}))
+
+	req := newBlobGetRequest("bytes=8-20", false)
+	recorder := httptest.NewRecorder()
+	handler.GetBlob(recorder, req)
+
+	resp := recorder.Result()
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusPartialContent)
+	}
+
+	if got := resp.Header.Get("Content-Range"); got != "bytes 8-9/10" {
+		t.Fatalf("content-range = %q, want %q", got, "bytes 8-9/10")
+	}
+}
+
+func TestGetBlobRejectsMalformedRangeHeader(t *testing.T) {
+	t.Parallel()
+
+	handler := newInternalBlobRouteHandler(withBinaryFallback(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return true, 10, nil
+		},
+	}))
+
+	testCases := []string{
+		"items=0-1",
+		"bytes=1",
+	}
+
+	for _, header := range testCases {
+		t.Run(header, func(t *testing.T) {
+			req := newBlobGetRequest(header, false)
+			recorder := httptest.NewRecorder()
+			handler.GetBlob(recorder, req)
+
+			if recorder.Code != http.StatusRequestedRangeNotSatisfiable {
+				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusRequestedRangeNotSatisfiable)
+			}
+		})
+	}
+}
+
+func TestGetBlobMultipleRangesStopsWhenBlobReadFails(t *testing.T) {
+	t.Parallel()
+
+	handler := newInternalBlobRouteHandler(withBinaryFallback(mocks.MockedImageStore{
+		CheckBlobFn: func(repo string, digest godigest.Digest) (bool, int64, error) {
+			return true, 10, nil
+		},
+		GetBlobPartialFn: func(repo string, digest godigest.Digest, mediaType string, from, to int64,
+		) (io.ReadCloser, int64, int64, error) {
+			return nil, 0, 0, stderrors.New("boom")
+		},
+	}))
+
+	req := newBlobGetRequest("bytes=0-1,5-7", false)
+	recorder := httptest.NewRecorder()
+	handler.GetBlob(recorder, req)
+
+	if recorder.Code != http.StatusPartialContent {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusPartialContent)
+	}
+
+	if got := recorder.Header().Get("Content-Type"); !strings.HasPrefix(got, "multipart/byteranges; boundary=") {
+		t.Fatalf("content-type = %q, want multipart/byteranges boundary", got)
+	}
+}

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1137,12 +1137,12 @@ func parseRangeHeader(contentRange string, size int64) ([]blobRange, error) {
 		return nil, zerr.ErrParsingHTTPHeader
 	}
 
-	var (
-		ranges    []blobRange
-		noOverlap bool
-	)
+	rangeValue := contentRange[len(prefix):]
+	ranges := make([]blobRange, 0, strings.Count(rangeValue, ",")+1)
 
-	for _, part := range strings.Split(contentRange[len(prefix):], ",") {
+	var noOverlap bool
+
+	for part := range strings.SplitSeq(rangeValue, ",") {
 		part = textproto.TrimString(part)
 		if part == "" {
 			continue
@@ -1214,25 +1214,28 @@ func parseRangeHeader(contentRange string, size int64) ([]blobRange, error) {
 	return ranges, nil
 }
 
-func rangesMIMESize(ranges []blobRange, contentType string, contentSize int64) (encSize int64) {
-	var w countingWriter
+func rangesMIMESize(ranges []blobRange, contentType string, contentSize int64) int64 {
+	var (
+		encodedSize int64
+		sizeWriter  countingWriter
+	)
 
-	mw := multipart.NewWriter(&w)
-	for _, ra := range ranges {
-		_, _ = mw.CreatePart(ra.mimeHeader(contentType, contentSize))
-		encSize += ra.length
+	multipartWriter := multipart.NewWriter(&sizeWriter)
+	for _, requestedRange := range ranges {
+		_, _ = multipartWriter.CreatePart(requestedRange.mimeHeader(contentType, contentSize))
+		encodedSize += requestedRange.length
 	}
 
-	_ = mw.Close()
-	encSize += int64(w)
+	_ = multipartWriter.Close()
+	encodedSize += int64(sizeWriter)
 
-	return encSize
+	return encodedSize
 }
 
 type countingWriter int64
 
-func (w *countingWriter) Write(p []byte) (n int, err error) {
-	*w += countingWriter(len(p))
+func (writer *countingWriter) Write(p []byte) (int, error) {
+	*writer += countingWriter(len(p))
 
 	return len(p), nil
 }
@@ -1246,54 +1249,54 @@ func writeMultipartByteRanges(
 	logger log.Logger,
 ) {
 	responseLength := rangesMIMESize(ranges, contentType, size)
-	pr, pw := io.Pipe()
-	mw := multipart.NewWriter(pw)
+	pipeReader, pipeWriter := io.Pipe()
+	multipartWriter := multipart.NewWriter(pipeWriter)
 
 	response.Header().Set("Content-Length", strconv.FormatInt(responseLength, 10))
-	response.Header().Set("Content-Type", "multipart/byteranges; boundary="+mw.Boundary())
+	response.Header().Set("Content-Type", "multipart/byteranges; boundary="+multipartWriter.Boundary())
 	response.WriteHeader(http.StatusPartialContent)
 
 	go func() {
-		for _, ra := range ranges {
-			part, err := mw.CreatePart(ra.mimeHeader(contentType, size))
+		for _, requestedRange := range ranges {
+			partWriter, err := multipartWriter.CreatePart(requestedRange.mimeHeader(contentType, size))
 			if err != nil {
-				_ = pw.CloseWithError(err)
+				_ = pipeWriter.CloseWithError(err)
 
 				return
 			}
 
-			reader, err := rangeReader(ra)
+			rangeContent, err := rangeReader(requestedRange)
 			if err != nil {
-				_ = pw.CloseWithError(err)
+				_ = pipeWriter.CloseWithError(err)
 
 				return
 			}
 
-			_, copyErr := io.CopyN(part, reader, ra.length)
-			closeErr := reader.Close()
+			_, copyErr := io.CopyN(partWriter, rangeContent, requestedRange.length)
+			closeErr := rangeContent.Close()
 			if copyErr != nil {
-				_ = pw.CloseWithError(copyErr)
+				_ = pipeWriter.CloseWithError(copyErr)
 
 				return
 			}
 
 			if closeErr != nil {
-				_ = pw.CloseWithError(closeErr)
+				_ = pipeWriter.CloseWithError(closeErr)
 
 				return
 			}
 		}
 
-		if err := mw.Close(); err != nil {
-			_ = pw.CloseWithError(err)
+		if err := multipartWriter.Close(); err != nil {
+			_ = pipeWriter.CloseWithError(err)
 
 			return
 		}
 
-		_ = pw.Close()
+		_ = pipeWriter.Close()
 	}()
 
-	if _, err := io.CopyN(response, pr, responseLength); err != nil {
+	if _, err := io.CopyN(response, pipeReader, responseLength); err != nil {
 		logger.Error().Err(err).Msg("failed to copy data into http response")
 	}
 }
@@ -1380,13 +1383,13 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 			mediaType,
 			blobSize,
 			ranges,
-			func(r blobRange) (io.ReadCloser, error) {
+			func(requestedRange blobRange) (io.ReadCloser, error) {
 				reader, _, _, err := imgStore.GetBlobPartial(
 					name,
 					digest,
 					mediaType,
-					r.start,
-					r.start+r.length-1,
+					requestedRange.start,
+					requestedRange.start+requestedRange.length-1,
 				)
 				if err != nil {
 					return nil, err

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -58,6 +58,8 @@ type blobRange struct {
 	start, length int64
 }
 
+const maxBlobRanges = 16
+
 func (r blobRange) contentRange(size int64) string {
 	return fmt.Sprintf("bytes %d-%d/%d", r.start, r.start+r.length-1, size)
 }
@@ -1145,7 +1147,7 @@ func parseRangeHeader(contentRange string, size int64) ([]blobRange, error) {
 	for part := range strings.SplitSeq(rangeValue, ",") {
 		part = textproto.TrimString(part)
 		if part == "" {
-			continue
+			return nil, zerr.ErrParsingHTTPHeader
 		}
 
 		rangeFrom, rangeTo, ok := strings.Cut(part, "-")
@@ -1164,12 +1166,20 @@ func parseRangeHeader(contentRange string, size int64) ([]blobRange, error) {
 			}
 
 			suffixLength, err := strconv.ParseInt(rangeTo, 10, 64)
-			if err != nil || suffixLength < 0 {
+			if err != nil {
 				return nil, zerr.ErrParsingHTTPHeader
+			}
+
+			if suffixLength <= 0 {
+				return nil, zerr.ErrBadUploadRange
 			}
 
 			if suffixLength > size {
 				suffixLength = size
+			}
+
+			if suffixLength == 0 {
+				return nil, zerr.ErrBadUploadRange
 			}
 
 			current.start = size - suffixLength
@@ -1204,11 +1214,19 @@ func parseRangeHeader(contentRange string, size int64) ([]blobRange, error) {
 			}
 		}
 
+		if len(ranges) == maxBlobRanges {
+			return nil, zerr.ErrBadUploadRange
+		}
+
 		ranges = append(ranges, current)
 	}
 
-	if noOverlap && len(ranges) == 0 {
-		return nil, zerr.ErrBadUploadRange
+	if len(ranges) == 0 {
+		if noOverlap {
+			return nil, zerr.ErrBadUploadRange
+		}
+
+		return nil, zerr.ErrParsingHTTPHeader
 	}
 
 	return ranges, nil
@@ -1241,6 +1259,7 @@ func (writer *countingWriter) Write(p []byte) (int, error) {
 }
 
 func writeMultipartByteRanges(
+	ctx context.Context,
 	response http.ResponseWriter,
 	contentType string,
 	size int64,
@@ -1251,13 +1270,22 @@ func writeMultipartByteRanges(
 	responseLength := rangesMIMESize(ranges, contentType, size)
 	pipeReader, pipeWriter := io.Pipe()
 	multipartWriter := multipart.NewWriter(pipeWriter)
+	writerDone := make(chan struct{})
 
 	response.Header().Set("Content-Length", strconv.FormatInt(responseLength, 10))
 	response.Header().Set("Content-Type", "multipart/byteranges; boundary="+multipartWriter.Boundary())
 	response.WriteHeader(http.StatusPartialContent)
 
 	go func() {
+		defer close(writerDone)
+
 		for _, requestedRange := range ranges {
+			if err := ctx.Err(); err != nil {
+				_ = pipeWriter.CloseWithError(err)
+
+				return
+			}
+
 			partWriter, err := multipartWriter.CreatePart(requestedRange.mimeHeader(contentType, size))
 			if err != nil {
 				_ = pipeWriter.CloseWithError(err)
@@ -1267,6 +1295,13 @@ func writeMultipartByteRanges(
 
 			rangeContent, err := rangeReader(requestedRange)
 			if err != nil {
+				_ = pipeWriter.CloseWithError(err)
+
+				return
+			}
+
+			if err := ctx.Err(); err != nil {
+				_ = rangeContent.Close()
 				_ = pipeWriter.CloseWithError(err)
 
 				return
@@ -1297,8 +1332,12 @@ func writeMultipartByteRanges(
 	}()
 
 	if _, err := io.CopyN(response, pipeReader, responseLength); err != nil {
+		_ = pipeReader.CloseWithError(err)
+		_ = pipeWriter.CloseWithError(err)
 		logger.Error().Err(err).Msg("failed to copy data into http response")
 	}
+
+	<-writerDone
 }
 
 // GetBlob godoc
@@ -1379,6 +1418,7 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 
 	if len(ranges) > 1 {
 		writeMultipartByteRanges(
+			request.Context(),
 			response,
 			mediaType,
 			blobSize,

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -13,10 +13,11 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"path"
-	"regexp"
 	"slices"
 	"sort"
 	"strconv"
@@ -52,6 +53,21 @@ import (
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 	"zotregistry.dev/zot/v2/pkg/test/inject"
 )
+
+type blobRange struct {
+	start, length int64
+}
+
+func (r blobRange) contentRange(size int64) string {
+	return fmt.Sprintf("bytes %d-%d/%d", r.start, r.start+r.length-1, size)
+}
+
+func (r blobRange) mimeHeader(contentType string, size int64) textproto.MIMEHeader {
+	return textproto.MIMEHeader{
+		"Content-Range": {r.contentRange(size)},
+		"Content-Type":  {contentType},
+	}
+}
 
 type RouteHandler struct {
 	c *Controller
@@ -1042,6 +1058,7 @@ func (rh *RouteHandler) CheckBlob(response http.ResponseWriter, request *http.Re
 	}
 
 	digest := godigest.Digest(digestStr)
+	mediaType := blobResponseMediaType(imgStore, name, digest, rh.c.Log)
 
 	userAc, err := reqCtx.UserAcFromContext(request.Context())
 	if err != nil {
@@ -1104,55 +1121,181 @@ func (rh *RouteHandler) CheckBlob(response http.ResponseWriter, request *http.Re
 
 	response.Header().Set("Content-Length", strconv.FormatInt(blen, 10))
 	response.Header().Set("Accept-Ranges", "bytes")
+	response.Header().Set("Content-Type", mediaType)
 	response.Header().Set(constants.DistContentDigestKey, digest.String())
 	response.WriteHeader(http.StatusOK)
 }
 
-/* parseRangeHeader validates the "Range" HTTP header and returns the range. */
-func parseRangeHeader(contentRange string) (int64, int64, error) {
-	/* bytes=<start>- and bytes=<start>-<end> formats are supported */
-	pattern := `bytes=(?P<rangeFrom>\d+)-(?P<rangeTo>\d*$)`
-
-	regex, err := regexp.Compile(pattern)
-	if err != nil {
-		return -1, -1, zerr.ErrParsingHTTPHeader
+/* parseRangeHeader validates the "Range" HTTP header and returns the ranges. */
+func parseRangeHeader(contentRange string, size int64) ([]blobRange, error) {
+	if contentRange == "" {
+		return nil, nil
 	}
 
-	match := regex.FindStringSubmatch(contentRange)
-
-	paramsMap := make(map[string]string)
-
-	for i, name := range regex.SubexpNames() {
-		if i > 0 && i <= len(match) {
-			paramsMap[name] = match[i]
-		}
+	const prefix = "bytes="
+	if !strings.HasPrefix(contentRange, prefix) {
+		return nil, zerr.ErrParsingHTTPHeader
 	}
 
-	var from int64
+	var (
+		ranges    []blobRange
+		noOverlap bool
+	)
 
-	to := int64(-1)
-
-	rangeFrom := paramsMap["rangeFrom"]
-	if rangeFrom == "" {
-		return -1, -1, zerr.ErrParsingHTTPHeader
-	}
-
-	if from, err = strconv.ParseInt(rangeFrom, 10, 64); err != nil {
-		return -1, -1, zerr.ErrParsingHTTPHeader
-	}
-
-	rangeTo := paramsMap["rangeTo"]
-	if rangeTo != "" {
-		if to, err = strconv.ParseInt(rangeTo, 10, 64); err != nil {
-			return -1, -1, zerr.ErrParsingHTTPHeader
+	for _, part := range strings.Split(contentRange[len(prefix):], ",") {
+		part = textproto.TrimString(part)
+		if part == "" {
+			continue
 		}
 
-		if to < from {
-			return -1, -1, zerr.ErrParsingHTTPHeader
+		rangeFrom, rangeTo, ok := strings.Cut(part, "-")
+		if !ok {
+			return nil, zerr.ErrParsingHTTPHeader
 		}
+
+		rangeFrom = textproto.TrimString(rangeFrom)
+		rangeTo = textproto.TrimString(rangeTo)
+
+		var current blobRange
+
+		if rangeFrom == "" {
+			if rangeTo == "" || rangeTo[0] == '-' {
+				return nil, zerr.ErrParsingHTTPHeader
+			}
+
+			suffixLength, err := strconv.ParseInt(rangeTo, 10, 64)
+			if err != nil || suffixLength < 0 {
+				return nil, zerr.ErrParsingHTTPHeader
+			}
+
+			if suffixLength > size {
+				suffixLength = size
+			}
+
+			current.start = size - suffixLength
+			current.length = size - current.start
+		} else {
+			start, err := strconv.ParseInt(rangeFrom, 10, 64)
+			if err != nil || start < 0 {
+				return nil, zerr.ErrParsingHTTPHeader
+			}
+
+			if start >= size {
+				noOverlap = true
+
+				continue
+			}
+
+			current.start = start
+
+			if rangeTo == "" {
+				current.length = size - current.start
+			} else {
+				end, err := strconv.ParseInt(rangeTo, 10, 64)
+				if err != nil || current.start > end {
+					return nil, zerr.ErrParsingHTTPHeader
+				}
+
+				if end >= size {
+					end = size - 1
+				}
+
+				current.length = end - current.start + 1
+			}
+		}
+
+		ranges = append(ranges, current)
 	}
 
-	return from, to, nil
+	if noOverlap && len(ranges) == 0 {
+		return nil, zerr.ErrBadUploadRange
+	}
+
+	return ranges, nil
+}
+
+func rangesMIMESize(ranges []blobRange, contentType string, contentSize int64) (encSize int64) {
+	var w countingWriter
+
+	mw := multipart.NewWriter(&w)
+	for _, ra := range ranges {
+		_, _ = mw.CreatePart(ra.mimeHeader(contentType, contentSize))
+		encSize += ra.length
+	}
+
+	_ = mw.Close()
+	encSize += int64(w)
+
+	return encSize
+}
+
+type countingWriter int64
+
+func (w *countingWriter) Write(p []byte) (n int, err error) {
+	*w += countingWriter(len(p))
+
+	return len(p), nil
+}
+
+func writeMultipartByteRanges(
+	response http.ResponseWriter,
+	contentType string,
+	size int64,
+	ranges []blobRange,
+	rangeReader func(blobRange) (io.ReadCloser, error),
+	logger log.Logger,
+) {
+	responseLength := rangesMIMESize(ranges, contentType, size)
+	pr, pw := io.Pipe()
+	mw := multipart.NewWriter(pw)
+
+	response.Header().Set("Content-Length", strconv.FormatInt(responseLength, 10))
+	response.Header().Set("Content-Type", "multipart/byteranges; boundary="+mw.Boundary())
+	response.WriteHeader(http.StatusPartialContent)
+
+	go func() {
+		for _, ra := range ranges {
+			part, err := mw.CreatePart(ra.mimeHeader(contentType, size))
+			if err != nil {
+				_ = pw.CloseWithError(err)
+
+				return
+			}
+
+			reader, err := rangeReader(ra)
+			if err != nil {
+				_ = pw.CloseWithError(err)
+
+				return
+			}
+
+			_, copyErr := io.CopyN(part, reader, ra.length)
+			closeErr := reader.Close()
+			if copyErr != nil {
+				_ = pw.CloseWithError(copyErr)
+
+				return
+			}
+
+			if closeErr != nil {
+				_ = pw.CloseWithError(closeErr)
+
+				return
+			}
+		}
+
+		if err := mw.Close(); err != nil {
+			_ = pw.CloseWithError(err)
+
+			return
+		}
+
+		_ = pw.Close()
+	}()
+
+	if _, err := io.CopyN(response, pr, responseLength); err != nil {
+		logger.Error().Err(err).Msg("failed to copy data into http response")
+	}
 }
 
 // GetBlob godoc
@@ -1187,14 +1330,7 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 
 	digest := godigest.Digest(digestStr)
 
-	mediaType := request.Header.Get("Accept")
-
-	/* content range is supported for resumbale pulls */
-	partial := false
-
-	var from, to int64
-
-	var err error
+	mediaType := blobResponseMediaType(imgStore, name, digest, rh.c.Log)
 
 	contentRange := request.Header.Get("Range")
 
@@ -1205,25 +1341,80 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 		return
 	}
 
+	var (
+		ranges   []blobRange
+		blobSize int64
+		err      error
+	)
+
 	if contentRange != "" {
-		from, to, err = parseRangeHeader(contentRange)
+		exists, size, checkErr := imgStore.CheckBlob(name, digest)
+		if checkErr != nil {
+			rh.c.Log.Error().Err(checkErr).Msg("unexpected error")
+			response.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		if !exists {
+			details := zerr.GetDetails(zerr.ErrBlobNotFound)
+			details["digest"] = digest.String()
+			e := apiErr.NewError(apiErr.BLOB_UNKNOWN).AddDetail(details)
+			zcommon.WriteJSON(response, http.StatusNotFound, apiErr.NewErrorList(e))
+
+			return
+		}
+
+		blobSize = size
+		ranges, err = parseRangeHeader(contentRange, size)
 		if err != nil {
 			response.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
 
 			return
 		}
+	}
 
-		partial = true
+	if len(ranges) > 1 {
+		writeMultipartByteRanges(
+			response,
+			mediaType,
+			blobSize,
+			ranges,
+			func(r blobRange) (io.ReadCloser, error) {
+				reader, _, _, err := imgStore.GetBlobPartial(
+					name,
+					digest,
+					mediaType,
+					r.start,
+					r.start+r.length-1,
+				)
+				if err != nil {
+					return nil, err
+				}
+
+				return reader, nil
+			},
+			rh.c.Log,
+		)
+
+		return
 	}
 
 	var repo io.ReadCloser
 
 	var blen, bsize int64
 
-	if partial {
-		repo, blen, bsize, err = imgStore.GetBlobPartial(name, digest, mediaType, from, to)
-	} else {
+	if len(ranges) == 0 {
 		repo, blen, err = imgStore.GetBlob(name, digest, mediaType)
+	} else if len(ranges) == 1 {
+		singleRange := ranges[0]
+		repo, blen, bsize, err = imgStore.GetBlobPartial(
+			name,
+			digest,
+			mediaType,
+			singleRange.start,
+			singleRange.start+singleRange.length-1,
+		)
 	}
 
 	if err != nil {
@@ -1254,16 +1445,29 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 
 	status := http.StatusOK
 
-	if partial {
+	if len(ranges) == 1 {
 		status = http.StatusPartialContent
-
-		response.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", from, from+blen-1, bsize))
+		response.Header().Set("Content-Range", ranges[0].contentRange(bsize))
 	} else {
 		response.Header().Set(constants.DistContentDigestKey, digest.String())
 	}
 
 	// return the blob data
 	WriteDataFromReader(response, status, blen, mediaType, repo, rh.c.Log)
+}
+
+func blobResponseMediaType(
+	imgStore storageTypes.ImageStore,
+	repo string,
+	digest godigest.Digest,
+	logger log.Logger,
+) string {
+	desc, err := storageCommon.GetBlobDescriptorFromRepo(imgStore, repo, digest, logger)
+	if err == nil && desc.MediaType != "" {
+		return desc.MediaType
+	}
+
+	return constants.BinaryMediaType
 }
 
 // DeleteBlob godoc


### PR DESCRIPTION
**What type of PR is this?**

bug / feature

**Which issue does this PR fix**:

https://github.com/project-zot/zot/issues/3623

**What does this PR do / Why do we need it**:

Currently zot does not support using stargaze snapshotter with containerd due to missing range requests and returning incorrect content types.

**Testing done on this change**:

The branch adds one unit test file, pkg/api/blob_content_type_test.go, with six tests. Verbose output from running just those added tests:

  === RUN   TestCheckBlobUsesDescriptorContentType
  --- PASS: TestCheckBlobUsesDescriptorContentType (0.00s)
  === RUN   TestGetBlobUsesDescriptorContentType
  --- PASS: TestGetBlobUsesDescriptorContentType (0.00s)
  === RUN   TestGetBlobPartialFallsBackToBinaryContentType
  {"time":"2026-04-17T11:17:52.512371-07:00","level":"error","message":"invalid JSON","error":"unexpected end of JSON input","dir":"test","caller":"/private/tmp/zot-upstream/pkg/storage/common/
  common.go:289","func":"zotregistry.dev/zot/v2/pkg/storage/common.GetIndex","goroutine":40}
  --- PASS: TestGetBlobPartialFallsBackToBinaryContentType (0.00s)
  === RUN   TestGetBlobPartialUsesDescriptorContentType
  --- PASS: TestGetBlobPartialUsesDescriptorContentType (0.00s)
  === RUN   TestGetBlobFallsBackToBinaryContentType
  {"time":"2026-04-17T11:17:52.512646-07:00","level":"error","message":"invalid JSON","error":"unexpected end of JSON input","dir":"test","caller":"/private/tmp/zot-upstream/pkg/storage/common/
  common.go:289","func":"zotregistry.dev/zot/v2/pkg/storage/common.GetIndex","goroutine":42}
  --- PASS: TestGetBlobFallsBackToBinaryContentType (0.00s)
  === RUN   TestGetBlobSupportsMultipleRanges
  {"time":"2026-04-17T11:17:52.512717-07:00","level":"error","message":"invalid JSON","error":"unexpected end of JSON input","dir":"test","caller":"/private/tmp/zot-upstream/pkg/storage/common/
  common.go:289","func":"zotregistry.dev/zot/v2/pkg/storage/common.GetIndex","goroutine":43}
  --- PASS: TestGetBlobSupportsMultipleRanges (0.00s)
  PASS
  ok    zotregistry.dev/zot/v2/pkg/api  0.471s
  

Manually validated with stargaze snapshotter on minikube and production clusters

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:


```release-note
Adds support for range requests and content types required by the stargaze snapshotter to enable lazy image pulls
https://github.com/containerd/stargz-snapshotter
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
