### PR TITLE
fix(security): limit manifest PUT body to 4 MiB (INPUT-1)

### DIFF
--- a/pkg/api/constants/consts.go
+++ b/pkg/api/constants/consts.go
@@ -19,7 +19,10 @@ const (
 	// for path and digest:
 	//
 	//	(8192 - 2048) / (len("tag=") + 128 + 1) == 46
-	MaxManifestDigestQueryTags   = (8192 - 2048) / (len("tag=") + 128 + 1)
+	MaxManifestDigestQueryTags = (8192 - 2048) / (len("tag=") + 128 + 1)
+	// MaxManifestBodySize is the maximum number of bytes accepted for a manifest PUT request body.
+	// OCI manifest JSON is always small metadata; 4 MiB is well above any realistic manifest.
+	MaxManifestBodySize          = 4 * 1024 * 1024
 	BlobUploadUUID               = "Blob-Upload-UUID"
 	DefaultMediaType             = "application/json"
 	BinaryMediaType              = "application/octet-stream"

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -689,6 +689,7 @@ func (rh *RouteHandler) GetReferrers(response http.ResponseWriter, request *http
 // @Header  201 {string} OCI-Tag "Echoed tag= value; this header is repeatable (one field per tag= query parameter)"
 // @Failure 400 {string} string "bad request"
 // @Failure 404 {string} string "not found"
+// @Failure 413 {string} string "request entity too large"
 // @Failure 414 {string} string "too many tag query parameters"
 // @Failure 500 {string} string "internal server error"
 // @Router /v2/{name}/manifests/{reference} [put].
@@ -746,21 +747,29 @@ func (rh *RouteHandler) UpdateManifest(response http.ResponseWriter, request *ht
 		}
 	}
 
-	body, err := io.ReadAll(request.Body)
-	// hard to reach test case, injected error (simulates an interrupted image manifest upload)
-	// err could be io.ErrUnexpectedEOF
-	if err := inject.Error(err); err != nil {
-		rh.c.Log.Error().Err(err).Msg("unexpected error")
-		response.WriteHeader(http.StatusInternalServerError)
-
-		return
-	}
-
 	if len(digestQueryTags) > 0 && !zcommon.IsDigest(reference) {
 		err := apiErr.NewError(apiErr.MANIFEST_INVALID).AddDetail(map[string]string{
 			"reason": "tag query parameters are only valid when pushing a manifest by digest",
 		})
 		zcommon.WriteJSON(response, http.StatusBadRequest, apiErr.NewErrorList(err))
+
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(response, request.Body, constants.MaxManifestBodySize))
+	// hard to reach test case, injected error (simulates an interrupted image manifest upload)
+	// err could be io.ErrUnexpectedEOF or *http.MaxBytesError
+	if err := inject.Error(err); err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			e := apiErr.NewError(apiErr.MANIFEST_INVALID).AddDetail(map[string]string{
+				"reason": fmt.Sprintf("manifest body exceeds maximum allowed size of %d bytes", constants.MaxManifestBodySize),
+			})
+			zcommon.WriteJSON(response, http.StatusRequestEntityTooLarge, apiErr.NewErrorList(e))
+		} else {
+			rh.c.Log.Error().Err(err).Msg("unexpected error")
+			response.WriteHeader(http.StatusInternalServerError)
+		}
 
 		return
 	}

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -26,6 +26,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api"
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
+	apiErr "zotregistry.dev/zot/v2/pkg/api/errors"
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	reqCtx "zotregistry.dev/zot/v2/pkg/requestcontext"
@@ -259,6 +260,27 @@ func TestRoutes(t *testing.T) {
 
 				return resp.StatusCode
 			}
+
+			Convey("body exceeds MaxManifestBodySize returns 413 with MANIFEST_INVALID error payload", func() {
+				ctlr.StoreController.DefaultStore = &mocks.MockedImageStore{}
+				oversized := make([]byte, constants.MaxManifestBodySize+1)
+				request, _ := http.NewRequestWithContext(context.TODO(), http.MethodPut, baseURL,
+					bytes.NewReader(oversized))
+				request = mux.SetURLVars(request, map[string]string{"name": "test", "reference": "v1"})
+				request.Header.Add("Content-Type", ispec.MediaTypeImageManifest)
+				response := httptest.NewRecorder()
+
+				rthdlr.UpdateManifest(response, request)
+
+				So(response.Code, ShouldEqual, http.StatusRequestEntityTooLarge)
+
+				var errList apiErr.ErrorList
+				err := json.NewDecoder(response.Body).Decode(&errList)
+				So(err, ShouldBeNil)
+				So(errList.Errors, ShouldHaveLength, 1)
+				So(errList.Errors[0].Code, ShouldEqual, apiErr.MANIFEST_INVALID.String())
+				So(errList.Errors[0].Detail["reason"], ShouldContainSubstring, "exceeds maximum allowed size")
+			})
 			// repo not found
 			statusCode := testUpdateManifest(
 				map[string]string{

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -786,6 +786,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "413": {
+                        "description": "request entity too large",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "414": {
                         "description": "too many tag query parameters",
                         "schema": {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -778,6 +778,12 @@
                             "type": "string"
                         }
                     },
+                    "413": {
+                        "description": "request entity too large",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "414": {
                         "description": "too many tag query parameters",
                         "schema": {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -840,6 +840,10 @@ paths:
           description: not found
           schema:
             type: string
+        "413":
+          description: request entity too large
+          schema:
+            type: string
         "414":
           description: too many tag query parameters
           schema:


### PR DESCRIPTION
Wrap request.Body with http.MaxBytesReader before io.ReadAll in UpdateManifest. Bodies exceeding MaxManifestBodySize (4 MiB) now return HTTP 413 with a MANIFEST_INVALID error body instead of buffering unlimited data into memory.

Add the MaxManifestBodySize constant and a unit test that sends an oversized body and asserts the 413 status.

Agent-Logs-Url: https://github.com/project-zot/zot/sessions/5eca86eb-9749-4cf8-9fb8-7b9ace2ba87f

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
