### PR TITLE
fix(security): limit API key creation body to 4 KiB (INPUT-2)

### DIFF
--- a/pkg/api/constants/consts.go
+++ b/pkg/api/constants/consts.go
@@ -22,7 +22,9 @@ const (
 	MaxManifestDigestQueryTags = (8192 - 2048) / (len("tag=") + 128 + 1)
 	// MaxManifestBodySize is the maximum number of bytes accepted for a manifest PUT request body.
 	// OCI manifest JSON is always small metadata; 4 MiB is well above any realistic manifest.
-	MaxManifestBodySize          = 4 * 1024 * 1024
+	MaxManifestBodySize = 4 * 1024 * 1024
+	// MaxAPIKeyBodySize is the maximum number of bytes accepted for an API-key creation request body.
+	MaxAPIKeyBodySize            = 4 * 1024
 	BlobUploadUUID               = "Blob-Upload-UUID"
 	DefaultMediaType             = "application/json"
 	BinaryMediaType              = "application/octet-stream"

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -2342,15 +2342,21 @@ func (rh *RouteHandler) GetAPIKeys(resp http.ResponseWriter, req *http.Request) 
 // @Success 201 {string} string "created"
 // @Failure 400 {string} string "bad request"
 // @Failure 401 {string} string "unauthorized"
+// @Failure 413 {string} string "request entity too large"
 // @Failure 500 {string} string "internal server error"
 // @Router  /zot/auth/apikey  [post].
 func (rh *RouteHandler) CreateAPIKey(resp http.ResponseWriter, req *http.Request) {
 	var payload APIKeyPayload
 
-	body, err := io.ReadAll(req.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(resp, req.Body, constants.MaxAPIKeyBodySize))
 	if err != nil {
-		rh.c.Log.Error().Msg("failed to read request body")
-		resp.WriteHeader(http.StatusInternalServerError)
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			resp.WriteHeader(http.StatusRequestEntityTooLarge)
+		} else {
+			rh.c.Log.Error().Msg("failed to read request body")
+			resp.WriteHeader(http.StatusInternalServerError)
+		}
 
 		return
 	}

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -1604,6 +1604,22 @@ func TestRoutes(t *testing.T) {
 				So(resp.StatusCode, ShouldEqual, http.StatusInternalServerError)
 			})
 
+			Convey("CreateAPIKey body exceeds MaxAPIKeyBodySize returns 413", func() {
+				userAc := reqCtx.NewUserAccessControl()
+				userAc.SetUsername("test")
+				ctx := userAc.DeriveContext(context.Background())
+
+				oversized := make([]byte, constants.MaxAPIKeyBodySize+1)
+				request, _ := http.NewRequestWithContext(ctx, http.MethodPost, baseURL, bytes.NewReader(oversized))
+				response := httptest.NewRecorder()
+
+				rthdlr.CreateAPIKey(response, request)
+
+				resp := response.Result()
+				defer resp.Body.Close()
+				So(resp.StatusCode, ShouldEqual, http.StatusRequestEntityTooLarge)
+			})
+
 			Convey("CreateAPIKey bad request body", func() {
 				userAc := reqCtx.NewUserAccessControl()
 				userAc.SetUsername("test")

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -1099,6 +1099,12 @@ const docTemplate = `{
                             "type": "string"
                         }
                     },
+                    "413": {
+                        "description": "request entity too large",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "internal server error",
                         "schema": {

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1091,6 +1091,12 @@
                             "type": "string"
                         }
                     },
+                    "413": {
+                        "description": "request entity too large",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "500": {
                         "description": "internal server error",
                         "schema": {

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -1004,6 +1004,10 @@ paths:
           description: unauthorized
           schema:
             type: string
+        "413":
+          description: request entity too large
+          schema:
+            type: string
         "500":
           description: internal server error
           schema:


### PR DESCRIPTION
Wrap req.Body with http.MaxBytesReader before io.ReadAll in CreateAPIKey. Requests with bodies larger than MaxAPIKeyBodySize (4 KiB) now return HTTP 413 instead of buffering arbitrary data.

Add the MaxAPIKeyBodySize constant, update the Swagger @Failure annotation to document 413, and add a unit test.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
