### PR TITLE
security: suppress Allow-Credentials on wildcard CORS origin (CORS-1)

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -248,9 +248,12 @@ func getUIHeadersHandler(config *config.Config, allowedMethods ...string) func(h
 			response.Header().Set("Access-Control-Allow-Headers",
 				"Authorization,content-type,"+constants.SessionClientHeaderName)
 
-			// Get auth config safely
+			// Access-Control-Allow-Credentials must not be "true" when
+			// Access-Control-Allow-Origin is the wildcard "*" (CORS spec §3.2).
+			// Only advertise credentials support when an explicit origin is set.
 			authConfig := config.CopyAuthConfig()
-			if authConfig.IsBasicAuthnEnabled() {
+			allowOrigin := strings.TrimSpace(config.GetAllowOrigin())
+			if authConfig.IsBasicAuthnEnabled() && allowOrigin != "" && allowOrigin != "*" {
 				response.Header().Set("Access-Control-Allow-Credentials", "true")
 			}
 
@@ -517,7 +520,8 @@ type ExtensionList struct {
 func (rh *RouteHandler) GetManifest(response http.ResponseWriter, request *http.Request) {
 	// Get auth config safely
 	authConfig := rh.c.Config.CopyAuthConfig()
-	if authConfig.IsBasicAuthnEnabled() {
+	allowOrigin := strings.TrimSpace(rh.c.Config.GetAllowOrigin())
+	if authConfig.IsBasicAuthnEnabled() && allowOrigin != "" && allowOrigin != "*" {
 		response.Header().Set("Access-Control-Allow-Credentials", "true")
 	}
 

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -241,6 +241,38 @@ func TestRoutes(t *testing.T) {
 
 			defer resp.Body.Close()
 			So(resp, ShouldNotBeNil)
+			So(resp.Header.Get("Access-Control-Allow-Credentials"), ShouldEqual, "")
+			So(resp.StatusCode, ShouldEqual, http.StatusNotFound)
+		})
+
+		Convey("Get manifest with explicit AllowOrigin emits credentials header", func() {
+			ctlr.StoreController.DefaultStore = &mocks.MockedImageStore{
+				GetImageManifestFn: func(repo string, reference string) ([]byte, godigest.Digest, string, error) {
+					return []byte{}, "", "", zerr.ErrRepoBadVersion
+				},
+			}
+
+			originalAllowOrigin := ctlr.Config.HTTP.AllowOrigin
+			ctlr.Config.HTTP.AllowOrigin = "https://example.com"
+
+			defer func() {
+				ctlr.Config.HTTP.AllowOrigin = originalAllowOrigin
+			}()
+
+			request, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, baseURL, nil)
+			request = mux.SetURLVars(request, map[string]string{
+				"name":      "test",
+				"reference": "b8b1231908844a55c251211c7a67ae3c809fb86a081a8eeb4a715e6d7d65625c",
+			})
+			response := httptest.NewRecorder()
+
+			rthdlr.GetManifest(response, request)
+
+			resp := response.Result()
+
+			defer resp.Body.Close()
+			So(resp, ShouldNotBeNil)
+			So(resp.Header.Get("Access-Control-Allow-Credentials"), ShouldEqual, "true")
 			So(resp.StatusCode, ShouldEqual, http.StatusNotFound)
 		})
 

--- a/pkg/common/http_server.go
+++ b/pkg/common/http_server.go
@@ -38,9 +38,12 @@ func ACHeadersMiddleware(config *config.Config, allowedMethods ...string) mux.Mi
 			resp.Header().Set("Access-Control-Allow-Methods", allowedMethodsValue)
 			resp.Header().Set("Access-Control-Allow-Headers", "Authorization,content-type,"+constants.SessionClientHeaderName)
 
-			// Get auth config safely
+			// Access-Control-Allow-Credentials must not be "true" when
+			// Access-Control-Allow-Origin is the wildcard "*" (CORS spec §3.2).
+			// Only advertise credentials support when an explicit origin is set.
 			authConfig := config.CopyAuthConfig()
-			if authConfig.IsBasicAuthnEnabled() {
+			allowOrigin := strings.TrimSpace(config.GetAllowOrigin())
+			if authConfig.IsBasicAuthnEnabled() && allowOrigin != "" && allowOrigin != "*" {
 				resp.Header().Set("Access-Control-Allow-Credentials", "true")
 			}
 


### PR DESCRIPTION
Per CORS spec §3.2, Access-Control-Allow-Credentials must not be "true" when Access-Control-Allow-Origin is the wildcard "*".

ACHeadersMiddleware (pkg/common/http_server.go) and getUIHeadersHandler (pkg/api/routes.go) now only emit the credentials header when an explicit, non-empty AllowOrigin is configured.  Deployments that leave AllowOrigin blank (default wildcard) no longer produce a contradictory header pair.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
