### PR TITLE
fix(api): recognize Docker Compose/Buildx User-Agent in v2 challenge workaround

### DIFF
--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -416,7 +416,12 @@ func (amw *AuthnMiddleware) tryAuthnHandlers(ctlr *Controller) mux.MiddlewareFun
 
 			isMgmtRequested := request.RequestURI == constants.FullMgmt
 			isV2Requested := strings.TrimSuffix(request.URL.Path, "/") == constants.RoutePrefix
-			isDockerClient := strings.Contains(request.Header.Get("User-Agent"), "Docker-Client")
+			// Match Docker daemon-proxied requests regardless of the upstream client tool.
+			// The Docker daemon always prefixes its UA with "docker/<version>" when proxying,
+			// while the upstream tool (docker CLI, compose, buildx, etc.) appears inside
+			// "UpstreamClient(...)". Direct Docker CLI requests use "Docker-Client/...".
+			ua := request.Header.Get("User-Agent")
+			isDockerClient := strings.Contains(ua, "Docker-Client") || strings.HasPrefix(ua, "docker/")
 
 			// Get auth config safely
 			authConfig := ctlr.Config.CopyAuthConfig()

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -14261,6 +14261,36 @@ func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 			So(resp, ShouldNotBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 
+			// Docker Compose client without credentials should get 401
+			// (daemon-proxied with compose upstream client, UA starts with "docker/")
+			composeUA := "docker/29.4.0 go/go1.24.2 UpstreamClient(compose/v5.1.2)"
+			resp, err = resty.R().
+				SetHeader("User-Agent", composeUA).
+				Get(baseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+			So(resp.Header().Get("WWW-Authenticate"), ShouldContainSubstring, "Basic realm=")
+
+			// Docker Compose client with valid credentials should get 200
+			resp, err = resty.R().
+				SetHeader("User-Agent", composeUA).
+				SetBasicAuth(htpasswdUsername, htpasswdPassword).
+				Get(baseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			// Docker Buildx client without credentials should get 401
+			// (daemon-proxied with buildx upstream client)
+			resp, err = resty.R().
+				SetHeader("User-Agent", "docker/29.4.0 go/go1.24.2 UpstreamClient(buildx/v0.21.2)").
+				Get(baseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+			So(resp.Header().Get("WWW-Authenticate"), ShouldContainSubstring, "Basic realm=")
+
 			// Podman client without credentials should get 200 (unaffected by workaround)
 			resp, err = resty.R().
 				SetHeader("User-Agent", "containers/5.33.0 (github.com/containers/image)").
@@ -14305,6 +14335,14 @@ func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 			// Docker client without credentials should get 200 (no mixed policies)
 			resp, err := resty.R().
 				SetHeader("User-Agent", "docker/26.1.3 go/go1.22.2 UpstreamClient(Docker-Client/26.1.3 (linux))").
+				Get(baseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			// Docker Compose client without credentials should get 200 (no mixed policies)
+			resp, err = resty.R().
+				SetHeader("User-Agent", "docker/29.4.0 go/go1.24.2 UpstreamClient(compose/v5.1.2)").
 				Get(baseURL + "/v2/")
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

Fixes #3991

**What does this PR do / Why do we need it**:

PR #3868 introduced a workaround that issues a 401 WWW-Authenticate challenge for Docker Client requests on registries with mixed anonymous/authenticated access policies. However, the check only matched the `Docker-Client/<version>` User-Agent string sent by direct `docker pull` commands.

When Docker Compose or Buildx proxy through the Docker daemon, the daemon sends a User-Agent starting with `docker/<version>` (e.g., `docker/29.4.0 go/go1.24.2 UpstreamClient(compose/v5.1.2)`), which did not match the existing check. This caused compose/buildx pulls to skip the 401 challenge, resulting in `unauthorized` errors on registries where some repos require auth and others allow anonymous access.

This PR adds `strings.HasPrefix(ua, "docker/")` alongside the existing `strings.Contains(ua, "Docker-Client")` check, so daemon-proxied requests from any upstream tool (compose, buildx, etc.) are handled correctly.

**Testing done on this change**:

Added 4 new test cases to `TestDockerClientV2ChallengeWorkaround`:
1. Docker Compose UA without credentials on mixed-policy registry → 401 with `WWW-Authenticate: Basic realm=`
2. Docker Compose UA with valid credentials on mixed-policy registry → 200
3. Docker Buildx UA without credentials on mixed-policy registry → 401 with `WWW-Authenticate: Basic realm=`
4. Docker Compose UA without credentials on anonymous-only registry → 200

```
=== RUN   TestDockerClientV2ChallengeWorkaround
--- PASS: TestDockerClientV2ChallengeWorkaround (3.63s)
PASS
```

**Automation added to e2e**:

Unit tests added to `pkg/api/controller_test.go` covering the new UA patterns. No new e2e integration test required — the existing `TestDockerClientV2ChallengeWorkaround` test function covers the full scenario.

**Will this break upgrades or downgrades?**

No. This is a strictly additive change to the User-Agent matching logic. Existing Docker Client behavior is unchanged.

**Does this PR introduce any user-facing change?**:

Yes — Docker Compose and Buildx pulls now work correctly on registries with mixed anonymous/authenticated access policies.

```release-note
fix(api): Docker Compose and Buildx pulls no longer fail with 'unauthorized' on registries with mixed anonymous/authenticated access policies. The v2 challenge workaround now recognizes the `docker/<version>` User-Agent prefix used by the Docker daemon when proxying requests from compose, buildx, and other upstream tools.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.