### PR TITLE
feat(cli): support default zli config

### DIFF
--- a/pkg/cli/client/config_cmd.go
+++ b/pkg/cli/client/config_cmd.go
@@ -28,6 +28,8 @@ func NewConfigCommand() *cobra.Command {
 
 	var isReset bool
 
+	var isSetDefault bool
+
 	configCmd := &cobra.Command{
 		Use:     "config <config-name> [variable] [value]",
 		Example: examples,
@@ -42,8 +44,16 @@ func NewConfigCommand() *cobra.Command {
 
 			configPath := path.Join(home, "/.zot")
 
+			if isSetDefault && (isListing || isReset) {
+				return zerr.ErrInvalidArgs
+			}
+
 			switch len(args) {
 			case noArgs:
+				if isSetDefault {
+					return zerr.ErrInvalidArgs
+				}
+
 				if isListing { // zot config -l
 					res, err := getConfigNames(configPath)
 					if err != nil {
@@ -57,6 +67,10 @@ func NewConfigCommand() *cobra.Command {
 
 				return zerr.ErrInvalidArgs
 			case oneArg:
+				if isSetDefault { // zot config <name> --set-default
+					return setDefaultConfig(configPath, args[0])
+				}
+
 				// zot config <name> -l
 				if isListing {
 					res, err := getAllConfig(configPath, args[0])
@@ -71,6 +85,10 @@ func NewConfigCommand() *cobra.Command {
 
 				return zerr.ErrInvalidArgs
 			case twoArgs:
+				if isSetDefault {
+					return zerr.ErrInvalidArgs
+				}
+
 				if isReset { // zot config <name> <key> --reset
 					return resetConfigValue(configPath, args[0], args[1])
 				}
@@ -81,6 +99,10 @@ func NewConfigCommand() *cobra.Command {
 				}
 				fmt.Fprintln(cmd.OutOrStdout(), res)
 			case threeArgs:
+				if isSetDefault {
+					return zerr.ErrInvalidArgs
+				}
+
 				// zot config <name> <key> <value>
 				if err := setConfigValue(configPath, args[0], args[1], args[2]); err != nil {
 					return err
@@ -96,6 +118,7 @@ func NewConfigCommand() *cobra.Command {
 
 	configCmd.Flags().BoolVarP(&isListing, "list", "l", false, "List configurations")
 	configCmd.Flags().BoolVar(&isReset, "reset", false, "Reset a variable value")
+	configCmd.Flags().BoolVar(&isSetDefault, setDefaultFlag, false, "Set configuration as default")
 	configCmd.SetUsageTemplate(configCmd.UsageTemplate() + supportedOptions)
 	configCmd.AddCommand(NewConfigAddCommand())
 	configCmd.AddCommand(NewConfigRemoveCommand())
@@ -313,6 +336,95 @@ func addDefaultConfigs(config map[string]any) {
 	}
 }
 
+func setDefaultConfig(configPath, configName string) error {
+	return updateDefaultConfig(configPath, configName, true)
+}
+
+func unsetDefaultConfig(configPath, configName string) error {
+	return updateDefaultConfig(configPath, configName, false)
+}
+
+func updateDefaultConfig(configPath, configName string, isDefault bool) error {
+	configs, err := getConfigMapFromFile(configPath)
+	if err != nil {
+		if errors.Is(err, zerr.ErrEmptyJSON) {
+			return zerr.ErrConfigNotFound
+		}
+
+		return err
+	}
+
+	found := false
+
+	for _, val := range configs {
+		configMap, ok := val.(map[string]any)
+		if !ok {
+			return zerr.ErrBadConfig
+		}
+
+		if configMap[nameKey] == configName {
+			if isDefault {
+				configMap[defaultConfigKey] = true
+			} else {
+				delete(configMap, defaultConfigKey)
+			}
+
+			found = true
+
+			continue
+		}
+
+		if isDefault {
+			delete(configMap, defaultConfigKey)
+		}
+	}
+
+	if !found {
+		return zerr.ErrConfigNotFound
+	}
+
+	return saveConfigMapToFile(configPath, configs)
+}
+
+func getDefaultConfigName(configPath string) (string, error) {
+	configs, err := getConfigMapFromFile(configPath)
+	if err != nil {
+		if errors.Is(err, zerr.ErrEmptyJSON) {
+			return "", zerr.ErrConfigNotFound
+		}
+
+		return "", err
+	}
+
+	for _, val := range configs {
+		configMap, ok := val.(map[string]any)
+		if !ok {
+			return "", zerr.ErrBadConfig
+		}
+
+		defaultValue, ok := configMap[defaultConfigKey]
+		if !ok {
+			continue
+		}
+
+		isDefault, err := strconv.ParseBool(fmt.Sprintf("%v", defaultValue))
+		if err != nil {
+			return "", err
+		}
+
+		if isDefault {
+			configName, ok := configMap[nameKey].(string)
+			if !ok || configName == "" {
+				return "", zerr.ErrBadConfig
+			}
+
+			return configName, nil
+		}
+	}
+
+	return "", zerr.ErrConfigNotFound
+}
+
 func getConfigValue(configPath, configName, key string) (string, error) {
 	configs, err := getConfigMapFromFile(configPath)
 	if err != nil {
@@ -347,6 +459,10 @@ func getConfigValue(configPath, configName, key string) (string, error) {
 func resetConfigValue(configPath, configName, key string) error {
 	if key == "url" || key == nameKey {
 		return zerr.ErrCannotResetConfigKey
+	}
+
+	if key == defaultConfigKey {
+		return unsetDefaultConfig(configPath, configName)
 	}
 
 	configs, err := getConfigMapFromFile(configPath)
@@ -385,6 +501,19 @@ func resetConfigValue(configPath, configName, key string) error {
 func setConfigValue(configPath, configName, key, value string) error {
 	if key == nameKey {
 		return zerr.ErrIllegalConfigKey
+	}
+
+	if key == defaultConfigKey {
+		isDefault, err := strconv.ParseBool(value)
+		if err != nil {
+			return err
+		}
+
+		if isDefault {
+			return setDefaultConfig(configPath, configName)
+		}
+
+		return unsetDefaultConfig(configPath, configName)
 	}
 
 	configs, err := getConfigMapFromFile(configPath)
@@ -478,6 +607,7 @@ const (
   zli config --list
   zli config main url
   zli config main --list
+  zli config main --set-default
   zli config remove main`
 
 	supportedOptions = `
@@ -485,6 +615,7 @@ Useful variables:
   url		zot server URL
   showspinner	show spinner while loading data [true/false]
   verify-tls	enable TLS certificate verification of the server [default: true]
+  default		mark configuration as default [true/false]
 `
 
 	nameKey = "_name"
@@ -496,4 +627,6 @@ Useful variables:
 
 	showspinnerConfig = "showspinner"
 	verifyTLSConfig   = "verify-tls"
+	defaultConfigKey  = "default"
+	setDefaultFlag    = "set-default"
 )

--- a/pkg/cli/client/config_cmd_test.go
+++ b/pkg/cli/client/config_cmd_test.go
@@ -4,6 +4,7 @@ package client_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"log"
 	"os"
 	"regexp"
@@ -310,6 +311,129 @@ func TestConfigCmdMain(t *testing.T) {
 
 			So(strings.TrimSpace(buff.String()), ShouldEqual, "")
 		})
+	})
+
+	Convey("Test set default config", t, func() {
+		args := []string{"configtest2", "--set-default"}
+
+		configPath := makeConfigFile(t, `{"configs":[
+			{"_name":"configtest1","url":"https://test-url1.com","default":true},
+			{"_name":"configtest2","url":"https://test-url2.com","showspinner":false}
+		]}`)
+
+		cmd := client.NewConfigCommand()
+		buff := bytes.NewBufferString("")
+		cmd.SetOut(buff)
+		cmd.SetErr(buff)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		So(err, ShouldBeNil)
+
+		actual, err := os.ReadFile(configPath)
+		So(err, ShouldBeNil)
+
+		var configFile map[string][]map[string]any
+
+		err = json.Unmarshal(actual, &configFile)
+		So(err, ShouldBeNil)
+		So(configFile["configs"][0]["default"], ShouldBeNil)
+		So(configFile["configs"][1]["default"], ShouldEqual, true)
+		So(buff.String(), ShouldEqual, "")
+	})
+
+	Convey("Test set default config variable", t, func() {
+		args := []string{"configtest2", "default", "true"}
+
+		configPath := makeConfigFile(t, `{"configs":[
+			{"_name":"configtest1","url":"https://test-url1.com","default":true},
+			{"_name":"configtest2","url":"https://test-url2.com"}
+		]}`)
+
+		cmd := client.NewConfigCommand()
+		buff := bytes.NewBufferString("")
+		cmd.SetOut(buff)
+		cmd.SetErr(buff)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		So(err, ShouldBeNil)
+
+		actual, err := os.ReadFile(configPath)
+		So(err, ShouldBeNil)
+
+		var configFile map[string][]map[string]any
+
+		err = json.Unmarshal(actual, &configFile)
+		So(err, ShouldBeNil)
+		So(configFile["configs"][0]["default"], ShouldBeNil)
+		So(configFile["configs"][1]["default"], ShouldEqual, true)
+		So(buff.String(), ShouldEqual, "")
+	})
+
+	Convey("Test reset default config variable", t, func() {
+		args := []string{"configtest", "default", "--reset"}
+
+		configPath := makeConfigFile(t,
+			`{"configs":[{"_name":"configtest","url":"https://test-url.com","default":true}]}`)
+
+		cmd := client.NewConfigCommand()
+		buff := bytes.NewBufferString("")
+		cmd.SetOut(buff)
+		cmd.SetErr(buff)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		So(err, ShouldBeNil)
+
+		actual, err := os.ReadFile(configPath)
+		So(err, ShouldBeNil)
+
+		var configFile map[string][]map[string]any
+
+		err = json.Unmarshal(actual, &configFile)
+		So(err, ShouldBeNil)
+		So(configFile["configs"][0]["default"], ShouldBeNil)
+		So(buff.String(), ShouldEqual, "")
+	})
+
+	Convey("Test set default missing config", t, func() {
+		args := []string{"missing", "--set-default"}
+
+		_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com"}]}`)
+
+		cmd := client.NewConfigCommand()
+		buff := bytes.NewBufferString("")
+		cmd.SetOut(buff)
+		cmd.SetErr(buff)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		So(err, ShouldNotBeNil)
+		So(buff.String(), ShouldContainSubstring, "does not exist")
+	})
+
+	Convey("Test set default rejects conflicting flags", t, func() {
+		args := []string{"configtest2", "--set-default", "--list"}
+
+		configPath := makeConfigFile(t, `{"configs":[
+			{"_name":"configtest1","url":"https://test-url1.com","default":true},
+			{"_name":"configtest2","url":"https://test-url2.com"}
+		]}`)
+
+		cmd := client.NewConfigCommand()
+		buff := bytes.NewBufferString("")
+		cmd.SetOut(buff)
+		cmd.SetErr(buff)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		So(err, ShouldEqual, zerr.ErrInvalidArgs)
+
+		actual, err := os.ReadFile(configPath)
+		So(err, ShouldBeNil)
+
+		var configFile map[string][]map[string]any
+
+		err = json.Unmarshal(actual, &configFile)
+		So(err, ShouldBeNil)
+		So(configFile["configs"][0]["default"], ShouldEqual, true)
+		So(configFile["configs"][1]["default"], ShouldBeNil)
 	})
 
 	Convey("Test fetch a config", t, func() {

--- a/pkg/cli/client/search_functions_internal_test.go
+++ b/pkg/cli/client/search_functions_internal_test.go
@@ -955,6 +955,27 @@ func TestUtils(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(isSpinner, ShouldBeFalse)
 		So(verifyTLS, ShouldBeFalse)
+
+		// default config
+		_ = makeConfigFile(t,
+			`{"configs":[{"_name":"imagetest","url":"https://test-url.com",`+
+				`"showspinner":false,"verify-tls":true,"default":true}]}`)
+		cmd = &cobra.Command{}
+		cmd.Flags().String(URLFlag, "", "")
+		cmd.Flags().String(ConfigFlag, "", "")
+		isSpinner, verifyTLS, err = GetCliConfigOptions(cmd)
+		So(err, ShouldBeNil)
+		So(isSpinner, ShouldBeFalse)
+		So(verifyTLS, ShouldBeTrue)
+
+		// explicit url skips default config options
+		cmd = &cobra.Command{}
+		cmd.Flags().String(URLFlag, "https://override-url.com", "")
+		cmd.Flags().String(ConfigFlag, "", "")
+		isSpinner, verifyTLS, err = GetCliConfigOptions(cmd)
+		So(err, ShouldBeNil)
+		So(isSpinner, ShouldBeFalse)
+		So(verifyTLS, ShouldBeFalse)
 	})
 
 	Convey("GetServerURLFromFlags", t, func() {
@@ -985,6 +1006,34 @@ func TestUtils(t *testing.T) {
 		url, err = GetServerURLFromFlags(cmd)
 		So(url, ShouldResemble, "")
 		So(err, ShouldNotBeNil)
+
+		// default config
+		_ = makeConfigFile(t,
+			`{"configs":[{"_name":"imagetest","url":"https://test-url.com",`+
+				`"showspinner":false,"verify-tls":true,"default":true}]}`)
+		cmd = &cobra.Command{}
+		cmd.Flags().String(URLFlag, "", "")
+		cmd.Flags().String(ConfigFlag, "", "")
+		url, err = GetServerURLFromFlags(cmd)
+		So(url, ShouldResemble, "https://test-url.com")
+		So(err, ShouldBeNil)
+
+		// bad default config entry
+		_ = makeConfigFile(t, `{"configs":[{"url":"https://test-url.com","default":true}]}`)
+		cmd = &cobra.Command{}
+		cmd.Flags().String(URLFlag, "", "")
+		cmd.Flags().String(ConfigFlag, "", "")
+		url, err = GetServerURLFromFlags(cmd)
+		So(url, ShouldResemble, "")
+		So(err, ShouldEqual, zerr.ErrBadConfig)
+
+		// explicit url takes precedence over default config
+		cmd = &cobra.Command{}
+		cmd.Flags().String(URLFlag, "https://override-url.com", "")
+		cmd.Flags().String(ConfigFlag, "", "")
+		url, err = GetServerURLFromFlags(cmd)
+		So(url, ShouldResemble, "https://override-url.com")
+		So(err, ShouldBeNil)
 	})
 
 	Convey("CheckExtEndPointQuery", t, func() {

--- a/pkg/cli/client/utils.go
+++ b/pkg/cli/client/utils.go
@@ -4,6 +4,7 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -443,8 +444,12 @@ func defaultIfError[T any](out T, err error) T {
 }
 
 func GetCliConfigOptions(cmd *cobra.Command) (bool, bool, error) {
-	configName, err := cmd.Flags().GetString(ConfigFlag)
+	configName, err := getConfigNameFromFlags(cmd)
 	if err != nil {
+		if errors.Is(err, zerr.ErrConfigNotFound) {
+			return false, false, nil
+		}
+
 		return false, false, err
 	}
 
@@ -478,13 +483,21 @@ func GetServerURLFromFlags(cmd *cobra.Command) (string, error) {
 		return serverURL, nil
 	}
 
-	configName, err := cmd.Flags().GetString(ConfigFlag)
+	configName, err := getConfigNameFromFlags(cmd)
 	if err != nil {
+		if errors.Is(err, zerr.ErrConfigNotFound) {
+			return "", fmt.Errorf(
+				"%w: specify either '--%s' or '--%s' flags, or set a default config with 'zli config <config-name> --%s'",
+				zerr.ErrNoURLProvided, URLFlag, ConfigFlag, setDefaultFlag)
+		}
+
 		return "", err
 	}
 
 	if configName == "" {
-		return "", fmt.Errorf("%w: specify either '--%s' or '--%s' flags", zerr.ErrNoURLProvided, URLFlag, ConfigFlag)
+		return "", fmt.Errorf(
+			"%w: specify either '--%s' or '--%s' flags, or set a default config with 'zli config <config-name> --%s'",
+			zerr.ErrNoURLProvided, URLFlag, ConfigFlag, setDefaultFlag)
 	}
 
 	serverURL, err = ReadServerURLFromConfig(configName)
@@ -501,6 +514,35 @@ func GetServerURLFromFlags(cmd *cobra.Command) (string, error) {
 	}
 
 	return serverURL, nil
+}
+
+func getConfigNameFromFlags(cmd *cobra.Command) (string, error) {
+	configName, err := cmd.Flags().GetString(ConfigFlag)
+	if err != nil {
+		return "", err
+	}
+
+	if configName != "" {
+		return configName, nil
+	}
+
+	serverURL, err := cmd.Flags().GetString(URLFlag)
+	if err == nil && serverURL != "" {
+		return "", nil
+	}
+
+	return ReadDefaultConfigName()
+}
+
+func ReadDefaultConfigName() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	configDir := path.Join(home, "/.zot")
+
+	return getDefaultConfigName(configDir)
 }
 
 func ReadServerURLFromConfig(configName string) (string, error) {


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:

Fixes #129

**What does this PR do / Why do we need it**:

Adds support for marking a saved zli config as the default so commands can omit `--config` when neither `--url` nor `--config` is provided.

This adds `zli config <config-name> --set-default`, keeps the `default` config key single-default aware, and reuses the default config for URL, spinner, and TLS settings. Explicit `--url` still takes precedence and does not read options from the default config.

**If an issue # is not available please add repro steps and logs showing the issue**:

N/A

**Testing done on this change**:

- `GOEXPERIMENT=jsonv2 go test -tags search ./pkg/cli/client -run 'TestConfigCmdMain|TestUtils'`
- `GOEXPERIMENT=jsonv2 go test -tags search ./pkg/cli/client -run 'TestConfigCmdBasics|TestConfigCmdMain|TestUtils|TestCVECommandErrors|TestServerStatusCommandErrors|TestSearchCLIErrors|TestReferrersCLIErrors'`
- `git diff --check`

I also ran `GOEXPERIMENT=jsonv2 go test -json -tags search ./pkg/cli/client`; it fails locally because the checkout is missing `test/data/alpine/blobs/sha256/f56be85fc22e46face30e2c3de3f7fe7c15f8fd7c4e5add29d7f64b87abdaa09`. The failing tests are `TestImagesCommandGQL`, `TestImageCommandREST`, and `TestNegativeServerResponse`.

**Automation added to e2e**:

No. Focused CLI unit coverage was added for the default config behavior.

**Will this break upgrades or downgrades?**

No.

**Does this PR introduce any user-facing change?**:

Yes.

```release-note
zli can now use a saved default registry configuration when --config is omitted. Mark one with `zli config <config-name> --set-default`.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
