### PR TITLE
feat(storage): support DynamoDB table prefix

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1004,15 +1004,19 @@ To set up a zot with dedupe enabled and dynamodb as a cache driver, "cacheDriver
         "cacheDriver": {
             "name": "dynamodb",  // driver name
             "endpoint": "http://localhost:4566", // aws endpoint
-            "region": "us-east-2" // aws region
-            "cacheTablename": "ZotBlobTable" // table used to store deduped blobs
+            "region": "us-east-2", // aws region
+            "tablenamePrefix": "Zot" // table name prefix
 
         }
     },
 ```
 Like s3 configuration AWS GO SDK will load additional config and credentials values from the environment variables, shared credentials, and shared configuration files
 
-Additionally if search extension is enabled, additional parameters are needed:
+With the `tablenamePrefix` value above, zot uses `ZotBlobTable` for dedupe cache data. When auth or the search
+extension is enabled, zot also uses `ZotUserDataTable`, `ZotApiKeyDataTable`, `ZotRepoMetadataTable`,
+`ZotImageMetaTable`, `ZotRepoBlobsInfoTable`, and `ZotVersionTable`.
+
+Individual table names can still be configured for backward compatibility or to override a derived name:
 
 ```
         "cacheDriver": {
@@ -1032,7 +1036,8 @@ Additionally if search extension is enabled, additional parameters are needed:
 ```
 
 ### DynamoDB permission scopes
-The following AWS policy is required by zot for caching blobs. Make sure to replace DYNAMODB_TABLE with the name of your table which in our case is the value of "cacheTablename" (ZotBlobTable)
+The following AWS policy is required by zot for caching blobs. Make sure to replace DYNAMODB_TABLE with the name of
+your table. When `tablenamePrefix` is used, this includes the generated table names described above.
 
 {
   "Version": "2012-10-17",
@@ -1189,4 +1194,3 @@ To set those options explicitly (for example to mirror standalone Trivy’s `--v
 - [config-cve-trivy.json](config-cve-trivy.json) — shows optional `dbRepository`, `javaDBRepository`, and `vulnSeveritySources`.
 
 `vulnSeveritySources` is a list of source names in priority order (for example `auto`, `nvd`, or vendor IDs such as `redhat`, `alpine`). If omitted, zot defaults it to `["auto"]`, consistent with the Trivy CLI. See [Trivy: severity selection](https://trivy.dev/docs/latest/scanner/vulnerability/#severity-selection).
-

--- a/examples/config-dynamodb.json
+++ b/examples/config-dynamodb.json
@@ -18,13 +18,7 @@
             "name": "dynamodb",
             "endpoint": "http://localhost:4566",
             "region": "us-east-2",
-            "cacheTablename": "ZotBlobTable",
-            "repoMetaTablename": "ZotRepoMetadataTable",
-            "imageMetaTablename": "ZotImageMetaTable",
-            "repoBlobsInfoTablename": "ZotRepoBlobsInfoTable",
-            "userDataTablename": "ZotUserDataTable",
-            "apiKeyTablename": "ZotApiKeyTable",
-            "versionTablename": "ZotVersion"
+            "tablenamePrefix": "Zot"
         }
     },
     "http": {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2,6 +2,7 @@ package meta
 
 import (
 	"fmt"
+	"strings"
 
 	"zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/api/config"
@@ -69,22 +70,32 @@ func getDynamoParams(cacheDriverConfig map[string]any, log log.Logger) mdynamodb
 	region, ok := toStringIfOk(cacheDriverConfig, "region", "", log)
 	allParametersOk = allParametersOk && ok
 
-	repoMetaTablename, ok := toStringIfOk(cacheDriverConfig, "repometatablename", "", log)
+	tablenamePrefix, hasTablenamePrefix, ok := optionalStringIfOk(
+		cacheDriverConfig, sconstants.DynamoDBTableNamePrefix, log)
 	allParametersOk = allParametersOk && ok
 
-	repoBlobsInfoTablename, ok := toStringIfOk(cacheDriverConfig, "repoblobsinfotablename", "", log)
+	repoMetaTablename, ok := tableNameIfOk(cacheDriverConfig, sconstants.DynamoDBRepoMetaTable,
+		sconstants.DynamoDBRepoMetaSuffix, tablenamePrefix, hasTablenamePrefix, log)
 	allParametersOk = allParametersOk && ok
 
-	imageMetaTablename, ok := toStringIfOk(cacheDriverConfig, "imagemetatablename", "", log)
+	repoBlobsInfoTablename, ok := tableNameIfOk(cacheDriverConfig, sconstants.DynamoDBRepoBlobsTable,
+		sconstants.DynamoDBRepoBlobsSuffix, tablenamePrefix, hasTablenamePrefix, log)
 	allParametersOk = allParametersOk && ok
 
-	apiKeyTablename, ok := toStringIfOk(cacheDriverConfig, "apikeytablename", "", log)
+	imageMetaTablename, ok := tableNameIfOk(cacheDriverConfig, sconstants.DynamoDBImageMetaTable,
+		sconstants.DynamoDBImageMetaSuffix, tablenamePrefix, hasTablenamePrefix, log)
 	allParametersOk = allParametersOk && ok
 
-	versionTablename, ok := toStringIfOk(cacheDriverConfig, "versiontablename", "", log)
+	apiKeyTablename, ok := tableNameIfOk(cacheDriverConfig, sconstants.DynamoDBAPIKeyTable,
+		sconstants.DynamoDBAPIKeySuffix, tablenamePrefix, hasTablenamePrefix, log)
 	allParametersOk = allParametersOk && ok
 
-	userDataTablename, ok := toStringIfOk(cacheDriverConfig, "userdatatablename", "", log)
+	versionTablename, ok := tableNameIfOk(cacheDriverConfig, sconstants.DynamoDBVersionTable,
+		sconstants.DynamoDBVersionSuffix, tablenamePrefix, hasTablenamePrefix, log)
+	allParametersOk = allParametersOk && ok
+
+	userDataTablename, ok := tableNameIfOk(cacheDriverConfig, sconstants.DynamoDBUserDataTable,
+		sconstants.DynamoDBUserDataSuffix, tablenamePrefix, hasTablenamePrefix, log)
 	allParametersOk = allParametersOk && ok
 
 	if !allParametersOk {
@@ -114,12 +125,47 @@ func getRedisParams(cacheDriverConfig map[string]any, log log.Logger) redis.DBDr
 	}
 }
 
+func tableNameIfOk(cacheDriverConfig map[string]any,
+	param string,
+	tableSuffix string,
+	tablenamePrefix string,
+	hasTablenamePrefix bool,
+	log log.Logger,
+) (string, bool) {
+	tableName, ok := configValue(cacheDriverConfig, param)
+	if ok {
+		return stringValueIfOk(tableName, param, log)
+	}
+
+	if hasTablenamePrefix {
+		return tablenamePrefix + tableSuffix, true
+	}
+
+	log.Error().Str("field", param).Msg("failed to parse CacheDriver config, field is not present")
+
+	return "", false
+}
+
+func optionalStringIfOk(cacheDriverConfig map[string]any,
+	param string,
+	log log.Logger,
+) (string, bool, bool) {
+	val, ok := configValue(cacheDriverConfig, param)
+	if !ok {
+		return "", false, true
+	}
+
+	str, ok := stringValueIfOk(val, param, log)
+
+	return str, true, ok
+}
+
 func toStringIfOk(cacheDriverConfig map[string]any,
 	param string,
 	defaultVal string,
 	log log.Logger,
 ) (string, bool) {
-	val, ok := cacheDriverConfig[param]
+	val, ok := configValue(cacheDriverConfig, param)
 
 	if !ok && defaultVal != "" {
 		log.Info().Str("field", param).Str("default", defaultVal).
@@ -132,6 +178,10 @@ func toStringIfOk(cacheDriverConfig map[string]any,
 		return "", false
 	}
 
+	return stringValueIfOk(val, param, log)
+}
+
+func stringValueIfOk(val any, param string, log log.Logger) (string, bool) {
 	str, ok := val.(string)
 	if !ok {
 		log.Error().Str("parameter", param).Msg("failed to parse CacheDriver config, parameter isn't a string")
@@ -146,6 +196,20 @@ func toStringIfOk(cacheDriverConfig map[string]any,
 	}
 
 	return str, true
+}
+
+func configValue(cacheDriverConfig map[string]any, key string) (any, bool) {
+	if val, ok := cacheDriverConfig[key]; ok {
+		return val, true
+	}
+
+	for candidate, val := range cacheDriverConfig {
+		if strings.EqualFold(candidate, key) {
+			return val, true
+		}
+	}
+
+	return nil, false
 }
 
 func Close(metadb mTypes.MetaDB) error {

--- a/pkg/meta/meta_internal_test.go
+++ b/pkg/meta/meta_internal_test.go
@@ -1,0 +1,95 @@
+package meta
+
+import (
+	"testing"
+
+	"zotregistry.dev/zot/v2/pkg/log"
+)
+
+func TestGetDynamoParamsWithTableNamePrefix(t *testing.T) {
+	t.Parallel()
+
+	params := getDynamoParams(map[string]any{
+		"endpoint":        "http://localhost:4566",
+		"region":          "us-east-2",
+		"tablenamePrefix": "Zot",
+	}, log.NewTestLogger())
+
+	expectedTables := map[string]string{
+		"RepoMetaTablename":      "ZotRepoMetadataTable",
+		"RepoBlobsInfoTablename": "ZotRepoBlobsInfoTable",
+		"ImageMetaTablename":     "ZotImageMetaTable",
+		"UserDataTablename":      "ZotUserDataTable",
+		"APIKeyTablename":        "ZotApiKeyDataTable",
+		"VersionTablename":       "ZotVersionTable",
+	}
+
+	actualTables := map[string]string{
+		"RepoMetaTablename":      params.RepoMetaTablename,
+		"RepoBlobsInfoTablename": params.RepoBlobsInfoTablename,
+		"ImageMetaTablename":     params.ImageMetaTablename,
+		"UserDataTablename":      params.UserDataTablename,
+		"APIKeyTablename":        params.APIKeyTablename,
+		"VersionTablename":       params.VersionTablename,
+	}
+
+	for table, expected := range expectedTables {
+		if actualTables[table] != expected {
+			t.Fatalf("%s = %q, want %q", table, actualTables[table], expected)
+		}
+	}
+}
+
+func TestGetDynamoParamsPrefersExplicitTableNames(t *testing.T) {
+	t.Parallel()
+
+	params := getDynamoParams(map[string]any{
+		"endpoint":           "http://localhost:4566",
+		"region":             "us-east-2",
+		"tablenamePrefix":    "Zot",
+		"imagemetatablename": "CustomImageMetaTable",
+	}, log.NewTestLogger())
+
+	if params.ImageMetaTablename != "CustomImageMetaTable" {
+		t.Fatalf("ImageMetaTablename = %q, want %q", params.ImageMetaTablename, "CustomImageMetaTable")
+	}
+
+	if params.RepoMetaTablename != "ZotRepoMetadataTable" {
+		t.Fatalf("RepoMetaTablename = %q, want %q", params.RepoMetaTablename, "ZotRepoMetadataTable")
+	}
+}
+
+func TestGetDynamoParamsRejectsInvalidTableNamePrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]any{
+		"empty":     "",
+		"nonString": false,
+	}
+
+	for name, prefix := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			requirePanic(t, func() {
+				getDynamoParams(map[string]any{
+					"endpoint":        "http://localhost:4566",
+					"region":          "us-east-2",
+					"tablenamePrefix": prefix,
+				}, log.NewTestLogger())
+			})
+		})
+	}
+}
+
+func requirePanic(t *testing.T, fn func()) {
+	t.Helper()
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("function did not panic")
+		}
+	}()
+
+	fn()
+}

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"strings"
 
 	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/api/config"
@@ -97,19 +98,67 @@ func getDynamoParams(storageConfig *config.StorageConfig) (cache.DynamoDBDriverP
 	dynamoParams := cache.DynamoDBDriverParameters{}
 	dynamoParams.Endpoint, _ = storageConfig.CacheDriver["endpoint"].(string)
 	dynamoParams.Region, _ = storageConfig.CacheDriver["region"].(string)
-	dynamoParams.TableName, _ = storageConfig.CacheDriver["cachetablename"].(string)
 
-	cachetable, ok := storageConfig.CacheDriver["cachetablename"]
-	if !ok {
-		return dynamoParams, fmt.Errorf("%w: cachetablename key is mandatory for dynamodb cache driver", zerr.ErrBadConfig)
+	tableName, err := getDynamoTableName(
+		storageConfig.CacheDriver,
+		constants.DynamoDBCacheTableName,
+		constants.DynamoDBCacheTableSuffix,
+	)
+	if err != nil {
+		return dynamoParams, err
 	}
 
-	dynamoParams.TableName, ok = cachetable.(string)
-	if !ok {
-		return dynamoParams, fmt.Errorf("%w: failed to cast cachetablename %s to string type", zerr.ErrBadConfig, cachetable)
-	}
+	dynamoParams.TableName = tableName
 
 	return dynamoParams, nil
+}
+
+func getDynamoTableName(cacheDriverConfig map[string]any, tableKey, tableSuffix string) (string, error) {
+	tableName, ok := cacheDriverConfigValue(cacheDriverConfig, tableKey)
+	if !ok {
+		prefix, ok := cacheDriverConfigValue(cacheDriverConfig, constants.DynamoDBTableNamePrefix)
+		if !ok {
+			return "", fmt.Errorf("%w: %s key or %s key is mandatory for dynamodb cache driver",
+				zerr.ErrBadConfig, tableKey, constants.DynamoDBTableNamePrefix)
+		}
+
+		prefixValue, ok := prefix.(string)
+		if !ok {
+			return "", fmt.Errorf("%w: failed to cast %s %s to string type",
+				zerr.ErrBadConfig, constants.DynamoDBTableNamePrefix, prefix)
+		}
+
+		if prefixValue == "" {
+			return "", fmt.Errorf("%w: %s key is empty", zerr.ErrBadConfig, constants.DynamoDBTableNamePrefix)
+		}
+
+		return prefixValue + tableSuffix, nil
+	}
+
+	tableValue, ok := tableName.(string)
+	if !ok {
+		return "", fmt.Errorf("%w: failed to cast %s %s to string type", zerr.ErrBadConfig, tableKey, tableName)
+	}
+
+	if tableValue == "" {
+		return "", fmt.Errorf("%w: %s key is empty", zerr.ErrBadConfig, tableKey)
+	}
+
+	return tableValue, nil
+}
+
+func cacheDriverConfigValue(cacheDriverConfig map[string]any, key string) (any, bool) {
+	if val, ok := cacheDriverConfig[key]; ok {
+		return val, true
+	}
+
+	for candidate, val := range cacheDriverConfig {
+		if strings.EqualFold(candidate, key) {
+			return val, true
+		}
+	}
+
+	return nil, false
 }
 
 func getRedisParams(storageConfig *config.StorageConfig, log zlog.Logger) (cache.RedisDriverParameters, error) {

--- a/pkg/storage/cache_internal_test.go
+++ b/pkg/storage/cache_internal_test.go
@@ -1,0 +1,78 @@
+package storage
+
+import (
+	"testing"
+
+	"zotregistry.dev/zot/v2/pkg/api/config"
+)
+
+func TestGetDynamoParamsWithTableNamePrefix(t *testing.T) {
+	t.Parallel()
+
+	storageConfig := &config.StorageConfig{
+		CacheDriver: map[string]any{
+			"endpoint":        "http://localhost:4566",
+			"region":          "us-east-2",
+			"tablenamePrefix": "Zot",
+		},
+	}
+
+	params, err := getDynamoParams(storageConfig)
+	if err != nil {
+		t.Fatalf("getDynamoParams() error = %v", err)
+	}
+
+	if params.TableName != "ZotBlobTable" {
+		t.Fatalf("params.TableName = %q, want %q", params.TableName, "ZotBlobTable")
+	}
+}
+
+func TestGetDynamoParamsPrefersExplicitCacheTableName(t *testing.T) {
+	t.Parallel()
+
+	storageConfig := &config.StorageConfig{
+		CacheDriver: map[string]any{
+			"endpoint":        "http://localhost:4566",
+			"region":          "us-east-2",
+			"tablenamePrefix": "Zot",
+			"cachetablename":  "CustomBlobTable",
+		},
+	}
+
+	params, err := getDynamoParams(storageConfig)
+	if err != nil {
+		t.Fatalf("getDynamoParams() error = %v", err)
+	}
+
+	if params.TableName != "CustomBlobTable" {
+		t.Fatalf("params.TableName = %q, want %q", params.TableName, "CustomBlobTable")
+	}
+}
+
+func TestGetDynamoParamsRejectsInvalidTableNamePrefix(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]any{
+		"empty":     "",
+		"nonString": false,
+	}
+
+	for name, prefix := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			storageConfig := &config.StorageConfig{
+				CacheDriver: map[string]any{
+					"endpoint":        "http://localhost:4566",
+					"region":          "us-east-2",
+					"tablenamePrefix": prefix,
+				},
+			}
+
+			_, err := getDynamoParams(storageConfig)
+			if err == nil {
+				t.Fatal("getDynamoParams() error = nil, want error")
+			}
+		})
+	}
+}

--- a/pkg/storage/constants/constants.go
+++ b/pkg/storage/constants/constants.go
@@ -27,3 +27,21 @@ const (
 	GCSStorageDriverName    = "gcs"
 	LocalStorageDriverName  = "local"
 )
+
+const (
+	DynamoDBTableNamePrefix  = "tablenameprefix"
+	DynamoDBCacheTableName   = "cachetablename"
+	DynamoDBRepoMetaTable    = "repometatablename"
+	DynamoDBRepoBlobsTable   = "repoblobsinfotablename"
+	DynamoDBImageMetaTable   = "imagemetatablename"
+	DynamoDBUserDataTable    = "userdatatablename"
+	DynamoDBAPIKeyTable      = "apikeytablename"
+	DynamoDBVersionTable     = "versiontablename"
+	DynamoDBCacheTableSuffix = "BlobTable"
+	DynamoDBRepoMetaSuffix   = "RepoMetadataTable"
+	DynamoDBRepoBlobsSuffix  = "RepoBlobsInfoTable"
+	DynamoDBImageMetaSuffix  = "ImageMetaTable"
+	DynamoDBUserDataSuffix   = "UserDataTable"
+	DynamoDBAPIKeySuffix     = "ApiKeyDataTable"
+	DynamoDBVersionSuffix    = "VersionTable"
+)


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:

Fixes #2966

**What does this PR do / Why do we need it**:

Adds `tablenamePrefix` support to DynamoDB cache/meta config so admins can derive zot table names from one prefix. Explicit table names continue to override derived names for backward compatibility. The DynamoDB example and cache driver docs now show the compact prefix form.

**If an issue # is not available please add repro steps and logs showing the issue**:

N/A

**Testing done on this change**:

```console
GOEXPERIMENT=jsonv2 go test ./pkg/storage ./pkg/meta -run TestGetDynamoParams
GOEXPERIMENT=jsonv2 go test -tags sync,scrub,metrics,search,lint,userprefs,mgmt,imagetrust,ui ./pkg/api -run "TestCreateCacheDatabaseDriver|TestCreateMetaDBDriver"
jq . examples/config-dynamodb.json >/dev/null
git diff --check
```

**Automation added to e2e**:

No e2e test added. Focused unit coverage was added for DynamoDB parameter derivation.

**Will this break upgrades or downgrades?**

No. Existing explicit table-name config remains supported and wins over derived names.

**Does this PR introduce any user-facing change?**:

Yes. DynamoDB cache config can now use `tablenamePrefix` to derive the zot table names.

```release-note
DynamoDB cache configuration now supports `tablenamePrefix` to derive zot table names while preserving explicit table-name overrides.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.