### PR TITLE
feat(storage): add GC time window

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -91,6 +91,13 @@ Orphan blobs are removed if they are older than gcDelay.
         "gcDelay": "2h"
 ```
 
+Periodic garbage collection can be restricted to a server-local time window.
+The window accepts `HH.MM - HH.MM` or `HH:MM - HH:MM` and can cross midnight.
+
+```
+        "gcTimeWindow": "01.00 - 08.00"
+```
+
 To limit the maximum number of repositories that can be created, set:
 
 ```
@@ -1189,4 +1196,3 @@ To set those options explicitly (for example to mirror standalone Trivy’s `--v
 - [config-cve-trivy.json](config-cve-trivy.json) — shows optional `dbRepository`, `javaDBRepository`, and `vulnSeveritySources`.
 
 `vulnSeveritySources` is a list of source names in priority order (for example `auto`, `nvd`, or vendor IDs such as `redhat`, `alpine`). If omitted, zot defaults it to `["auto"]`, consistent with the Trivy CLI. See [Trivy: severity selection](https://trivy.dev/docs/latest/scanner/vulnerability/#severity-selection).
-

--- a/examples/config-gc-periodic.json
+++ b/examples/config-gc-periodic.json
@@ -5,12 +5,14 @@
         "gc": true,
         "gcDelay": "1h",
         "gcInterval": "1h",
+        "gcTimeWindow": "01.00 - 08.00",
         "subPaths": {
             "/a": {
                 "rootDirectory": "/tmp/zot1",
                 "gc": true,
                 "gcDelay": "1h",
-                "gcInterval": "1h"
+                "gcInterval": "1h",
+                "gcTimeWindow": "01.00 - 08.00"
             }
         }
     },

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -36,6 +36,7 @@ type StorageConfig struct {
 	Commit        bool
 	GCDelay       time.Duration // applied for blobs
 	GCInterval    time.Duration
+	GCTimeWindow  string `json:"gcTimeWindow,omitempty" mapstructure:"gcTimeWindow,omitempty"`
 	Retention     ImageRetention
 	StorageDriver map[string]any `mapstructure:",omitempty"`
 	CacheDriver   map[string]any `mapstructure:",omitempty"`
@@ -668,7 +669,8 @@ func New() *Config {
 
 func (expConfig StorageConfig) ParamsEqual(actConfig StorageConfig) bool {
 	return expConfig.GC == actConfig.GC && expConfig.Dedupe == actConfig.Dedupe &&
-		expConfig.GCDelay == actConfig.GCDelay && expConfig.GCInterval == actConfig.GCInterval
+		expConfig.GCDelay == actConfig.GCDelay && expConfig.GCInterval == actConfig.GCInterval &&
+		expConfig.GCTimeWindow == actConfig.GCTimeWindow
 }
 
 // isRetentionEnabledInternal checks if retention is enabled without acquiring a lock (internal use only).
@@ -794,6 +796,7 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 	c.Storage.Dedupe = newConfig.Storage.Dedupe
 	c.Storage.GCDelay = newConfig.Storage.GCDelay
 	c.Storage.GCInterval = newConfig.Storage.GCInterval
+	c.Storage.GCTimeWindow = newConfig.Storage.GCTimeWindow
 
 	// Only update retention if we have a metaDB already in place
 	if c.isRetentionEnabledInternal() {
@@ -811,6 +814,7 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 		subPathConfig.Dedupe = storageConfig.Dedupe
 		subPathConfig.GCDelay = storageConfig.GCDelay
 		subPathConfig.GCInterval = storageConfig.GCInterval
+		subPathConfig.GCTimeWindow = storageConfig.GCTimeWindow
 
 		// Only update retention if we have a metaDB already in place
 		if c.isRetentionEnabledInternal() {

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -49,6 +49,14 @@ func TestConfig(t *testing.T) {
 
 		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
 
+		firstStorageConfig.GCTimeWindow = "01.00 - 08.00"
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeFalse)
+
+		secondStorageConfig.GCTimeWindow = "01.00 - 08.00"
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
+
 		isSame, err := config.SameFile("test-config", "test")
 		So(err, ShouldNotBeNil)
 		So(isSame, ShouldBeFalse)
@@ -3063,16 +3071,18 @@ func TestConfig(t *testing.T) {
 					},
 					SubPaths: map[string]config.StorageConfig{
 						"/path1": {
-							GC:         true,
-							Dedupe:     false,
-							GCDelay:    time.Hour,
-							GCInterval: time.Hour * 24,
+							GC:           true,
+							Dedupe:       false,
+							GCDelay:      time.Hour,
+							GCInterval:   time.Hour * 24,
+							GCTimeWindow: "01.00 - 02.00",
 						},
 						"/path2": {
-							GC:         false,
-							Dedupe:     true,
-							GCDelay:    time.Hour * 2,
-							GCInterval: time.Hour * 48,
+							GC:           false,
+							Dedupe:       true,
+							GCDelay:      time.Hour * 2,
+							GCInterval:   time.Hour * 48,
+							GCTimeWindow: "02.00 - 03.00",
 						},
 					},
 				},
@@ -3087,16 +3097,18 @@ func TestConfig(t *testing.T) {
 					},
 					SubPaths: map[string]config.StorageConfig{
 						"/path1": {
-							GC:         false,          // Changed
-							Dedupe:     true,           // Changed
-							GCDelay:    time.Hour * 2,  // Changed
-							GCInterval: time.Hour * 12, // Changed
+							GC:           false,          // Changed
+							Dedupe:       true,           // Changed
+							GCDelay:      time.Hour * 2,  // Changed
+							GCInterval:   time.Hour * 12, // Changed
+							GCTimeWindow: "03.00 - 04.00",
 						},
 						"/path2": {
-							GC:         true,           // Changed
-							Dedupe:     false,          // Changed
-							GCDelay:    time.Hour * 3,  // Changed
-							GCInterval: time.Hour * 36, // Changed
+							GC:           true,           // Changed
+							Dedupe:       false,          // Changed
+							GCDelay:      time.Hour * 3,  // Changed
+							GCInterval:   time.Hour * 36, // Changed
+							GCTimeWindow: "04.00 - 05.00",
 						},
 					},
 				},
@@ -3114,6 +3126,7 @@ func TestConfig(t *testing.T) {
 			So(path1Config.Dedupe, ShouldBeTrue)
 			So(path1Config.GCDelay, ShouldEqual, time.Hour*2)
 			So(path1Config.GCInterval, ShouldEqual, time.Hour*12)
+			So(path1Config.GCTimeWindow, ShouldEqual, "03.00 - 04.00")
 
 			// Check /path2
 			path2Config := cfg.Storage.SubPaths["/path2"]
@@ -3121,6 +3134,7 @@ func TestConfig(t *testing.T) {
 			So(path2Config.Dedupe, ShouldBeFalse)
 			So(path2Config.GCDelay, ShouldEqual, time.Hour*3)
 			So(path2Config.GCInterval, ShouldEqual, time.Hour*36)
+			So(path2Config.GCTimeWindow, ShouldEqual, "04.00 - 05.00")
 		})
 
 		Convey("Test new SubPaths are not added (only existing ones are updated)", func() {

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -602,13 +602,20 @@ func RunGCTasks(conf *config.Config, storeController storage.StoreController, me
 	// Enable running garbage-collect periodically for DefaultStore
 	storageConfig := conf.CopyStorageConfig()
 	if storageConfig.GC {
-		gc := gc.NewGarbageCollect(storeController.DefaultStore, metaDB, gc.Options{
-			Delay:             storageConfig.GCDelay,
-			ImageRetention:    storageConfig.Retention,
-			MaxSchedulerDelay: storageConfig.GCMaxSchedulerDelay,
-		}, audit, logger)
+		gcTimeWindow, err := gc.ParseTimeWindow(storageConfig.GCTimeWindow)
+		if err != nil {
+			logger.Error().Err(err).Str("gcTimeWindow", storageConfig.GCTimeWindow).
+				Msg("invalid garbage-collect time window, skipping scheduled garbage collection")
+		} else {
+			garbageCollect := gc.NewGarbageCollect(storeController.DefaultStore, metaDB, gc.Options{
+				Delay:             storageConfig.GCDelay,
+				ImageRetention:    storageConfig.Retention,
+				MaxSchedulerDelay: storageConfig.GCMaxSchedulerDelay,
+				TimeWindow:        gcTimeWindow,
+			}, audit, logger)
 
-		gc.CleanImageStorePeriodically(storageConfig.GCInterval, taskScheduler)
+			garbageCollect.CleanImageStorePeriodically(storageConfig.GCInterval, taskScheduler)
+		}
 	}
 
 	// Handle subpaths
@@ -616,14 +623,24 @@ func RunGCTasks(conf *config.Config, storeController storage.StoreController, me
 		for route, subStorageConfig := range storageConfig.SubPaths {
 			// Enable running garbage-collect periodically for subImageStore
 			if subStorageConfig.GC {
-				gc := gc.NewGarbageCollect(storeController.SubStore[route], metaDB,
+				gcTimeWindow, err := gc.ParseTimeWindow(subStorageConfig.GCTimeWindow)
+				if err != nil {
+					logger.Error().Err(err).Str("gcTimeWindow", subStorageConfig.GCTimeWindow).
+						Str("subPath", route).
+						Msg("invalid garbage-collect time window, skipping scheduled garbage collection")
+
+					continue
+				}
+
+				garbageCollect := gc.NewGarbageCollect(storeController.SubStore[route], metaDB,
 					gc.Options{
 						Delay:             subStorageConfig.GCDelay,
 						ImageRetention:    subStorageConfig.Retention,
 						MaxSchedulerDelay: subStorageConfig.GCMaxSchedulerDelay,
+						TimeWindow:        gcTimeWindow,
 					}, audit, logger)
 
-				gc.CleanImageStorePeriodically(subStorageConfig.GCInterval, taskScheduler)
+				garbageCollect.CleanImageStorePeriodically(subStorageConfig.GCInterval, taskScheduler)
 			}
 		}
 	}

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -31,6 +31,7 @@ import (
 	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
+	storageGC "zotregistry.dev/zot/v2/pkg/storage/gc"
 )
 
 // metadataConfig reports metadata after parsing, which we use to track
@@ -1473,6 +1474,10 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 			zerr.ErrBadConfig, storageConfig.GCInterval)
 	}
 
+	if err := validateGCTimeWindow(storageConfig.GCTimeWindow, logger); err != nil {
+		return err
+	}
+
 	if !storageConfig.GC {
 		if storageConfig.GCDelay != 0 {
 			logger.Warn().Err(zerr.ErrBadConfig).
@@ -1483,6 +1488,11 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 			logger.Warn().Err(zerr.ErrBadConfig).
 				Msg("periodic garbage-collect interval specified without enabling garbage-collect, will be ignored")
 		}
+
+		if storageConfig.GCTimeWindow != "" {
+			logger.Warn().Err(zerr.ErrBadConfig).
+				Msg("garbage-collect time window specified without enabling garbage-collect, will be ignored")
+		}
 	}
 
 	if err := validateGCRules(storageConfig.Retention, logger); err != nil {
@@ -1491,6 +1501,10 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 
 	// subpaths
 	for name, subPath := range storageConfig.SubPaths {
+		if err := validateGCTimeWindow(subPath.GCTimeWindow, logger); err != nil {
+			return err
+		}
+
 		if subPath.GC && subPath.GCDelay <= 0 {
 			logger.Error().Err(zerr.ErrBadConfig).
 				Str("subPath", name).
@@ -1504,6 +1518,18 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 		if err := validateGCRules(subPath.Retention, logger); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func validateGCTimeWindow(raw string, logger zlog.Logger) error {
+	if _, err := storageGC.ParseTimeWindow(raw); err != nil {
+		logger.Error().Err(zerr.ErrBadConfig).Str("gcTimeWindow", raw).
+			Msg("invalid garbage-collect time window specified")
+
+		return fmt.Errorf("%w: invalid garbage-collect time window specified %q: %w",
+			zerr.ErrBadConfig, raw, err)
 	}
 
 	return nil

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -131,10 +131,12 @@ func TestSchema(t *testing.T) {
 		So(storageProperties, ShouldContainKey, "rootDirectory")
 		So(storageProperties, ShouldContainKey, "gcDelay")
 		So(storageProperties, ShouldContainKey, "gcInterval")
+		So(storageProperties, ShouldContainKey, "gcTimeWindow")
 		So(storageProperties, ShouldContainKey, "subPaths")
 		So(storageProperties, ShouldNotContainKey, "gcMaxSchedulerDelay")
 		So(storageProperties, ShouldNotContainKey, "gCDelay")
 		So(storageProperties, ShouldNotContainKey, "gCInterval")
+		So(storageProperties, ShouldNotContainKey, "gCTimeWindow")
 
 		httpSchema, ok := mustResolvePropertySchema(configProperties, "http", defs)
 		So(ok, ShouldBeTrue)
@@ -2629,6 +2631,31 @@ func TestGC(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			file := MakeTempFileWithContent(t, "gc-config.json", string(contents))
+			err = cli.LoadConfiguration(config, file)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("GC time window", func() {
+			config := config.New()
+
+			content := `{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot",
+			"gc": true, "gcTimeWindow": "01.00 - 08.00"}, "http": {"address": "127.0.0.1", "port": "8080"},
+			"log": {"level": "debug"}}`
+
+			file := MakeTempFileWithContent(t, "gc-time-window-config.json", content)
+			err = cli.LoadConfiguration(config, file)
+			So(err, ShouldBeNil)
+			So(config.Storage.GCTimeWindow, ShouldEqual, "01.00 - 08.00")
+		})
+
+		Convey("Invalid GC time window", func() {
+			config := config.New()
+
+			content := `{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot",
+			"gc": true, "gcTimeWindow": "24.00 - 08.00"}, "http": {"address": "127.0.0.1", "port": "8080"},
+			"log": {"level": "debug"}}`
+
+			file := MakeTempFileWithContent(t, "bad-gc-time-window-config.json", content)
 			err = cli.LoadConfiguration(config, file)
 			So(err, ShouldNotBeNil)
 		})

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -42,6 +42,8 @@ type Options struct {
 	// Defaults to 30 seconds if not specified
 	MaxSchedulerDelay time.Duration
 
+	TimeWindow TimeWindow
+
 	ImageRetention config.ImageRetention
 }
 
@@ -84,6 +86,7 @@ func (gc GarbageCollect) CleanImageStorePeriodically(interval time.Duration, sch
 		gc:             gc,
 		processedRepos: processedRepos,
 		maxDelay:       maxDelay,
+		timeWindow:     gc.opts.TimeWindow,
 	}
 
 	sch.SubmitGenerator(generator, interval, scheduler.MediumPriority)
@@ -871,6 +874,7 @@ type GCTaskGenerator struct {
 	done           bool
 	rand           *rand.Rand
 	maxDelay       time.Duration
+	timeWindow     TimeWindow
 }
 
 func (gen *GCTaskGenerator) getRandomDelay() time.Duration {
@@ -919,7 +923,12 @@ func (gen *GCTaskGenerator) IsDone() bool {
 }
 
 func (gen *GCTaskGenerator) IsReady() bool {
-	return time.Now().After(gen.nextRun)
+	now := time.Now()
+	if !gen.timeWindow.Contains(now) {
+		return false
+	}
+
+	return now.After(gen.nextRun)
 }
 
 func (gen *GCTaskGenerator) Reset() {

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -34,6 +34,98 @@ var (
 	repoName = "test" //nolint: gochecknoglobals
 )
 
+func TestGCTimeWindow(t *testing.T) {
+	t.Parallel()
+
+	window, err := ParseTimeWindow("01.00 - 08.00")
+	if err != nil {
+		t.Fatalf("ParseTimeWindow() error = %v", err)
+	}
+
+	if window.Start != time.Hour || window.End != 8*time.Hour {
+		t.Fatalf("ParseTimeWindow() = %v, want start %s end %s", window, time.Hour, 8*time.Hour)
+	}
+
+	if !window.Contains(time.Date(2026, 4, 25, 4, 0, 0, 0, time.Local)) {
+		t.Fatal("time window should contain 04:00")
+	}
+
+	if window.Contains(time.Date(2026, 4, 25, 9, 0, 0, 0, time.Local)) {
+		t.Fatal("time window should not contain 09:00")
+	}
+}
+
+func TestGCTimeWindowOvernight(t *testing.T) {
+	t.Parallel()
+
+	window, err := ParseTimeWindow("22:30 - 02:00")
+	if err != nil {
+		t.Fatalf("ParseTimeWindow() error = %v", err)
+	}
+
+	if !window.Contains(time.Date(2026, 4, 25, 23, 0, 0, 0, time.Local)) {
+		t.Fatal("overnight time window should contain 23:00")
+	}
+
+	if !window.Contains(time.Date(2026, 4, 26, 1, 0, 0, 0, time.Local)) {
+		t.Fatal("overnight time window should contain 01:00")
+	}
+
+	if window.Contains(time.Date(2026, 4, 25, 12, 0, 0, 0, time.Local)) {
+		t.Fatal("overnight time window should not contain 12:00")
+	}
+}
+
+func TestGCTimeWindowRejectsInvalidValues(t *testing.T) {
+	t.Parallel()
+
+	tests := []string{
+		"01.00",
+		"24.00 - 08.00",
+		"01.60 - 08.00",
+		"08.00 - 08.00",
+	}
+
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := ParseTimeWindow(raw); err == nil {
+				t.Fatalf("ParseTimeWindow(%q) error = nil, want error", raw)
+			}
+		})
+	}
+}
+
+func TestGCTaskGeneratorIsReadyRespectsTimeWindow(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	insideWindow, err := ParseTimeWindow(formatTimeWindow(now.Add(-time.Hour), now.Add(time.Hour)))
+	if err != nil {
+		t.Fatalf("ParseTimeWindow() error = %v", err)
+	}
+
+	generator := GCTaskGenerator{timeWindow: insideWindow}
+	if !generator.IsReady() {
+		t.Fatal("generator should be ready inside gc time window")
+	}
+
+	outsideWindow, err := ParseTimeWindow(formatTimeWindow(now.Add(time.Hour), now.Add(2*time.Hour)))
+	if err != nil {
+		t.Fatalf("ParseTimeWindow() error = %v", err)
+	}
+
+	generator = GCTaskGenerator{timeWindow: outsideWindow}
+	if generator.IsReady() {
+		t.Fatal("generator should not be ready outside gc time window")
+	}
+}
+
+func formatTimeWindow(start, end time.Time) string {
+	return start.Format(gcTimeOfDayLayout) + " - " + end.Format(gcTimeOfDayLayout)
+}
+
 func TestGarbageCollectManifestErrors(t *testing.T) {
 	Convey("Make imagestore and upload manifest", t, func(c C) {
 		dir := t.TempDir()

--- a/pkg/storage/gc/time_window.go
+++ b/pkg/storage/gc/time_window.go
@@ -1,0 +1,67 @@
+package gc
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const gcTimeOfDayLayout = "15:04"
+
+type TimeWindow struct {
+	Start time.Duration
+	End   time.Duration
+}
+
+func ParseTimeWindow(raw string) (TimeWindow, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return TimeWindow{}, nil
+	}
+
+	parts := strings.Split(raw, "-")
+	if len(parts) != 2 { //nolint:mnd
+		return TimeWindow{}, fmt.Errorf("expected time window format HH.MM - HH.MM")
+	}
+
+	start, err := parseTimeOfDay(parts[0])
+	if err != nil {
+		return TimeWindow{}, fmt.Errorf("invalid start time: %w", err)
+	}
+
+	end, err := parseTimeOfDay(parts[1])
+	if err != nil {
+		return TimeWindow{}, fmt.Errorf("invalid end time: %w", err)
+	}
+
+	if start == end {
+		return TimeWindow{}, fmt.Errorf("start and end times must differ")
+	}
+
+	return TimeWindow{Start: start, End: end}, nil
+}
+
+func (window TimeWindow) Contains(now time.Time) bool {
+	if window == (TimeWindow{}) {
+		return true
+	}
+
+	current := time.Duration(now.Hour())*time.Hour + time.Duration(now.Minute())*time.Minute
+
+	if window.Start < window.End {
+		return current >= window.Start && current < window.End
+	}
+
+	return current >= window.Start || current < window.End
+}
+
+func parseTimeOfDay(raw string) (time.Duration, error) {
+	normalized := strings.ReplaceAll(strings.TrimSpace(raw), ".", ":")
+
+	parsed, err := time.Parse(gcTimeOfDayLayout, normalized)
+	if err != nil {
+		return 0, err
+	}
+
+	return time.Duration(parsed.Hour())*time.Hour + time.Duration(parsed.Minute())*time.Minute, nil
+}


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:

Fixes #3001

**What does this PR do / Why do we need it**:

Adds a `storage.gcTimeWindow` setting for scheduled garbage collection, so periodic GC task generation only starts during an allowed server-local time window. The parser accepts `HH.MM - HH.MM` and `HH:MM - HH:MM`, supports windows that cross midnight, and rejects invalid or zero-length windows during config validation.

The setting is available for the default store and subpaths, participates in reloadable storage config comparison/update, and is documented in the GC example.

**If an issue # is not available please add repro steps and logs showing the issue**:

N/A

**Testing done on this change**:

```console
GOEXPERIMENT=jsonv2 go test ./pkg/storage/gc -run 'TestGCTimeWindow|TestGCTaskGeneratorIsReadyRespectsTimeWindow'
GOEXPERIMENT=jsonv2 go test ./pkg/api/config -run TestConfig
GOEXPERIMENT=jsonv2 go test -tags sync,scrub,metrics,search,lint,userprefs,mgmt,imagetrust,ui ./pkg/cli/server -run 'TestGC|TestConfigSchemaUsesJSONNames'
GOEXPERIMENT=jsonv2 go test -tags sync,scrub,metrics,search,lint,userprefs,mgmt,imagetrust,ui ./pkg/api -run TestPeriodicGC
jq . examples/config-gc-periodic.json >/dev/null && git diff --check
```

**Automation added to e2e**:

No. This is covered with focused config validation and scheduler unit tests.

**Will this break upgrades or downgrades?**

No. The new setting is optional; empty or omitted `gcTimeWindow` preserves the existing unrestricted scheduled GC behavior.

**Does this PR introduce any user-facing change?**:

Yes. Users can configure a scheduled GC time window.

```release-note
Added optional `storage.gcTimeWindow` configuration to restrict scheduled garbage collection to a server-local time window.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
