### PR TITLE
fix(search): include digest-only images

### DIFF
--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -4820,6 +4820,11 @@ func TestImageList(t *testing.T) {
 		err = UploadImage(image, baseURL, "a/zot-test", "0.0.1")
 		So(err, ShouldBeNil)
 
+		digestOnlyRepo := "zot-digest-only"
+		digestOnlyImage := CreateRandomImage()
+		err = UploadImage(digestOnlyImage, baseURL, digestOnlyRepo, digestOnlyImage.DigestStr())
+		So(err, ShouldBeNil)
+
 		imageStore := ctlr.StoreController.DefaultStore
 
 		repos, err := imageStore.GetRepositories()
@@ -4877,6 +4882,32 @@ func TestImageList(t *testing.T) {
 
 			So(len(responseStruct.Results), ShouldEqual, len(tags))
 			So(len(responseStruct.Results[0].Manifests[0].History), ShouldEqual, len(imageConfigInfo.History))
+		})
+
+		Convey("without pagination, includes digest-only image", func() {
+			query := fmt.Sprintf(`{
+				ImageList(repo:"%s"){
+					Results {
+						RepoName
+						Tag
+						Digest
+					}
+				}
+			}`, digestOnlyRepo)
+
+			resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, 200)
+			So(resp, ShouldNotBeNil)
+
+			var responseStruct zcommon.ImageListResponse
+			err = json.Unmarshal(resp.Body(), &responseStruct)
+			So(err, ShouldBeNil)
+
+			So(len(responseStruct.Results), ShouldEqual, 1)
+			So(responseStruct.Results[0].RepoName, ShouldEqual, digestOnlyRepo)
+			So(responseStruct.Results[0].Tag, ShouldEqual, digestOnlyImage.DigestStr())
+			So(responseStruct.Results[0].Digest, ShouldEqual, digestOnlyImage.DigestStr())
 		})
 
 		Convey("Pagination with valid params", func() {
@@ -7551,7 +7582,9 @@ func RunReadUploadDeleteTests(t *testing.T, baseURL string) {
 			So(err, ShouldBeNil)
 
 			results := GlobalSearchGQL("", baseURL)
-			So(len(results.Repos), ShouldEqual, 0)
+			So(len(results.Repos), ShouldEqual, 1)
+			So(results.Repos[0].NewestImage.Tag, ShouldEqual, imageWithoutTag.DigestStr())
+			So(results.Repos[0].NewestImage.Digest, ShouldEqual, imageWithoutTag.DigestStr())
 
 			Convey("Add tag and delete it", func() {
 				err := UploadImage(image, baseURL, repo1, tag1)
@@ -7565,7 +7598,9 @@ func RunReadUploadDeleteTests(t *testing.T, baseURL string) {
 				So(err, ShouldBeNil)
 
 				results = GlobalSearchGQL("", baseURL)
-				So(len(results.Repos), ShouldEqual, 0)
+				So(len(results.Repos), ShouldEqual, 1)
+				So(results.Repos[0].NewestImage.Tag, ShouldEqual, imageWithoutTag.DigestStr())
+				So(results.Repos[0].NewestImage.Digest, ShouldEqual, imageWithoutTag.DigestStr())
 			})
 		})
 		Convey("Push a random image", func() {
@@ -7588,7 +7623,9 @@ func RunReadUploadDeleteTests(t *testing.T, baseURL string) {
 					So(err, ShouldBeNil)
 
 					results := GlobalSearchGQL("", baseURL)
-					So(len(results.Repos), ShouldEqual, 0)
+					So(len(results.Repos), ShouldEqual, 1)
+					So(results.Repos[0].NewestImage.Tag, ShouldEqual, imageWithoutTag.DigestStr())
+					So(results.Repos[0].NewestImage.Digest, ShouldEqual, imageWithoutTag.DigestStr())
 				})
 			})
 			Convey("Delete the image pushed multiple times", func() {
@@ -7732,7 +7769,7 @@ func RunReadUploadDeleteTests(t *testing.T, baseURL string) {
 
 					results := GlobalSearchGQL("", baseURL)
 					So(len(results.Repos), ShouldEqual, 1)
-					So(results.Repos[0].NewestImage.Digest, ShouldResemble, afterImage.DigestStr())
+					So(results.Repos[0].NewestImage.Digest, ShouldResemble, imageWithoutTag.DigestStr())
 				})
 
 				Convey("Delete afterImage", func() {

--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -252,27 +252,8 @@ func (bdw *BoltDB) SetRepoReference(ctx context.Context, repo string, reference 
 			protoRepoMeta.Referrers[subject.Digest.String()] = refInfo
 		}
 
-		// 3. Update tag
-		if !common.ReferenceIsDigest(reference) {
-			// Set TaggedTimestamp to now if this is a new tag, otherwise preserve existing timestamp
-			// For old data without TaggedTimestamp, leave it nil so it falls back to PushTimestamp
-			var taggedTimestamp *timestamppb.Timestamp
-			if existingTag, exists := protoRepoMeta.Tags[reference]; exists {
-				// Tag exists - preserve TaggedTimestamp if present, otherwise leave nil (old data)
-				if existingTag.GetTaggedTimestamp() != nil {
-					taggedTimestamp = existingTag.GetTaggedTimestamp()
-				}
-				// else leave taggedTimestamp as nil (old data without TaggedTimestamp)
-			} else {
-				// New tag - set timestamp to now
-				taggedTimestamp = timestamppb.Now()
-			}
-			protoRepoMeta.Tags[reference] = &proto_go.TagDescriptor{
-				Digest:          imageMeta.Digest.String(),
-				MediaType:       imageMeta.MediaType,
-				TaggedTimestamp: taggedTimestamp,
-			}
-		}
+		// 3. Update reference
+		common.SetRepoReferenceDescriptor(protoRepoMeta, reference, imageMeta)
 
 		digestStr := imageMeta.Digest.String()
 		stats, ok := protoRepoMeta.Statistics[digestStr]

--- a/pkg/meta/common/common.go
+++ b/pkg/meta/common/common.go
@@ -7,6 +7,7 @@ import (
 
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	zerr "zotregistry.dev/zot/v2/errors"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
@@ -51,6 +52,50 @@ func ValidateRepoReferenceInput(repo, reference string, manifestDigest godigest.
 	}
 
 	return nil
+}
+
+func SetRepoReferenceDescriptor(repoMeta *proto_go.RepoMeta, reference string, imageMeta mTypes.ImageMeta) {
+	var taggedTimestamp *timestamppb.Timestamp
+
+	if !ReferenceIsDigest(reference) {
+		if existingTag, exists := repoMeta.Tags[reference]; exists {
+			taggedTimestamp = existingTag.GetTaggedTimestamp()
+		} else {
+			taggedTimestamp = timestamppb.Now()
+		}
+	}
+
+	repoMeta.Tags[reference] = &proto_go.TagDescriptor{
+		Digest:          imageMeta.Digest.String(),
+		MediaType:       imageMeta.MediaType,
+		TaggedTimestamp: taggedTimestamp,
+	}
+}
+
+func removeIndexChildDigestReferences(repoMeta *proto_go.RepoMeta, repoBlobs *proto_go.RepoBlobs) {
+	indexChildDigests := map[string]struct{}{}
+
+	for digest, blobInfo := range repoBlobs.Blobs {
+		if blobInfo == nil || len(blobInfo.SubBlobs) == 0 {
+			continue
+		}
+
+		for _, subBlob := range blobInfo.SubBlobs {
+			if subBlob == digest || !ReferenceIsDigest(subBlob) {
+				continue
+			}
+
+			if childBlobInfo, ok := repoBlobs.Blobs[subBlob]; ok && len(childBlobInfo.GetSubBlobs()) > 0 {
+				indexChildDigests[subBlob] = struct{}{}
+			}
+		}
+	}
+
+	for digest := range indexChildDigests {
+		if descriptor, ok := repoMeta.Tags[digest]; ok && descriptor.GetDigest() == digest {
+			delete(repoMeta.Tags, digest)
+		}
+	}
 }
 
 // These constants are meant used to describe how high or low in rank a match is.
@@ -247,10 +292,7 @@ func AddImageMetaToRepoMeta(repoMeta *proto_go.RepoMeta, repoBlobs *proto_go.Rep
 		}
 	}
 
-	// update info only when a tag is added
-	if zcommon.IsDigest(reference) {
-		return repoMeta, repoBlobs
-	}
+	removeIndexChildDigestReferences(repoMeta, repoBlobs)
 
 	size, platforms, vendors := recalculateAggregateFields(repoMeta, repoBlobs)
 	repoMeta.Vendors = vendors

--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -461,27 +461,8 @@ func (dwr *DynamoDB) SetRepoReference(ctx context.Context, repo string, referenc
 		repoMeta.Referrers[subject.Digest.String()] = refInfo
 	}
 
-	// 3. Update tag
-	if !common.ReferenceIsDigest(reference) {
-		// Set TaggedTimestamp to now if this is a new tag, otherwise preserve existing timestamp
-		// For old data without TaggedTimestamp, leave it nil so it falls back to PushTimestamp
-		var taggedTimestamp *timestamppb.Timestamp
-		if existingTag, exists := repoMeta.Tags[reference]; exists {
-			// Tag exists - preserve TaggedTimestamp if present, otherwise leave nil (old data)
-			if existingTag.GetTaggedTimestamp() != nil {
-				taggedTimestamp = existingTag.GetTaggedTimestamp()
-			}
-			// else leave taggedTimestamp as nil (old data without TaggedTimestamp)
-		} else {
-			// New tag - set timestamp to now
-			taggedTimestamp = timestamppb.Now()
-		}
-		repoMeta.Tags[reference] = &proto_go.TagDescriptor{
-			Digest:          imageMeta.Digest.String(),
-			MediaType:       imageMeta.MediaType,
-			TaggedTimestamp: taggedTimestamp,
-		}
-	}
+	// 3. Update reference
+	common.SetRepoReferenceDescriptor(repoMeta, reference, imageMeta)
 
 	digestStr := imageMeta.Digest.String()
 	stats, ok := repoMeta.Statistics[digestStr]

--- a/pkg/meta/parse_test.go
+++ b/pkg/meta/parse_test.go
@@ -499,7 +499,7 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 		So(err, ShouldBeNil)
 
 		So(len(repos), ShouldEqual, 1)
-		So(len(repos[0].Tags), ShouldEqual, 2)
+		So(len(repos[0].Tags), ShouldEqual, 3)
 
 		for tag, descriptor := range repos[0].Tags {
 			imageManifestData, err := metaDB.GetFullImageMeta(ctx, repo, tag)

--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -805,27 +805,8 @@ func (rc *RedisDB) SetRepoReference(ctx context.Context, repo string,
 			protoRepoMeta.Referrers[subject.Digest.String()] = refInfo
 		}
 
-		// 3. Update tag
-		if !common.ReferenceIsDigest(reference) {
-			// Set TaggedTimestamp to now if this is a new tag, otherwise preserve existing timestamp
-			// For old data without TaggedTimestamp, leave it nil so it falls back to PushTimestamp
-			var taggedTimestamp *timestamppb.Timestamp
-			if existingTag, exists := protoRepoMeta.Tags[reference]; exists {
-				// Tag exists - preserve TaggedTimestamp if present, otherwise leave nil (old data)
-				if existingTag.GetTaggedTimestamp() != nil {
-					taggedTimestamp = existingTag.GetTaggedTimestamp()
-				}
-				// else leave taggedTimestamp as nil (old data without TaggedTimestamp)
-			} else {
-				// New tag - set timestamp to now
-				taggedTimestamp = timestamppb.Now()
-			}
-			protoRepoMeta.Tags[reference] = &proto_go.TagDescriptor{
-				Digest:          imageMeta.Digest.String(),
-				MediaType:       imageMeta.MediaType,
-				TaggedTimestamp: taggedTimestamp,
-			}
-		}
+		// 3. Update reference
+		common.SetRepoReferenceDescriptor(protoRepoMeta, reference, imageMeta)
 
 		digestStr := imageMeta.Digest.String()
 		stats, ok := protoRepoMeta.Statistics[digestStr]


### PR DESCRIPTION
#### What this does
- keeps digest-only manifest pushes as visible repository references so WebUI/zli search can list them
- updates shared metadata reference handling across BoltDB, Redis, and DynamoDB
- prunes digest references that are only multi-arch index children so index internals do not become standalone search hits

Fixes #3381

#### Testing
- GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search imagetrust" ./pkg/meta ./pkg/meta/common ./pkg/extensions/search -count=1
- git diff --check