### PR TITLE
feat(storage): redirect blob pulls to backend URLs

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -922,6 +922,7 @@ The following AWS policy is required by zot for push and pull. Make sure to repl
     "storage": {
         "rootDirectory": "/tmp/zot",  # local path used to store dedupe cache database
         "dedupe": true,
+        "redirect": true,
         "storageDriver": {
             "name": "s3",
             "rootdirectory": "/zot",  # this is a prefix that is applied to all S3 keys to allow you to segment data in your bucket if necessary.
@@ -935,6 +936,8 @@ The following AWS policy is required by zot for push and pull. Make sure to repl
         }
     }
 ```
+
+Blob pull redirects are disabled by default. With S3 or GCS storage, set `redirect` to `true` under `storage` or under a `subPaths` entry to return a `307 Temporary Redirect` to the storage driver's signed URL after zot authorization. If the storage driver does not return a redirect URL, zot proxies the blob as before.
 
 There are multiple ways to specify S3 credentials besides config file:
 
@@ -1189,4 +1192,3 @@ To set those options explicitly (for example to mirror standalone Trivy’s `--v
 - [config-cve-trivy.json](config-cve-trivy.json) — shows optional `dbRepository`, `javaDBRepository`, and `vulnSeveritySources`.
 
 `vulnSeveritySources` is a list of source names in priority order (for example `auto`, `nvd`, or vendor IDs such as `redhat`, `alpine`). If omitted, zot defaults it to `["auto"]`, consistent with the Trivy CLI. See [Trivy: severity selection](https://trivy.dev/docs/latest/scanner/vulnerability/#severity-selection).
-

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -32,6 +32,7 @@ type StorageConfig struct {
 	MaxRepos      int
 	Dedupe        bool
 	RemoteCache   bool
+	Redirect      bool
 	GC            bool
 	Commit        bool
 	GCDelay       time.Duration // applied for blobs
@@ -668,7 +669,8 @@ func New() *Config {
 
 func (expConfig StorageConfig) ParamsEqual(actConfig StorageConfig) bool {
 	return expConfig.GC == actConfig.GC && expConfig.Dedupe == actConfig.Dedupe &&
-		expConfig.GCDelay == actConfig.GCDelay && expConfig.GCInterval == actConfig.GCInterval
+		expConfig.Redirect == actConfig.Redirect && expConfig.GCDelay == actConfig.GCDelay &&
+		expConfig.GCInterval == actConfig.GCInterval
 }
 
 // isRetentionEnabledInternal checks if retention is enabled without acquiring a lock (internal use only).
@@ -792,6 +794,7 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 	// Update storage configuration
 	c.Storage.GC = newConfig.Storage.GC
 	c.Storage.Dedupe = newConfig.Storage.Dedupe
+	c.Storage.Redirect = newConfig.Storage.Redirect
 	c.Storage.GCDelay = newConfig.Storage.GCDelay
 	c.Storage.GCInterval = newConfig.Storage.GCInterval
 
@@ -809,6 +812,7 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 
 		subPathConfig.GC = storageConfig.GC
 		subPathConfig.Dedupe = storageConfig.Dedupe
+		subPathConfig.Redirect = storageConfig.Redirect
 		subPathConfig.GCDelay = storageConfig.GCDelay
 		subPathConfig.GCInterval = storageConfig.GCInterval
 

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -49,6 +49,14 @@ func TestConfig(t *testing.T) {
 
 		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
 
+		firstStorageConfig.Redirect = true
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeFalse)
+
+		firstStorageConfig.Redirect = false
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
+
 		isSame, err := config.SameFile("test-config", "test")
 		So(err, ShouldNotBeNil)
 		So(isSame, ShouldBeFalse)
@@ -2135,6 +2143,39 @@ func TestConfig(t *testing.T) {
 			So(cfg.CopyExtensionsConfig().IsSearchEnabled(), ShouldBeTrue)
 		})
 
+		Convey("Test with Storage update", func() {
+			cfg := &config.Config{
+				Storage: config.GlobalStorageConfig{
+					StorageConfig: config.StorageConfig{
+						GC:         true,
+						Dedupe:     false,
+						Redirect:   false,
+						GCDelay:    time.Hour,
+						GCInterval: 2 * time.Hour,
+					},
+				},
+			}
+			newConfig := &config.Config{
+				Storage: config.GlobalStorageConfig{
+					StorageConfig: config.StorageConfig{
+						GC:         false,
+						Dedupe:     true,
+						Redirect:   true,
+						GCDelay:    3 * time.Hour,
+						GCInterval: 4 * time.Hour,
+					},
+				},
+			}
+
+			cfg.UpdateReloadableConfig(newConfig)
+
+			So(cfg.Storage.GC, ShouldBeFalse)
+			So(cfg.Storage.Dedupe, ShouldBeTrue)
+			So(cfg.Storage.Redirect, ShouldBeTrue)
+			So(cfg.Storage.GCDelay, ShouldEqual, 3*time.Hour)
+			So(cfg.Storage.GCInterval, ShouldEqual, 4*time.Hour)
+		})
+
 		Convey("Test search CVE config removal when new config has nil Search.CVE", func() {
 			// First set up a config with search enabled and CVE config
 			enabled := true
@@ -3058,19 +3099,22 @@ func TestConfig(t *testing.T) {
 			cfg := &config.Config{
 				Storage: config.GlobalStorageConfig{
 					StorageConfig: config.StorageConfig{
-						GC:     true,
-						Dedupe: false,
+						GC:       true,
+						Dedupe:   false,
+						Redirect: false,
 					},
 					SubPaths: map[string]config.StorageConfig{
 						"/path1": {
 							GC:         true,
 							Dedupe:     false,
+							Redirect:   false,
 							GCDelay:    time.Hour,
 							GCInterval: time.Hour * 24,
 						},
 						"/path2": {
 							GC:         false,
 							Dedupe:     true,
+							Redirect:   true,
 							GCDelay:    time.Hour * 2,
 							GCInterval: time.Hour * 48,
 						},
@@ -3082,19 +3126,22 @@ func TestConfig(t *testing.T) {
 			newConfig := &config.Config{
 				Storage: config.GlobalStorageConfig{
 					StorageConfig: config.StorageConfig{
-						GC:     true,
-						Dedupe: false,
+						GC:       true,
+						Dedupe:   false,
+						Redirect: true,
 					},
 					SubPaths: map[string]config.StorageConfig{
 						"/path1": {
 							GC:         false,          // Changed
 							Dedupe:     true,           // Changed
+							Redirect:   true,           // Changed
 							GCDelay:    time.Hour * 2,  // Changed
 							GCInterval: time.Hour * 12, // Changed
 						},
 						"/path2": {
 							GC:         true,           // Changed
 							Dedupe:     false,          // Changed
+							Redirect:   false,          // Changed
 							GCDelay:    time.Hour * 3,  // Changed
 							GCInterval: time.Hour * 36, // Changed
 						},
@@ -3112,6 +3159,7 @@ func TestConfig(t *testing.T) {
 			path1Config := cfg.Storage.SubPaths["/path1"]
 			So(path1Config.GC, ShouldBeFalse)
 			So(path1Config.Dedupe, ShouldBeTrue)
+			So(path1Config.Redirect, ShouldBeTrue)
 			So(path1Config.GCDelay, ShouldEqual, time.Hour*2)
 			So(path1Config.GCInterval, ShouldEqual, time.Hour*12)
 
@@ -3119,6 +3167,7 @@ func TestConfig(t *testing.T) {
 			path2Config := cfg.Storage.SubPaths["/path2"]
 			So(path2Config.GC, ShouldBeTrue)
 			So(path2Config.Dedupe, ShouldBeFalse)
+			So(path2Config.Redirect, ShouldBeFalse)
 			So(path2Config.GCDelay, ShouldEqual, time.Hour*3)
 			So(path2Config.GCInterval, ShouldEqual, time.Hour*36)
 		})

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1168,6 +1168,19 @@ func parseRangeHeader(contentRange string) (int64, int64, error) {
 	return from, to, nil
 }
 
+func (rh *RouteHandler) isBlobRedirectEnabled(name string) bool {
+	storageConfig := rh.c.Config.CopyStorageConfig()
+	storePath := rh.c.StoreController.GetStorePath(name)
+
+	if storePath != storage.DefaultStorePath {
+		if subPathConfig, ok := storageConfig.SubPaths[storePath]; ok {
+			return subPathConfig.Redirect
+		}
+	}
+
+	return storageConfig.Redirect
+}
+
 // GetBlob godoc
 // @Summary Get image blob/layer
 // @Description Get an image's blob/layer given a digest
@@ -1233,10 +1246,23 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 
 	var blen, bsize int64
 
-	if partial {
-		repo, blen, bsize, err = imgStore.GetBlobPartial(name, digest, mediaType, from, to)
-	} else {
-		repo, blen, err = imgStore.GetBlob(name, digest, mediaType)
+	if rh.isBlobRedirectEnabled(name) {
+		redirectURL, redirectErr := imgStore.GetBlobRedirectURL(request, name, digest)
+		if redirectErr != nil {
+			err = redirectErr
+		} else if redirectURL != "" {
+			http.Redirect(response, request, redirectURL, http.StatusTemporaryRedirect)
+
+			return
+		}
+	}
+
+	if err == nil {
+		if partial {
+			repo, blen, bsize, err = imgStore.GetBlobPartial(name, digest, mediaType, from, to)
+		} else {
+			repo, blen, err = imgStore.GetBlob(name, digest, mediaType)
+		}
 	}
 
 	if err != nil {

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -750,6 +750,162 @@ func TestRoutes(t *testing.T) {
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusBadRequest)
+
+			Convey("redirects blob pulls when storage redirect is enabled", func() {
+				blobDigest := "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621"
+				redirectURL := "https://storage.example.com/zot/repo/blobs/sha256/layer"
+				getBlobCalled := false
+
+				ctlr.Config.Storage.Redirect = true
+				defer func() {
+					ctlr.Config.Storage.Redirect = false
+				}()
+
+				ctlr.StoreController.DefaultStore = &mocks.MockedImageStore{
+					GetBlobRedirectURLFn: func(r *http.Request, repo string, digest godigest.Digest) (string, error) {
+						So(r.Method, ShouldEqual, http.MethodGet)
+						So(repo, ShouldEqual, "repo")
+						So(digest.String(), ShouldEqual, blobDigest)
+
+						return redirectURL, nil
+					},
+					GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
+						getBlobCalled = true
+
+						return io.NopCloser(bytes.NewBufferString("")), 0, nil
+					},
+				}
+
+				request, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, baseURL, nil)
+				request = mux.SetURLVars(request, map[string]string{
+					"name":   "repo",
+					"digest": blobDigest,
+				})
+				response := httptest.NewRecorder()
+
+				rthdlr.GetBlob(response, request)
+
+				resp := response.Result()
+				defer resp.Body.Close()
+				So(resp.StatusCode, ShouldEqual, http.StatusTemporaryRedirect)
+				So(resp.Header.Get("Location"), ShouldEqual, redirectURL)
+				So(getBlobCalled, ShouldBeFalse)
+			})
+
+			Convey("falls back to proxying when redirect URL is unavailable", func() {
+				blobDigest := "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621"
+				getBlobCalled := false
+
+				ctlr.Config.Storage.Redirect = true
+				defer func() {
+					ctlr.Config.Storage.Redirect = false
+				}()
+
+				ctlr.StoreController.DefaultStore = &mocks.MockedImageStore{
+					GetBlobRedirectURLFn: func(r *http.Request, repo string, digest godigest.Digest) (string, error) {
+						return "", nil
+					},
+					GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
+						getBlobCalled = true
+
+						return io.NopCloser(bytes.NewBufferString("blob")), 4, nil
+					},
+				}
+
+				request, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, baseURL, nil)
+				request = mux.SetURLVars(request, map[string]string{
+					"name":   "repo",
+					"digest": blobDigest,
+				})
+				response := httptest.NewRecorder()
+
+				rthdlr.GetBlob(response, request)
+
+				resp := response.Result()
+				defer resp.Body.Close()
+				So(resp.StatusCode, ShouldEqual, http.StatusOK)
+				So(getBlobCalled, ShouldBeTrue)
+			})
+
+			Convey("uses subpath redirect config", func() {
+				blobDigest := "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621"
+				redirectURL := "https://storage.example.com/zot-a/repo/blobs/sha256/layer"
+				getBlobCalled := false
+				subStore := &mocks.MockedImageStore{
+					GetBlobRedirectURLFn: func(r *http.Request, repo string, digest godigest.Digest) (string, error) {
+						So(repo, ShouldEqual, "a/repo")
+
+						return redirectURL, nil
+					},
+					GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
+						getBlobCalled = true
+
+						return io.NopCloser(bytes.NewBufferString("")), 0, nil
+					},
+				}
+
+				ctlr.Config.Storage.Redirect = false
+				ctlr.Config.Storage.SubPaths = map[string]config.StorageConfig{
+					"/a": {Redirect: true},
+				}
+				ctlr.StoreController.SubStore = map[string]storageTypes.ImageStore{
+					"/a": subStore,
+				}
+				defer func() {
+					ctlr.Config.Storage.SubPaths = nil
+					ctlr.StoreController.SubStore = nil
+				}()
+
+				request, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, baseURL, nil)
+				request = mux.SetURLVars(request, map[string]string{
+					"name":   "a/repo",
+					"digest": blobDigest,
+				})
+				response := httptest.NewRecorder()
+
+				rthdlr.GetBlob(response, request)
+
+				resp := response.Result()
+				defer resp.Body.Close()
+				So(resp.StatusCode, ShouldEqual, http.StatusTemporaryRedirect)
+				So(resp.Header.Get("Location"), ShouldEqual, redirectURL)
+				So(getBlobCalled, ShouldBeFalse)
+			})
+
+			Convey("returns registry errors from redirect lookup", func() {
+				blobDigest := "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621"
+				getBlobCalled := false
+
+				ctlr.Config.Storage.Redirect = true
+				defer func() {
+					ctlr.Config.Storage.Redirect = false
+				}()
+
+				ctlr.StoreController.DefaultStore = &mocks.MockedImageStore{
+					GetBlobRedirectURLFn: func(r *http.Request, repo string, digest godigest.Digest) (string, error) {
+						return "", zerr.ErrBlobNotFound
+					},
+					GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
+						getBlobCalled = true
+
+						return io.NopCloser(bytes.NewBufferString("")), 0, nil
+					},
+				}
+
+				request, _ := http.NewRequestWithContext(context.TODO(), http.MethodGet, baseURL, nil)
+				request = mux.SetURLVars(request, map[string]string{
+					"name":   "repo",
+					"digest": blobDigest,
+				})
+				response := httptest.NewRecorder()
+
+				rthdlr.GetBlob(response, request)
+
+				resp := response.Result()
+				defer resp.Body.Close()
+				So(resp.StatusCode, ShouldEqual, http.StatusNotFound)
+				So(getBlobCalled, ShouldBeFalse)
+			})
 		})
 
 		Convey("CreateBlobUpload", func() {

--- a/pkg/storage/gcs/driver.go
+++ b/pkg/storage/gcs/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"strings"
 
 	// Add gcs support.
@@ -174,6 +175,12 @@ func (driver *Driver) SameFile(path1, path2 string) bool {
 // from cache.
 func (driver *Driver) Link(src, dest string) error {
 	return driver.formatErr(driver.store.PutContent(context.Background(), dest, []byte{}), dest)
+}
+
+func (driver *Driver) RedirectURL(r *http.Request, path string) (string, error) {
+	redirectURL, err := driver.store.RedirectURL(r, path)
+
+	return redirectURL, driver.formatErr(err, path)
 }
 
 // formatErr converts GCS-specific 404/not found errors to PathNotFoundError.

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"path"
 	"path/filepath"
 	"slices"
@@ -1655,6 +1656,24 @@ func (is *ImageStore) GetBlob(repo string, digest godigest.Digest, mediaType str
 
 	// The caller function is responsible for calling Close()
 	return blobReadCloser, binfo.Size(), nil
+}
+
+func (is *ImageStore) GetBlobRedirectURL(r *http.Request, repo string, digest godigest.Digest) (string, error) {
+	var lockLatency time.Time
+
+	if err := digest.Validate(); err != nil {
+		return "", err
+	}
+
+	is.RLock(&lockLatency)
+	defer is.RUnlock(&lockLatency)
+
+	binfo, err := is.originalBlobInfo(repo, digest)
+	if err != nil {
+		return "", err
+	}
+
+	return is.storeDriver.RedirectURL(r, binfo.Path())
 }
 
 // GetBlobContent returns blob contents, the caller function MUST lock from outside.

--- a/pkg/storage/local/driver.go
+++ b/pkg/storage/local/driver.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"sort"
@@ -291,6 +292,10 @@ func (driver *Driver) Link(src, dest string) error {
 	}
 
 	return nil
+}
+
+func (driver *Driver) RedirectURL(_ *http.Request, _ string) (string, error) {
+	return "", nil
 }
 
 func (driver *Driver) formatErr(err error) error {

--- a/pkg/storage/s3/driver.go
+++ b/pkg/storage/s3/driver.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	"io"
+	"net/http"
 
 	// Add s3 support.
 	"github.com/distribution/distribution/v3/registry/storage/driver"
@@ -109,4 +110,8 @@ func (driver *Driver) SameFile(path1, path2 string) bool {
 // from cache.
 func (driver *Driver) Link(src, dest string) error {
 	return driver.store.PutContent(context.Background(), dest, []byte{})
+}
+
+func (driver *Driver) RedirectURL(r *http.Request, path string) (string, error) {
+	return driver.store.RedirectURL(r, path)
 }

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"io"
+	"net/http"
 	"time"
 
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
@@ -70,6 +71,7 @@ type ImageStore interface { //nolint:interfacebloat
 	PopulateStorageMetrics(interval time.Duration, sch *scheduler.Scheduler)
 	VerifyBlobDigestValue(repo string, digest godigest.Digest) error
 	GetAllDedupeReposCandidates(digest godigest.Digest) ([]string, error)
+	GetBlobRedirectURL(r *http.Request, repo string, digest godigest.Digest) (string, error)
 }
 
 type Driver interface { //nolint:interfacebloat
@@ -87,4 +89,5 @@ type Driver interface { //nolint:interfacebloat
 	Move(sourcePath string, destPath string) error
 	SameFile(path1, path2 string) bool
 	Link(src, dest string) error
+	RedirectURL(r *http.Request, path string) (string, error)
 }

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"context"
 	"io"
+	"net/http"
 	"time"
 
 	godigest "github.com/opencontainers/go-digest"
@@ -62,6 +63,7 @@ type MockedImageStore struct {
 	StatIndexFn                   func(repo string) (bool, int64, time.Time, error)
 	VerifyBlobDigestValueFn       func(repo string, digest godigest.Digest) error
 	GetAllDedupeReposCandidatesFn func(digest godigest.Digest) ([]string, error)
+	GetBlobRedirectURLFn          func(r *http.Request, repo string, digest godigest.Digest) (string, error)
 }
 
 func (is MockedImageStore) StatIndex(repo string) (bool, int64, time.Time, error) {
@@ -338,6 +340,16 @@ func (is MockedImageStore) GetBlob(repo string, digest godigest.Digest, mediaTyp
 	}
 
 	return io.NopCloser(&io.LimitedReader{}), 0, nil
+}
+
+func (is MockedImageStore) GetBlobRedirectURL(
+	r *http.Request, repo string, digest godigest.Digest,
+) (string, error) {
+	if is.GetBlobRedirectURLFn != nil {
+		return is.GetBlobRedirectURLFn(r, repo, digest)
+	}
+
+	return "", nil
 }
 
 func (is MockedImageStore) DeleteBlobUpload(repo string, uuid string) error {


### PR DESCRIPTION
Fixes #2752

## What this changes
- adds an opt-in `storage.redirect` flag for blob pulls
- redirects blob GETs with `307 Temporary Redirect` when the selected storage driver returns a signed backend URL
- preserves existing proxy behavior by default and when a driver has no redirect URL
- supports per-subpath redirect settings and reloadable config updates

## Validation
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint mgmt" ./pkg/api -run 'TestRoutes' -count=1`\n- `GOEXPERIMENT=jsonv2 go test ./pkg/api/config -run 'TestConfig' -count=1`\n- `GOEXPERIMENT=jsonv2 go test ./pkg/storage/imagestore ./pkg/storage/local ./pkg/storage/s3 ./pkg/storage/gcs -run '^$' -count=1`\n- `GOEXPERIMENT=jsonv2 go test ./pkg/cli/server -run 'TestSchema|TestLoadConfig' -count=1`\n- `git diff --check`