### PR TITLE
fix(exporter): forward auth to zot metrics

### DIFF
--- a/pkg/exporter/api/exporter.go
+++ b/pkg/exporter/api/exporter.go
@@ -21,6 +21,7 @@ import (
 const (
 	idleTimeout       = 120 * time.Second
 	readHeaderTimeout = 5 * time.Second
+	authorization     = "Authorization"
 )
 
 type Collector struct {
@@ -169,20 +170,52 @@ func GetCollector(c *Controller) *Collector {
 	}
 }
 
+func forwardedMetricsHeaders(r *http.Request) http.Header {
+	headers := make(http.Header)
+
+	for _, value := range r.Header.Values(authorization) {
+		headers.Add(authorization, value)
+	}
+
+	return headers
+}
+
+func metricsHandler(c *Controller) http.Handler {
+	collector := GetCollector(c)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCollector := *collector
+		requestCollector.Client = collector.Client.WithHeaders(forwardedMetricsHeaders(r))
+
+		registry := prometheus.NewRegistry()
+
+		if err := registry.Register(&requestCollector); err != nil {
+			c.Log.Debug().Err(err).Msg("ignoring error")
+		}
+
+		if err := registry.Register(prometheus.NewGoCollector()); err != nil {
+			c.Log.Debug().Err(err).Msg("ignoring error")
+		}
+
+		if err := registry.Register(prometheus.NewProcessCollector(prometheus.ProcessCollectorOpts{})); err != nil {
+			c.Log.Debug().Err(err).Msg("ignoring error")
+		}
+
+		promhttp.HandlerFor(registry, promhttp.HandlerOpts{}).ServeHTTP(w, r)
+	})
+}
+
 func runExporter(c *Controller) {
 	exporterAddr := ":" + c.Config.Exporter.Port
+	mux := http.NewServeMux()
+	mux.Handle(c.Config.Exporter.Metrics.Path, metricsHandler(c))
+
 	server := &http.Server{
 		Addr:              exporterAddr,
+		Handler:           mux,
 		IdleTimeout:       idleTimeout,
 		ReadHeaderTimeout: readHeaderTimeout,
 	}
-
-	err := prometheus.Register(GetCollector(c))
-	if err != nil {
-		c.Log.Debug().Err(err).Msg("ignoring error")
-	}
-
-	http.Handle(c.Config.Exporter.Metrics.Path, promhttp.Handler())
 	c.Log.Info().Str("addr", exporterAddr).
 		Str("path", c.Config.Exporter.Metrics.Path).
 		Msg("exporter listening")

--- a/pkg/exporter/api/exporter_internal_test.go
+++ b/pkg/exporter/api/exporter_internal_test.go
@@ -1,0 +1,83 @@
+//go:build !metrics
+
+package api
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+)
+
+func TestMetricsHandlerForwardsAuthorizationToZot(t *testing.T) {
+	const authHeader = "Basic b2JzZXJ2YWJpbGl0eTpwYXNzd29yZA=="
+
+	receivedAuth := make(chan string, 1)
+	zotServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth <- r.Header.Get(authorization)
+
+		if r.Header.Get(authorization) != authHeader {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+
+		_ = json.NewEncoder(w).Encode(&monitoring.MetricsInfo{
+			Gauges: []*monitoring.GaugeValue{
+				{Name: "zot.scheduler.workers.total", Value: 7},
+			},
+		})
+	}))
+	defer zotServer.Close()
+
+	config := DefaultConfig()
+	setTestServerAddress(t, config, zotServer.URL)
+
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	request.Header.Set(authorization, authHeader)
+
+	recorder := httptest.NewRecorder()
+	metricsHandler(NewController(config)).ServeHTTP(recorder, request)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d: %s", http.StatusOK, recorder.Code, recorder.Body.String())
+	}
+
+	if got := <-receivedAuth; got != authHeader {
+		t.Fatalf("expected Authorization header %q, got %q", authHeader, got)
+	}
+
+	body := recorder.Body.String()
+	if !strings.Contains(body, "zot_up 1") {
+		t.Fatalf("expected successful zot scrape in body:\n%s", body)
+	}
+
+	if !strings.Contains(body, "zot_scheduler_workers_total 7") {
+		t.Fatalf("expected zot metrics in body:\n%s", body)
+	}
+}
+
+func setTestServerAddress(t *testing.T, config *Config, rawURL string) {
+	t.Helper()
+
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+
+	host, port, err := net.SplitHostPort(parsedURL.Host)
+	if err != nil {
+		t.Fatalf("failed to split test server host/port: %v", err)
+	}
+
+	config.Server.Protocol = parsedURL.Scheme
+	config.Server.Host = host
+	config.Server.Port = port
+}

--- a/pkg/extensions/monitoring/minimal_client.go
+++ b/pkg/extensions/monitoring/minimal_client.go
@@ -38,6 +38,9 @@ type MetricsConfig struct {
 
 	// HTTPClient is the client to use.
 	HTTPClient *http.Client
+
+	// Headers are copied to each metrics scrape request.
+	Headers http.Header
 }
 
 type MetricsClient struct {
@@ -105,7 +108,14 @@ func NewMetricsClient(config *MetricsConfig, logger log.Logger) *MetricsClient {
 		}
 	}
 
-	return &MetricsClient{config: *config, headers: make(http.Header), log: logger}
+	return &MetricsClient{config: *config, headers: config.Headers.Clone(), log: logger}
+}
+
+func (mc *MetricsClient) WithHeaders(headers http.Header) *MetricsClient {
+	clone := *mc
+	clone.headers = headers.Clone()
+
+	return &clone
 }
 
 func (mc *MetricsClient) GetMetrics() (*MetricsInfo, error) {
@@ -123,12 +133,18 @@ func (mc *MetricsClient) makeGETRequest(url string, resultsPtr any) (http.Header
 		return nil, fmt.Errorf("metric scraping failed: %w", err)
 	}
 
+	req.Header = mc.headers.Clone()
+
 	resp, err := mc.config.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("metric scraping failed: %w", err)
 	}
 
 	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return resp.Header, fmt.Errorf("metric scraping failed: unexpected status code %d", resp.StatusCode)
+	}
 
 	if err := json.NewDecoder(resp.Body).Decode(resultsPtr); err != nil {
 		return nil, fmt.Errorf("metric scraping failed: %w", err)

--- a/pkg/extensions/monitoring/minimal_client_test.go
+++ b/pkg/extensions/monitoring/minimal_client_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -140,6 +141,27 @@ func TestNewMetricsClientFallbackKeepsTLSHardening(t *testing.T) {
 
 	if transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
 		t.Fatalf("expected fallback MinVersion TLS1.2, got: %d", transport.TLSClientConfig.MinVersion)
+	}
+}
+
+func TestMetricsClientReturnsErrorForUnexpectedStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	cfg := &MetricsConfig{Address: srv.URL}
+	mc := NewMetricsClient(cfg, log.NewLogger("debug", ""))
+
+	_, err := mc.GetMetrics()
+	if err == nil {
+		t.Fatal("expected error for unauthorized metrics response")
+	}
+
+	if !strings.Contains(err.Error(), "unexpected status code 401") {
+		t.Fatalf("expected status code in error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #3263.

## What's changed
- Forward the incoming `Authorization` header from zxp scrape requests to zot's `/metrics` endpoint.
- Build the exporter collector per scrape so authorization remains request-scoped.
- Treat non-2xx zot metrics responses as scrape failures instead of decoding them as empty metrics.

## Testing
- `GOEXPERIMENT=jsonv2 go test ./pkg/exporter/api ./pkg/extensions/monitoring -count=1`
- `GOEXPERIMENT=jsonv2 go test ./pkg/exporter/... -count=1`
- `GOEXPERIMENT=jsonv2 go test -race ./pkg/exporter/api -run TestMetricsHandlerForwardsAuthorizationToZot -count=1`
- `git diff --check`