### PR TITLE
fix(sync): apply tag filters before destination mapping

### DIFF
--- a/pkg/extensions/sync/content.go
+++ b/pkg/extensions/sync/content.go
@@ -50,7 +50,7 @@ func (cm ContentManager) MatchesContent(repo string) bool {
 
 // FilterTags filters a repo tags based on content config rules (semver, regex).
 func (cm ContentManager) FilterTags(repo string, tags []string) ([]string, error) {
-	content := cm.GetContentByLocalRepo(repo)
+	content := cm.getContentByUpstreamRepo(repo)
 
 	var err error
 	// filter based on tags rules

--- a/pkg/extensions/sync/content.go
+++ b/pkg/extensions/sync/content.go
@@ -106,7 +106,9 @@ func (cm ContentManager) GetRepoSource(repo string) string {
 
 // utilies functions.
 func (cm ContentManager) getContentByUpstreamRepo(repo string) *syncconf.Content {
-	for _, content := range cm.contents {
+	for i := range cm.contents {
+		content := &cm.contents[i]
+
 		var prefix string
 		// handle prefixes starting with '/'
 		if strings.HasPrefix(content.Prefix, "/") {
@@ -125,7 +127,7 @@ func (cm ContentManager) getContentByUpstreamRepo(repo string) *syncconf.Content
 		}
 
 		if matched {
-			return &content
+			return content
 		}
 	}
 

--- a/pkg/extensions/sync/content_test.go
+++ b/pkg/extensions/sync/content_test.go
@@ -82,6 +82,12 @@ func TestContentManager(t *testing.T) {
 		}
 	})
 
+	Convey("Test GetRepoSource() no match", t, func() {
+		content := syncconf.Content{Prefix: "repo", Destination: "/mirror"}
+		cm := sync.NewContentManager([]syncconf.Content{content}, log.NewTestLogger())
+		So(cm.GetRepoSource("other"), ShouldEqual, "")
+	})
+
 	Convey("Test MatchesContent() error", t, func() {
 		content := syncconf.Content{Prefix: "[repo%^&"}
 		cm := sync.NewContentManager([]syncconf.Content{content}, log.NewTestLogger())
@@ -169,6 +175,8 @@ func TestGetContentByLocalRepo(t *testing.T) {
 
 func TestFilterTags(t *testing.T) {
 	allTagsRegex := ".*"
+	emptyRegex := ""
+	kubeRouterRegex := "1.5.0"
 	badRegex := "[*"
 	excludeArchRegex := ".*(x86_64|aarch64|amd64|arm64)$"
 	semverFalse := false
@@ -217,6 +225,33 @@ func TestFilterTags(t *testing.T) {
 			err:          false,
 		},
 		{
+			repo: "kubernetes/kube-router",
+			content: []syncconf.Content{
+				{
+					Prefix:      "kubernetes/kube-router",
+					Destination: "/mirror",
+					Tags:        &syncconf.Tags{Regex: &kubeRouterRegex, Semver: &semverTrue},
+				},
+			},
+			tags:         []string{"1.5.0", "v2.5.0"},
+			filteredTags: []string{"1.5.0"},
+			err:          false,
+		},
+		{
+			repo: "kubernetes/kube-router",
+			content: []syncconf.Content{
+				{
+					Prefix:      "kubernetes/kube-router",
+					Destination: "/mirror",
+					StripPrefix: true,
+					Tags:        &syncconf.Tags{Regex: &kubeRouterRegex, Semver: &semverTrue},
+				},
+			},
+			tags:         []string{"1.5.0", "v2.5.0"},
+			filteredTags: []string{"1.5.0"},
+			err:          false,
+		},
+		{
 			repo: "repo",
 			content: []syncconf.Content{
 				{Prefix: "repo*", Tags: &syncconf.Tags{Regex: &badRegex}},
@@ -251,6 +286,15 @@ func TestFilterTags(t *testing.T) {
 			},
 			tags:         []string{"v1", "v2-x86_64", "v3-aarch64"},
 			filteredTags: []string{"v1"},
+			err:          false,
+		},
+		{
+			repo: "alpine",
+			content: []syncconf.Content{
+				{Prefix: "**", Tags: &syncconf.Tags{ExcludeRegex: &emptyRegex}},
+			},
+			tags:         []string{"v1", "v2", "v3"},
+			filteredTags: []string{"v1", "v2", "v3"},
 			err:          false,
 		},
 		{


### PR DESCRIPTION
Fixes #3242.

## What's changed
- Match sync tag filters against the upstream repo name before applying `destination` and `stripPrefix`.
- Add regression coverage for tag regex filtering with destination-only and destination-plus-stripPrefix content rules.

## Testing
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run TestFilterTags -count=1`
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run 'Test(FilterTags|ContentManager|GetContentByLocalRepo)' -count=1`
- `git diff --check`