### PR TITLE
fix(sync): prime catalog auth before listing repos

### DIFF
--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -422,6 +422,7 @@ func (amw *AuthnMiddleware) tryAuthnHandlers(ctlr *Controller) mux.MiddlewareFun
 			// "UpstreamClient(...)". Direct Docker CLI requests use "Docker-Client/...".
 			ua := request.Header.Get("User-Agent")
 			isDockerClient := strings.Contains(ua, "Docker-Client") || strings.HasPrefix(ua, "docker/")
+			isZotSyncClient := strings.HasPrefix(ua, "zot-sync")
 
 			// Get auth config safely
 			authConfig := ctlr.Config.CopyAuthConfig()
@@ -473,12 +474,14 @@ func (amw *AuthnMiddleware) tryAuthnHandlers(ctlr *Controller) mux.MiddlewareFun
 
 			// If no credentials provided - check for anonymous / mgmt requests
 			case allowAnonymous || isMgmtRequested:
-				// Docker workaround: force 401 on /v2/ when anonymous policies coexist with
-				// authenticated-only policies. Otherwise Docker treats 200 on /v2/ as "no auth"
-				// and will not send stored credentials for protected repositories.
+				// Force 401 on /v2/ for clients that need an auth challenge before their first
+				// catalog request when anonymous policies coexist with authenticated-only
+				// policies. Otherwise these clients treat 200 on /v2/ as "no auth" and will not
+				// send stored credentials for protected repositories.
 				// See: https://github.com/opencontainers/wg-auth/blob/main/docs/implementations/moby.md
 				hasMixedPolicy := accessControlConfig.HasMixedAnonymousAndAuthenticatedPolicies()
-				if isDockerClient && isV2Requested && hasMixedPolicy && authConfig.CanAuthenticateWithBasicCredentials() {
+				if (isDockerClient || isZotSyncClient) && isV2Requested && hasMixedPolicy &&
+					authConfig.CanAuthenticateWithBasicCredentials() {
 					authenticated = false
 				} else {
 					authenticated = true

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -14361,6 +14361,24 @@ func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
 			So(resp.Header().Get("WWW-Authenticate"), ShouldContainSubstring, "Basic realm=")
 
+			// zot sync client without an Authorization header should get 401 so regclient can prime auth.
+			resp, err = resty.R().
+				SetHeader("User-Agent", "zot-sync").
+				Get(baseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+			So(resp.Header().Get("WWW-Authenticate"), ShouldContainSubstring, "Basic realm=")
+
+			// zot sync client with valid credentials should get 200.
+			resp, err = resty.R().
+				SetHeader("User-Agent", "zot-sync").
+				SetBasicAuth(htpasswdUsername, htpasswdPassword).
+				Get(baseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
 			// Podman client without credentials should get 200 (unaffected by workaround)
 			resp, err = resty.R().
 				SetHeader("User-Agent", "containers/5.33.0 (github.com/containers/image)").
@@ -14405,6 +14423,14 @@ func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 			// Docker client without credentials should get 200 (no mixed policies)
 			resp, err := resty.R().
 				SetHeader("User-Agent", "docker/26.1.3 go/go1.22.2 UpstreamClient(Docker-Client/26.1.3 (linux))").
+				Get(baseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			// zot sync client without an Authorization header should get 200 (no mixed policies).
+			resp, err = resty.R().
+				SetHeader("User-Agent", "zot-sync").
 				Get(baseURL + "/v2/")
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)

--- a/pkg/extensions/sync/remote.go
+++ b/pkg/extensions/sync/remote.go
@@ -71,6 +71,18 @@ func (registry *RemoteRegistry) GetRepositories(ctx context.Context) ([]string, 
 func (registry *RemoteRegistry) getRepoList(ctx context.Context, hostname string) ([]string, error) {
 	repositories := []string{}
 
+	if registry.hasConfiguredCredentials(hostname) {
+		hostRef, err := ref.NewHost(hostname)
+		if err != nil {
+			return repositories, fmt.Errorf("failed to parse remote registry host %s: %w", hostname, err)
+		}
+
+		_, err = registry.client.Ping(ctx, hostRef)
+		if err != nil {
+			return repositories, err
+		}
+	}
+
 	last := ""
 
 	for {
@@ -100,6 +112,18 @@ func (registry *RemoteRegistry) getRepoList(ctx context.Context, hostname string
 	}
 
 	return repositories, nil
+}
+
+func (registry *RemoteRegistry) hasConfiguredCredentials(hostname string) bool {
+	for _, host := range registry.hosts {
+		if host.Hostname != hostname && host.Name != hostname {
+			continue
+		}
+
+		return host.User != "" || host.Pass != "" || host.Token != ""
+	}
+
+	return false
 }
 
 func (registry *RemoteRegistry) GetImageReference(repo, reference string) (ref.Ref, error) {

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -34,6 +34,7 @@ import (
 )
 
 const defaultExpireMinutes = 30 * time.Minute
+const zotSyncUserAgent = "zot-sync"
 
 type BaseService struct {
 	config           syncconf.RegistryConfig
@@ -919,6 +920,7 @@ func newClient(opts syncconf.RegistryConfig, credentials syncconf.CredentialsFil
 	regOpts = append(regOpts, reg.WithHTTPClient(httpClient))
 
 	client := regclient.New(
+		regclient.WithUserAgent(zotSyncUserAgent),
 		regclient.WithDockerCerts(),
 		regclient.WithDockerCreds(),
 		regclient.WithRegOpts(regOpts...),

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -730,6 +731,84 @@ func TestSyncLegacyCosignTagsSyncReferrers(t *testing.T) {
 		err = service.SyncReferrers(ctx, "repo", digest, nil)
 		// We don't care if it fails, only that getTags was called.
 		So(getTagsCallCount, ShouldEqual, 1)
+	})
+}
+
+func TestRemoteRegistryCatalogAuth(t *testing.T) {
+	Convey("Remote registry primes auth before catalog listing", t, func() {
+		const (
+			authUser = "sync-user"
+			authPass = "sync-pass"
+		)
+
+		var sawPing atomic.Bool
+		var sawZotSyncUserAgent atomic.Bool
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hasAuth := func() bool {
+				user, pass, ok := r.BasicAuth()
+
+				return ok && user == authUser && pass == authPass
+			}
+
+			switch r.URL.Path {
+			case "/v2/":
+				sawPing.Store(true)
+				sawZotSyncUserAgent.Store(strings.HasPrefix(r.Header.Get("User-Agent"), zotSyncUserAgent))
+				if !hasAuth() {
+					w.Header().Set("WWW-Authenticate", `Basic realm="zot"`)
+					w.WriteHeader(http.StatusUnauthorized)
+
+					return
+				}
+
+				w.WriteHeader(http.StatusOK)
+			case "/v2/_catalog":
+				w.Header().Set("Content-Type", "application/json")
+
+				if hasAuth() {
+					_, _ = w.Write([]byte(`{"repositories":["library/alpine","chat/app"]}`))
+
+					return
+				}
+
+				_, _ = w.Write([]byte(`{"repositories":["library/alpine"]}`))
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		defer server.Close()
+
+		host := strings.TrimPrefix(server.URL, "http://")
+		credentials := syncconf.CredentialsFile{
+			host: syncconf.Credentials{
+				Username: authUser,
+				Password: authPass,
+			},
+		}
+
+		client, hosts, err := newClient(syncconf.RegistryConfig{URLs: []string{server.URL}}, credentials, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		registry := NewRemoteRegistry(client, hosts, log.NewTestLogger())
+
+		repositories, err := registry.GetRepositories(context.Background())
+		So(err, ShouldBeNil)
+		So(sawPing.Load(), ShouldBeTrue)
+		So(sawZotSyncUserAgent.Load(), ShouldBeTrue)
+		So(repositories, ShouldResemble, []string{"library/alpine", "chat/app"})
+
+		sawPing.Store(false)
+		sawZotSyncUserAgent.Store(false)
+		client, hosts, err = newClient(syncconf.RegistryConfig{URLs: []string{server.URL}}, nil, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		registry = NewRemoteRegistry(client, hosts, log.NewTestLogger())
+
+		repositories, err = registry.GetRepositories(context.Background())
+		So(err, ShouldBeNil)
+		So(sawPing.Load(), ShouldBeFalse)
+		So(sawZotSyncUserAgent.Load(), ShouldBeFalse)
+		So(repositories, ShouldResemble, []string{"library/alpine"})
 	})
 }
 


### PR DESCRIPTION
## What

Fixes #3869.

This updates periodic sync catalog discovery so zot-to-zot sync can see repositories that require configured Basic credentials when the upstream registry also exposes some anonymous repositories.

## Why

regclient does not send stored Basic credentials on the first `_catalog` request unless it has already received an auth challenge. With mixed anonymous/authenticated policies, zot can return `200` for unauthenticated catalog requests while filtering the catalog down to anonymous repositories, so periodic sync never discovers protected repos.

## How

- Use a `zot-sync` User-Agent for sync-created regclient instances.
- Ping `/v2/` before `_catalog` only when credentials are configured for the remote host, giving regclient a chance to handle the Basic auth challenge.
- Extend the mixed-policy `/v2/` challenge workaround to `zot-sync` clients, while preserving anonymous-only behavior.
- Add focused sync and API regression coverage.

## Validation

- `GOEXPERIMENT=jsonv2 go test -tags "sync lint" ./pkg/extensions/sync -run TestRemoteRegistryCatalogAuth -count=1`
- `GOEXPERIMENT=jsonv2 go test -race -tags "sync lint" ./pkg/extensions/sync -run TestRemoteRegistryCatalogAuth -count=1`
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint userprefs mgmt imagetrust ui" ./pkg/api -run TestDockerClientV2ChallengeWorkaround -count=1`
- `git diff --check`

`GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run "TestRemoteRegistryCatalogAuth|TestBasicAuth" -count=1` still hits the existing missing vulnerable alpine fixture before `TestBasicAuth` can run: `test/data/alpine/blobs/sha256/f56be85fc22e46face30e2c3de3f7fe7c15f8fd7c4e5add29d7f64b87abdaa09`.