### PR TITLE
feat(metrics): add garbage collection metrics

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -919,6 +919,12 @@ Set server path on which metrics will be exposed:
 
 In order to test the Metrics feature locally in a [Kind](https://kind.sigs.k8s.io/) cluster, folow [this guide](metrics/README.md).
 
+When garbage collection is enabled, zot also exposes:
+
+- `zot_gc_runs_total{error="true|false"}`: garbage collection runs by result.
+- `zot_gc_duration_seconds`: garbage collection run duration.
+- `zot_gc_deleted_total{type="blob|manifest|upload"}`: items removed by garbage collection.
+
 ## Storage Drivers
 
 Beside filesystem storage backend, zot also supports S3 storage backend, check below url to see how to configure it:

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -540,7 +540,7 @@ func (c *Controller) StartBackgroundTasks() {
 	}
 
 	// Run GC and retention tasks
-	RunGCTasks(c.Config, c.StoreController, c.MetaDB, c.taskScheduler, c.Log, c.Audit)
+	RunGCTasks(c.Config, c.StoreController, c.MetaDB, c.taskScheduler, c.Log, c.Audit, c.Metrics)
 
 	// Enable running dedupe blobs both ways (dedupe or restore deduped blobs)
 	c.StoreController.DefaultStore.RunDedupeBlobs(time.Duration(0), c.taskScheduler)
@@ -600,7 +600,7 @@ func (c *Controller) StartBackgroundTasks() {
 
 // RunGCTasks runs minimal GC and retention tasks without full controller.
 func RunGCTasks(conf *config.Config, storeController storage.StoreController, metaDB mTypes.MetaDB,
-	taskScheduler *scheduler.Scheduler, logger log.Logger, audit *log.Logger,
+	taskScheduler *scheduler.Scheduler, logger log.Logger, audit *log.Logger, metrics monitoring.MetricServer,
 ) {
 	// Enable running garbage-collect periodically for DefaultStore
 	storageConfig := conf.CopyStorageConfig()
@@ -609,6 +609,7 @@ func RunGCTasks(conf *config.Config, storeController storage.StoreController, me
 			Delay:             storageConfig.GCDelay,
 			ImageRetention:    storageConfig.Retention,
 			MaxSchedulerDelay: storageConfig.GCMaxSchedulerDelay,
+			Metrics:           metrics,
 		}, audit, logger)
 
 		gc.CleanImageStorePeriodically(storageConfig.GCInterval, taskScheduler)
@@ -624,6 +625,7 @@ func RunGCTasks(conf *config.Config, storeController storage.StoreController, me
 						Delay:             subStorageConfig.GCDelay,
 						ImageRetention:    subStorageConfig.Retention,
 						MaxSchedulerDelay: subStorageConfig.GCMaxSchedulerDelay,
+						Metrics:           metrics,
 					}, audit, logger)
 
 				gc.CleanImageStorePeriodically(subStorageConfig.GCInterval, taskScheduler)

--- a/pkg/cli/server/verify_retention.go
+++ b/pkg/cli/server/verify_retention.go
@@ -156,7 +156,7 @@ func newVerifyFeatureRetentionCmd(conf *config.Config) *cobra.Command {
 			logger.Info().Msg("garbage collection and retention tasks will be submitted to the scheduler")
 
 			// Run GC and retention tasks
-			api.RunGCTasks(conf, storeController, metaDB, taskScheduler, logger, nil)
+			api.RunGCTasks(conf, storeController, metaDB, taskScheduler, logger, nil, nil)
 
 			// Wait for tasks to complete with optional timeout
 			timeout, err := cmd.PersistentFlags().GetDuration("timeout")

--- a/pkg/extensions/monitoring/common.go
+++ b/pkg/extensions/monitoring/common.go
@@ -18,6 +18,12 @@ type MetricServer interface {
 	Stop()
 }
 
+const (
+	GCDeletedBlob     = "blob"
+	GCDeletedManifest = "manifest"
+	GCDeletedUpload   = "upload"
+)
+
 func GetDirSize(path string) (int64, error) {
 	var size int64
 

--- a/pkg/extensions/monitoring/extension.go
+++ b/pkg/extensions/monitoring/extension.go
@@ -4,6 +4,7 @@ package monitoring
 
 import (
 	"path"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -128,6 +129,29 @@ var (
 			Buckets:   GetDefaultBuckets(),
 		},
 		[]string{"name"},
+	)
+	gcRuns = promauto.NewCounterVec( //nolint: gochecknoglobals
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "gc_runs_total",
+			Help:      "Total number of garbage collection runs",
+		},
+		[]string{"error"},
+	)
+	gcDuration = promauto.NewSummary( //nolint: gochecknoglobals
+		prometheus.SummaryOpts{
+			Namespace: metricsNamespace,
+			Name:      "gc_duration_seconds",
+			Help:      "Duration of garbage collection runs",
+		},
+	)
+	gcDeleted = promauto.NewCounterVec( //nolint: gochecknoglobals
+		prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "gc_deleted_total",
+			Help:      "Total number of items deleted by garbage collection",
+		},
+		[]string{"type"},
 	)
 )
 
@@ -291,5 +315,26 @@ func SetSchedulerTasksQueue(ms MetricServer, tq map[string]int) {
 func ObserveWorkersTasksDuration(ms MetricServer, taskName string, duration time.Duration) {
 	ms.SendMetric(func() {
 		workersTasksDuration.WithLabelValues(taskName).Observe(duration.Seconds())
+	})
+}
+
+func ObserveGCRun(ms MetricServer, duration time.Duration, runErr error) {
+	if ms == nil {
+		return
+	}
+
+	ms.SendMetric(func() {
+		gcRuns.WithLabelValues(strconv.FormatBool(runErr != nil)).Inc()
+		gcDuration.Observe(duration.Seconds())
+	})
+}
+
+func AddGCDeleted(ms MetricServer, itemType string, count int) {
+	if ms == nil || count <= 0 {
+		return
+	}
+
+	ms.SendMetric(func() {
+		gcDeleted.WithLabelValues(itemType).Add(float64(count))
 	})
 }

--- a/pkg/extensions/monitoring/minimal.go
+++ b/pkg/extensions/monitoring/minimal.go
@@ -22,6 +22,8 @@ const (
 	repoDownloads       = metricsNamespace + ".repo.downloads"
 	repoUploads         = metricsNamespace + ".repo.uploads"
 	schedulerGenerators = metricsNamespace + ".scheduler.generators"
+	gcRuns              = metricsNamespace + ".gc.runs"
+	gcDeleted           = metricsNamespace + ".gc.deleted"
 	// Gauge.
 	repoStorageBytes          = metricsNamespace + ".repo.storage.bytes"
 	serverInfo                = metricsNamespace + ".info"
@@ -31,6 +33,7 @@ const (
 	schedulerTasksQueue       = metricsNamespace + ".scheduler.tasksqueue.length"
 	// Summary.
 	httpRepoLatencySeconds = metricsNamespace + ".http.repo.latency.seconds"
+	gcDurationSeconds      = metricsNamespace + ".gc.duration.seconds"
 	// Histogram.
 	httpMethodLatencySeconds  = metricsNamespace + ".http.method.latency.seconds"
 	storageLockLatencySeconds = metricsNamespace + ".storage.lock.latency.seconds"
@@ -274,6 +277,8 @@ func GetCounters() map[string][]string {
 		repoDownloads:       {"repo"},
 		repoUploads:         {"repo"},
 		schedulerGenerators: {},
+		gcRuns:              {"error"},
+		gcDeleted:           {"type"},
 	}
 }
 
@@ -291,6 +296,7 @@ func GetGauges() map[string][]string {
 func GetSummaries() map[string][]string {
 	return map[string][]string{
 		httpRepoLatencySeconds: {"repo"},
+		gcDurationSeconds:      {},
 	}
 }
 
@@ -364,13 +370,18 @@ func (ms *metricServer) CounterInc(cv *CounterValue) {
 		return
 	}
 
+	increment := cv.Count
+	if increment <= 0 {
+		increment = 1
+	}
+
 	index, ok := findCounterValueIndex(ms.cache.Counters, cv.Name, cv.LabelValues)
 	if !ok {
 		// cv not found in cache: add it
-		cv.Count = 1
+		cv.Count = increment
 		ms.cache.Counters = append(ms.cache.Counters, cv)
 	} else {
-		ms.cache.Counters[index].Count++
+		ms.cache.Counters[index].Count += increment
 	}
 }
 
@@ -604,6 +615,39 @@ func ObserveWorkersTasksDuration(ms MetricServer, taskName string, duration time
 		LabelValues: []string{taskName},
 	}
 	ms.SendMetric(h)
+}
+
+func ObserveGCRun(ms MetricServer, duration time.Duration, runErr error) {
+	if ms == nil {
+		return
+	}
+
+	run := CounterValue{
+		Name:        gcRuns,
+		LabelNames:  []string{"error"},
+		LabelValues: []string{strconv.FormatBool(runErr != nil)},
+	}
+	durationSummary := SummaryValue{
+		Name: gcDurationSeconds,
+		Sum:  duration.Seconds(),
+	}
+
+	ms.SendMetric(run)
+	ms.SendMetric(durationSummary)
+}
+
+func AddGCDeleted(ms MetricServer, itemType string, count int) {
+	if ms == nil || count <= 0 {
+		return
+	}
+
+	deleted := CounterValue{
+		Name:        gcDeleted,
+		Count:       count,
+		LabelNames:  []string{"type"},
+		LabelValues: []string{itemType},
+	}
+	ms.SendMetric(deleted)
 }
 
 func SetSchedulerGenerators(ms MetricServer, gen map[string]map[string]uint64) {

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -3,6 +3,7 @@
 package monitoring_test
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -37,6 +38,7 @@ func TestExtensionMetrics(t *testing.T) {
 		rootDir := t.TempDir()
 
 		conf.Storage.RootDirectory = rootDir
+		conf.Storage.GC = false
 		conf.Extensions = &extconf.ExtensionConfig{}
 		enabled := true
 		conf.Extensions.Metrics = &extconf.MetricsConfig{
@@ -71,6 +73,11 @@ func TestExtensionMetrics(t *testing.T) {
 		monitoring.SetStorageUsage(ctlr.Metrics, rootDir, "alpine")
 
 		monitoring.ObserveStorageLockLatency(ctlr.Metrics, time.Millisecond, rootDir, "RWLock")
+		monitoring.ObserveGCRun(ctlr.Metrics, time.Millisecond, nil)
+		monitoring.ObserveGCRun(ctlr.Metrics, 2*time.Millisecond, errors.New("gc error"))
+		monitoring.AddGCDeleted(ctlr.Metrics, monitoring.GCDeletedBlob, 2)
+		monitoring.AddGCDeleted(ctlr.Metrics, monitoring.GCDeletedManifest, 1)
+		monitoring.AddGCDeleted(ctlr.Metrics, monitoring.GCDeletedUpload, 3)
 
 		resp, err := resty.R().Get(baseURL + "/metrics")
 		So(err, ShouldBeNil)
@@ -84,6 +91,12 @@ func TestExtensionMetrics(t *testing.T) {
 		So(respStr, ShouldContainSubstring, "zot_storage_lock_latency_seconds_bucket")
 		So(respStr, ShouldContainSubstring, "zot_storage_lock_latency_seconds_sum")
 		So(respStr, ShouldContainSubstring, "zot_storage_lock_latency_seconds_bucket")
+		So(respStr, ShouldContainSubstring, "zot_gc_runs_total{error=\"false\"} 1")
+		So(respStr, ShouldContainSubstring, "zot_gc_runs_total{error=\"true\"} 1")
+		So(respStr, ShouldContainSubstring, "zot_gc_duration_seconds_count 2")
+		So(respStr, ShouldContainSubstring, "zot_gc_deleted_total{type=\"blob\"} 2")
+		So(respStr, ShouldContainSubstring, "zot_gc_deleted_total{type=\"manifest\"} 1")
+		So(respStr, ShouldContainSubstring, "zot_gc_deleted_total{type=\"upload\"} 3")
 	})
 	Convey("Make a new controller with disabled metrics extension", t, func() {
 		port := test.GetFreePort()

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -19,6 +19,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
 	"zotregistry.dev/zot/v2/pkg/compat"
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/retention"
@@ -43,12 +44,15 @@ type Options struct {
 	MaxSchedulerDelay time.Duration
 
 	ImageRetention config.ImageRetention
+
+	Metrics monitoring.MetricServer
 }
 
 type GarbageCollect struct {
 	imgStore  types.ImageStore
 	opts      Options
 	metaDB    mTypes.MetaDB
+	metrics   monitoring.MetricServer
 	policyMgr rTypes.PolicyManager
 	auditLog  *zlog.Logger
 	log       zlog.Logger
@@ -60,6 +64,7 @@ func NewGarbageCollect(imgStore types.ImageStore, metaDB mTypes.MetaDB, opts Opt
 	return GarbageCollect{
 		imgStore:  imgStore,
 		metaDB:    metaDB,
+		metrics:   opts.Metrics,
 		opts:      opts,
 		policyMgr: retention.NewPolicyManager(opts.ImageRetention, log, auditLog),
 		auditLog:  auditLog,
@@ -95,11 +100,16 @@ in any manifests referenced in repo's index.json
 It also gc referrers with missing subject if the Referrer Option is enabled
 It also gc untagged manifests.
 */
-func (gc GarbageCollect) CleanRepo(ctx context.Context, repo string) error {
+func (gc GarbageCollect) CleanRepo(ctx context.Context, repo string) (err error) {
+	start := time.Now()
+	defer func() {
+		monitoring.ObserveGCRun(gc.metrics, time.Since(start), err)
+	}()
+
 	gc.log.Info().Str("module", "gc").
 		Msg("executing gc of orphaned blobs for " + path.Join(gc.imgStore.RootDir(), repo))
 
-	if err := gc.cleanRepo(ctx, repo); err != nil {
+	if err = gc.cleanRepo(ctx, repo); err != nil {
 		errMessage := "failed to run GC for " + path.Join(gc.imgStore.RootDir(), repo)
 		gc.log.Error().Err(err).Str("module", "gc").Msg(errMessage)
 		gc.log.Info().Str("module", "gc").
@@ -141,6 +151,8 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 		return err
 	}
 
+	manifestCount := len(index.Manifests)
+
 	// apply tags retention
 	if err := gc.removeTagsPerRetentionPolicy(ctx, repo, &index); err != nil {
 		return err
@@ -158,6 +170,8 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 		if err := gc.imgStore.PutIndexContent(repo, index); err != nil {
 			return err
 		}
+
+		monitoring.AddGCDeleted(gc.metrics, monitoring.GCDeletedManifest, manifestCount-len(index.Manifests))
 	}
 
 	// gc unreferenced blobs
@@ -625,6 +639,7 @@ func (gc GarbageCollect) removeBlobUploads(repo string, delay time.Duration) err
 	}
 
 	var aggregatedErr error
+	deleted := 0
 
 	for _, uuid := range blobUploads {
 		_, size, modtime, err := gc.imgStore.StatBlobUpload(repo, uuid)
@@ -648,8 +663,12 @@ func (gc GarbageCollect) removeBlobUploads(repo string, delay time.Duration) err
 				Str("size", strconv.FormatInt(size, 10)).Str("modified", modtime.String()).Msg("failed to delete blob upload")
 
 			aggregatedErr = errors.Join(aggregatedErr, err)
+		} else {
+			deleted++
 		}
 	}
+
+	monitoring.AddGCDeleted(gc.metrics, monitoring.GCDeletedUpload, deleted)
 
 	return aggregatedErr
 }
@@ -719,6 +738,8 @@ func (gc GarbageCollect) removeUnreferencedBlobs(repo string, delay time.Duratio
 	if err != nil {
 		return err
 	}
+
+	monitoring.AddGCDeleted(gc.metrics, monitoring.GCDeletedBlob, reaped)
 
 	log.Info().Str("module", "gc").Str("repository", repo).Int("count", reaped).
 		Msg("garbage collected blobs")

--- a/pkg/storage/gc/gc_metrics_internal_test.go
+++ b/pkg/storage/gc/gc_metrics_internal_test.go
@@ -1,0 +1,175 @@
+//go:build !metrics
+
+package gc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	. "github.com/smartystreets/goconvey/convey"
+
+	zerr "zotregistry.dev/zot/v2/errors"
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	zlog "zotregistry.dev/zot/v2/pkg/log"
+	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+func counterValue(metrics monitoring.MetricsCopy, name string, labelValues ...string) int {
+	for _, counter := range metrics.Counters {
+		if counter.Name == name && metricLabelsMatch(counter.LabelValues, labelValues) {
+			return counter.Count
+		}
+	}
+
+	return 0
+}
+
+func summaryValue(metrics monitoring.MetricsCopy, name string) monitoring.SummaryValue {
+	for _, summary := range metrics.Summaries {
+		if summary.Name == name {
+			return summary
+		}
+	}
+
+	return monitoring.SummaryValue{}
+}
+
+func metricLabelsMatch(actual, expected []string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+
+	for index := range actual {
+		if actual[index] != expected[index] {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestGarbageCollectMetrics(t *testing.T) {
+	Convey("Garbage collection records run, duration, and deletion metrics", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(true, log)
+		defer metrics.Stop()
+
+		repo := "repo"
+		manifestDigest := godigest.FromString("manifest")
+		orphanDigest := godigest.FromString("orphan")
+		configDigest := godigest.FromString("config")
+		deleteUntagged := true
+
+		storedIndex := ispec.Index{
+			MediaType: ispec.MediaTypeImageIndex,
+			Manifests: []ispec.Descriptor{
+				{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    manifestDigest,
+				},
+			},
+		}
+		manifestContent, err := json.Marshal(ispec.Manifest{
+			MediaType: ispec.MediaTypeImageManifest,
+			Config: ispec.Descriptor{
+				Digest: configDigest,
+			},
+		})
+		So(err, ShouldBeNil)
+
+		imgStore := mocks.MockedImageStore{
+			GetIndexContentFn: func(repo string) ([]byte, error) {
+				return json.Marshal(storedIndex)
+			},
+			PutIndexContentFn: func(repo string, index ispec.Index) error {
+				storedIndex = index
+
+				return nil
+			},
+			GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+				So(digest, ShouldEqual, manifestDigest)
+
+				return manifestContent, nil
+			},
+			StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+				return true, 1, time.Now().Add(-2 * time.Hour), nil
+			},
+			GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+				return []godigest.Digest{manifestDigest, orphanDigest}, nil
+			},
+			CleanupRepoFn: func(repo string, blobs []godigest.Digest, removeRepo bool) (int, error) {
+				So(blobs, ShouldHaveLength, 2)
+				So(removeRepo, ShouldBeTrue)
+
+				return len(blobs), nil
+			},
+			ListBlobUploadsFn: func(repo string) ([]string, error) {
+				return []string{"upload-1", "upload-2"}, nil
+			},
+			StatBlobUploadFn: func(repo, uuid string) (bool, int64, time.Time, error) {
+				return true, 1, time.Now().Add(-2 * time.Hour), nil
+			},
+		}
+
+		garbageCollect := NewGarbageCollect(imgStore, nil, Options{
+			Delay:   time.Hour,
+			Metrics: metrics,
+			ImageRetention: config.ImageRetention{
+				Delay: storageConstants.DefaultGCDelay,
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:   []string{"**"},
+						DeleteUntagged: &deleteUntagged,
+					},
+				},
+			},
+		}, nil, log)
+
+		err = garbageCollect.CleanRepo(context.Background(), repo)
+		So(err, ShouldBeNil)
+
+		metricsCopy := metrics.ReceiveMetrics().(monitoring.MetricsCopy)
+		So(counterValue(metricsCopy, "zot.gc.runs", "false"), ShouldEqual, 1)
+		So(counterValue(metricsCopy, "zot.gc.deleted", "manifest"), ShouldEqual, 1)
+		So(counterValue(metricsCopy, "zot.gc.deleted", "blob"), ShouldEqual, 2)
+		So(counterValue(metricsCopy, "zot.gc.deleted", "upload"), ShouldEqual, 2)
+
+		summary := summaryValue(metricsCopy, "zot.gc.duration.seconds")
+		So(summary.Count, ShouldEqual, 1)
+		So(summary.Sum, ShouldBeGreaterThanOrEqualTo, 0)
+	})
+
+	Convey("Failed garbage collection records an errored run", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(true, log)
+		defer metrics.Stop()
+
+		imgStore := mocks.MockedImageStore{
+			DirExistsFn: func(d string) bool {
+				return false
+			},
+		}
+		garbageCollect := NewGarbageCollect(imgStore, nil, Options{
+			Delay:   time.Hour,
+			Metrics: metrics,
+		}, nil, log)
+
+		err := garbageCollect.CleanRepo(context.Background(), "repo")
+		So(err, ShouldNotBeNil)
+		So(errors.Is(err, zerr.ErrRepoNotFound), ShouldBeTrue)
+
+		metricsCopy := metrics.ReceiveMetrics().(monitoring.MetricsCopy)
+		So(counterValue(metricsCopy, "zot.gc.runs", "true"), ShouldEqual, 1)
+
+		summary := summaryValue(metricsCopy, "zot.gc.duration.seconds")
+		So(summary.Count, ShouldEqual, 1)
+		So(summary.Sum, ShouldBeGreaterThanOrEqualTo, 0)
+	})
+}


### PR DESCRIPTION
Fixes #3864

Adds GC Prometheus metrics without per-repository labels:

- `zot_gc_runs_total{error}` for GC run results
- `zot_gc_duration_seconds` for per-repo GC run duration
- `zot_gc_deleted_total{type}` for removed blobs, manifests, and uploads

The same metrics are exposed through the minimal/exporter metrics path. Scheduled GC now receives the controller metrics server, while retention verification keeps nil metrics.

Validation:

- `GOEXPERIMENT=jsonv2 go test ./pkg/storage/gc -run TestGarbageCollectMetrics -count=1`
- `GOEXPERIMENT=jsonv2 go test ./pkg/storage/gc -count=1`
- `GOEXPERIMENT=jsonv2 go test -tags metrics ./pkg/extensions/monitoring -count=1`
- `GOEXPERIMENT=jsonv2 go test ./pkg/extensions/monitoring -count=1`
- `GOEXPERIMENT=jsonv2 go test ./pkg/exporter/api -count=1`
- `GOEXPERIMENT=jsonv2 go test ./pkg/api ./pkg/cli/server -run TestDoesNotExist -count=1`
- `git diff --check`
