### PR TITLE
feat(ui): show zot version info

### DIFF
--- a/pkg/extensions/extension_ui.go
+++ b/pkg/extensions/extension_ui.go
@@ -4,6 +4,7 @@ package extensions
 
 import (
 	"embed"
+	"encoding/json"
 	"io/fs"
 	"net/http"
 	"strings"
@@ -21,15 +22,44 @@ import (
 var content embed.FS
 
 type uiHandler struct {
-	log log.Logger
+	conf *config.Config
+	log  log.Logger
 }
 
 func (uih uiHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	buf, _ := content.ReadFile("build/index.html")
+	buf = injectVersionInfoScript(buf)
 
 	_, err := w.Write(buf)
 	if err != nil {
 		uih.log.Error().Err(err).Msg("failed to serve index.html")
+	}
+}
+
+func (uih uiHandler) HandleVersionInfoScript(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/javascript; charset=utf-8")
+
+	if _, err := w.Write([]byte(uiVersionInfoScript)); err != nil {
+		uih.log.Error().Err(err).Msg("failed to serve UI version info script")
+	}
+}
+
+func (uih uiHandler) HandleVersionInfo(w http.ResponseWriter, r *http.Request) {
+	sanitizedConfig := uih.conf.Sanitize()
+	versionInfo := uiVersionInfo{}
+
+	if sanitizedConfig != nil {
+		versionInfo.Commit = sanitizedConfig.Commit
+		versionInfo.ReleaseTag = sanitizedConfig.ReleaseTag
+		versionInfo.BinaryType = sanitizedConfig.BinaryType
+		versionInfo.GoVersion = sanitizedConfig.GoVersion
+		versionInfo.DistSpecVersion = sanitizedConfig.DistSpecVersion
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+
+	if err := json.NewEncoder(w).Encode(versionInfo); err != nil {
+		uih.log.Error().Err(err).Msg("failed to serve UI version info")
 	}
 }
 
@@ -72,7 +102,7 @@ func SetupUIRoutes(conf *config.Config, router *mux.Router,
 	log.Info().Msg("setting up ui routes")
 
 	fsub, _ := fs.Sub(content, "build")
-	uih := uiHandler{log: log}
+	uih := uiHandler{conf: conf, log: log}
 
 	// See https://go-review.googlesource.com/c/go/+/482635/2/src/net/http/fs.go
 	// See https://github.com/golang/go/issues/59469
@@ -82,6 +112,10 @@ func SetupUIRoutes(conf *config.Config, router *mux.Router,
 	// If we don't add this, all unmatched http methods on any urls would match the UI routes.
 	allowedMethods := zcommon.AllowedMethods(http.MethodGet)
 
+	router.Path(uiVersionInfoScriptPath).Methods(allowedMethods...).
+		Handler(addUISecurityHeaders(http.HandlerFunc(uih.HandleVersionInfoScript)))
+	router.Path(uiVersionInfoJSONPath).Methods(allowedMethods...).
+		Handler(addUISecurityHeaders(http.HandlerFunc(uih.HandleVersionInfo)))
 	router.PathPrefix("/login").Methods(allowedMethods...).
 		Handler(addUISecurityHeaders(uih))
 	router.PathPrefix("/home").Methods(allowedMethods...).
@@ -91,6 +125,8 @@ func SetupUIRoutes(conf *config.Config, router *mux.Router,
 	router.PathPrefix("/image").Methods(allowedMethods...).
 		Handler(addUISecurityHeaders(uih))
 	router.PathPrefix("/user").Methods(allowedMethods...).
+		Handler(addUISecurityHeaders(uih))
+	router.Path("/").Methods(allowedMethods...).
 		Handler(addUISecurityHeaders(uih))
 	router.PathPrefix("/").Methods(allowedMethods...).
 		Handler(addUISecurityHeaders(http.FileServer(http.FS(fsub))))

--- a/pkg/extensions/extension_ui.go
+++ b/pkg/extensions/extension_ui.go
@@ -128,6 +128,8 @@ func SetupUIRoutes(conf *config.Config, router *mux.Router,
 		Handler(addUISecurityHeaders(uih))
 	router.Path("/").Methods(allowedMethods...).
 		Handler(addUISecurityHeaders(uih))
+	router.Path("/index.html").Methods(allowedMethods...).
+		Handler(addUISecurityHeaders(uih))
 	router.PathPrefix("/").Methods(allowedMethods...).
 		Handler(addUISecurityHeaders(http.FileServer(http.FS(fsub))))
 

--- a/pkg/extensions/extension_ui_test.go
+++ b/pkg/extensions/extension_ui_test.go
@@ -3,6 +3,7 @@
 package extensions_test
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"os"
@@ -26,6 +27,11 @@ func TestUIExtension(t *testing.T) {
 		port := test.GetFreePort()
 		baseURL := test.GetBaseURL(port)
 		conf.HTTP.Port = port
+		conf.Commit = "abc123"
+		conf.ReleaseTag = "v2.1.0"
+		conf.BinaryType = "server"
+		conf.GoVersion = "go1.24.0"
+		conf.DistSpecVersion = "1.1.1"
 
 		// we won't use the logging config feature as we want logs in both
 		// stdout and a file
@@ -49,6 +55,7 @@ func TestUIExtension(t *testing.T) {
 
 		ctlrManager := test.NewControllerManager(ctlr)
 		ctlrManager.StartAndWait(port)
+		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath, "\"UI\":{\"Enable\":true}", 2*time.Minute)
 		So(found, ShouldBeTrue)
@@ -71,6 +78,40 @@ func TestUIExtension(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+		So(string(resp.Body()), ShouldContainSubstring, "/assets/zot-version-info.js")
+
+		resp, err = resty.R().Get(baseURL + "/")
+		So(err, ShouldBeNil)
+		So(resp, ShouldNotBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+		So(string(resp.Body()), ShouldContainSubstring, "/assets/zot-version-info.js")
+
+		resp, err = resty.R().Get(baseURL + "/assets/zot-version-info.js")
+		So(err, ShouldBeNil)
+		So(resp, ShouldNotBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+		So(string(resp.Body()), ShouldContainSubstring, "zot-version-info")
+
+		resp, err = resty.R().Get(baseURL + "/assets/zot-version.json")
+		So(err, ShouldBeNil)
+		So(resp, ShouldNotBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+		So(resp.Header().Get("Content-Type"), ShouldContainSubstring, "application/json")
+
+		versionInfo := struct {
+			Commit          string `json:"commit"`
+			ReleaseTag      string `json:"releaseTag"`
+			BinaryType      string `json:"binaryType"`
+			GoVersion       string `json:"goVersion"`
+			DistSpecVersion string `json:"distSpecVersion"`
+		}{}
+		err = json.Unmarshal(resp.Body(), &versionInfo)
+		So(err, ShouldBeNil)
+		So(versionInfo.Commit, ShouldEqual, "abc123")
+		So(versionInfo.ReleaseTag, ShouldEqual, "v2.1.0")
+		So(versionInfo.BinaryType, ShouldEqual, "server")
+		So(versionInfo.GoVersion, ShouldEqual, "go1.24.0")
+		So(versionInfo.DistSpecVersion, ShouldEqual, "1.1.1")
 
 		resp, err = resty.R().Get(baseURL + "/image/")
 		So(err, ShouldBeNil)

--- a/pkg/extensions/extension_ui_test.go
+++ b/pkg/extensions/extension_ui_test.go
@@ -86,6 +86,12 @@ func TestUIExtension(t *testing.T) {
 		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 		So(string(resp.Body()), ShouldContainSubstring, "/assets/zot-version-info.js")
 
+		resp, err = resty.R().Get(baseURL + "/index.html")
+		So(err, ShouldBeNil)
+		So(resp, ShouldNotBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+		So(string(resp.Body()), ShouldContainSubstring, "/assets/zot-version-info.js")
+
 		resp, err = resty.R().Get(baseURL + "/assets/zot-version-info.js")
 		So(err, ShouldBeNil)
 		So(resp, ShouldNotBeNil)

--- a/pkg/extensions/extension_ui_version.go
+++ b/pkg/extensions/extension_ui_version.go
@@ -1,0 +1,166 @@
+//go:build search && ui
+
+package extensions
+
+import "bytes"
+
+const (
+	uiVersionInfoScriptPath = "/assets/zot-version-info.js"
+	uiVersionInfoJSONPath   = "/assets/zot-version.json"
+	uiVersionInfoScriptTag  = `<script type="module" crossorigin src="` + uiVersionInfoScriptPath + `"></script>`
+	uiVersionInfoScript     = `
+const versionInfoID = "zot-version-info";
+const versionEndpoint = "/assets/zot-version.json";
+
+const copyText = async (text) => {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text);
+
+    return;
+  }
+
+  const textArea = document.createElement("textarea");
+  textArea.value = text;
+  textArea.setAttribute("readonly", "");
+  textArea.style.position = "fixed";
+  textArea.style.opacity = "0";
+  document.body.appendChild(textArea);
+  textArea.select();
+  document.execCommand("copy");
+  textArea.remove();
+};
+
+const displayValue = (value, fallback) => {
+  if (typeof value !== "string" || value.trim() === "") {
+    return fallback;
+  }
+
+  return value.trim();
+};
+
+const renderVersionInfo = (versionInfo) => {
+  if (document.getElementById(versionInfoID)) {
+    return;
+  }
+
+  const releaseTag = displayValue(versionInfo.releaseTag, "unknown");
+  const commit = displayValue(versionInfo.commit, "unknown");
+  const binaryType = displayValue(versionInfo.binaryType, "");
+  const copyValue = "zot " + releaseTag + " commit " + commit;
+  const visibleValue = binaryType === ""
+    ? "zot " + releaseTag + " | commit " + commit
+    : "zot " + releaseTag + " | " + binaryType + " | commit " + commit;
+
+  const style = document.createElement("style");
+  style.textContent = [
+    "#" + versionInfoID + " {",
+    "  position: fixed;",
+    "  right: 16px;",
+    "  bottom: 16px;",
+    "  z-index: 1200;",
+    "  display: flex;",
+    "  max-width: calc(100vw - 32px);",
+    "  align-items: center;",
+    "  gap: 8px;",
+    "  box-sizing: border-box;",
+    "  padding: 6px 8px 6px 10px;",
+    "  border: 1px solid rgba(31, 41, 55, 0.18);",
+    "  border-radius: 4px;",
+    "  background: rgba(255, 255, 255, 0.94);",
+    "  color: #1f2937;",
+    "  box-shadow: 0 4px 12px rgba(31, 41, 55, 0.16);",
+    "  font-family: Roboto, Arial, sans-serif;",
+    "  font-size: 12px;",
+    "  line-height: 16px;",
+    "}",
+    "#" + versionInfoID + " span {",
+    "  overflow: hidden;",
+    "  text-overflow: ellipsis;",
+    "  white-space: nowrap;",
+    "  user-select: text;",
+    "}",
+    "#" + versionInfoID + " button {",
+    "  flex: 0 0 auto;",
+    "  min-width: 44px;",
+    "  height: 24px;",
+    "  border: 1px solid rgba(31, 41, 55, 0.28);",
+    "  border-radius: 4px;",
+    "  background: #ffffff;",
+    "  color: #1f2937;",
+    "  cursor: pointer;",
+    "  font: inherit;",
+    "}",
+    "#" + versionInfoID + " button:focus-visible {",
+    "  outline: 2px solid #1d4ed8;",
+    "  outline-offset: 2px;",
+    "}",
+  ].join("\n");
+  document.head.appendChild(style);
+
+  const container = document.createElement("aside");
+  container.id = versionInfoID;
+  container.setAttribute("aria-label", "zot version information");
+
+  const label = document.createElement("span");
+  label.textContent = visibleValue;
+  label.title = visibleValue;
+
+  const copyButton = document.createElement("button");
+  copyButton.type = "button";
+  copyButton.textContent = "Copy";
+  copyButton.title = "Copy zot version information";
+  copyButton.addEventListener("click", async () => {
+    try {
+      await copyText(copyValue);
+      copyButton.textContent = "Copied";
+      window.setTimeout(() => {
+        copyButton.textContent = "Copy";
+      }, 1200);
+    } catch (error) {
+      copyButton.textContent = "Copy";
+    }
+  });
+
+  container.appendChild(label);
+  container.appendChild(copyButton);
+  document.body.appendChild(container);
+};
+
+const loadVersionInfo = async () => {
+  const response = await fetch(versionEndpoint, {
+    credentials: "same-origin",
+    headers: { Accept: "application/json" },
+  });
+
+  if (!response.ok) {
+    return;
+  }
+
+  renderVersionInfo(await response.json());
+};
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", () => {
+    loadVersionInfo().catch(() => {});
+  }, { once: true });
+} else {
+  loadVersionInfo().catch(() => {});
+}
+`
+)
+
+type uiVersionInfo struct {
+	Commit          string `json:"commit"`
+	ReleaseTag      string `json:"releaseTag"`
+	BinaryType      string `json:"binaryType"`
+	GoVersion       string `json:"goVersion"`
+	DistSpecVersion string `json:"distSpecVersion"`
+}
+
+func injectVersionInfoScript(indexHTML []byte) []byte {
+	if bytes.Contains(indexHTML, []byte(uiVersionInfoScriptPath)) {
+		return indexHTML
+	}
+
+	return bytes.Replace(indexHTML, []byte("</head>"), []byte("    "+uiVersionInfoScriptTag+"\n  </head>"), 1)
+}


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:

Fixes #1669

**What does this PR do / Why do we need it**:

Shows zot release and commit information in the UI in a compact copyable format.

The UI build output is generated from the zui artifact, so this keeps the zot-side change source-controlled by injecting a small version-info module when the UI extension serves `index.html`. The module reads build metadata from `/assets/zot-version.json` and renders a copyable version chip.

**If an issue # is not available please add repro steps and logs showing the issue**:

N/A

**Testing done on this change**:

```console
GOEXPERIMENT=jsonv2 go test -tags "search ui" ./pkg/extensions -run TestUIExtension -count=1
GOEXPERIMENT=jsonv2 go test -tags "search ui" ./pkg/extensions -count=1
GOEXPERIMENT=jsonv2 go test -tags "search ui mgmt" ./pkg/extensions -run TestUIExtension -count=1
GOEXPERIMENT=jsonv2 go test ./pkg/extensions -run TestDoesNotExist -count=1
git diff --check
```

**Automation added to e2e**:

No. Covered by UI extension route tests.

**Will this break upgrades or downgrades?**

No.

**Does this PR introduce any user-facing change?**:

Yes.

```release-note
Show zot version and commit information in the UI in a copyable format.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
