### PR TITLE
feat(server): notify systemd when ready

### DIFF
--- a/examples/zot.service
+++ b/examples/zot.service
@@ -4,7 +4,8 @@ Documentation=https://github.com/project-zot/zot
 After=network.target auditd.service local-fs.target
 
 [Service]
-Type=simple
+Type=notify
+NotifyAccess=main
 ExecStart=/usr/bin/zot serve /etc/zot/config.json
 Restart=on-failure
 User=zot

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/cloudevents/sdk-go/protocol/nats/v2 v2.16.2
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/coreos/go-oidc/v3 v3.18.0
+	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/dchest/siphash v1.2.3
 	github.com/didip/tollbooth/v7 v7.0.2
 	github.com/distribution/distribution/v3 v3.1.0

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -301,13 +301,13 @@ func (c *Controller) Run() error {
 		// Set GetCertificate callback for dynamic certificate reloading
 		server.TLSConfig.GetCertificate = watcher.GetCertificate
 
-		c.Healthz.Ready()
+		c.markReady()
 
 		// Pass empty strings to ServeTLS since GetCertificate handles certificate loading
 		return server.ServeTLS(listener, "", "")
 	}
 
-	c.Healthz.Ready()
+	c.markReady()
 
 	return server.Serve(listener)
 }

--- a/pkg/api/systemd.go
+++ b/pkg/api/systemd.go
@@ -1,0 +1,23 @@
+package api
+
+import "github.com/coreos/go-systemd/v22/daemon"
+
+var systemdNotify = daemon.SdNotify
+
+func (c *Controller) markReady() {
+	c.Healthz.Ready()
+	c.notifySystemdReady()
+}
+
+func (c *Controller) notifySystemdReady() {
+	sent, err := systemdNotify(false, daemon.SdNotifyReady)
+	if err != nil {
+		c.Log.Warn().Err(err).Msg("failed to notify systemd readiness")
+
+		return
+	}
+
+	if sent {
+		c.Log.Debug().Msg("notified systemd readiness")
+	}
+}

--- a/pkg/api/systemd_internal_test.go
+++ b/pkg/api/systemd_internal_test.go
@@ -1,0 +1,55 @@
+//go:build sync && scrub && metrics && search && lint && userprefs && mgmt && imagetrust && ui
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coreos/go-systemd/v22/daemon"
+
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/common"
+	"zotregistry.dev/zot/v2/pkg/log"
+)
+
+func TestMarkReadyNotifiesSystemd(t *testing.T) {
+	logger := log.NewLogger("debug", "")
+	ctlr := &Controller{
+		Healthz: common.NewHealthzServer(config.New(), logger),
+		Log:     logger,
+	}
+
+	originalNotify := systemdNotify
+	t.Cleanup(func() {
+		systemdNotify = originalNotify
+	})
+
+	var gotState string
+	var gotUnsetEnvironment bool
+	systemdNotify = func(unsetEnvironment bool, state string) (bool, error) {
+		gotUnsetEnvironment = unsetEnvironment
+		gotState = state
+
+		return true, nil
+	}
+
+	ctlr.markReady()
+
+	if gotUnsetEnvironment {
+		t.Fatal("expected systemd notify environment to remain set")
+	}
+
+	if gotState != daemon.SdNotifyReady {
+		t.Fatalf("expected systemd ready notification, got %q", gotState)
+	}
+
+	response := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+	ctlr.Healthz.Handler.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected readyz to return 200, got %d", response.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- send `READY=1` through `go-systemd` when zot reaches its existing ready state
- keep `/readyz` as the readiness source and notify after the HTTP listener is bound
- switch `examples/zot.service` to `Type=notify` with `NotifyAccess=main`

Fixes #2188

## Testing
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint userprefs mgmt imagetrust ui" ./pkg/api -run TestMarkReadyNotifiesSystemd -count=1`
- `GOEXPERIMENT=jsonv2 go test ./pkg/api ./pkg/cli/server -run TestDoesNotExist -count=1`
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint userprefs mgmt imagetrust ui" ./pkg/api -run 'TestRunPortZeroTracksChosenPort|TestMarkReadyNotifiesSystemd' -count=1`\n- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint userprefs mgmt imagetrust ui" ./pkg/cli/server -run TestServe -count=1`\n- `GOEXPERIMENT=jsonv2 go vet -tags "sync scrub metrics search lint userprefs mgmt imagetrust ui" ./pkg/api ./pkg/cli/server`\n- `git diff --check`