### PR TITLE
feat(server): support systemd socket activation

### DIFF
--- a/examples/systemd-socket-activation/README.md
+++ b/examples/systemd-socket-activation/README.md
@@ -1,0 +1,28 @@
+# Systemd Socket Activation
+
+This example lets zot listen on a privileged port such as `80` or `443` without granting the zot
+process `CAP_NET_BIND_SERVICE`.
+
+Systemd creates the listening socket from `ListenStream` in `zot.socket`. When the first client
+connects, systemd starts `zot.service` and passes the listener to zot through the socket activation
+file descriptor environment.
+
+Install the example units as `root` after reviewing the paths and port:
+
+```bash
+install zot.service /etc/systemd/system/zot.service
+install zot.socket /etc/systemd/system/zot.socket
+systemctl daemon-reload
+systemctl enable zot.socket
+systemctl start zot.socket
+```
+
+For local development, build zot and run it through `systemd-socket-activate`:
+
+```bash
+systemd-socket-activate \
+  --listen=127.0.0.1:9999 \
+  ./bin/zot-linux-amd64 \
+  serve \
+  examples/config-minimal.json
+```

--- a/examples/systemd-socket-activation/zot.service
+++ b/examples/systemd-socket-activation/zot.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=OCI Distribution Registry
+Documentation=https://github.com/project-zot/zot
+After=network.target auditd.service local-fs.target
+Requires=zot.socket
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/zot serve /etc/zot/config.json
+Restart=on-failure
+User=zot
+Group=zot
+LimitNOFILE=500000
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/systemd-socket-activation/zot.socket
+++ b/examples/systemd-socket-activation/zot.socket
@@ -1,0 +1,10 @@
+[Unit]
+Description=OCI Distribution Registry Socket
+
+[Socket]
+ListenStream=80
+FileDescriptorName=http
+Service=zot.service
+
+[Install]
+WantedBy=sockets.target

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/cloudevents/sdk-go/protocol/nats/v2 v2.16.2
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/coreos/go-oidc/v3 v3.18.0
+	github.com/coreos/go-systemd/v22 v22.7.0
 	github.com/dchest/siphash v1.2.3
 	github.com/didip/tollbooth/v7 v7.0.2
 	github.com/distribution/distribution/v3 v3.1.0

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -7,7 +7,6 @@ import (
 	"crypto/x509"
 	goerrors "errors"
 	"fmt"
-	"net"
 	"net/http"
 	"os"
 	"strconv"
@@ -172,6 +171,12 @@ func (c *Controller) Run() error {
 
 	port := c.Config.GetHTTPPort()
 	addr := fmt.Sprintf("%s:%s", c.Config.GetHTTPAddress(), port)
+
+	listener, addr, err := c.createListener(addr, port)
+	if err != nil {
+		return err
+	}
+
 	server := &http.Server{
 		Addr:              addr,
 		Handler:           c.Router,
@@ -179,29 +184,6 @@ func (c *Controller) Run() error {
 		ReadHeaderTimeout: readHeaderTimeout,
 	}
 	c.Server = server
-
-	// Create the listener
-	listener, err := net.Listen("tcp", addr) //nolint: noctx
-	if err != nil {
-		return err
-	}
-
-	// Always derive the bound port from the listener so GetPort matches the actual socket (numeric
-	// config, kernel-chosen :0, or service names like "http" resolved by net.Listen).
-	chosenAddr, ok := listener.Addr().(*net.TCPAddr)
-	if !ok {
-		c.Log.Error().Str("port", port).Msg("invalid addr type")
-
-		return errors.ErrBadType
-	}
-
-	c.chosenPort.Store(int64(chosenAddr.Port))
-
-	if port == "0" || port == "" {
-		c.Log.Info().Int("port", chosenAddr.Port).IPAddr("address", chosenAddr.IP).Msg(
-			"port is unspecified, listening on kernel chosen port",
-		)
-	}
 
 	tlsConfig := c.Config.CopyTLSConfig()
 	if tlsConfig != nil && tlsConfig.Key != "" && tlsConfig.Cert != "" {

--- a/pkg/api/listener.go
+++ b/pkg/api/listener.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/coreos/go-systemd/v22/activation"
+
+	"zotregistry.dev/zot/v2/errors"
+)
+
+var systemdActivationListeners = activation.Listeners
+
+func (c *Controller) createListener(addr, port string) (net.Listener, string, error) {
+	listener, activated, err := c.systemdListener()
+	if err != nil {
+		return nil, "", err
+	}
+
+	if activated {
+		return listener, listener.Addr().String(), c.setChosenPort(listener, port, true)
+	}
+
+	listener, err = net.Listen("tcp", addr) //nolint: noctx
+	if err != nil {
+		return nil, "", err
+	}
+
+	if err := c.setChosenPort(listener, port, false); err != nil {
+		_ = listener.Close()
+
+		return nil, "", err
+	}
+
+	return listener, addr, nil
+}
+
+func (c *Controller) systemdListener() (net.Listener, bool, error) {
+	listeners, err := systemdActivationListeners()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to get systemd socket activation listeners: %w", err)
+	}
+
+	if len(listeners) == 0 {
+		return nil, false, nil
+	}
+
+	if len(listeners) != 1 {
+		closeListeners(listeners)
+
+		return nil, false, fmt.Errorf("expected exactly one systemd socket activation listener, got %d", len(listeners))
+	}
+
+	listener := listeners[0]
+	if listener == nil {
+		return nil, false, fmt.Errorf("systemd socket activation listener is not a stream listener")
+	}
+
+	if _, ok := listener.Addr().(*net.TCPAddr); !ok {
+		_ = listener.Close()
+		c.Log.Error().Str("addr", listener.Addr().String()).Msg("systemd socket activation listener is not TCP")
+
+		return nil, false, errors.ErrBadType
+	}
+
+	return listener, true, nil
+}
+
+func (c *Controller) setChosenPort(listener net.Listener, port string, systemd bool) error {
+	chosenAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		c.Log.Error().Str("port", port).Msg("invalid addr type")
+
+		return errors.ErrBadType
+	}
+
+	c.chosenPort.Store(int64(chosenAddr.Port))
+
+	if systemd {
+		c.Log.Info().Int("port", chosenAddr.Port).IPAddr("address", chosenAddr.IP).
+			Msg("using systemd socket activation listener")
+	} else if port == "0" || port == "" {
+		c.Log.Info().Int("port", chosenAddr.Port).IPAddr("address", chosenAddr.IP).Msg(
+			"port is unspecified, listening on kernel chosen port",
+		)
+	}
+
+	return nil
+}
+
+func closeListeners(listeners []net.Listener) {
+	for _, listener := range listeners {
+		if listener != nil {
+			_ = listener.Close()
+		}
+	}
+}

--- a/pkg/api/listener_internal_test.go
+++ b/pkg/api/listener_internal_test.go
@@ -1,0 +1,120 @@
+//go:build sync && scrub && metrics && search && lint && userprefs && mgmt && imagetrust && ui
+
+package api
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/log"
+)
+
+func TestCreateListenerUsesSystemdActivation(t *testing.T) {
+	activatedListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create activated listener: %v", err)
+	}
+
+	originalActivationListeners := systemdActivationListeners
+	t.Cleanup(func() {
+		systemdActivationListeners = originalActivationListeners
+	})
+
+	systemdActivationListeners = func() ([]net.Listener, error) {
+		return []net.Listener{activatedListener}, nil
+	}
+
+	conf := config.New()
+	conf.HTTP.Port = "1"
+	ctlr := &Controller{
+		Config: conf,
+		Log:    log.NewLogger("debug", ""),
+	}
+
+	listener, addr, err := ctlr.createListener("127.0.0.1:1", conf.GetHTTPPort())
+	if err != nil {
+		t.Fatalf("unexpected create listener error: %v", err)
+	}
+	defer listener.Close()
+
+	wantPort := activatedListener.Addr().(*net.TCPAddr).Port
+	if ctlr.GetPort() != wantPort {
+		t.Fatalf("expected chosen port %d, got %d", wantPort, ctlr.GetPort())
+	}
+
+	if addr != activatedListener.Addr().String() {
+		t.Fatalf("expected server address %q, got %q", activatedListener.Addr().String(), addr)
+	}
+}
+
+func TestCreateListenerRejectsMultipleSystemdActivationListeners(t *testing.T) {
+	firstListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create first listener: %v", err)
+	}
+	defer firstListener.Close()
+
+	secondListener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to create second listener: %v", err)
+	}
+	defer secondListener.Close()
+
+	originalActivationListeners := systemdActivationListeners
+	t.Cleanup(func() {
+		systemdActivationListeners = originalActivationListeners
+	})
+
+	systemdActivationListeners = func() ([]net.Listener, error) {
+		return []net.Listener{firstListener, secondListener}, nil
+	}
+
+	conf := config.New()
+	ctlr := &Controller{
+		Config: conf,
+		Log:    log.NewLogger("debug", ""),
+	}
+
+	_, _, err = ctlr.createListener("127.0.0.1:0", conf.GetHTTPPort())
+	if err == nil {
+		t.Fatal("expected multiple systemd listeners to fail")
+	}
+
+	if !strings.Contains(err.Error(), "expected exactly one systemd socket activation listener") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCreateListenerFallsBackToConfiguredAddress(t *testing.T) {
+	originalActivationListeners := systemdActivationListeners
+	t.Cleanup(func() {
+		systemdActivationListeners = originalActivationListeners
+	})
+
+	systemdActivationListeners = func() ([]net.Listener, error) {
+		return nil, nil
+	}
+
+	conf := config.New()
+	conf.HTTP.Port = "0"
+	ctlr := &Controller{
+		Config: conf,
+		Log:    log.NewLogger("debug", ""),
+	}
+
+	listener, addr, err := ctlr.createListener("127.0.0.1:0", conf.GetHTTPPort())
+	if err != nil {
+		t.Fatalf("unexpected create listener error: %v", err)
+	}
+	defer listener.Close()
+
+	if ctlr.GetPort() <= 0 {
+		t.Fatalf("expected chosen port to be set, got %d", ctlr.GetPort())
+	}
+
+	if addr != "127.0.0.1:0" {
+		t.Fatalf("expected configured server address, got %q", addr)
+	}
+}


### PR DESCRIPTION
## Summary
- accept a single TCP listener passed through systemd socket activation
- preserve the existing configured `net.Listen` path when no activation listener is present
- add systemd socket activation example units and documentation

This revives the direction from the stale #2186 patch against current `main`.

Fixes #2182

## Testing
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint userprefs mgmt imagetrust ui" ./pkg/api -run 'TestCreateListener' -count=1`\n- `GOEXPERIMENT=jsonv2 go test ./pkg/api ./pkg/cli/server -run TestDoesNotExist -count=1`\n- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint userprefs mgmt imagetrust ui" ./pkg/cli/server -run TestServe -count=1`\n- `GOEXPERIMENT=jsonv2 go vet -tags "sync scrub metrics search lint userprefs mgmt imagetrust ui" ./pkg/api ./pkg/cli/server`\n- `GOEXPERIMENT=jsonv2 go build -tags "sync scrub metrics search lint userprefs mgmt imagetrust ui" -o /tmp/zot-socket-test ./cmd/zot`\n- `systemd-socket-activate --listen=127.0.0.1:18080 /tmp/zot-socket-test serve examples/config-minimal.json` plus `curl -i http://127.0.0.1:18080/v2/` returned `HTTP/1.1 200 OK`\n- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint userprefs mgmt imagetrust ui" ./pkg/api -run 'TestRunPortZeroTracksChosenPort|TestCreateListener' -count=1`\n- `git diff --check`