### PR TITLE
feat(sync): control recursive referrer sync

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1156,6 +1156,8 @@ Configure each registry sync:
 				"maxRetries": 5,                    # maxRetries in case of temporary errors (default: no retries)
 				"retryDelay": "10m",                # delay between retries, retry options are applied for both on demand and periodically sync and retryDelay is mandatory when using maxRetries.
 				"onlySigned": true,                 # sync only signed images (either notary or cosign)
+				"syncLegacyCosignTags": true,       # sync legacy digest-tag cosign/SBOM referrers (default is true)
+				"syncReferrersRecursive": true,     # recursively sync referrers during polling (default is true)
 				"content":[                         # which content to periodically pull, also it's used for filtering ondemand images, if not set then periodically polling will not run
 					{
 						"prefix":"/repo1/repo",         # pull image repo1/repo

--- a/examples/config-sync.json
+++ b/examples/config-sync.json
@@ -26,6 +26,8 @@
 					"maxRetries": 3,
 					"retryDelay": "5m",
 					"onlySigned": true,
+					"syncLegacyCosignTags": true,
+					"syncReferrersRecursive": true,
 					"content": [
 						{
 							"prefix": "/repo1/repo",

--- a/pkg/cli/server/schema_test.go
+++ b/pkg/cli/server/schema_test.go
@@ -62,10 +62,11 @@ func TestSchemaAllowsNullForPointerFields(t *testing.T) {
 					"enable": nil,
 					"registries": []any{
 						map[string]any{
-							"tlsVerify":            nil,
-							"retryDelay":           nil,
-							"onlySigned":           nil,
-							"syncLegacyCosignTags": nil,
+							"tlsVerify":              nil,
+							"retryDelay":             nil,
+							"onlySigned":             nil,
+							"syncLegacyCosignTags":   nil,
+							"syncReferrersRecursive": nil,
 						},
 					},
 				},

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -23,26 +23,33 @@ type Config struct {
 }
 
 type RegistryConfig struct {
-	URLs                  []string
-	PollInterval          time.Duration
-	Content               []Content
-	TLSVerify             *bool
-	OnDemand              bool
-	CertDir               string
-	MaxRetries            *int
-	RetryDelay            *time.Duration
-	OnlySigned            *bool
-	SyncLegacyCosignTags  *bool // when unset, defaults to true
-	CredentialHelper      string
-	PreserveDigest        bool          // sync without converting
-	SyncTimeout           time.Duration // overall HTTP client timeout for all sync operations
-	ResponseHeaderTimeout time.Duration `yaml:"-"` // response header timeout; set in root.go
+	URLs                   []string
+	PollInterval           time.Duration
+	Content                []Content
+	TLSVerify              *bool
+	OnDemand               bool
+	CertDir                string
+	MaxRetries             *int
+	RetryDelay             *time.Duration
+	OnlySigned             *bool
+	SyncLegacyCosignTags   *bool // when unset, defaults to true
+	SyncReferrersRecursive *bool // when unset, defaults to true
+	CredentialHelper       string
+	PreserveDigest         bool          // sync without converting
+	SyncTimeout            time.Duration // overall HTTP client timeout for all sync operations
+	ResponseHeaderTimeout  time.Duration `yaml:"-"` // response header timeout; set in root.go
 }
 
 // ShouldSyncLegacyCosignTags returns whether to sync legacy cosign tags (e.g. sha256-<digest>.sig/sbom).
 // Default is true when SyncLegacyCosignTags is unset (nil).
 func (r RegistryConfig) ShouldSyncLegacyCosignTags() bool {
 	return r.SyncLegacyCosignTags == nil || *r.SyncLegacyCosignTags
+}
+
+// ShouldSyncReferrersRecursively returns whether periodic sync follows referrers of referrers.
+// Default is true when SyncReferrersRecursive is unset (nil).
+func (r RegistryConfig) ShouldSyncReferrersRecursively() bool {
+	return r.SyncReferrersRecursive == nil || *r.SyncReferrersRecursive
 }
 
 type Content struct {

--- a/pkg/extensions/config/sync/config_test.go
+++ b/pkg/extensions/config/sync/config_test.go
@@ -29,3 +29,25 @@ func TestRegistryConfig_ShouldSyncLegacyCosignTags(t *testing.T) {
 		})
 	})
 }
+
+func TestRegistryConfig_ShouldSyncReferrersRecursively(t *testing.T) {
+	Convey("ShouldSyncReferrersRecursively", t, func() {
+		Convey("returns true when SyncReferrersRecursive is nil (default)", func() {
+			cfg := syncconf.RegistryConfig{}
+			So(cfg.SyncReferrersRecursive, ShouldBeNil)
+			So(cfg.ShouldSyncReferrersRecursively(), ShouldBeTrue)
+		})
+
+		Convey("returns true when SyncReferrersRecursive is true", func() {
+			v := true
+			cfg := syncconf.RegistryConfig{SyncReferrersRecursive: &v}
+			So(cfg.ShouldSyncReferrersRecursively(), ShouldBeTrue)
+		})
+
+		Convey("returns false when SyncReferrersRecursive is false", func() {
+			v := false
+			cfg := syncconf.RegistryConfig{SyncReferrersRecursive: &v}
+			So(cfg.ShouldSyncReferrersRecursively(), ShouldBeFalse)
+		})
+	})
+}

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -626,7 +626,8 @@ func (service *BaseService) syncImage(ctx context.Context, localRepo, remoteRepo
 	}
 
 	if withReferrers {
-		_ = service.syncReferrers(ctx, repoTags, localRepo, remoteRepo, localImageRef, remoteImageRef, true)
+		_ = service.syncReferrers(ctx, repoTags, localRepo, remoteRepo, localImageRef, remoteImageRef,
+			service.config.ShouldSyncReferrersRecursively())
 	}
 
 	// convert image to oci if needed

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -241,6 +241,34 @@ func makeUpstreamServer(
 	return makeUpstreamServerWithCerts(t, secure, basicAuth, "", nil)
 }
 
+func makeReferrerTestUpstreamServer(t *testing.T) (*api.Controller, string) {
+	t.Helper()
+
+	srcPort := test.GetFreePort()
+	srcBaseURL := test.GetBaseURL(srcPort)
+	srcConfig := config.New()
+	srcConfig.HTTP.Port = srcPort
+	srcConfig.Storage.GC = false
+
+	srcDir := t.TempDir()
+	srcStorageCtrl := ociutils.GetDefaultStoreController(srcDir, log.NewTestLogger())
+
+	err := WriteImageToFileSystem(CreateDefaultImage(), testImage, testImageTag, srcStorageCtrl)
+	if err != nil {
+		panic(err)
+	}
+
+	srcConfig.Storage.RootDirectory = srcDir
+
+	defVal := true
+	srcConfig.Extensions = &extconf.ExtensionConfig{}
+	srcConfig.Extensions.Search = &extconf.SearchConfig{
+		BaseConfig: extconf.BaseConfig{Enable: &defVal},
+	}
+
+	return api.NewController(srcConfig), srcBaseURL
+}
+
 // makeDownstreamServerWithCerts creates a downstream server using shared certificates.
 func makeDownstreamServerWithCerts(
 	t *testing.T, secure bool, syncConfig *syncconf.Config, certDir string, caCertPEM []byte,
@@ -8134,6 +8162,126 @@ func TestOnDemandReferrerSyncFlags(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(len(refs), ShouldEqual, 1)
 	})
+}
+
+func TestPeriodicSyncReferrersRecursiveFlag(t *testing.T) {
+	Convey("syncReferrersRecursive=false keeps periodic sync to direct referrers", t, func() {
+		sctlr, srcBaseURL := makeReferrerTestUpstreamServer(t)
+
+		scm := test.NewControllerManager(sctlr)
+		scm.StartAndWait(sctlr.Config.HTTP.Port)
+
+		defer scm.StopServer()
+
+		resp, err := resty.R().Get(srcBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		subjectDigest := resp.Header().Get("Docker-Content-Digest")
+		subjectSize := len(resp.Body())
+
+		directRefDigest, directRefSize := pushReferrerManifestByDigest(
+			t,
+			srcBaseURL,
+			testImage,
+			godigest.Digest(subjectDigest),
+			int64(subjectSize),
+			map[string]string{"level": "direct"},
+		)
+
+		nestedRefDigest, _ := pushReferrerManifestByDigest(
+			t,
+			srcBaseURL,
+			testImage,
+			directRefDigest,
+			directRefSize,
+			map[string]string{"level": "nested"},
+		)
+
+		resp, err = resty.R().Get(srcBaseURL + "/v2/" + testImage + "/tags/list")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+		So(resp.String(), ShouldNotContainSubstring, directRefDigest.String())
+		So(resp.String(), ShouldNotContainSubstring, nestedRefDigest.String())
+
+		dctlr, _, _, _ := makeDownstreamServer(t, false, nil)
+
+		dcm := test.NewControllerManager(dctlr)
+		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+
+		defer dcm.StopServer()
+
+		var tlsVerify bool
+		syncLegacyFalse := false
+		syncRecursiveFalse := false
+
+		serviceConfig := syncconf.RegistryConfig{
+			Content: []syncconf.Content{{
+				Prefix: testImage,
+			}},
+			URLs:                   []string{srcBaseURL},
+			TLSVerify:              &tlsVerify,
+			SyncLegacyCosignTags:   &syncLegacyFalse,
+			SyncReferrersRecursive: &syncRecursiveFalse,
+		}
+
+		service, err := sync.New(serviceConfig, "", nil, "", dctlr.StoreController, dctlr.MetaDB, dctlr.Log)
+		So(err, ShouldBeNil)
+
+		err = service.SyncRepo(context.Background(), testImage)
+		So(err, ShouldBeNil)
+
+		directRefs, err := dctlr.MetaDB.GetReferrersInfo(testImage, godigest.Digest(subjectDigest), nil)
+		So(err, ShouldBeNil)
+		So(len(directRefs), ShouldEqual, 1)
+
+		nestedRefs, err := dctlr.MetaDB.GetReferrersInfo(testImage, directRefDigest, nil)
+		So(err, ShouldBeNil)
+		So(len(nestedRefs), ShouldEqual, 0)
+	})
+}
+
+func pushReferrerManifestByDigest(t *testing.T, url, repoName string, subjectDigest godigest.Digest,
+	subjectSize int64, annotations map[string]string,
+) (godigest.Digest, int64) {
+	t.Helper()
+
+	_ = pushBlob(url, repoName, ispec.DescriptorEmptyJSON.Data)
+
+	manifest := ispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		Subject: &ispec.Descriptor{
+			MediaType: ispec.MediaTypeImageManifest,
+			Digest:    subjectDigest,
+			Size:      subjectSize,
+		},
+		Config: ispec.Descriptor{
+			MediaType: ispec.MediaTypeEmptyJSON,
+			Digest:    ispec.DescriptorEmptyJSON.Digest,
+			Size:      2,
+		},
+		Layers: []ispec.Descriptor{{
+			MediaType: ispec.MediaTypeEmptyJSON,
+			Digest:    ispec.DescriptorEmptyJSON.Digest,
+			Size:      2,
+		}},
+		MediaType:   ispec.MediaTypeImageManifest,
+		Annotations: annotations,
+	}
+
+	blob, err := json.Marshal(manifest)
+	So(err, ShouldBeNil)
+
+	digest := godigest.FromBytes(blob)
+
+	resp, err := resty.R().
+		SetHeader("Content-type", ispec.MediaTypeImageManifest).
+		SetBody(blob).
+		Put(url + "/v2/" + repoName + "/manifests/" + digest.String())
+	So(err, ShouldBeNil)
+	So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+	return digest, int64(len(blob))
 }
 
 func generateKeyPairs(tdir string) {


### PR DESCRIPTION
## Summary
- add `syncReferrersRecursive` to let periodic sync stop after direct referrers
- preserve existing recursive behavior by default
- document `syncReferrersRecursive` and `syncLegacyCosignTags` in sync examples

## Tests
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/config/sync -run 'TestRegistryConfig_ShouldSync(LegacyCosignTags|ReferrersRecursively)' -count=1`
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run TestPeriodicSyncReferrersRecursiveFlag -count=1`
- `GOEXPERIMENT=jsonv2 go test -race -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run TestPeriodicSyncReferrersRecursiveFlag -count=1`
- `GOEXPERIMENT=jsonv2 go test ./pkg/cli/server -run TestSchemaAllowsNullForPointerFields -count=1`
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run '^$' -count=1`
- `GOEXPERIMENT=jsonv2 go test ./pkg/cli/server -run '^$' -count=1`
- `jq empty examples/config-sync.json`
- `git diff --check`

Fixes #3839
