### PR TITLE
feat(sync): add local catalog fallback

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1151,6 +1151,7 @@ Configure each registry sync:
 				"urls": ["https://registry1:5000"],
 				"onDemand": false,                  # pull any image which the local registry doesn't have
 				"pollInterval": "6h",               # polling interval, if not set then periodically polling will not run
+				"localCatalogFallback": false,      # when remote catalog listing fails, poll locally cached repositories
 				"tlsVerify": true,                  # whether or not to verify tls (default is true)
 				"certDir": "/home/user/certs",      # use certificates at certDir path similar to Docker's /etc/docker/certs.d., if not specified then use the default certs dir,
 				"maxRetries": 5,                    # maxRetries in case of temporary errors (default: no retries)

--- a/examples/config-sync.json
+++ b/examples/config-sync.json
@@ -21,6 +21,7 @@
 					],
 					"onDemand": false,
 					"pollInterval": "6h",
+					"localCatalogFallback": false,
 					"tlsVerify": true,
 					"certDir": "/home/user/certs",
 					"maxRetries": 3,

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -28,6 +28,7 @@ type RegistryConfig struct {
 	Content               []Content
 	TLSVerify             *bool
 	OnDemand              bool
+	LocalCatalogFallback  bool
 	CertDir               string
 	MaxRetries            *int
 	RetryDelay            *time.Duration

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -31,6 +31,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/storage"
+	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 )
 
 const defaultExpireMinutes = 30 * time.Minute
@@ -247,6 +248,67 @@ func (service *BaseService) getNextRepoFromCatalog(lastRepo string) string {
 	return nextRepo
 }
 
+func (service *BaseService) getLocalCatalogRepositories() ([]string, error) {
+	repositories := []string{}
+	seen := map[string]struct{}{}
+
+	addRepositories := func(imgStore storageTypes.ImageStore) error {
+		if imgStore == nil {
+			return nil
+		}
+
+		localRepos, err := imgStore.GetRepositories()
+		if err != nil {
+			return err
+		}
+
+		for _, localRepo := range localRepos {
+			repo := strings.Trim(localRepo, "/")
+			if repo == "" {
+				continue
+			}
+
+			if len(service.config.Content) > 0 {
+				repo = service.contentManager.GetRepoSource(repo)
+				if repo == "" {
+					continue
+				}
+			}
+
+			if _, ok := seen[repo]; ok {
+				continue
+			}
+
+			seen[repo] = struct{}{}
+			repositories = append(repositories, repo)
+		}
+
+		return nil
+	}
+
+	if err := addRepositories(service.storeController.GetDefaultImageStore()); err != nil {
+		return nil, err
+	}
+
+	subStores := service.storeController.GetImageSubStores()
+	subStorePaths := make([]string, 0, len(subStores))
+	for subStorePath := range subStores {
+		subStorePaths = append(subStorePaths, subStorePath)
+	}
+
+	slices.Sort(subStorePaths)
+
+	for _, subStorePath := range subStorePaths {
+		if err := addRepositories(subStores[subStorePath]); err != nil {
+			return nil, err
+		}
+	}
+
+	slices.Sort(repositories)
+
+	return repositories, nil
+}
+
 func (service *BaseService) GetNextRepo(lastRepo string) (string, error) {
 	var err error
 
@@ -259,7 +321,20 @@ func (service *BaseService) GetNextRepo(lastRepo string) (string, error) {
 			service.log.Error().Str("errorType", common.TypeOf(err)).Str("remote registry", service.remote.GetHostName()).
 				Err(err).Msg("error while getting repositories from remote registry")
 
-			return "", err
+			if !service.config.LocalCatalogFallback {
+				return "", err
+			}
+
+			service.repositories, err = service.getLocalCatalogRepositories()
+			if err != nil {
+				service.log.Error().Str("errorType", common.TypeOf(err)).
+					Err(err).Msg("error while getting repositories from local catalog fallback")
+
+				return "", err
+			}
+
+			service.log.Info().Strs("repoList", service.repositories).
+				Msg("using local repositories as sync catalog fallback")
 		}
 	}
 

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -733,6 +733,130 @@ func TestSyncLegacyCosignTagsSyncReferrers(t *testing.T) {
 	})
 }
 
+func TestGetNextRepoLocalCatalogFallback(t *testing.T) {
+	Convey("local catalog fallback is disabled by default", t, func() {
+		remoteCatalogErr := errors.New("remote catalog unavailable")
+		localCatalogCalled := false
+
+		conf := syncconf.RegistryConfig{
+			URLs: []string{"http://localhost"},
+			Content: []syncconf.Content{{
+				Prefix: "repo/**",
+			}},
+		}
+
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{
+			DefaultStore: mocks.MockedImageStore{
+				GetRepositoriesFn: func() ([]string, error) {
+					localCatalogCalled = true
+
+					return []string{"repo/app"}, nil
+				},
+			},
+		}, mocks.MetaDBMock{}, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		service.remote = mocks.SyncRemoteMock{
+			GetRepositoriesFn: func(ctx context.Context) ([]string, error) {
+				return nil, remoteCatalogErr
+			},
+		}
+
+		repo, err := service.GetNextRepo("")
+		So(err, ShouldEqual, remoteCatalogErr)
+		So(repo, ShouldBeEmpty)
+		So(localCatalogCalled, ShouldBeFalse)
+	})
+
+	Convey("local catalog fallback uses cached repositories when enabled", t, func() {
+		conf := syncconf.RegistryConfig{
+			URLs:                 []string{"http://localhost"},
+			LocalCatalogFallback: true,
+			Content: []syncconf.Content{{
+				Prefix: "repo/**",
+			}},
+		}
+
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{
+			DefaultStore: mocks.MockedImageStore{
+				GetRepositoriesFn: func() ([]string, error) {
+					return []string{"repo/app", "other/app"}, nil
+				},
+			},
+		}, mocks.MetaDBMock{}, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		service.remote = mocks.SyncRemoteMock{
+			GetRepositoriesFn: func(ctx context.Context) ([]string, error) {
+				return nil, errors.New("remote catalog unavailable")
+			},
+		}
+
+		repo, err := service.GetNextRepo("")
+		So(err, ShouldBeNil)
+		So(repo, ShouldEqual, "repo/app")
+	})
+
+	Convey("local catalog fallback returns local catalog errors", t, func() {
+		localCatalogErr := errors.New("local catalog unavailable")
+
+		conf := syncconf.RegistryConfig{
+			URLs:                 []string{"http://localhost"},
+			LocalCatalogFallback: true,
+		}
+
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{
+			DefaultStore: mocks.MockedImageStore{
+				GetRepositoriesFn: func() ([]string, error) {
+					return nil, localCatalogErr
+				},
+			},
+		}, mocks.MetaDBMock{}, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		service.remote = mocks.SyncRemoteMock{
+			GetRepositoriesFn: func(ctx context.Context) ([]string, error) {
+				return nil, errors.New("remote catalog unavailable")
+			},
+		}
+
+		repo, err := service.GetNextRepo("")
+		So(err, ShouldEqual, localCatalogErr)
+		So(repo, ShouldBeEmpty)
+	})
+
+	Convey("local catalog fallback maps destination repositories back to upstream names", t, func() {
+		conf := syncconf.RegistryConfig{
+			URLs:                 []string{"http://localhost"},
+			LocalCatalogFallback: true,
+			Content: []syncconf.Content{{
+				Prefix:      "upstream/**",
+				Destination: "mirror",
+				StripPrefix: true,
+			}},
+		}
+
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{
+			DefaultStore: mocks.MockedImageStore{
+				GetRepositoriesFn: func() ([]string, error) {
+					return []string{"mirror/app"}, nil
+				},
+			},
+		}, mocks.MetaDBMock{}, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		service.remote = mocks.SyncRemoteMock{
+			GetRepositoriesFn: func(ctx context.Context) ([]string, error) {
+				return nil, errors.New("remote catalog unavailable")
+			},
+		}
+
+		repo, err := service.GetNextRepo("")
+		So(err, ShouldBeNil)
+		So(repo, ShouldEqual, "upstream/app")
+	})
+}
+
 func TestOnDemandSyncReferrersNonRecursive(t *testing.T) {
 	Convey("SyncReferrers (on-demand) uses non-recursive sync", t, func() {
 		// Verify that recursive calls are not made.


### PR DESCRIPTION
## Summary
- add `localCatalogFallback` for sync registries when upstream catalog listing fails
- enumerate locally cached repositories and map destination/stripPrefix repos back to upstream names
- document the new sync option in the examples

## Tests
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run TestGetNextRepoLocalCatalogFallback -count=1`
- `GOEXPERIMENT=jsonv2 go test -race -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run TestGetNextRepoLocalCatalogFallback -count=1`
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run '^$' -count=1`
- `GOEXPERIMENT=jsonv2 go test ./pkg/cli/server -run '^$' -count=1`
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/config/sync -count=1`
- `jq empty examples/config-sync.json`
- `git diff --check`

Fixes #3843
