### PR TITLE
feat(sync): limit download rate

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1151,6 +1151,7 @@ Configure each registry sync:
 				"urls": ["https://registry1:5000"],
 				"onDemand": false,                  # pull any image which the local registry doesn't have
 				"pollInterval": "6h",               # polling interval, if not set then periodically polling will not run
+				"downloadRate": "100mbps",          # optional sync download limit
 				"tlsVerify": true,                  # whether or not to verify tls (default is true)
 				"certDir": "/home/user/certs",      # use certificates at certDir path similar to Docker's /etc/docker/certs.d., if not specified then use the default certs dir,
 				"maxRetries": 5,                    # maxRetries in case of temporary errors (default: no retries)
@@ -1207,6 +1208,9 @@ Configure each registry sync:
 		}
 ```
 Prefixes can be strings that exactly match repositories or they can be [glob](https://en.wikipedia.org/wiki/Glob_(programming)) patterns.
+
+`downloadRate` accepts bit-rate units such as `bps`, `kbps`, `mbps`, and `gbps`.
+It also accepts byte-rate units such as `Bps`, `KBps`, `MBps`, `GBps`, `KiBps`, `MiBps`, and `GiBps`.
 
 ### Sync's certDir option
 

--- a/examples/config-sync.json
+++ b/examples/config-sync.json
@@ -21,6 +21,7 @@
 					],
 					"onDemand": false,
 					"pollInterval": "6h",
+					"downloadRate": "100mbps",
 					"tlsVerify": true,
 					"certDir": "/home/user/certs",
 					"maxRetries": 3,

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -28,6 +28,7 @@ type RegistryConfig struct {
 	Content               []Content
 	TLSVerify             *bool
 	OnDemand              bool
+	DownloadRate          string
 	CertDir               string
 	MaxRetries            *int
 	RetryDelay            *time.Duration

--- a/pkg/extensions/sync/download_rate.go
+++ b/pkg/extensions/sync/download_rate.go
@@ -1,0 +1,228 @@
+//go:build sync
+
+package sync
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"strconv"
+	"strings"
+	stdsync "sync"
+	"time"
+
+	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/types/blob"
+)
+
+type downloadRateLimiter struct {
+	rateBytesPerSecond int64
+	next               time.Time
+	now                func() time.Time
+	sleep              func(context.Context, time.Duration) error
+	mu                 stdsync.Mutex
+}
+
+type rateLimitedBlobReader struct {
+	ctx     context.Context
+	source  *blob.BReader
+	limiter *downloadRateLimiter
+}
+
+func newDownloadRateLimiter(downloadRate string) (*downloadRateLimiter, error) {
+	rateBytesPerSecond, err := parseDownloadRate(downloadRate)
+	if err != nil {
+		return nil, err
+	}
+
+	if rateBytesPerSecond == 0 {
+		return nil, nil //nolint:nilnil
+	}
+
+	return &downloadRateLimiter{
+		rateBytesPerSecond: rateBytesPerSecond,
+		now:                time.Now,
+		sleep:              sleepWithContext,
+	}, nil
+}
+
+func parseDownloadRate(downloadRate string) (int64, error) {
+	value := strings.TrimSpace(downloadRate)
+	if value == "" {
+		return 0, nil
+	}
+
+	numberEnd := 0
+	for numberEnd < len(value) {
+		char := value[numberEnd]
+		if (char < '0' || char > '9') && char != '.' {
+			break
+		}
+
+		numberEnd++
+	}
+
+	if numberEnd == 0 {
+		return 0, fmt.Errorf("invalid downloadRate %q: missing numeric value", downloadRate)
+	}
+
+	amount, err := strconv.ParseFloat(value[:numberEnd], 64)
+	if err != nil || amount <= 0 {
+		return 0, fmt.Errorf("invalid downloadRate %q: value must be greater than zero", downloadRate)
+	}
+
+	unit := strings.ReplaceAll(strings.TrimSpace(value[numberEnd:]), " ", "")
+	multiplier, ok := downloadRateUnitMultiplier(unit)
+	if !ok {
+		return 0, fmt.Errorf("invalid downloadRate %q: unsupported unit %q", downloadRate, unit)
+	}
+
+	rate := amount * multiplier
+	if rate < 1 || rate > math.MaxInt64 {
+		return 0, fmt.Errorf("invalid downloadRate %q: value must be between 1 byte/sec and %d bytes/sec",
+			downloadRate, int64(math.MaxInt64))
+	}
+
+	return int64(rate), nil
+}
+
+func downloadRateUnitMultiplier(unit string) (float64, bool) {
+	switch unit {
+	case "", "B", "Bps", "B/s", "byte/s", "bytes/s":
+		return 1, true
+	case "KB", "KBps", "KB/s":
+		return 1000, true
+	case "MB", "MBps", "MB/s":
+		return 1000 * 1000, true
+	case "GB", "GBps", "GB/s":
+		return 1000 * 1000 * 1000, true
+	case "TB", "TBps", "TB/s":
+		return 1000 * 1000 * 1000 * 1000, true
+	case "KiB", "KiBps", "KiB/s":
+		return 1024, true
+	case "MiB", "MiBps", "MiB/s":
+		return 1024 * 1024, true
+	case "GiB", "GiBps", "GiB/s":
+		return 1024 * 1024 * 1024, true
+	case "TiB", "TiBps", "TiB/s":
+		return 1024 * 1024 * 1024 * 1024, true
+	}
+
+	switch strings.ToLower(unit) {
+	case "bps", "b/s", "bit/s", "bits/s":
+		return 1.0 / 8.0, true
+	case "kbps", "kb/s", "kbit/s", "kbits/s":
+		return 1000.0 / 8.0, true
+	case "mbps", "mb/s", "mbit/s", "mbits/s":
+		return 1000.0 * 1000.0 / 8.0, true
+	case "gbps", "gb/s", "gbit/s", "gbits/s":
+		return 1000.0 * 1000.0 * 1000.0 / 8.0, true
+	case "tbps", "tb/s", "tbit/s", "tbits/s":
+		return 1000.0 * 1000.0 * 1000.0 * 1000.0 / 8.0, true
+	}
+
+	return 0, false
+}
+
+func (limiter *downloadRateLimiter) imageCopyOptions(ctx context.Context) []regclient.ImageOpts {
+	if limiter == nil {
+		return nil
+	}
+
+	return []regclient.ImageOpts{
+		regclient.ImageWithBlobReaderHook(limiter.blobReaderHook(ctx)),
+	}
+}
+
+func (limiter *downloadRateLimiter) blobReaderHook(ctx context.Context) func(*blob.BReader) (*blob.BReader, error) {
+	return func(reader *blob.BReader) (*blob.BReader, error) {
+		if limiter == nil || reader == nil {
+			return reader, nil
+		}
+
+		if ctx == nil {
+			ctx = context.Background()
+		}
+
+		return blob.NewReader(
+			blob.WithDesc(reader.GetDescriptor()),
+			blob.WithHeader(reader.RawHeaders()),
+			blob.WithResp(reader.Response()),
+			blob.WithReader(&rateLimitedBlobReader{
+				ctx:     ctx,
+				source:  reader,
+				limiter: limiter,
+			}),
+		), nil
+	}
+}
+
+func (reader *rateLimitedBlobReader) Read(p []byte) (int, error) {
+	n, err := reader.source.Read(p)
+	if n <= 0 || reader.limiter == nil {
+		return n, err
+	}
+
+	if waitErr := reader.limiter.waitN(reader.ctx, n); waitErr != nil {
+		return n, waitErr
+	}
+
+	return n, err
+}
+
+func (reader *rateLimitedBlobReader) Close() error {
+	return reader.source.Close()
+}
+
+func (reader *rateLimitedBlobReader) Seek(offset int64, whence int) (int64, error) {
+	return reader.source.Seek(offset, whence)
+}
+
+func (limiter *downloadRateLimiter) waitN(ctx context.Context, n int) error {
+	if limiter == nil || limiter.rateBytesPerSecond <= 0 || n <= 0 {
+		return nil
+	}
+
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	delay := time.Duration(float64(n) * float64(time.Second) / float64(limiter.rateBytesPerSecond))
+	if delay <= 0 {
+		return nil
+	}
+
+	limiter.mu.Lock()
+	now := limiter.now()
+	if limiter.next.Before(now) {
+		limiter.next = now
+	}
+
+	wakeAt := limiter.next.Add(delay)
+	wait := wakeAt.Sub(now)
+	limiter.next = wakeAt
+	limiter.mu.Unlock()
+
+	return limiter.sleep(ctx, wait)
+}
+
+func sleepWithContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+var _ io.Reader = (*rateLimitedBlobReader)(nil)
+var _ io.Closer = (*rateLimitedBlobReader)(nil)
+var _ io.Seeker = (*rateLimitedBlobReader)(nil)

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -46,6 +46,7 @@ type BaseService struct {
 	storeController  storage.StoreController
 	metaDB           mTypes.MetaDB
 	repositories     []string
+	downloadLimiter  *downloadRateLimiter
 	rc               *regclient.RegClient
 	hosts            []config.Host
 	tagsCache        *tagsCache
@@ -73,6 +74,11 @@ func New(
 	service.tagsCache = newTagsCache(defaultExpireMinutes)
 
 	var err error
+
+	service.downloadLimiter, err = newDownloadRateLimiter(config.DownloadRate)
+	if err != nil {
+		return nil, err
+	}
 
 	var credentialsFile syncconf.CredentialsFile
 
@@ -478,7 +484,7 @@ func (service *BaseService) syncRef(ctx context.Context, localRepo string, remot
 		reference = remoteImageRef.Digest
 	}
 
-	copyOpts := []regclient.ImageOpts{}
+	copyOpts := service.downloadLimiter.imageCopyOptions(ctx)
 
 	// check if image is already synced
 	skipImage, err = service.destination.CanSkipImage(localRepo, reference, remoteDigest)

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -19,6 +20,8 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/types/blob"
+	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/ref"
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -37,6 +40,114 @@ import (
 	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
 )
+
+func TestDownloadRateLimiter(t *testing.T) {
+	Convey("downloadRate parser accepts documented units", t, func() {
+		tests := []struct {
+			rate     string
+			expected int64
+		}{
+			{rate: "", expected: 0},
+			{rate: "1024", expected: 1024},
+			{rate: "8bps", expected: 1},
+			{rate: "100mbps", expected: 12500000},
+			{rate: "100Mbps", expected: 12500000},
+			{rate: "1MBps", expected: 1000000},
+			{rate: "1MiBps", expected: 1048576},
+			{rate: "2 GB/s", expected: 2000000000},
+		}
+
+		for _, test := range tests {
+			parsed, err := parseDownloadRate(test.rate)
+			So(err, ShouldBeNil)
+			So(parsed, ShouldEqual, test.expected)
+		}
+	})
+
+	Convey("downloadRate parser rejects invalid values", t, func() {
+		for _, rate := range []string{"fast", "0mbps", "-1mbps", "1bps", "10widgets"} {
+			parsed, err := parseDownloadRate(rate)
+			So(err, ShouldNotBeNil)
+			So(parsed, ShouldEqual, 0)
+		}
+	})
+
+	Convey("new service rejects invalid downloadRate", t, func() {
+		service, err := New(syncconf.RegistryConfig{
+			URLs:         []string{"http://localhost"},
+			DownloadRate: "fast",
+		}, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+
+		So(err, ShouldNotBeNil)
+		So(service, ShouldBeNil)
+	})
+
+	Convey("downloadRate config installs image copy options", t, func() {
+		service, err := New(syncconf.RegistryConfig{
+			URLs:         []string{"http://localhost"},
+			DownloadRate: "8Bps",
+		}, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+
+		So(err, ShouldBeNil)
+		So(service.downloadLimiter, ShouldNotBeNil)
+		So(len(service.downloadLimiter.imageCopyOptions(context.Background())), ShouldEqual, 1)
+	})
+
+	Convey("rate-limited reader waits according to bytes read", t, func() {
+		now := time.Unix(0, 0)
+		waits := []time.Duration{}
+		limiter := &downloadRateLimiter{
+			rateBytesPerSecond: 100,
+			now: func() time.Time {
+				return now
+			},
+			sleep: func(ctx context.Context, delay time.Duration) error {
+				waits = append(waits, delay)
+				now = now.Add(delay)
+
+				return nil
+			},
+		}
+
+		content := []byte("0123456789")
+		desc := descriptor.Descriptor{
+			Size:   int64(len(content)),
+			Digest: godigest.FromBytes(content),
+		}
+		reader := blob.NewReader(blob.WithDesc(desc), blob.WithReader(bytes.NewReader(content)))
+		wrapped, err := limiter.blobReaderHook(context.Background())(reader)
+		So(err, ShouldBeNil)
+
+		readContent, err := io.ReadAll(wrapped)
+		So(err, ShouldBeNil)
+		So(readContent, ShouldResemble, content)
+		So(waits, ShouldResemble, []time.Duration{100 * time.Millisecond})
+	})
+
+	Convey("rate-limited reader returns context cancellation", t, func() {
+		limiter := &downloadRateLimiter{
+			rateBytesPerSecond: 100,
+			now:                time.Now,
+			sleep:              sleepWithContext,
+		}
+		content := []byte("cancel me")
+		desc := descriptor.Descriptor{
+			Size:   int64(len(content)),
+			Digest: godigest.FromBytes(content),
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		reader := blob.NewReader(blob.WithDesc(desc), blob.WithReader(bytes.NewReader(content)))
+		wrapped, err := limiter.blobReaderHook(ctx)(reader)
+		So(err, ShouldBeNil)
+
+		readContent := make([]byte, len(content))
+		n, err := wrapped.Read(readContent)
+		So(n, ShouldEqual, len(content))
+		So(err, ShouldEqual, context.Canceled)
+	})
+}
 
 func TestService(t *testing.T) {
 	Convey("trigger fetch tags error", t, func() {


### PR DESCRIPTION
## Summary
- add per-registry `downloadRate` for sync downloads
- throttle sync blob reads through regclient blob reader hooks using one shared limiter per registry
- document supported bit-rate and byte-rate units

## Tests
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run TestDownloadRateLimiter -count=1`
- `GOEXPERIMENT=jsonv2 go test -race -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run TestDownloadRateLimiter -count=1`
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/sync -run '^$' -count=1`
- `GOEXPERIMENT=jsonv2 go test -tags "sync scrub metrics search lint" ./pkg/extensions/config/sync -count=1`
- `GOEXPERIMENT=jsonv2 go test ./pkg/cli/server -run '^$' -count=1`
- `GOEXPERIMENT=jsonv2 go test ./pkg/cli/server -run TestSchemaAllowsNullForPointerFields -count=1`
- `jq empty examples/config-sync.json`
- `git diff --check`

Fixes #2410
