### PR TITLE
feat(auth): expose user profile endpoint

### DIFF
--- a/pkg/extensions/README_userprefs.md
+++ b/pkg/extensions/README_userprefs.md
@@ -1,11 +1,13 @@
 # `userprefs`
 
-`userprefs` component provides an endpoint for adding user preferences for repos. It is available only to authentificated users. Unauthentificated users will be denied access.
+`userprefs` component provides endpoints for adding user preferences for repos and reading the authenticated user's profile data.
+It is available only to authenticated users. Unauthenticated users will be denied access.
 
-| Supported queries | Input | Output | Description |
+| Supported endpoints | Input | Output | Description |
 | --- | --- | --- | --- |
-| [Toggle repo star](#toggle-repo-star) | None | None | Sets the repo starred property to true if it is false, and to false if it is true | 
-| [Toggle repo bookmark](#toggle-repo-bookmark) | None | None | Sets the repo bookmarked property to true if it is false, and to false if it is true | 
+| [Toggle repo star](#toggle-repo-star) | None | None | Sets the repo starred property to true if it is false, and to false if it is true |
+| [Toggle repo bookmark](#toggle-repo-bookmark) | None | None | Sets the repo bookmarked property to true if it is false, and to false if it is true |
+| [Get user profile](#get-user-profile) | None | JSON | Returns the authenticated user's username and groups |
 
 ## General usage
 The userprefs endpoint accepts as a query parameter what `action` to perform and then all other required parameters for the specified action.
@@ -15,7 +17,7 @@ The userprefs endpoint accepts as a query parameter what `action` to perform and
 | --- | --- | --- | --- |
 | toggleStar | repo | string | The repo name which should be starred |
 
-A request to togle a star on a repo would look like this:
+A request to toggle a star on a repo would look like this:
 ```
 (PUT) http://localhost:8080/v2/_zot/ext/userprefs?action=toggleStar&repo=repoName
 ```
@@ -25,7 +27,23 @@ A request to togle a star on a repo would look like this:
 | --- | --- | --- | --- |
 | toggleBookmark | repo | string | The repo name which should be bookmarked |
 
-A request to togle a bookmark on a repo would look like this:
+A request to toggle a bookmark on a repo would look like this:
 ```
 (PUT) http://localhost:8080/v2/_zot/ext/userprefs?action=toggleBookmark&repo=repoName
+```
+
+## Get user profile
+The profile endpoint returns the username and groups currently associated with the authenticated request.
+This is useful for checking authorization data from OIDC, LDAP, mTLS, or local group configuration.
+
+```
+(GET) http://localhost:8080/v2/_zot/ext/userprefs/profile
+```
+
+Example response:
+```
+{
+  "username": "alice",
+  "groups": ["developers", "release-admins"]
+}
 ```

--- a/pkg/extensions/extension_userprefs.go
+++ b/pkg/extensions/extension_userprefs.go
@@ -5,6 +5,7 @@ package extensions
 import (
 	"errors"
 	"net/http"
+	"slices"
 
 	"github.com/gorilla/mux"
 
@@ -14,12 +15,19 @@ import (
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
+	reqCtx "zotregistry.dev/zot/v2/pkg/requestcontext"
 )
 
 const (
 	ToggleRepoBookmarkAction = "toggleBookmark"
 	ToggleRepoStarAction     = "toggleStar"
+	UserProfilePath          = "/profile"
 )
+
+type UserProfile struct {
+	Username string   `json:"username"`
+	Groups   []string `json:"groups"`
+}
 
 func IsBuiltWithUserPrefsExtension() bool {
 	return true
@@ -37,15 +45,54 @@ func SetupUserPreferencesRoutes(conf *config.Config, router *mux.Router,
 
 	log.Info().Msg("setting up user preferences routes")
 
-	allowedMethods := zcommon.AllowedMethods(http.MethodPut)
-
-	userPrefsRouter := router.PathPrefix(constants.ExtUserPrefs).Subrouter()
+	userPrefsRouter := router.Path(constants.ExtUserPrefs).Subrouter()
 	userPrefsRouter.Use(zcommon.CORSHeadersMiddleware(conf.HTTP.AllowOrigin))
 	userPrefsRouter.Use(zcommon.AddExtensionSecurityHeaders())
-	userPrefsRouter.Use(zcommon.ACHeadersMiddleware(conf, allowedMethods...))
-	userPrefsRouter.Methods(allowedMethods...).Handler(HandleUserPrefs(metaDB, log))
+	userPrefsRouter.Use(zcommon.ACHeadersMiddleware(conf, zcommon.AllowedMethods(http.MethodPut)...))
+	userPrefsRouter.Methods(zcommon.AllowedMethods(http.MethodPut)...).Handler(HandleUserPrefs(metaDB, log))
+
+	userProfileRouter := router.Path(constants.ExtUserPrefs + UserProfilePath).Subrouter()
+	userProfileRouter.Use(zcommon.CORSHeadersMiddleware(conf.HTTP.AllowOrigin))
+	userProfileRouter.Use(zcommon.AddExtensionSecurityHeaders())
+	userProfileRouter.Use(zcommon.ACHeadersMiddleware(conf, zcommon.AllowedMethods(http.MethodGet)...))
+	userProfileRouter.Methods(zcommon.AllowedMethods(http.MethodGet)...).Handler(HandleUserProfile())
 
 	log.Info().Msg("finished setting up user preferences routes")
+}
+
+// HandleUserProfile godoc
+// @Summary Get authenticated user profile
+// @Description Get the authenticated user's username and groups
+// @Router  /v2/_zot/ext/userprefs/profile [get]
+// @Accept  json
+// @Produce json
+// @Success 200 {object} extensions.UserProfile
+// @Failure 401 {string} string "unauthorized"
+// @Failure 500 {string} string "internal server error".
+func HandleUserProfile() http.Handler {
+	return http.HandlerFunc(func(rsp http.ResponseWriter, req *http.Request) {
+		userAc, err := reqCtx.UserAcFromContext(req.Context())
+		if err != nil {
+			rsp.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		if userAc.IsAnonymous() {
+			rsp.WriteHeader(http.StatusUnauthorized)
+
+			return
+		}
+
+		groups := append([]string{}, userAc.GetGroups()...)
+		slices.Sort(groups)
+		groups = slices.Compact(groups)
+
+		zcommon.WriteJSON(rsp, http.StatusOK, UserProfile{
+			Username: userAc.GetUsername(),
+			Groups:   groups,
+		})
+	})
 }
 
 // HandleUserPrefs godoc

--- a/pkg/extensions/extension_userprefs_test.go
+++ b/pkg/extensions/extension_userprefs_test.go
@@ -4,6 +4,7 @@ package extensions_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -22,6 +23,7 @@ import (
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
+	reqCtx "zotregistry.dev/zot/v2/pkg/requestcontext"
 	test "zotregistry.dev/zot/v2/pkg/test/common"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
 )
@@ -56,6 +58,67 @@ func TestAllowedMethodsHeaderUserPrefs(t *testing.T) {
 		So(resp, ShouldNotBeNil)
 		So(resp.Header().Get("Access-Control-Allow-Methods"), ShouldResemble, "PUT,OPTIONS")
 		So(resp.StatusCode(), ShouldEqual, http.StatusNoContent)
+
+		resp, _ = resty.R().Options(baseURL + constants.FullUserPrefs + extensions.UserProfilePath)
+		So(resp, ShouldNotBeNil)
+		So(resp.Header().Get("Access-Control-Allow-Methods"), ShouldResemble, "GET,OPTIONS")
+		So(resp.StatusCode(), ShouldEqual, http.StatusNoContent)
+	})
+}
+
+func TestUserProfileRoute(t *testing.T) {
+	defaultVal := true
+	username := "alice"
+	password := "password"
+	htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
+
+	Convey("Test authenticated user profile response", t, func() {
+		conf := config.New()
+		port := test.GetFreePort()
+		conf.HTTP.Port = port
+		conf.HTTP.Auth.HTPasswd.Path = htpasswdPath
+		conf.HTTP.AccessControl = &config.AccessControlConfig{
+			Repositories: config.Repositories{
+				"**": config.PolicyGroup{
+					Policies: []config.Policy{
+						{
+							Users:   []string{username},
+							Actions: []string{constants.ReadPermission},
+						},
+					},
+				},
+			},
+			Groups: config.Groups{
+				"release-admins": config.Group{Users: []string{username}},
+				"developers":     config.Group{Users: []string{username}},
+			},
+		}
+		conf.Extensions = &extconf.ExtensionConfig{}
+		conf.Extensions.Search = &extconf.SearchConfig{}
+		conf.Extensions.Search.Enable = &defaultVal
+		conf.Extensions.Search.CVE = nil
+		conf.Extensions.UI = &extconf.UIConfig{}
+		conf.Extensions.UI.Enable = &defaultVal
+
+		baseURL := test.GetBaseURL(port)
+
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
+
+		ctrlManager := test.NewControllerManager(ctlr)
+		ctrlManager.StartAndWait(port)
+		defer ctrlManager.StopServer()
+
+		resp, err := resty.R().
+			SetBasicAuth(username, password).
+			Get(baseURL + constants.FullUserPrefs + extensions.UserProfilePath)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		var profile extensions.UserProfile
+		So(json.Unmarshal(resp.Body(), &profile), ShouldBeNil)
+		So(profile.Username, ShouldEqual, username)
+		So(profile.Groups, ShouldResemble, []string{"developers", "release-admins"})
 	})
 }
 
@@ -187,5 +250,51 @@ func TestHandlers(t *testing.T) {
 
 			So(res.StatusCode, ShouldEqual, http.StatusInternalServerError)
 		})
+	})
+
+	Convey("Get user profile", t, func() {
+		request := httptest.NewRequest(http.MethodGet, UserprefsBaseURL+extensions.UserProfilePath, nil)
+		userAc := reqCtx.NewUserAccessControl()
+		userAc.SetUsername("alice")
+		userAc.AddGroups([]string{"ops", "dev", "ops"})
+		userAc.SaveOnRequest(request)
+
+		response := httptest.NewRecorder()
+		extensions.HandleUserProfile().ServeHTTP(response, request)
+
+		res := response.Result()
+		defer res.Body.Close()
+
+		So(res.StatusCode, ShouldEqual, http.StatusOK)
+
+		var profile extensions.UserProfile
+		So(json.NewDecoder(res.Body).Decode(&profile), ShouldBeNil)
+		So(profile.Username, ShouldEqual, "alice")
+		So(profile.Groups, ShouldResemble, []string{"dev", "ops"})
+	})
+
+	Convey("Get user profile rejects anonymous user", t, func() {
+		request := httptest.NewRequest(http.MethodGet, UserprefsBaseURL+extensions.UserProfilePath, nil)
+		response := httptest.NewRecorder()
+
+		extensions.HandleUserProfile().ServeHTTP(response, request)
+
+		res := response.Result()
+		defer res.Body.Close()
+
+		So(res.StatusCode, ShouldEqual, http.StatusUnauthorized)
+	})
+
+	Convey("Get user profile rejects bad request context", t, func() {
+		request := httptest.NewRequest(http.MethodGet, UserprefsBaseURL+extensions.UserProfilePath, nil)
+		request = request.WithContext(context.WithValue(request.Context(), reqCtx.GetContextKey(), "bad"))
+		response := httptest.NewRecorder()
+
+		extensions.HandleUserProfile().ServeHTTP(response, request)
+
+		res := response.Result()
+		defer res.Body.Close()
+
+		So(res.StatusCode, ShouldEqual, http.StatusInternalServerError)
 	})
 }


### PR DESCRIPTION
## Summary
- add `GET /v2/_zot/ext/userprefs/profile` for authenticated callers
- return the caller username and sorted unique groups from request auth context
- document the profile endpoint in the userprefs README

Fixes #3745

## Testing
- `GOEXPERIMENT=jsonv2 go test -tags userprefs ./pkg/extensions -run 'TestAllowedMethodsHeaderUserPrefs|TestUserProfileRoute|TestHandlers' -count=1`
- `GOEXPERIMENT=jsonv2 go test -tags 'sync scrub metrics search lint userprefs mgmt imagetrust ui' ./pkg/extensions -count=1`
- `git diff --check origin/main...HEAD`
