### PR TITLE
test(blackbox): deduplicate pushpull bats tests

### DIFF
--- a/test/blackbox/fips140.bats
+++ b/test/blackbox/fips140.bats
@@ -3,21 +3,8 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load helpers_upgrade
 load ../port_helper
-
-function verify_prerequisites {
-    if [ ! $(command -v curl) ]; then
-        echo "you need to install curl as a prerequisite to running the tests" >&3
-        return 1
-    fi
-
-    if [ ! $(command -v jq) ]; then
-        echo "you need to install jq as a prerequisite to running the tests" >&3
-        return 1
-    fi
-
-    return 0
-}
 
 function setup_file() {
     # Verify prerequisites are available
@@ -70,325 +57,97 @@ function teardown_file() {
 }
 
 @test "push image" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run skopeo --insecure-policy copy --dest-tls-verify=false \
-        oci:${TEST_DATA_DIR}/golang:1.20 \
-        docker://127.0.0.1:${zot_port}/golang:1.20
-    [ "$status" -eq 0 ]
-    run curl http://127.0.0.1:${zot_port}/v2/_catalog
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.repositories[]') = '"golang"' ]
-    run curl http://127.0.0.1:${zot_port}/v2/golang/tags/list
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.20"' ]
+    helper_push_image golang 1.20
 }
 
 @test "pull image" {
-    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run skopeo --insecure-policy copy --src-tls-verify=false \
-        docker://127.0.0.1:${zot_port}/golang:1.20 \
-        oci:${oci_data_dir}/golang:1.20
-    [ "$status" -eq 0 ]
-    run cat ${BATS_FILE_TMPDIR}/oci/golang/index.json
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests[].annotations."org.opencontainers.image.ref.name"') = '"1.20"' ]
+    helper_pull_image golang 1.20
 }
 
 @test "push image index" {
-    # --multi-arch below pushes an image index (containing many images) instead
-    # of an image manifest (single image)
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run skopeo --insecure-policy copy --format=oci --dest-tls-verify=false --multi-arch=all \
-        docker://public.ecr.aws/docker/library/busybox:latest \
-        docker://127.0.0.1:${zot_port}/busybox:latest
-    [ "$status" -eq 0 ]
-    run curl http://127.0.0.1:${zot_port}/v2/_catalog
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.repositories[0]') = '"busybox"' ]
-    run curl http://127.0.0.1:${zot_port}/v2/busybox/tags/list
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"latest"' ]
+    helper_push_image_index docker://public.ecr.aws/docker/library/busybox:latest busybox latest
 }
 
 @test "pull image index" {
-    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run skopeo --insecure-policy copy --src-tls-verify=false --multi-arch=all \
-        docker://127.0.0.1:${zot_port}/busybox:latest \
-        oci:${oci_data_dir}/busybox:latest
-    [ "$status" -eq 0 ]
-    run cat ${BATS_FILE_TMPDIR}/oci/busybox/index.json
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests[].annotations."org.opencontainers.image.ref.name"') = '"latest"' ]
-    run skopeo --insecure-policy --override-arch=arm64 --override-os=linux copy --src-tls-verify=false --multi-arch=all \
-        docker://127.0.0.1:${zot_port}/busybox:latest \
-        oci:${oci_data_dir}/busybox:latest
-    [ "$status" -eq 0 ]
-    run cat ${BATS_FILE_TMPDIR}/oci/busybox/index.json
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests[].annotations."org.opencontainers.image.ref.name"') = '"latest"' ]
-    run curl -X DELETE http://127.0.0.1:${zot_port}/v2/busybox/manifests/latest
-    [ "$status" -eq 0 ]
+    helper_pull_image_index_and_delete busybox latest
 }
 
 @test "push oras artifact" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    echo "{\"name\":\"foo\",\"value\":\"bar\"}" > config.json
-    echo "hello world" > artifact.txt
-    run oras push --plain-http 127.0.0.1:${zot_port}/hello-artifact:v2 \
-        --config config.json:application/vnd.acme.rocket.config.v1+json artifact.txt:text/plain -d -v
-    [ "$status" -eq 0 ]
-    rm -f artifact.txt
-    rm -f config.json
+    helper_push_oras_artifact hello-artifact v2
 }
 
 @test "pull oras artifact" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run oras pull --plain-http 127.0.0.1:${zot_port}/hello-artifact:v2 -d -v
-    [ "$status" -eq 0 ]
-    grep -q "hello world" artifact.txt
-    rm -f artifact.txt
+    helper_pull_oras_artifact hello-artifact v2
 }
 
 @test "attach oras artifacts" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    # attach signature
-    echo "{\"artifact\": \"\", \"signature\": \"pat hancock\"}" > ${BATS_FILE_TMPDIR}/signature.json
-    run oras attach --disable-path-validation --plain-http 127.0.0.1:${zot_port}/golang:1.20 --artifact-type 'signature/example' ${BATS_FILE_TMPDIR}/signature.json:application/json
-    [ "$status" -eq 0 ]
-    # attach sbom
-    echo "{\"version\": \"0.0.0.0\", \"artifact\": \"'127.0.0.1:${zot_port}/golang:1.20'\", \"contents\": \"good\"}" > ${BATS_FILE_TMPDIR}/sbom.json
-    run oras attach --disable-path-validation --plain-http 127.0.0.1:${zot_port}/golang:1.20 --artifact-type 'sbom/example' ${BATS_FILE_TMPDIR}/sbom.json:application/json
-    [ "$status" -eq 0 ]
+    helper_attach_oras_artifacts golang 1.20
 }
 
 @test "discover oras artifacts" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run oras discover --plain-http --format json 127.0.0.1:${zot_port}/golang:1.20
-    [ "$status" -eq 0 ]
-    [ $(echo "$output" | jq -r ".manifests | length") -eq 2 ]
+    helper_discover_oras_artifacts golang 1.20 2
 }
 
 @test "add and list tags using oras" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run skopeo --insecure-policy copy --dest-tls-verify=false \
-        oci:${TEST_DATA_DIR}/golang:1.20 \
-        docker://127.0.0.1:${zot_port}/oras-tags:1.20
-    [ "$status" -eq 0 ]
-    run oras tag --plain-http 127.0.0.1:${zot_port}/oras-tags:1.20 1 new latest
-    [ "$status" -eq 0 ]
-    run oras repo tags --plain-http 127.0.0.1:${zot_port}/oras-tags
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 4 ]
-    [ "${lines[-1]}" == "new" ]
-    [ "${lines[-2]}" == "latest" ]
-    [ "${lines[-3]}" == "1.20" ]
-    [ "${lines[-4]}" == "1" ]
-    run oras repo tags --plain-http --last new 127.0.0.1:${zot_port}/oras-tags
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ -z $output ]
-    run oras repo tags --plain-http --last latest 127.0.0.1:${zot_port}/oras-tags
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 1 ]
-    [ "${lines[-1]}" == "new" ]
-    run oras repo tags --plain-http --last "1.20" 127.0.0.1:${zot_port}/oras-tags
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 2 ]
-    [ "${lines[-2]}" == "latest" ]
-    [ "${lines[-1]}" == "new" ]
-    run oras repo tags --plain-http --last "1" 127.0.0.1:${zot_port}/oras-tags
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 3 ]
-    [ "${lines[-3]}" == "1.20" ]
-    [ "${lines[-2]}" == "latest" ]
-    [ "${lines[-1]}" == "new" ]
+    helper_add_and_list_tags_using_oras
 }
 
 @test "push helm chart" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run helm package ${BATS_FILE_TMPDIR}/helm-charts/charts/zot -d ${BATS_FILE_TMPDIR}
-    [ "$status" -eq 0 ]
-    local chart_version=$(awk '/version/{printf $2}' ${BATS_FILE_TMPDIR}/helm-charts/charts/zot/Chart.yaml)
-    run helm push ${BATS_FILE_TMPDIR}/zot-${chart_version}.tgz oci://localhost:${zot_port}/zot-chart
-    [ "$status" -eq 0 ]
+    helper_push_helm_chart
 }
 
 @test "pull helm chart" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    local chart_version=$(awk '/version/{printf $2}' ${BATS_FILE_TMPDIR}/helm-charts/charts/zot/Chart.yaml)
-    run helm pull oci://localhost:${zot_port}/zot-chart/zot --version ${chart_version} -d ${BATS_FILE_TMPDIR}
-    [ "$status" -eq 0 ]
+    helper_pull_helm_chart
 }
 
 @test "push image with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl registry set localhost:${zot_port} --tls disabled
-    [ "$status" -eq 0 ]
-    run regctl image copy ocidir://${TEST_DATA_DIR}/golang:1.20 localhost:${zot_port}/test-regclient
-    [ "$status" -eq 0 ]
+    helper_push_image_with_regclient
 }
 
 @test "pull image with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl image copy localhost:${zot_port}/test-regclient ocidir://${TEST_DATA_DIR}/golang:1.20
-    [ "$status" -eq 0 ]
+    helper_pull_image_with_regclient
 }
 
 @test "list repositories with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl repo ls localhost:${zot_port}
-    [ "$status" -eq 0 ]
-
-    found=0
-    for i in "${lines[@]}"
-    do
-
-        if [ "$i" = 'test-regclient' ]; then
-            found=1
-        fi
-    done
-    [ "$found" -eq 1 ]
-
-    run regctl repo ls --limit 2 localhost:${zot_port}
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 2 ]
-    [ "${lines[-2]}" == "busybox" ]
-    [ "${lines[-1]}" == "golang" ]
-
-    run regctl repo ls --last busybox --limit 1 localhost:${zot_port}
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 1 ]
-    [ "${lines[-1]}" == "golang" ]
+    helper_list_repositories_with_regclient_pagination
 }
 
 @test "list image tags with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl tag ls localhost:${zot_port}/test-regclient
-    [ "$status" -eq 0 ]
-
-    found=0
-    for i in "${lines[@]}"
-    do
-
-        if [ "$i" = 'latest' ]; then
-            found=1
-        fi
-    done
-    [ "$found" -eq 1 ]
+    helper_list_image_tags_with_regclient
 }
 
 @test "push manifest with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    manifest=$(regctl manifest get localhost:${zot_port}/test-regclient --format=raw-body)
-    run regctl manifest put localhost:${zot_port}/test-regclient:1.0.0 --format oci --content-type application/vnd.oci.image.manifest.v1+json --format oci <<EOF
-    $manifest
-EOF
-    [ "$status" -eq 0 ]
+    helper_push_manifest_with_regclient
 }
 
 @test "pull manifest with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl manifest get localhost:${zot_port}/test-regclient
-    [ "$status" -eq 0 ]
+    helper_pull_manifest_with_regclient
 }
 
 @test "pull manifest with docker client" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run docker pull localhost:${zot_port}/test-regclient
-    [ "$status" -eq 0 ]
+    helper_pull_manifest_with_docker_client
 }
 
 @test "pull manifest with crictl" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run crictl pull localhost:${zot_port}/test-regclient
-    [ "$status" -eq 0 ]
+    helper_pull_manifest_with_crictl
 }
 
 @test "push OCI artifact with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl artifact put localhost:${zot_port}/artifact:demo <<EOF
-this is an artifact
-EOF
-    [ "$status" -eq 0 ]
+    helper_push_oci_artifact_with_regclient
 }
 
 @test "pull OCI artifact with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl manifest get localhost:${zot_port}/artifact:demo
-    [ "$status" -eq 0 ]
-    run regctl artifact get localhost:${zot_port}/artifact:demo
-    [ "$status" -eq 0 ]
-    [ "${lines[-1]}" == "this is an artifact" ]
+    helper_pull_oci_artifact_with_regclient
 }
 
 @test "push OCI artifact references with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl artifact put localhost:${zot_port}/manifest-ref:demo <<EOF
-test artifact
-EOF
-    [ "$status" -eq 0 ]
-    run regctl artifact list localhost:${zot_port}/manifest-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 0 ]
-    run regctl artifact put --annotation  demo=true --annotation format=oci --artifact-type "application/vnd.example.icecream.v1" --subject localhost:${zot_port}/manifest-ref:demo << EOF
-test reference
-EOF
-    [ "$status" -eq 0 ]
-    # with artifact media-type
-    run regctl artifact put localhost:${zot_port}/artifact-ref:demo <<EOF
-test artifact
-EOF
-    [ "$status" -eq 0 ]
-    run regctl artifact list localhost:${zot_port}/artifact-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 0 ]
-    run regctl artifact put --annotation  demo=true --annotation format=oci --artifact-type "application/vnd.example.icecream.v1" --subject localhost:${zot_port}/artifact-ref:demo << EOF
-test reference
-EOF
-    [ "$status" -eq 0 ]
+    helper_push_oci_artifact_references_with_regclient 0
 }
 
 @test "pull OCI artifact references with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl artifact list localhost:${zot_port}/manifest-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 1 ]
-    run regctl artifact list --filter-artifact-type "application/vnd.example.icecream.v1" localhost:${zot_port}/manifest-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 1 ]
-    run regctl artifact list --filter-artifact-type "application/invalid" localhost:${zot_port}/manifest-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 0 ]
-    # with artifact media-type
-    run regctl artifact list localhost:${zot_port}/artifact-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 1 ]
-    run regctl artifact list --filter-artifact-type "application/vnd.example.icecream.v1" localhost:${zot_port}/artifact-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 1 ]
-    run regctl artifact list --filter-artifact-type "application/invalid" localhost:${zot_port}/artifact-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 0 ]
+    helper_pull_oci_artifact_references_with_regclient 1
 }
 
 @test "push docker image" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    cat > Dockerfile <<EOF
-    FROM ghcr.io/project-zot/test-images/busybox-docker:1.37
-    RUN echo "hello world" > /testfile
-EOF
-    run sh -c 'unset GODEBUG; docker build -f Dockerfile -t localhost:'${zot_port}'/test .'
-    [ "$status" -eq 0 ]
-    run docker push localhost:${zot_port}/test
-    [ "$status" -eq 1 ]
-    run docker pull localhost:${zot_port}/test
-    [ "$status" -eq 1 ]
+    helper_push_docker_image
 }

--- a/test/blackbox/helpers_upgrade.bash
+++ b/test/blackbox/helpers_upgrade.bash
@@ -1,7 +1,7 @@
-# Common helper functions and test utilities for upgrade tests
-# Used by upgrade.bats and upgrade_minimal.bats
+# Common helper functions and test utilities for blackbox compatibility and upgrade tests.
+# Used by push/pull and upgrade BATS suites.
 
-# Verify prerequisites for upgrade tests
+# Verify prerequisites for shared push/pull helpers.
 function verify_prerequisites {
     if [ ! $(command -v curl) ]; then
         echo "you need to install curl as a prerequisite to running the tests" >&3
@@ -29,7 +29,7 @@ function teardown_file() {
 
 # ==============================================================================
 # COMMON HELPER FUNCTIONS
-# These are the core functions used by both release and new test functions
+# These are the core functions used by push/pull and upgrade test functions
 # ==============================================================================
 
 # Helper: Get the zot port
@@ -111,6 +111,17 @@ function helper_pull_image_index() {
     run cat ${oci_data_dir}/${image_name}/index.json
     [ "$status" -eq 0 ]
     [ $(echo "${lines[-1]}" | jq --arg tag "${tag}" '.manifests[].annotations."org.opencontainers.image.ref.name" == $tag') = true ]
+}
+
+# Helper: Pull an image index and remove its tag, preserving legacy standalone suite behavior.
+# Args: $1 = image_name, $2 = tag
+function helper_pull_image_index_and_delete() {
+    local image_name=${1:-busybox}
+    local tag=${2:-latest}
+    local zot_port=$(get_zot_port)
+    helper_pull_image_index "${image_name}" "${tag}"
+    run curl -X DELETE http://127.0.0.1:${zot_port}/v2/${image_name}/manifests/${tag}
+    [ "$status" -eq 0 ]
 }
 
 # Helper: Push an ORAS artifact
@@ -244,16 +255,14 @@ function helper_pull_image_with_regclient() {
 }
 
 # Helper: List repositories with regclient
-# Args: $1 = limit (optional), $2 = expected_first_repos (optional, space separated)
+# Args: $1 = limit (optional)
 function helper_list_repositories_with_regclient() {
     local limit=${1:-2}
-    local first_repo=${2:-busybox}
-    local second_repo=${3:-golang}
     local zot_port=$(get_zot_port)
     run regctl repo ls localhost:${zot_port}
     [ "$status" -eq 0 ]
 
-    found=0
+    local found=0
     for i in "${lines[@]}"
     do
         if [ "$i" = 'test-regclient' ]; then
@@ -268,13 +277,41 @@ function helper_list_repositories_with_regclient() {
     [ $(echo "$output" | wc -l) -eq ${limit} ]
 }
 
+function helper_list_repositories_with_regclient_pagination() {
+    local zot_port=$(get_zot_port)
+    run regctl repo ls localhost:${zot_port}
+    [ "$status" -eq 0 ]
+
+    local found=0
+    for i in "${lines[@]}"
+    do
+        if [ "$i" = 'test-regclient' ]; then
+            found=1
+        fi
+    done
+    [ "$found" -eq 1 ]
+
+    run regctl repo ls --limit 2 localhost:${zot_port}
+    [ "$status" -eq 0 ]
+    echo "$output"
+    [ $(echo "$output" | wc -l) -eq 2 ]
+    [ "${lines[-2]}" == "busybox" ]
+    [ "${lines[-1]}" == "golang" ]
+
+    run regctl repo ls --last busybox --limit 1 localhost:${zot_port}
+    [ "$status" -eq 0 ]
+    echo "$output"
+    [ $(echo "$output" | wc -l) -eq 1 ]
+    [ "${lines[-1]}" == "golang" ]
+}
+
 # Helper: List image tags with regclient
 function helper_list_image_tags_with_regclient() {
     local zot_port=$(get_zot_port)
     run regctl tag ls localhost:${zot_port}/test-regclient
     [ "$status" -eq 0 ]
 
-    found=0
+    local found=0
     for i in "${lines[@]}"
     do
         if [ "$i" = 'latest' ]; then
@@ -397,7 +434,8 @@ function helper_push_docker_image() {
     FROM ghcr.io/project-zot/test-images/busybox-docker:1.37
     RUN echo "hello world" > /testfile
 DOCKERFILE
-    docker build -f Dockerfile . -t localhost:${zot_port}/test
+    run sh -c "unset GODEBUG; docker build -f Dockerfile -t localhost:${zot_port}/test ."
+    [ "$status" -eq 0 ]
     run docker push localhost:${zot_port}/test
     [ "$status" -eq 1 ]
     run docker pull localhost:${zot_port}/test
@@ -410,17 +448,7 @@ DOCKERFILE
 # ==============================================================================
 
 function test_release_push_image() {
-    local zot_port=$(get_zot_port)
-    run skopeo --insecure-policy copy --dest-tls-verify=false \
-        oci:${TEST_DATA_DIR}/golang:1.20 \
-        docker://127.0.0.1:${zot_port}/golang:1.20
-    [ "$status" -eq 0 ]
-    run curl http://127.0.0.1:${zot_port}/v2/_catalog
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.repositories[]') = '"golang"' ]
-    run curl http://127.0.0.1:${zot_port}/v2/golang/tags/list
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.20"' ]
+    helper_push_image golang 1.20
 }
 
 function test_release_pull_image() {
@@ -472,31 +500,7 @@ function test_release_pull_image_with_regclient() {
 }
 
 function test_release_list_repositories_with_regclient() {
-    local zot_port=$(get_zot_port)
-    run regctl repo ls localhost:${zot_port}
-    [ "$status" -eq 0 ]
-
-    found=0
-    for i in "${lines[@]}"
-    do
-        if [ "$i" = 'test-regclient' ]; then
-            found=1
-        fi
-    done
-    [ "$found" -eq 1 ]
-
-    run regctl repo ls --limit 2 localhost:${zot_port}
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 2 ]
-    [ "${lines[-2]}" == "busybox" ]
-    [ "${lines[-1]}" == "golang" ]
-
-    run regctl repo ls --last busybox --limit 1 localhost:${zot_port}
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 1 ]
-    [ "${lines[-1]}" == "golang" ]
+    helper_list_repositories_with_regclient_pagination
 }
 
 function test_release_list_image_tags_with_regclient() {
@@ -584,40 +588,11 @@ function test_new_pull_image() {
 }
 
 function test_new_push_image_index() {
-    local zot_port=$(get_zot_port)
-    # --multi-arch below pushes an image index (containing many images) instead
-    # of an image manifest (single image)
-    run skopeo --insecure-policy copy --format=oci --dest-tls-verify=false --multi-arch=all \
-        docker://public.ecr.aws/docker/library/busybox:latest \
-        docker://127.0.0.1:${zot_port}/busybox:latest
-    [ "$status" -eq 0 ]
-    run curl http://127.0.0.1:${zot_port}/v2/_catalog
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq 'any(.repositories[]; . == "busybox")') = true ] 
-    run curl http://127.0.0.1:${zot_port}/v2/busybox/tags/list
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"latest"' ]
+    helper_push_image_index docker://public.ecr.aws/docker/library/busybox:latest busybox latest
 }
 
 function test_new_pull_image_index() {
-    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
-    local zot_port=$(get_zot_port)
-    run skopeo --insecure-policy copy --src-tls-verify=false --multi-arch=all \
-        docker://127.0.0.1:${zot_port}/busybox:latest \
-        oci:${oci_data_dir}/busybox:latest
-    [ "$status" -eq 0 ]
-    run cat ${BATS_FILE_TMPDIR}/oci/busybox/index.json
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests[].annotations."org.opencontainers.image.ref.name"') = '"latest"' ]
-    run skopeo --insecure-policy --override-arch=arm64 --override-os=linux copy --src-tls-verify=false --multi-arch=all \
-        docker://127.0.0.1:${zot_port}/busybox:latest \
-        oci:${oci_data_dir}/busybox:latest
-    [ "$status" -eq 0 ]
-    run cat ${BATS_FILE_TMPDIR}/oci/busybox/index.json
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests[].annotations."org.opencontainers.image.ref.name"') = '"latest"' ]
-    run curl -X DELETE http://127.0.0.1:${zot_port}/v2/busybox/manifests/latest
-    [ "$status" -eq 0 ]
+    helper_pull_image_index_and_delete busybox latest
 }
 
 function test_new_push_oras_artifact() {
@@ -663,7 +638,7 @@ function test_new_list_repositories_with_regclient() {
     run regctl repo ls localhost:${zot_port}
     [ "$status" -eq 0 ]
 
-    found=0
+    local found=0
     for i in "${lines[@]}"
     do
         if [ "$i" = 'test-regclient' ]; then

--- a/test/blackbox/pushpull.bats
+++ b/test/blackbox/pushpull.bats
@@ -3,21 +3,8 @@
 #       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
 
 load helpers_zot
+load helpers_upgrade
 load ../port_helper
-
-function verify_prerequisites {
-    if [ ! $(command -v curl) ]; then
-        echo "you need to install curl as a prerequisite to running the tests" >&3
-        return 1
-    fi
-
-    if [ ! $(command -v jq) ]; then
-        echo "you need to install jq as a prerequisite to running the tests" >&3
-        return 1
-    fi
-
-    return 0
-}
 
 function setup_file() {
     # Verify prerequisites are available
@@ -65,324 +52,97 @@ function teardown_file() {
 }
 
 @test "push image" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run skopeo --insecure-policy copy --dest-tls-verify=false \
-        oci:${TEST_DATA_DIR}/golang:1.20 \
-        docker://127.0.0.1:${zot_port}/golang:1.20
-    [ "$status" -eq 0 ]
-    run curl http://127.0.0.1:${zot_port}/v2/_catalog
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.repositories[]') = '"golang"' ]
-    run curl http://127.0.0.1:${zot_port}/v2/golang/tags/list
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.20"' ]
+    helper_push_image golang 1.20
 }
 
 @test "pull image" {
-    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run skopeo --insecure-policy copy --src-tls-verify=false \
-        docker://127.0.0.1:${zot_port}/golang:1.20 \
-        oci:${oci_data_dir}/golang:1.20
-    [ "$status" -eq 0 ]
-    run cat ${BATS_FILE_TMPDIR}/oci/golang/index.json
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests[].annotations."org.opencontainers.image.ref.name"') = '"1.20"' ]
+    helper_pull_image golang 1.20
 }
 
 @test "push image index" {
-    # --multi-arch below pushes an image index (containing many images) instead
-    # of an image manifest (single image)
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run skopeo --insecure-policy copy --format=oci --dest-tls-verify=false --multi-arch=all \
-        docker://public.ecr.aws/docker/library/busybox:latest \
-        docker://127.0.0.1:${zot_port}/busybox:latest
-    [ "$status" -eq 0 ]
-    run curl http://127.0.0.1:${zot_port}/v2/_catalog
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.repositories[0]') = '"busybox"' ]
-    run curl http://127.0.0.1:${zot_port}/v2/busybox/tags/list
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"latest"' ]
+    helper_push_image_index docker://public.ecr.aws/docker/library/busybox:latest busybox latest
 }
 
 @test "pull image index" {
-    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run skopeo --insecure-policy copy --src-tls-verify=false --multi-arch=all \
-        docker://127.0.0.1:${zot_port}/busybox:latest \
-        oci:${oci_data_dir}/busybox:latest
-    [ "$status" -eq 0 ]
-    run cat ${BATS_FILE_TMPDIR}/oci/busybox/index.json
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests[].annotations."org.opencontainers.image.ref.name"') = '"latest"' ]
-    run skopeo --insecure-policy --override-arch=arm64 --override-os=linux copy --src-tls-verify=false --multi-arch=all \
-        docker://127.0.0.1:${zot_port}/busybox:latest \
-        oci:${oci_data_dir}/busybox:latest
-    [ "$status" -eq 0 ]
-    run cat ${BATS_FILE_TMPDIR}/oci/busybox/index.json
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests[].annotations."org.opencontainers.image.ref.name"') = '"latest"' ]
-    run curl -X DELETE http://127.0.0.1:${zot_port}/v2/busybox/manifests/latest
-    [ "$status" -eq 0 ]
+    helper_pull_image_index_and_delete busybox latest
 }
 
 @test "push oras artifact" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    echo "{\"name\":\"foo\",\"value\":\"bar\"}" > config.json
-    echo "hello world" > artifact.txt
-    run oras push --plain-http 127.0.0.1:${zot_port}/hello-artifact:v2 \
-        --config config.json:application/vnd.acme.rocket.config.v1+json artifact.txt:text/plain -d -v
-    [ "$status" -eq 0 ]
-    rm -f artifact.txt
-    rm -f config.json
+    helper_push_oras_artifact hello-artifact v2
 }
 
 @test "pull oras artifact" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run oras pull --plain-http 127.0.0.1:${zot_port}/hello-artifact:v2 -d -v
-    [ "$status" -eq 0 ]
-    grep -q "hello world" artifact.txt
-    rm -f artifact.txt
+    helper_pull_oras_artifact hello-artifact v2
 }
 
 @test "attach oras artifacts" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    # attach signature
-    echo "{\"artifact\": \"\", \"signature\": \"pat hancock\"}" > ${BATS_FILE_TMPDIR}/signature.json
-    run oras attach --disable-path-validation --plain-http 127.0.0.1:${zot_port}/golang:1.20 --artifact-type 'signature/example' ${BATS_FILE_TMPDIR}/signature.json:application/json
-    [ "$status" -eq 0 ]
-    # attach sbom
-    echo "{\"version\": \"0.0.0.0\", \"artifact\": \"'127.0.0.1:${zot_port}/golang:1.20'\", \"contents\": \"good\"}" > ${BATS_FILE_TMPDIR}/sbom.json
-    run oras attach --disable-path-validation --plain-http 127.0.0.1:${zot_port}/golang:1.20 --artifact-type 'sbom/example' ${BATS_FILE_TMPDIR}/sbom.json:application/json
-    [ "$status" -eq 0 ]
+    helper_attach_oras_artifacts golang 1.20
 }
 
 @test "discover oras artifacts" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run oras discover --plain-http --format json 127.0.0.1:${zot_port}/golang:1.20
-    [ "$status" -eq 0 ]
-    [ $(echo "$output" | jq -r ".manifests | length") -eq 2 ]
+    helper_discover_oras_artifacts golang 1.20 2
 }
 
 @test "add and list tags using oras" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run skopeo --insecure-policy copy --dest-tls-verify=false \
-        oci:${TEST_DATA_DIR}/golang:1.20 \
-        docker://127.0.0.1:${zot_port}/oras-tags:1.20
-    [ "$status" -eq 0 ]
-    run oras tag --plain-http 127.0.0.1:${zot_port}/oras-tags:1.20 1 new latest
-    [ "$status" -eq 0 ]
-    run oras repo tags --plain-http 127.0.0.1:${zot_port}/oras-tags
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 4 ]
-    [ "${lines[-1]}" == "new" ]
-    [ "${lines[-2]}" == "latest" ]
-    [ "${lines[-3]}" == "1.20" ]
-    [ "${lines[-4]}" == "1" ]
-    run oras repo tags --plain-http --last new 127.0.0.1:${zot_port}/oras-tags
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ -z $output ]
-    run oras repo tags --plain-http --last latest 127.0.0.1:${zot_port}/oras-tags
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 1 ]
-    [ "${lines[-1]}" == "new" ]
-    run oras repo tags --plain-http --last "1.20" 127.0.0.1:${zot_port}/oras-tags
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 2 ]
-    [ "${lines[-2]}" == "latest" ]
-    [ "${lines[-1]}" == "new" ]
-    run oras repo tags --plain-http --last "1" 127.0.0.1:${zot_port}/oras-tags
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 3 ]
-    [ "${lines[-3]}" == "1.20" ]
-    [ "${lines[-2]}" == "latest" ]
-    [ "${lines[-1]}" == "new" ]
+    helper_add_and_list_tags_using_oras
 }
 
 @test "push helm chart" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run helm package ${BATS_FILE_TMPDIR}/helm-charts/charts/zot -d ${BATS_FILE_TMPDIR}
-    [ "$status" -eq 0 ]
-    local chart_version=$(awk '/version/{printf $2}' ${BATS_FILE_TMPDIR}/helm-charts/charts/zot/Chart.yaml)
-    run helm push ${BATS_FILE_TMPDIR}/zot-${chart_version}.tgz oci://localhost:${zot_port}/zot-chart
-    [ "$status" -eq 0 ]
+    helper_push_helm_chart
 }
 
 @test "pull helm chart" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    local chart_version=$(awk '/version/{printf $2}' ${BATS_FILE_TMPDIR}/helm-charts/charts/zot/Chart.yaml)
-    run helm pull oci://localhost:${zot_port}/zot-chart/zot --version ${chart_version} -d ${BATS_FILE_TMPDIR}
-    [ "$status" -eq 0 ]
+    helper_pull_helm_chart
 }
 
 @test "push image with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl registry set localhost:${zot_port} --tls disabled
-    [ "$status" -eq 0 ]
-    run regctl image copy ocidir://${TEST_DATA_DIR}/golang:1.20 localhost:${zot_port}/test-regclient
-    [ "$status" -eq 0 ]
+    helper_push_image_with_regclient
 }
 
 @test "pull image with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl image copy localhost:${zot_port}/test-regclient ocidir://${TEST_DATA_DIR}/golang:1.20
-    [ "$status" -eq 0 ]
+    helper_pull_image_with_regclient
 }
 
 @test "list repositories with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl repo ls localhost:${zot_port}
-    [ "$status" -eq 0 ]
-
-    found=0
-    for i in "${lines[@]}"
-    do
-
-        if [ "$i" = 'test-regclient' ]; then
-            found=1
-        fi
-    done
-    [ "$found" -eq 1 ]
-
-    run regctl repo ls --limit 2 localhost:${zot_port}
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 2 ]
-    [ "${lines[-2]}" == "busybox" ]
-    [ "${lines[-1]}" == "golang" ]
-
-    run regctl repo ls --last busybox --limit 1 localhost:${zot_port}
-    [ "$status" -eq 0 ]
-    echo "$output"
-    [ $(echo "$output" | wc -l) -eq 1 ]
-    [ "${lines[-1]}" == "golang" ]
+    helper_list_repositories_with_regclient_pagination
 }
 
 @test "list image tags with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl tag ls localhost:${zot_port}/test-regclient
-    [ "$status" -eq 0 ]
-
-    found=0
-    for i in "${lines[@]}"
-    do
-
-        if [ "$i" = 'latest' ]; then
-            found=1
-        fi
-    done
-    [ "$found" -eq 1 ]
+    helper_list_image_tags_with_regclient
 }
 
 @test "push manifest with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    manifest=$(regctl manifest get localhost:${zot_port}/test-regclient --format=raw-body)
-    run regctl manifest put localhost:${zot_port}/test-regclient:1.0.0 --format oci --content-type application/vnd.oci.image.manifest.v1+json --format oci <<EOF
-    $manifest
-EOF
-    [ "$status" -eq 0 ]
+    helper_push_manifest_with_regclient
 }
 
 @test "pull manifest with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl manifest get localhost:${zot_port}/test-regclient
-    [ "$status" -eq 0 ]
+    helper_pull_manifest_with_regclient
 }
 
 @test "pull manifest with docker client" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run docker pull localhost:${zot_port}/test-regclient
-    [ "$status" -eq 0 ]
+    helper_pull_manifest_with_docker_client
 }
 
 @test "pull manifest with crictl" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run crictl pull localhost:${zot_port}/test-regclient
-    [ "$status" -eq 0 ]
+    helper_pull_manifest_with_crictl
 }
 
 @test "push OCI artifact with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl artifact put localhost:${zot_port}/artifact:demo <<EOF
-this is an artifact
-EOF
-    [ "$status" -eq 0 ]
+    helper_push_oci_artifact_with_regclient
 }
 
 @test "pull OCI artifact with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl manifest get localhost:${zot_port}/artifact:demo
-    [ "$status" -eq 0 ]
-    run regctl artifact get localhost:${zot_port}/artifact:demo
-    [ "$status" -eq 0 ]
-    [ "${lines[-1]}" == "this is an artifact" ]
+    helper_pull_oci_artifact_with_regclient
 }
 
 @test "push OCI artifact references with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl artifact put localhost:${zot_port}/manifest-ref:demo <<EOF
-test artifact
-EOF
-    [ "$status" -eq 0 ]
-    run regctl artifact list localhost:${zot_port}/manifest-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 0 ]
-    run regctl artifact put --annotation  demo=true --annotation format=oci --artifact-type "application/vnd.example.icecream.v1" --subject localhost:${zot_port}/manifest-ref:demo << EOF
-test reference
-EOF
-    [ "$status" -eq 0 ]
-    # with artifact media-type
-    run regctl artifact put localhost:${zot_port}/artifact-ref:demo <<EOF
-test artifact
-EOF
-    [ "$status" -eq 0 ]
-    run regctl artifact list localhost:${zot_port}/artifact-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 0 ]
-    run regctl artifact put --annotation  demo=true --annotation format=oci --artifact-type "application/vnd.example.icecream.v1" --subject localhost:${zot_port}/artifact-ref:demo << EOF
-test reference
-EOF
-    [ "$status" -eq 0 ]
+    helper_push_oci_artifact_references_with_regclient 0
 }
 
 @test "pull OCI artifact references with regclient" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    run regctl artifact list localhost:${zot_port}/manifest-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 1 ]
-    run regctl artifact list --filter-artifact-type "application/vnd.example.icecream.v1" localhost:${zot_port}/manifest-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 1 ]
-    run regctl artifact list --filter-artifact-type "application/invalid" localhost:${zot_port}/manifest-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 0 ]
-    # with artifact media-type
-    run regctl artifact list localhost:${zot_port}/artifact-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 1 ]
-    run regctl artifact list --filter-artifact-type "application/vnd.example.icecream.v1" localhost:${zot_port}/artifact-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 1 ]
-    run regctl artifact list --filter-artifact-type "application/invalid" localhost:${zot_port}/artifact-ref:demo --format raw-body
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.manifests | length') -eq 0 ]
+    helper_pull_oci_artifact_references_with_regclient 1
 }
 
 @test "push docker image" {
-    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
-    cat > Dockerfile <<EOF
-    FROM ghcr.io/project-zot/test-images/busybox-docker:1.37
-    RUN echo "hello world" > /testfile
-EOF
-    docker build -f Dockerfile . -t localhost:${zot_port}/test
-    run docker push localhost:${zot_port}/test
-    [ "$status" -eq 1 ]
-    run docker pull localhost:${zot_port}/test
-    [ "$status" -eq 1 ]
+    helper_push_docker_image
 }


### PR DESCRIPTION
Fixes #3727

## Summary
- reuse the shared blackbox helper layer from the push/pull and FIPS push/pull suites
- keep suite-specific setup/teardown local while moving repeated image, ORAS, Helm, regclient, and Docker checks behind helper calls
- add helpers for the image-index pull/delete flow and strict regclient pagination checks
- simplify matching upgrade helper wrappers where they can call the same generic helpers

## Validation
- bash -n test/blackbox/helpers_upgrade.bash
- transformed BATS syntax check for test/blackbox/pushpull.bats, test/blackbox/fips140.bats, test/blackbox/upgrade.bats, and test/blackbox/upgrade_minimal.bats
- hack/tools/bin/bats --count test/blackbox/pushpull.bats test/blackbox/fips140.bats test/blackbox/upgrade.bats test/blackbox/upgrade_minimal.bats
- git diff --check