### PR TITLE
feat(gc): add gcTimeWindow to limit periodic GC to a local time range

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -91,6 +91,14 @@ Orphan blobs are removed if they are older than gcDelay.
         "gcDelay": "2h"
 ```
 
+Periodic garbage collection can also be limited to a local time window to avoid
+running during active usage hours. The window accepts `HH.MM - HH.MM` or
+`HH:MM - HH:MM` and can cross midnight.
+
+```
+        "gcTimeWindow": "01.00 - 08.00"
+```
+
 To limit the maximum number of repositories that can be created, set:
 
 ```

--- a/examples/config-gc-periodic.json
+++ b/examples/config-gc-periodic.json
@@ -5,12 +5,14 @@
         "gc": true,
         "gcDelay": "1h",
         "gcInterval": "1h",
+        "gcTimeWindow": "01.00 - 08.00",
         "subPaths": {
             "/a": {
                 "rootDirectory": "/tmp/zot1",
                 "gc": true,
                 "gcDelay": "1h",
-                "gcInterval": "1h"
+                "gcInterval": "1h",
+                "gcTimeWindow": "01.00 - 08.00"
             }
         }
     },

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -36,6 +36,7 @@ type StorageConfig struct {
 	Commit        bool
 	GCDelay       time.Duration // applied for blobs
 	GCInterval    time.Duration
+	GCTimeWindow  string `json:"gcTimeWindow,omitempty" mapstructure:"gcTimeWindow,omitempty"`
 	Retention     ImageRetention
 	StorageDriver map[string]any `mapstructure:",omitempty"`
 	CacheDriver   map[string]any `mapstructure:",omitempty"`
@@ -668,7 +669,8 @@ func New() *Config {
 
 func (expConfig StorageConfig) ParamsEqual(actConfig StorageConfig) bool {
 	return expConfig.GC == actConfig.GC && expConfig.Dedupe == actConfig.Dedupe &&
-		expConfig.GCDelay == actConfig.GCDelay && expConfig.GCInterval == actConfig.GCInterval
+		expConfig.GCDelay == actConfig.GCDelay && expConfig.GCInterval == actConfig.GCInterval &&
+		expConfig.GCTimeWindow == actConfig.GCTimeWindow
 }
 
 // isRetentionEnabledInternal checks if retention is enabled without acquiring a lock (internal use only).
@@ -794,6 +796,7 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 	c.Storage.Dedupe = newConfig.Storage.Dedupe
 	c.Storage.GCDelay = newConfig.Storage.GCDelay
 	c.Storage.GCInterval = newConfig.Storage.GCInterval
+	c.Storage.GCTimeWindow = newConfig.Storage.GCTimeWindow
 
 	// Only update retention if we have a metaDB already in place
 	if c.isRetentionEnabledInternal() {
@@ -811,6 +814,7 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 		subPathConfig.Dedupe = storageConfig.Dedupe
 		subPathConfig.GCDelay = storageConfig.GCDelay
 		subPathConfig.GCInterval = storageConfig.GCInterval
+		subPathConfig.GCTimeWindow = storageConfig.GCTimeWindow
 
 		// Only update retention if we have a metaDB already in place
 		if c.isRetentionEnabledInternal() {

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -49,6 +49,14 @@ func TestConfig(t *testing.T) {
 
 		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
 
+		firstStorageConfig.GCTimeWindow = "01.00 - 08.00"
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeFalse)
+
+		secondStorageConfig.GCTimeWindow = "01.00 - 08.00"
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
+
 		isSame, err := config.SameFile("test-config", "test")
 		So(err, ShouldNotBeNil)
 		So(isSame, ShouldBeFalse)
@@ -3362,5 +3370,25 @@ func TestConfig(t *testing.T) {
 			So(path2Config.GC, ShouldBeFalse)    // Unchanged
 			So(path2Config.Dedupe, ShouldBeTrue) // Unchanged
 		})
+	})
+}
+
+func TestGCTimeWindowReloadableConfig(t *testing.T) {
+	Convey("UpdateReloadableConfig updates GC time window settings", t, func() {
+		conf := config.New()
+		conf.Storage.SubPaths = map[string]config.StorageConfig{
+			"/a": {GCTimeWindow: "01.00 - 02.00"},
+		}
+
+		newConfig := config.New()
+		newConfig.Storage.GCTimeWindow = "03.00 - 04.00"
+		newConfig.Storage.SubPaths = map[string]config.StorageConfig{
+			"/a": {GCTimeWindow: "04.00 - 05.00"},
+		}
+
+		conf.UpdateReloadableConfig(newConfig)
+
+		So(conf.Storage.GCTimeWindow, ShouldEqual, "03.00 - 04.00")
+		So(conf.Storage.SubPaths["/a"].GCTimeWindow, ShouldEqual, "04.00 - 05.00")
 	})
 }

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -602,13 +602,20 @@ func RunGCTasks(conf *config.Config, storeController storage.StoreController, me
 	// Enable running garbage-collect periodically for DefaultStore
 	storageConfig := conf.CopyStorageConfig()
 	if storageConfig.GC {
-		gc := gc.NewGarbageCollect(storeController.DefaultStore, metaDB, gc.Options{
-			Delay:             storageConfig.GCDelay,
-			ImageRetention:    storageConfig.Retention,
-			MaxSchedulerDelay: storageConfig.GCMaxSchedulerDelay,
-		}, audit, logger)
+		gcTimeWindow, err := gc.ParseTimeWindow(storageConfig.GCTimeWindow)
+		if err != nil {
+			logger.Error().Err(err).Str("gcTimeWindow", storageConfig.GCTimeWindow).
+				Msg("invalid garbage-collect time window, skipping scheduled garbage collection")
+		} else {
+			garbageCollect := gc.NewGarbageCollect(storeController.DefaultStore, metaDB, gc.Options{
+				Delay:             storageConfig.GCDelay,
+				ImageRetention:    storageConfig.Retention,
+				MaxSchedulerDelay: storageConfig.GCMaxSchedulerDelay,
+				TimeWindow:        gcTimeWindow,
+			}, audit, logger)
 
-		gc.CleanImageStorePeriodically(storageConfig.GCInterval, taskScheduler)
+			garbageCollect.CleanImageStorePeriodically(storageConfig.GCInterval, taskScheduler)
+		}
 	}
 
 	// Handle subpaths
@@ -616,14 +623,23 @@ func RunGCTasks(conf *config.Config, storeController storage.StoreController, me
 		for route, subStorageConfig := range storageConfig.SubPaths {
 			// Enable running garbage-collect periodically for subImageStore
 			if subStorageConfig.GC {
-				gc := gc.NewGarbageCollect(storeController.SubStore[route], metaDB,
+				gcTimeWindow, err := gc.ParseTimeWindow(subStorageConfig.GCTimeWindow)
+				if err != nil {
+					logger.Error().Err(err).Str("subPath", route).Str("gcTimeWindow", subStorageConfig.GCTimeWindow).
+						Msg("invalid garbage-collect time window, skipping scheduled garbage collection")
+
+					continue
+				}
+
+				garbageCollect := gc.NewGarbageCollect(storeController.SubStore[route], metaDB,
 					gc.Options{
 						Delay:             subStorageConfig.GCDelay,
 						ImageRetention:    subStorageConfig.Retention,
 						MaxSchedulerDelay: subStorageConfig.GCMaxSchedulerDelay,
+						TimeWindow:        gcTimeWindow,
 					}, audit, logger)
 
-				gc.CleanImageStorePeriodically(subStorageConfig.GCInterval, taskScheduler)
+				garbageCollect.CleanImageStorePeriodically(subStorageConfig.GCInterval, taskScheduler)
 			}
 		}
 	}

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -31,6 +31,7 @@ import (
 	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
+	storageGC "zotregistry.dev/zot/v2/pkg/storage/gc"
 )
 
 // metadataConfig reports metadata after parsing, which we use to track
@@ -1473,6 +1474,10 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 			zerr.ErrBadConfig, storageConfig.GCInterval)
 	}
 
+	if err := validateGCTimeWindow(storageConfig.GCTimeWindow, logger); err != nil {
+		return err
+	}
+
 	if !storageConfig.GC {
 		if storageConfig.GCDelay != 0 {
 			logger.Warn().Err(zerr.ErrBadConfig).
@@ -1483,6 +1488,11 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 			logger.Warn().Err(zerr.ErrBadConfig).
 				Msg("periodic garbage-collect interval specified without enabling garbage-collect, will be ignored")
 		}
+
+		if storageConfig.GCTimeWindow != "" {
+			logger.Warn().Err(zerr.ErrBadConfig).
+				Msg("garbage-collect time window specified without enabling garbage-collect, will be ignored")
+		}
 	}
 
 	if err := validateGCRules(storageConfig.Retention, logger); err != nil {
@@ -1491,6 +1501,10 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 
 	// subpaths
 	for name, subPath := range storageConfig.SubPaths {
+		if err := validateGCTimeWindow(subPath.GCTimeWindow, logger); err != nil {
+			return fmt.Errorf("%w for subpath %s", err, name)
+		}
+
 		if subPath.GC && subPath.GCDelay <= 0 {
 			logger.Error().Err(zerr.ErrBadConfig).
 				Str("subPath", name).
@@ -1504,6 +1518,18 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 		if err := validateGCRules(subPath.Retention, logger); err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+func validateGCTimeWindow(gcTimeWindow string, logger zlog.Logger) error {
+	if _, err := storageGC.ParseTimeWindow(gcTimeWindow); err != nil {
+		logger.Error().Err(zerr.ErrBadConfig).Str("gcTimeWindow", gcTimeWindow).
+			Msg("invalid garbage-collect time window specified")
+
+		return fmt.Errorf("%w: invalid garbage-collect time window specified %q: %w",
+			zerr.ErrBadConfig, gcTimeWindow, err)
 	}
 
 	return nil

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -131,6 +131,7 @@ func TestSchema(t *testing.T) {
 		So(storageProperties, ShouldContainKey, "rootDirectory")
 		So(storageProperties, ShouldContainKey, "gcDelay")
 		So(storageProperties, ShouldContainKey, "gcInterval")
+		So(storageProperties, ShouldContainKey, "gcTimeWindow")
 		So(storageProperties, ShouldContainKey, "subPaths")
 		So(storageProperties, ShouldNotContainKey, "gcMaxSchedulerDelay")
 		So(storageProperties, ShouldNotContainKey, "gCDelay")
@@ -2630,6 +2631,40 @@ func TestGC(t *testing.T) {
 
 			file := MakeTempFileWithContent(t, "gc-config.json", string(contents))
 			err = cli.LoadConfiguration(config, file)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Valid GC time window", func() {
+			cfg := config.New()
+			err = json.Unmarshal(contents, cfg)
+			cfg.Storage.GCTimeWindow = "01.00 - 08.00"
+			cfg.Storage.SubPaths = map[string]config.StorageConfig{
+				"/a": {
+					RootDirectory: "/tmp/zot-a",
+					GC:            true,
+					GCDelay:       1 * time.Hour,
+					GCTimeWindow:  "23:30 - 02:15",
+				},
+			}
+
+			contents, err = json.MarshalIndent(cfg, "", " ")
+			So(err, ShouldBeNil)
+
+			file := MakeTempFileWithContent(t, "gc-config.json", string(contents))
+			err = cli.LoadConfiguration(cfg, file)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Invalid GC time window", func() {
+			cfg := config.New()
+			err = json.Unmarshal(contents, cfg)
+			cfg.Storage.GCTimeWindow = "24.00 - 08.00"
+
+			contents, err = json.MarshalIndent(cfg, "", " ")
+			So(err, ShouldBeNil)
+
+			file := MakeTempFileWithContent(t, "gc-config.json", string(contents))
+			err = cli.LoadConfiguration(cfg, file)
 			So(err, ShouldNotBeNil)
 		})
 	})

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -42,6 +42,9 @@ type Options struct {
 	// Defaults to 30 seconds if not specified
 	MaxSchedulerDelay time.Duration
 
+	// TimeWindow limits scheduled garbage collection to a configured local time range.
+	TimeWindow TimeWindow
+
 	ImageRetention config.ImageRetention
 }
 
@@ -84,6 +87,7 @@ func (gc GarbageCollect) CleanImageStorePeriodically(interval time.Duration, sch
 		gc:             gc,
 		processedRepos: processedRepos,
 		maxDelay:       maxDelay,
+		timeWindow:     gc.opts.TimeWindow,
 	}
 
 	sch.SubmitGenerator(generator, interval, scheduler.MediumPriority)
@@ -871,6 +875,7 @@ type GCTaskGenerator struct {
 	done           bool
 	rand           *rand.Rand
 	maxDelay       time.Duration
+	timeWindow     TimeWindow
 }
 
 func (gen *GCTaskGenerator) getRandomDelay() time.Duration {
@@ -919,7 +924,15 @@ func (gen *GCTaskGenerator) IsDone() bool {
 }
 
 func (gen *GCTaskGenerator) IsReady() bool {
-	return time.Now().After(gen.nextRun)
+	return gen.isReadyAt(time.Now())
+}
+
+func (gen *GCTaskGenerator) isReadyAt(now time.Time) bool {
+	if !gen.timeWindow.Contains(now) {
+		return false
+	}
+
+	return now.After(gen.nextRun)
 }
 
 func (gen *GCTaskGenerator) Reset() {

--- a/pkg/storage/gc/time_window.go
+++ b/pkg/storage/gc/time_window.go
@@ -1,0 +1,114 @@
+package gc
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	hoursPerDay    = 24
+	minutesPerHour = 60
+)
+
+var (
+	errInvalidTimeWindow      = errors.New("invalid GC time window")
+	errInvalidClockTime       = errors.New("invalid clock time")
+	errClockSeparatorConflict = errors.New("use either ':' or '.' as the separator")
+	errClockOutOfRange        = errors.New("clock value out of range")
+)
+
+// TimeWindow describes the local time range during which scheduled GC may run.
+type TimeWindow struct {
+	startMinute int
+	endMinute   int
+	configured  bool
+}
+
+// ParseTimeWindow parses a GC time window in HH.MM - HH.MM or HH:MM - HH:MM format.
+func ParseTimeWindow(raw string) (TimeWindow, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return TimeWindow{}, nil
+	}
+
+	parts := strings.Split(raw, "-")
+	if len(parts) != 2 { //nolint:mnd
+		return TimeWindow{}, fmt.Errorf("%w: expected '<start> - <end>'", errInvalidTimeWindow)
+	}
+
+	start, err := parseClockMinute(parts[0])
+	if err != nil {
+		return TimeWindow{}, fmt.Errorf("%w: invalid start time: %w", errInvalidTimeWindow, err)
+	}
+
+	end, err := parseClockMinute(parts[1])
+	if err != nil {
+		return TimeWindow{}, fmt.Errorf("%w: invalid end time: %w", errInvalidTimeWindow, err)
+	}
+
+	if start == end {
+		return TimeWindow{}, fmt.Errorf("%w: start and end time must be different", errInvalidTimeWindow)
+	}
+
+	return TimeWindow{startMinute: start, endMinute: end, configured: true}, nil
+}
+
+// Contains reports whether the provided local time falls inside the GC time window.
+func (window TimeWindow) Contains(now time.Time) bool {
+	if !window.configured {
+		return true
+	}
+
+	minute := now.Hour()*minutesPerHour + now.Minute()
+	if window.startMinute < window.endMinute {
+		return minute >= window.startMinute && minute < window.endMinute
+	}
+
+	return minute >= window.startMinute || minute < window.endMinute
+}
+
+func parseClockMinute(raw string) (int, error) {
+	raw = strings.TrimSpace(raw)
+	hasColon := strings.Contains(raw, ":")
+	hasDot := strings.Contains(raw, ".")
+
+	var sep string
+	switch {
+	case hasColon && hasDot:
+		return 0, errClockSeparatorConflict
+	case hasColon:
+		sep = ":"
+	case hasDot:
+		sep = "."
+	default:
+		return 0, fmt.Errorf("%w: expected HH.MM or HH:MM", errInvalidClockTime)
+	}
+
+	parts := strings.Split(raw, sep)
+	if len(parts) != 2 { //nolint:mnd
+		return 0, fmt.Errorf("%w: expected HH%sMM", errInvalidClockTime, sep)
+	}
+
+	hour, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid hour: %w", errInvalidClockTime, err)
+	}
+
+	minute, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid minute: %w", errInvalidClockTime, err)
+	}
+
+	if hour < 0 || hour >= hoursPerDay {
+		return 0, fmt.Errorf("%w: hour must be between 0 and 23", errClockOutOfRange)
+	}
+
+	if minute < 0 || minute >= minutesPerHour {
+		return 0, fmt.Errorf("%w: minute must be between 0 and 59", errClockOutOfRange)
+	}
+
+	return hour*minutesPerHour + minute, nil
+}

--- a/pkg/storage/gc/time_window_internal_test.go
+++ b/pkg/storage/gc/time_window_internal_test.go
@@ -1,0 +1,71 @@
+package gc
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestGCTimeWindow(t *testing.T) {
+	Convey("Parse empty GC time window", t, func() {
+		window, err := ParseTimeWindow("")
+
+		So(err, ShouldBeNil)
+		So(window.Contains(time.Date(2026, time.April, 26, 12, 0, 0, 0, time.Local)), ShouldBeTrue)
+	})
+
+	Convey("Parse same-day GC time window", t, func() {
+		window, err := ParseTimeWindow("01.00 - 08.00")
+
+		So(err, ShouldBeNil)
+		So(window.Contains(time.Date(2026, time.April, 26, 1, 0, 0, 0, time.Local)), ShouldBeTrue)
+		So(window.Contains(time.Date(2026, time.April, 26, 7, 59, 0, 0, time.Local)), ShouldBeTrue)
+		So(window.Contains(time.Date(2026, time.April, 26, 0, 59, 0, 0, time.Local)), ShouldBeFalse)
+		So(window.Contains(time.Date(2026, time.April, 26, 8, 0, 0, 0, time.Local)), ShouldBeFalse)
+	})
+
+	Convey("Parse GC time window crossing midnight", t, func() {
+		window, err := ParseTimeWindow("23:30 - 02:15")
+
+		So(err, ShouldBeNil)
+		So(window.Contains(time.Date(2026, time.April, 26, 23, 30, 0, 0, time.Local)), ShouldBeTrue)
+		So(window.Contains(time.Date(2026, time.April, 26, 1, 0, 0, 0, time.Local)), ShouldBeTrue)
+		So(window.Contains(time.Date(2026, time.April, 26, 2, 15, 0, 0, time.Local)), ShouldBeFalse)
+		So(window.Contains(time.Date(2026, time.April, 26, 12, 0, 0, 0, time.Local)), ShouldBeFalse)
+	})
+
+	Convey("Reject invalid GC time windows", t, func() {
+		invalidWindows := []string{
+			"24.00 - 08.00",
+			"10.60 - 12.00",
+			"10.00 12.00",
+			"08.00 - 08.00",
+			"bad - 08.00",
+		}
+
+		for _, raw := range invalidWindows {
+			_, err := ParseTimeWindow(raw)
+			So(err, ShouldNotBeNil)
+		}
+	})
+}
+
+func TestGCTaskGeneratorGCTimeWindow(t *testing.T) {
+	Convey("GCTaskGenerator readiness respects GC time window", t, func() {
+		window, err := ParseTimeWindow("01.00 - 02.00")
+		So(err, ShouldBeNil)
+
+		base := time.Date(2026, time.April, 26, 1, 30, 0, 0, time.Local)
+		generator := &GCTaskGenerator{
+			nextRun:    base.Add(-1 * time.Second),
+			timeWindow: window,
+		}
+
+		So(generator.isReadyAt(base), ShouldBeTrue)
+		So(generator.isReadyAt(time.Date(2026, time.April, 26, 2, 0, 0, 0, time.Local)), ShouldBeFalse)
+
+		generator.nextRun = base.Add(1 * time.Second)
+		So(generator.isReadyAt(base), ShouldBeFalse)
+	})
+}


### PR DESCRIPTION
## Summary

- Adds a new optional `gcTimeWindow` storage setting that confines scheduled garbage collection to a local time range (e.g. `01.00 - 08.00`), supporting both `.` and `:` separators and windows that cross midnight.
- Honours the window for the default store and each subpath, validates the value at config load, and gates the GC task generator's readiness on the window.
- Updates `examples/README.md` and `examples/config-gc-periodic.json` so operators can discover and copy the new option.

Closes #3001

## Implementation notes

- `pkg/storage/gc/time_window.go` exposes `ParseTimeWindow` / `TimeWindow.Contains`. The window is empty by default (matches today's behaviour).
- `pkg/api/controller.go` plumbs the parsed window through `gc.Options` for both the default store and subpaths; an invalid value logs and skips scheduled GC for that store rather than failing the whole server.
- `pkg/cli/server/root.go` rejects malformed values up-front and warns when a window is set without `gc: true`.
- `UpdateReloadableConfig` carries the new field across reloads so live config edits take effect without a restart.

## Test plan

- [x] `go test ./pkg/storage/gc/... ./pkg/api/config/... ./pkg/cli/server/...`
- [x] `golangci-lint run` on the touched packages
- [x] Verified parsing of same-day window, midnight-crossing window, and invalid inputs via unit tests
- [x] Verified GC task generator readiness honours the window via unit test