### PR TITLE
fix(exporter): forward Authorization header from zxp to zot metrics endpoint

### DIFF
--- a/pkg/exporter/api/exporter.go
+++ b/pkg/exporter/api/exporter.go
@@ -29,6 +29,13 @@ type Collector struct {
 	invalidChars *regexp.Regexp
 }
 
+func (zc *Collector) WithHeaders(headers http.Header) *Collector {
+	clone := *zc
+	clone.Client = zc.Client.WithHeaders(headers)
+
+	return &clone
+}
+
 // Describe implements prometheus.Collector interface.
 func (zc Collector) Describe(ch chan<- *prometheus.Desc) {
 	for _, metricDescription := range zc.MetricsDesc {
@@ -169,20 +176,43 @@ func GetCollector(c *Controller) *Collector {
 	}
 }
 
+func metricsHeaders(headers http.Header) http.Header {
+	forwardedHeaders := make(http.Header)
+
+	for _, authHeader := range headers.Values("Authorization") {
+		forwardedHeaders.Add("Authorization", authHeader)
+	}
+
+	return forwardedHeaders
+}
+
+func newMetricsHandler(collector *Collector) http.Handler {
+	return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		registry := prometheus.NewRegistry()
+		if err := registry.Register(collector.WithHeaders(metricsHeaders(request.Header))); err != nil {
+			http.Error(response, err.Error(), http.StatusInternalServerError)
+
+			return
+		}
+
+		promhttp.HandlerFor(prometheus.Gatherers{prometheus.DefaultGatherer, registry}, promhttp.HandlerOpts{}).ServeHTTP(
+			response, request,
+		)
+	})
+}
+
 func runExporter(c *Controller) {
 	exporterAddr := ":" + c.Config.Exporter.Port
+	router := http.NewServeMux()
+	collector := GetCollector(c)
 	server := &http.Server{
 		Addr:              exporterAddr,
+		Handler:           router,
 		IdleTimeout:       idleTimeout,
 		ReadHeaderTimeout: readHeaderTimeout,
 	}
 
-	err := prometheus.Register(GetCollector(c))
-	if err != nil {
-		c.Log.Debug().Err(err).Msg("ignoring error")
-	}
-
-	http.Handle(c.Config.Exporter.Metrics.Path, promhttp.Handler())
+	router.Handle(c.Config.Exporter.Metrics.Path, newMetricsHandler(collector))
 	c.Log.Info().Str("addr", exporterAddr).
 		Str("path", c.Config.Exporter.Metrics.Path).
 		Msg("exporter listening")

--- a/pkg/exporter/api/exporter_internal_test.go
+++ b/pkg/exporter/api/exporter_internal_test.go
@@ -1,0 +1,98 @@
+//go:build !metrics
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+)
+
+func TestMetricsHandlerForwardsAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+
+	const authorizationHeader = "Basic b2JzZXJ2YWJpbGl0eTpwYXNzd29yZA=="
+
+	var forwardedAuthorization atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != authorizationHeader {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"errors":[{"code":"UNAUTHORIZED"}]}`))
+
+			return
+		}
+
+		forwardedAuthorization.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Counters":[],"Gauges":[],"Summaries":[],"Histograms":[]}`))
+	}))
+	defer server.Close()
+
+	controller := NewController(DefaultConfig())
+	collector := GetCollector(controller)
+	collector.Client = monitoring.NewMetricsClient(
+		&monitoring.MetricsConfig{Address: server.URL, HTTPClient: server.Client()},
+		controller.Log,
+	)
+
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	request.Header.Set("Authorization", authorizationHeader)
+	response := httptest.NewRecorder()
+
+	newMetricsHandler(collector).ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected HTTP 200 from exporter, got %d with body: %s", response.Code, response.Body.String())
+	}
+
+	if !forwardedAuthorization.Load() {
+		t.Fatal("expected exporter to forward Authorization header to zot metrics endpoint")
+	}
+
+	if !strings.Contains(response.Body.String(), "zot_up 1") {
+		t.Fatalf("expected successful zot scrape in exporter metrics, got body: %s", response.Body.String())
+	}
+}
+
+func TestMetricsHandlerReportsZotDownWithoutAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+
+	const authorizationHeader = "Basic b2JzZXJ2YWJpbGl0eTpwYXNzd29yZA=="
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != authorizationHeader {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"errors":[{"code":"UNAUTHORIZED"}]}`))
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Counters":[],"Gauges":[],"Summaries":[],"Histograms":[]}`))
+	}))
+	defer server.Close()
+
+	controller := NewController(DefaultConfig())
+	collector := GetCollector(controller)
+	collector.Client = monitoring.NewMetricsClient(
+		&monitoring.MetricsConfig{Address: server.URL, HTTPClient: server.Client()},
+		controller.Log,
+	)
+
+	request := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	response := httptest.NewRecorder()
+
+	newMetricsHandler(collector).ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("expected HTTP 200 from exporter, got %d with body: %s", response.Code, response.Body.String())
+	}
+
+	if !strings.Contains(response.Body.String(), "zot_up 0") {
+		t.Fatalf("expected failed zot scrape in exporter metrics, got body: %s", response.Body.String())
+	}
+}

--- a/pkg/extensions/monitoring/minimal_client.go
+++ b/pkg/extensions/monitoring/minimal_client.go
@@ -108,6 +108,13 @@ func NewMetricsClient(config *MetricsConfig, logger log.Logger) *MetricsClient {
 	return &MetricsClient{config: *config, headers: make(http.Header), log: logger}
 }
 
+func (mc *MetricsClient) WithHeaders(headers http.Header) *MetricsClient {
+	clone := *mc
+	clone.headers = headers.Clone()
+
+	return &clone
+}
+
 func (mc *MetricsClient) GetMetrics() (*MetricsInfo, error) {
 	metrics := &MetricsInfo{}
 	if _, err := mc.makeGETRequest(mc.config.Address+"/metrics", metrics); err != nil {
@@ -123,12 +130,22 @@ func (mc *MetricsClient) makeGETRequest(url string, resultsPtr any) (http.Header
 		return nil, fmt.Errorf("metric scraping failed: %w", err)
 	}
 
+	for name, values := range mc.headers {
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+
 	resp, err := mc.config.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("metric scraping failed: %w", err)
 	}
 
 	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("metric scraping failed: unexpected status code %d", resp.StatusCode)
+	}
 
 	if err := json.NewDecoder(resp.Body).Decode(resultsPtr); err != nil {
 		return nil, fmt.Errorf("metric scraping failed: %w", err)

--- a/pkg/extensions/monitoring/minimal_client_test.go
+++ b/pkg/extensions/monitoring/minimal_client_test.go
@@ -17,6 +17,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -140,6 +141,50 @@ func TestNewMetricsClientFallbackKeepsTLSHardening(t *testing.T) {
 
 	if transport.TLSClientConfig.MinVersion != tls.VersionTLS12 {
 		t.Fatalf("expected fallback MinVersion TLS1.2, got: %d", transport.TLSClientConfig.MinVersion)
+	}
+}
+
+func TestMetricsClientForwardsHeadersAndRejectsNonSuccessStatus(t *testing.T) {
+	t.Parallel()
+
+	const authorizationHeader = "Basic b2JzZXJ2YWJpbGl0eTpwYXNzd29yZA=="
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != authorizationHeader {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"errors":[{"code":"UNAUTHORIZED"}]}`))
+
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"Counters":[],"Gauges":[],"Summaries":[],"Histograms":[]}`))
+	}))
+	defer server.Close()
+
+	client := NewMetricsClient(
+		&MetricsConfig{Address: server.URL, HTTPClient: server.Client()},
+		log.NewLogger("debug", ""),
+	)
+
+	_, err := client.GetMetrics()
+	if err == nil {
+		t.Fatal("expected unauthenticated scrape to fail")
+	}
+
+	if !strings.Contains(err.Error(), "unexpected status code 401") {
+		t.Fatalf("expected 401 status error, got: %v", err)
+	}
+
+	authorizedClient := client.WithHeaders(http.Header{"Authorization": []string{authorizationHeader}})
+
+	metrics, err := authorizedClient.GetMetrics()
+	if err != nil {
+		t.Fatalf("expected scrape with forwarded authorization header to succeed, got: %v", err)
+	}
+
+	if metrics == nil {
+		t.Fatal("expected metrics response")
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

Fixes #3263

**What does this PR do / Why do we need it**:

When zot is configured with authentication (e.g. htpasswd), the `zxp` node exporter could not scrape zot's `/metrics` endpoint because it always issued an unauthenticated request. The JSON decoder silently consumed the 401 error body, so the resulting Prometheus output was missing every `zot_*` metric (only `go_*`/`process_*` showed up) and `zot_up` never flipped to 0 to surface the failure.

This PR makes the exporter forward the `Authorization` header from the inbound `/metrics` request to the upstream zot scrape:

- `pkg/exporter/api/exporter.go` swaps the global `prometheus.Register` + `promhttp.Handler()` wiring for a per-request handler. Each request now builds a fresh `prometheus.Registry` and registers a collector clone scoped to that request via `Collector.WithHeaders`, which carries the forwarded `Authorization` header(s) into the scrape.
- `pkg/extensions/monitoring/minimal_client.go` adds `MetricsClient.WithHeaders` and copies any configured headers onto every outgoing request in `makeGETRequest`. Non-2xx responses are now treated as scrape failures instead of being decoded as JSON, so `zot_up` correctly reports 0 and the underlying error is logged.

Behavior with no auth on zot is unchanged because no `Authorization` header is forwarded when none is sent.

**If an issue # is not available please add repro steps and logs showing the issue**:

N/A — see #3263 for repro steps and logs.

**Testing done on this change**:

- Added `TestMetricsHandlerForwardsAuthorizationHeader` and `TestMetricsHandlerReportsZotDownWithoutAuthorizationHeader` in `pkg/exporter/api/exporter_internal_test.go` which spin up an httptest server that requires a Basic Authorization header. The first test asserts the exporter forwards the header (200 + `zot_up 1`); the second asserts that without the header the scrape is treated as a failure (`zot_up 0`).
- Added `TestMetricsClientForwardsHeadersAndRejectsNonSuccessStatus` in `pkg/extensions/monitoring/minimal_client_test.go` which verifies that an unauthenticated `GetMetrics()` call now returns `unexpected status code 401` (instead of decoding the error body) and that calling `WithHeaders` produces a client whose request carries the `Authorization` header.
- `go build ./pkg/exporter/... ./pkg/extensions/monitoring/...`
- `go test ./pkg/exporter/api/... ./pkg/extensions/monitoring/...` — both packages pass locally.
- `gofmt -l` and `go vet` clean on the touched files.

**Automation added to e2e**:

No e2e change. The fix is fully covered by the new unit/internal tests against an httptest server that mirrors a 401-protected zot. An e2e test that boots a real htpasswd-protected zot under zxp can be tracked separately if desired.

**Will this break upgrades or downgrades?**

No. The wire format of the `/metrics` endpoint is unchanged. Existing zxp deployments that do not pass an `Authorization` header continue to work exactly as before; the only behavior change is that scrape failures (any non-2xx from zot) now correctly surface as `zot_up 0` rather than an empty success.

**Does this PR introduce any user-facing change?**:

Yes — operators running `zxp` against a zot with authentication enabled can now scrape it by forwarding their Prometheus credentials (e.g. `basic_auth` in the Prometheus scrape config pointed at `zxp`). zxp passes the inbound `Authorization` header straight through to zot.

```release-note
fix(exporter): zxp now forwards the inbound `Authorization` header to zot's /metrics endpoint, so it can scrape zot when authentication (e.g. htpasswd) is enabled. Non-2xx responses from zot are also treated as scrape failures and reported via `zot_up 0`.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.