### PR TITLE
Introduce expiration field for `accessConfig` policies

### DIFF
--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"slices"
+	"time"
 
 	glob "github.com/bmatcuk/doublestar/v4"
 	"github.com/gorilla/mux"
@@ -80,16 +81,24 @@ func (ac *AccessController) getGlobPatterns(username string, groups []string, ac
 		}
 
 		// check user based policy
-		for _, p := range policyGroup.Policies {
-			if slices.Contains(p.Users, username) && slices.Contains(p.Actions, action) {
+		for _, policy := range policyGroup.Policies {
+			if isPolicyExpired(policy) {
+				continue
+			}
+
+			if slices.Contains(policy.Users, username) && slices.Contains(policy.Actions, action) {
 				globPatterns[pattern] = true
 			}
 		}
 
 		// check group based policy
 		for _, group := range groups {
-			for _, p := range policyGroup.Policies {
-				if slices.Contains(p.Groups, group) && slices.Contains(p.Actions, action) {
+			for _, policy := range policyGroup.Policies {
+				if isPolicyExpired(policy) {
+					continue
+				}
+
+				if slices.Contains(policy.Groups, group) && slices.Contains(policy.Actions, action) {
 					globPatterns[pattern] = true
 				}
 			}
@@ -211,21 +220,34 @@ func (ac *AccessController) getAuthnMiddlewareContext(authnType string, request 
 	return ctx
 }
 
+// isPolicyExpired reports whether a policy's optional ExpiresAt has passed.
+func isPolicyExpired(p config.Policy) bool {
+	return p.ExpiresAt != nil && p.ExpiresAt.Before(time.Now())
+}
+
 // isPermitted returns true if username can do action on a repository policy.
 func (ac *AccessController) isPermitted(userGroups []string, username, action string,
 	policyGroup config.PolicyGroup,
 ) bool {
 	// check repo/system based policies
-	for _, p := range policyGroup.Policies {
-		if slices.Contains(p.Users, username) && slices.Contains(p.Actions, action) {
+	for _, policy := range policyGroup.Policies {
+		if isPolicyExpired(policy) {
+			continue
+		}
+
+		if slices.Contains(policy.Users, username) && slices.Contains(policy.Actions, action) {
 			return true
 		}
 	}
 
 	if userGroups != nil {
-		for _, p := range policyGroup.Policies {
-			if slices.Contains(p.Actions, action) {
-				for _, group := range p.Groups {
+		for _, policy := range policyGroup.Policies {
+			if isPolicyExpired(policy) {
+				continue
+			}
+
+			if slices.Contains(policy.Actions, action) {
+				for _, group := range policy.Groups {
 					if slices.Contains(userGroups, group) {
 						return true
 					}

--- a/pkg/api/authz_internal_test.go
+++ b/pkg/api/authz_internal_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/api/constants"
+	"zotregistry.dev/zot/v2/pkg/log"
+)
+
+func TestPolicyExpiresAt(t *testing.T) {
+	t.Parallel()
+
+	past := time.Now().Add(-time.Hour)
+	future := time.Now().Add(time.Hour)
+
+	makeAC := func(policies []config.Policy, groups config.Groups) *AccessController {
+		return &AccessController{
+			Config: &config.AccessControlConfig{
+				Repositories: config.Repositories{
+					"**": config.PolicyGroup{Policies: policies},
+				},
+				Groups: groups,
+			},
+			Log: log.NewLogger("debug", ""),
+		}
+	}
+
+	t.Run("user policy without ExpiresAt is permitted", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]config.Policy{{
+			Users:   []string{"alice"},
+			Actions: []string{constants.ReadPermission},
+		}}, nil)
+
+		assert.True(t, ac.isPermitted(nil, "alice", constants.ReadPermission,
+			ac.Config.Repositories["**"]))
+	})
+
+	t.Run("user policy with future ExpiresAt is permitted", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]config.Policy{{
+			Users:     []string{"alice"},
+			Actions:   []string{constants.ReadPermission},
+			ExpiresAt: &future,
+		}}, nil)
+
+		assert.True(t, ac.isPermitted(nil, "alice", constants.ReadPermission,
+			ac.Config.Repositories["**"]))
+	})
+
+	t.Run("user policy with past ExpiresAt is denied", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]config.Policy{{
+			Users:     []string{"alice"},
+			Actions:   []string{constants.ReadPermission},
+			ExpiresAt: &past,
+		}}, nil)
+
+		assert.False(t, ac.isPermitted(nil, "alice", constants.ReadPermission,
+			ac.Config.Repositories["**"]))
+	})
+
+	t.Run("group policy with past ExpiresAt is denied", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]config.Policy{{
+			Groups:    []string{"devs"},
+			Actions:   []string{constants.ReadPermission},
+			ExpiresAt: &past,
+		}}, config.Groups{"devs": config.Group{Users: []string{"alice"}}})
+
+		assert.False(t, ac.isPermitted([]string{"devs"}, "alice", constants.ReadPermission,
+			ac.Config.Repositories["**"]))
+	})
+
+	t.Run("group policy with future ExpiresAt is permitted", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]config.Policy{{
+			Groups:    []string{"devs"},
+			Actions:   []string{constants.ReadPermission},
+			ExpiresAt: &future,
+		}}, config.Groups{"devs": config.Group{Users: []string{"alice"}}})
+
+		assert.True(t, ac.isPermitted([]string{"devs"}, "alice", constants.ReadPermission,
+			ac.Config.Repositories["**"]))
+	})
+
+	t.Run("expired entry does not contribute glob patterns", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]config.Policy{{
+			Users:     []string{"alice"},
+			Actions:   []string{constants.ReadPermission},
+			ExpiresAt: &past,
+		}}, nil)
+
+		patterns := ac.getGlobPatterns("alice", nil, constants.ReadPermission)
+		assert.False(t, patterns["**"])
+	})
+
+	t.Run("non-expired entry contributes glob patterns", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]config.Policy{{
+			Users:     []string{"alice"},
+			Actions:   []string{constants.ReadPermission},
+			ExpiresAt: &future,
+		}}, nil)
+
+		patterns := ac.getGlobPatterns("alice", nil, constants.ReadPermission)
+		assert.True(t, patterns["**"])
+	})
+
+	t.Run("expiry on one entry does not affect another", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]config.Policy{
+			{
+				Users:     []string{"alice"},
+				Actions:   []string{constants.ReadPermission},
+				ExpiresAt: &past,
+			},
+			{
+				Users:   []string{"alice"},
+				Actions: []string{constants.ReadPermission},
+			},
+		}, nil)
+
+		assert.True(t, ac.isPermitted(nil, "alice", constants.ReadPermission,
+			ac.Config.Repositories["**"]))
+	})
+}

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -634,6 +634,10 @@ type Policy struct {
 	Users   []string
 	Actions []string
 	Groups  []string
+
+	// ExpiresAt is an optional expiration time for this policy entry.
+	// When set, the policy is ignored once the timestamp is in the past.
+	ExpiresAt *time.Time
 }
 
 type Metrics struct {

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -1150,6 +1150,7 @@ func LoadConfiguration(config *config.Config, configPath string) error {
 		viper.DecodeHook(
 			mapstructure.ComposeDecodeHookFunc(
 				mapstructure.StringToTimeDurationHookFunc(),
+				mapstructure.StringToTimeHookFunc(time.RFC3339),
 				eventsconf.SinkConfigDecoderHook(),
 			),
 		),

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -87,6 +87,77 @@ func TestServerUsage(t *testing.T) {
 	})
 }
 
+func TestLoadConfigurationDecodesPolicyExpiresAt(t *testing.T) {
+	Convey("expiresAt on accessControl policy decodes into *time.Time", t, func() {
+		htpasswdPath := MakeHtpasswdFileFromString(t, "alice:$2y$05$ajq8Q7fbtFRQvPndnct8OuRu7n6BDpRYHvz7dNH0G9z2j5XbB7yIm")
+		content := fmt.Sprintf(`{
+			"storage": {"rootDirectory": "/tmp/zot"},
+			"http": {
+				"address": "127.0.0.1",
+				"port": "8080",
+				"auth": {"htpasswd": {"path": %q}},
+				"accessControl": {
+					"repositories": {
+						"**": {
+							"policies": [
+								{
+									"users": ["alice"],
+									"actions": ["read"],
+									"expiresAt": "2099-12-31T23:59:59Z"
+								},
+								{
+									"users": ["bob"],
+									"actions": ["read"]
+								}
+							]
+						}
+					}
+				}
+			}
+		}`, htpasswdPath)
+
+		tmpfile := MakeTempFileWithContent(t, "zot-policy-expiresat.json", content)
+		cfg := config.New()
+
+		err := cli.LoadConfiguration(cfg, tmpfile)
+		So(err, ShouldBeNil)
+
+		policies := cfg.HTTP.AccessControl.Repositories["**"].Policies
+		So(policies, ShouldHaveLength, 2)
+		So(policies[0].ExpiresAt, ShouldNotBeNil)
+
+		expected, perr := time.Parse(time.RFC3339, "2099-12-31T23:59:59Z")
+		So(perr, ShouldBeNil)
+		So(policies[0].ExpiresAt.Equal(expected), ShouldBeTrue)
+		So(policies[1].ExpiresAt, ShouldBeNil)
+	})
+
+	Convey("malformed expiresAt fails to load", t, func() {
+		content := `{
+			"storage": {"rootDirectory": "/tmp/zot"},
+			"http": {
+				"address": "127.0.0.1",
+				"port": "8080",
+				"accessControl": {
+					"repositories": {
+						"**": {
+							"policies": [
+								{"users": ["alice"], "actions": ["read"], "expiresAt": "not-a-date"}
+							]
+						}
+					}
+				}
+			}
+		}`
+
+		tmpfile := MakeTempFileWithContent(t, "zot-policy-expiresat-bad.json", content)
+		cfg := config.New()
+
+		err := cli.LoadConfiguration(cfg, tmpfile)
+		So(err, ShouldNotBeNil)
+	})
+}
+
 func TestLoadConfigurationInjectsHTTPTimeoutDefaults(t *testing.T) {
 	Convey("load config sets HTTP read/write timeout defaults when not explicitly configured", t, func() {
 		content := `{


### PR DESCRIPTION
### Use case

Similar to #3755 (implemented via #3761), but now for the `accessConfig` policies. It turns out that issuing customer licenses as simple "ID cards" i.e. without the permissions embedded directly on them is much better (i.e. use OIDC federation), because we don't have to re-issue a license for a customer every time their permissions change. This feature allows us to configure the customer access on the server side via static Zot config (e.g. giving a customer limited access to a container image as a free trial, for example), and they can always use the same license, which is now just an attestation of their identity.

### Why this feature belongs in Zot from a separation of concerns perspective

This is an important feature for OIDC federation users: OIDC's responsibility is to simply identify a user/identity (authn), and the relying party (Zot) is fully responsible for authz. When OIDC federation was introduced (via #3711), we agreed that it would entirely rely on `accessConfig`. So to implement a rule like this for OIDC, the only system that can do it is Zot, the relying party. There's nowhere else  where this rule can be enforced from OIDC perspective. So the separation of concerns is:

* Zot delegates authn to the configured OIDC provider
* Zot takes full responsibility for the authz part

Furthermore, a feature like this for access control is very common and it would simply enrich Zot's capabilities. All the three major cloud providers have this feature, see below.

AWS:

https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws-dates.html

```json
{
    "Version":"2012-10-17",
    "Statement": [
        {
            "Effect": "Allow",
            "Action": "service-prefix:action-name",
            "Resource": "*",
            "Condition": {
                "DateGreaterThan": {"aws:CurrentTime": "2020-04-01T00:00:00Z"},
                "DateLessThan": {"aws:CurrentTime": "2020-06-30T23:59:59Z"}
            }
        }
    ]
}
```

GCP:

https://docs.cloud.google.com/iam/docs/conditions-overview#example-date-time

```cel
request.time < timestamp('2021-01-01T00:00:00Z')
```

Azure:

https://learn.microsoft.com/en-us/azure/role-based-access-control/pim-integration

```json
{
    "properties": {
        "principalId": "aaaaaaaa-bbbb-cccc-1111-222222222222",
        "roleDefinitionId": "/subscriptions/.../providers/Microsoft.Authorization/roleDefinitions/c8d4ff99-41c3-41a8-9f60-21dfdad59608",
        "requestType": "AdminAssign",
        "scheduleInfo": {
            "startDateTime": "2020-04-01T00:00:00Z",
            "expiration": {
                "type": "AfterDateTime",
                "endDateTime": "2020-06-30T23:59:59Z"
            }
        }
    }
}
```