### PR TITLE
feat(zli): add config list/show/get/set/reset and isolate deprecated syntax

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -87,6 +87,7 @@ var (
 	ErrScanNotSupported                 = errors.New("scanning is not supported for given media type")
 	ErrCLITimeout                       = errors.New("query timed out while waiting for results")
 	ErrDuplicateConfigName              = errors.New("cli config name already added")
+	ErrReservedConfigName               = errors.New("cli config name is reserved")
 	ErrInvalidRoute                     = errors.New("invalid route prefix")
 	ErrImgStoreNotFound                 = errors.New("image store not found corresponding to given route")
 	ErrLocalImgStoreNotFound            = errors.New("local image store not found corresponding to given route")

--- a/pkg/cli/client/config.go
+++ b/pkg/cli/client/config.go
@@ -217,7 +217,7 @@ func (f *ZliConfigFile) RemoveEntry(configName string) error {
 	return zerr.ErrConfigNotFound
 }
 
-// FormatNames renders name and URL columns for `zli config --list`.
+// FormatNames renders name and URL columns for `zli config list`.
 func (f *ZliConfigFile) FormatNames() (string, error) {
 	var builder strings.Builder
 
@@ -317,7 +317,7 @@ func (c *ZliConfig) ResetVar(key string) error {
 	return nil
 }
 
-// FormatListedVars renders lines for `zli config <name> --list`.
+// FormatListedVars renders lines for `zli config show <name>`.
 func (c *ZliConfig) FormatListedVars() string {
 	var builder strings.Builder
 

--- a/pkg/cli/client/config_cmd.go
+++ b/pkg/cli/client/config_cmd.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -18,78 +21,87 @@ func NewConfigCommand() *cobra.Command {
 	var isReset bool
 
 	configCmd := &cobra.Command{
-		Use:     "config <config-name> [variable] [value]",
+		Use:     "config",
 		Example: examples,
 		Short:   "Configure zot registry parameters for CLI",
-		Long:    `Configure zot registry parameters for CLI`,
 		Args:    cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			home, err := os.UserHomeDir()
+			configPath, err := zliUserConfigPath()
 			if err != nil {
 				return err
 			}
 
-			configPath := filepath.Join(home, ".zot")
-
-			switch len(args) {
-			case noArgs:
-				if isListing { // zli config -l
-					res, err := getConfigNames(configPath)
-					if err != nil {
-						return err
-					}
-
-					fmt.Fprint(cmd.OutOrStdout(), res)
-
-					return nil
-				}
-
-				return zerr.ErrInvalidArgs
-			case oneArg:
-				// zli config <name> -l
-				if isListing {
-					res, err := getAllConfig(configPath, args[0])
-					if err != nil {
-						return err
-					}
-
-					fmt.Fprint(cmd.OutOrStdout(), res)
-
-					return nil
-				}
-
-				return zerr.ErrInvalidArgs
-			case twoArgs:
-				if isReset { // zli config <name> <key> --reset
-					return resetConfigValue(configPath, args[0], args[1])
-				}
-				// zli config <name> <key>
-				res, err := getConfigValue(configPath, args[0], args[1])
-				if err != nil {
-					return err
-				}
-				fmt.Fprintln(cmd.OutOrStdout(), res)
-			case threeArgs:
-				// zli config <name> <key> <value>
-				if err := setConfigValue(configPath, args[0], args[1], args[2]); err != nil {
-					return err
-				}
-
-			default:
-				return zerr.ErrInvalidArgs
-			}
-
-			return nil
+			return runLegacyConfig(cmd, args, configPath, isListing, isReset)
 		},
 	}
 
-	configCmd.Flags().BoolVarP(&isListing, "list", "l", false, "List configurations")
-	configCmd.Flags().BoolVar(&isReset, "reset", false, "Reset a variable value")
+	configCmd.Flags().BoolVarP(&isListing, "list", "l", false,
+		"[deprecated: use \"config list\" or \"config show <name>\"] List configurations")
+
+	configCmd.Flags().BoolVar(&isReset, "reset", false,
+		"[deprecated: use \"config reset\"] Reset a variable value")
+
 	configCmd.SetUsageTemplate(configCmd.UsageTemplate() + supportedOptions)
 	configCmd.AddCommand(NewConfigAddCommand())
 	configCmd.AddCommand(NewConfigRemoveCommand())
+	configCmd.AddCommand(NewConfigListCommand())
+	configCmd.AddCommand(NewConfigShowCommand())
+	configCmd.AddCommand(NewConfigGetCommand())
+	configCmd.AddCommand(NewConfigSetCommand())
+	configCmd.AddCommand(NewConfigResetCommand())
+
+	// Build this from actual subcommands to avoid drift.
+	reserved := strings.Join(reservedProfileNames(configCmd), ", ")
+	configCmd.Long = fmt.Sprintf(`Configure zot registry parameters for CLI.
+
+Use the list, show, get, set, and reset subcommands for inspecting and editing profiles.
+Profile names must not collide with subcommand names (%s).
+
+Older positional syntax on this command is deprecated and will soon be removed.`, reserved)
 
 	return configCmd
+}
+
+func zliUserConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(home, ".zot"), nil
+}
+
+// validateProfileNameForCreation prevents creating profiles that shadow subcommand names.
+// We intentionally allow interacting with pre-existing profiles that collide with subcommand names
+// so users can migrate/rename/remove them without editing ~/.zot by hand.
+func validateProfileNameForCreation(configCmd *cobra.Command, name string) error {
+	if slices.Contains(reservedProfileNames(configCmd), name) {
+		return fmt.Errorf("%w: %q", zerr.ErrReservedConfigName, name)
+	}
+
+	return nil
+}
+
+func reservedProfileNames(configCmd *cobra.Command) []string {
+	seen := make(map[string]struct{})
+
+	for _, sub := range configCmd.Commands() {
+		name := sub.Name()
+		if name == "" {
+			continue
+		}
+
+		seen[name] = struct{}{}
+	}
+
+	reserved := make([]string, 0, len(seen))
+	for name := range seen {
+		reserved = append(reserved, name)
+	}
+
+	sort.Strings(reserved)
+
+	return reserved
 }
 
 func NewConfigAddCommand() *cobra.Command {
@@ -100,13 +112,20 @@ func NewConfigAddCommand() *cobra.Command {
 		Long:    "Add configuration for a zot registry",
 		Args:    cobra.ExactArgs(twoArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			home, err := os.UserHomeDir()
+			configPath, err := zliUserConfigPath()
 			if err != nil {
 				return err
 			}
 
-			configPath := filepath.Join(home, ".zot")
-			// zli config add <config-name> <url>
+			configRoot := cmd.Parent()
+			if configRoot == nil {
+				configRoot = cmd
+			}
+
+			if err := validateProfileNameForCreation(configRoot, args[0]); err != nil {
+				return err
+			}
+
 			err = addConfig(configPath, args[0], args[1])
 			if err != nil {
 				return err
@@ -130,13 +149,11 @@ func NewConfigRemoveCommand() *cobra.Command {
 		Long:    "Remove configuration for a zot registry",
 		Args:    cobra.ExactArgs(oneArg),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			home, err := os.UserHomeDir()
+			configPath, err := zliUserConfigPath()
 			if err != nil {
 				return err
 			}
 
-			configPath := filepath.Join(home, ".zot")
-			// zli config remove <config-name>
 			err = removeConfig(configPath, args[0])
 			if err != nil {
 				return err
@@ -150,6 +167,137 @@ func NewConfigRemoveCommand() *cobra.Command {
 	configRemoveCmd.SetUsageTemplate(configRemoveCmd.UsageTemplate())
 
 	return configRemoveCmd
+}
+
+func NewConfigListCommand() *cobra.Command {
+	listCmd := &cobra.Command{
+		Use:     "list",
+		Example: "  zli config list",
+		Short:   "List all configuration profile names",
+		Long:    "Print every configured CLI profile name (and URLs where applicable).",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := zliUserConfigPath()
+			if err != nil {
+				return err
+			}
+
+			res, err := getConfigNames(configPath)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprint(cmd.OutOrStdout(), res)
+
+			return nil
+		},
+	}
+
+	listCmd.SetUsageTemplate(listCmd.UsageTemplate())
+
+	return listCmd
+}
+
+func NewConfigShowCommand() *cobra.Command {
+	showCmd := &cobra.Command{
+		Use:     "show <name>",
+		Example: "  zli config show main",
+		Short:   "Show all variables for one profile",
+		Long:    "Print every variable set for the named CLI profile.",
+		Args:    cobra.ExactArgs(oneArg),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := zliUserConfigPath()
+			if err != nil {
+				return err
+			}
+
+			res, err := getAllConfig(configPath, args[0])
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprint(cmd.OutOrStdout(), res)
+
+			return nil
+		},
+	}
+
+	showCmd.SetUsageTemplate(showCmd.UsageTemplate())
+
+	return showCmd
+}
+
+func NewConfigGetCommand() *cobra.Command {
+	getCmd := &cobra.Command{
+		Use:     "get <name> <key>",
+		Example: "  zli config get main url",
+		Short:   "Print one configuration variable",
+		Long:    "Print the value of a single key for the named profile.",
+		Args:    cobra.ExactArgs(twoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := zliUserConfigPath()
+			if err != nil {
+				return err
+			}
+
+			res, err := getConfigValue(configPath, args[0], args[1])
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprintln(cmd.OutOrStdout(), res)
+
+			return nil
+		},
+	}
+
+	getCmd.SetUsageTemplate(getCmd.UsageTemplate())
+
+	return getCmd
+}
+
+func NewConfigSetCommand() *cobra.Command {
+	setCmd := &cobra.Command{
+		Use:     "set <name> <key> <value>",
+		Example: "  zli config set main showspinner false",
+		Short:   "Set a configuration variable",
+		Long:    "Set a single key for the named profile and persist ~/.zot.",
+		Args:    cobra.ExactArgs(threeArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := zliUserConfigPath()
+			if err != nil {
+				return err
+			}
+
+			return setConfigValue(configPath, args[0], args[1], args[2])
+		},
+	}
+
+	setCmd.SetUsageTemplate(setCmd.UsageTemplate())
+
+	return setCmd
+}
+
+func NewConfigResetCommand() *cobra.Command {
+	resetCmd := &cobra.Command{
+		Use:     "reset <name> <key>",
+		Example: "  zli config reset main showspinner",
+		Short:   "Reset a configuration variable to its default",
+		Long:    "Remove a non-default key from the named profile (URL and profile name cannot be reset).",
+		Args:    cobra.ExactArgs(twoArgs),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := zliUserConfigPath()
+			if err != nil {
+				return err
+			}
+
+			return resetConfigValue(configPath, args[0], args[1])
+		},
+	}
+
+	resetCmd.SetUsageTemplate(resetCmd.UsageTemplate())
+
+	return resetCmd
 }
 
 func getConfigNames(configPath string) (string, error) {
@@ -289,9 +437,11 @@ func getAllConfig(configPath, configName string) (string, error) {
 
 const (
 	examples = `  zli config add main https://zot-foo.com:8080
-  zli config --list
-  zli config main url
-  zli config main --list
+  zli config list
+  zli config show main
+  zli config get main url
+  zli config set main showspinner false
+  zli config reset main showspinner
   zli config remove main`
 
 	supportedOptions = `

--- a/pkg/cli/client/config_cmd_deprecated.go
+++ b/pkg/cli/client/config_cmd_deprecated.go
@@ -1,0 +1,89 @@
+//go:build search
+
+package client
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	zerr "zotregistry.dev/zot/v2/errors"
+)
+
+// runLegacyConfig handles deprecated positional syntax and --list/--reset on the parent command.
+// Prefer subcommands (list, show, get, set, reset); this file emits deprecation warnings to stderr.
+func runLegacyConfig(cmd *cobra.Command, args []string, configPath string, isListing, isReset bool) error {
+	switch len(args) {
+	case noArgs:
+		if isListing { // zli config -l
+			warnLegacyDeprecatedInvocation(cmd.ErrOrStderr(), "`zli config --list`", "`zli config list`")
+
+			res, err := getConfigNames(configPath)
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprint(cmd.OutOrStdout(), res)
+
+			return nil
+		}
+
+		return zerr.ErrInvalidArgs
+	case oneArg:
+		// zli config <name> -l
+		if isListing {
+			warnLegacyDeprecatedInvocation(cmd.ErrOrStderr(), "`zli config <name> --list`", "`zli config show <name>`")
+
+			res, err := getAllConfig(configPath, args[0])
+			if err != nil {
+				return err
+			}
+
+			fmt.Fprint(cmd.OutOrStdout(), res)
+
+			return nil
+		}
+
+		return zerr.ErrInvalidArgs
+	case twoArgs:
+		if isReset { // zli config <name> <key> --reset
+			warnLegacyDeprecatedInvocation(
+				cmd.ErrOrStderr(),
+				"`zli config <name> <key> --reset`",
+				"`zli config reset <name> <key>`",
+			)
+
+			return resetConfigValue(configPath, args[0], args[1])
+		}
+
+		warnLegacyDeprecatedInvocation(cmd.ErrOrStderr(), "`zli config <name> <key>`", "`zli config get <name> <key>`")
+
+		res, err := getConfigValue(configPath, args[0], args[1])
+		if err != nil {
+			return err
+		}
+
+		fmt.Fprintln(cmd.OutOrStdout(), res)
+
+	case threeArgs:
+		warnLegacyDeprecatedInvocation(
+			cmd.ErrOrStderr(),
+			"`zli config <name> <key> <value>`",
+			"`zli config set <name> <key> <value>`",
+		)
+
+		if err := setConfigValue(configPath, args[0], args[1], args[2]); err != nil {
+			return err
+		}
+
+	default:
+		return zerr.ErrInvalidArgs
+	}
+
+	return nil
+}
+
+func warnLegacyDeprecatedInvocation(w io.Writer, invoked, replacement string) {
+	fmt.Fprintf(w, "Warning: deprecated invocation %s; use %s instead.\n", invoked, replacement)
+}

--- a/pkg/cli/client/config_cmd_deprecated_test.go
+++ b/pkg/cli/client/config_cmd_deprecated_test.go
@@ -1,5 +1,6 @@
 //go:build search
 
+// Deprecated parent `config` invocation (--list, positional args, --reset). Prefer tests in config_cmd_test.go.
 package client_test
 
 import (
@@ -16,7 +17,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/cli/client"
 )
 
-func TestConfigCmdBasics(t *testing.T) {
+func TestConfigCmdDeprecatedBasics(t *testing.T) {
 	Convey("Test config help", t, func() {
 		args := []string{"--help"}
 
@@ -66,7 +67,7 @@ func TestConfigCmdBasics(t *testing.T) {
 	})
 }
 
-func TestConfigCmdMain(t *testing.T) {
+func TestConfigCmdDeprecatedMain(t *testing.T) {
 	Convey("Test add config", t, func() {
 		args := []string{"add", "configtest1", "https://test-url.com"}
 
@@ -86,63 +87,6 @@ func TestConfigCmdMain(t *testing.T) {
 		actualStr := string(actual)
 		So(actualStr, ShouldContainSubstring, "configtest1")
 		So(actualStr, ShouldContainSubstring, "https://test-url.com")
-	})
-
-	Convey("Test add config rejects reserved names", t, func() {
-		args := []string{"add", "list", "https://test-url.com"}
-
-		_ = makeConfigFile(t, "")
-
-		cmd := client.NewConfigCommand()
-		buff := bytes.NewBufferString("")
-		cmd.SetOut(buff)
-		cmd.SetErr(buff)
-		cmd.SetArgs(args)
-		err := cmd.Execute()
-
-		So(err, ShouldNotBeNil)
-		So(errors.Is(err, zerr.ErrReservedConfigName), ShouldBeTrue)
-		So(err.Error(), ShouldContainSubstring, `"list"`)
-	})
-
-	Convey("Test reserved-named profiles are still accessible for migration", t, func() {
-		_ = makeConfigFile(t,
-			`{"configs":[{"_name":"list","url":"https://test-url.com","showspinner":false}]}`)
-
-		Convey("show", func() {
-			cmd := client.NewConfigCommand()
-			out := bytes.NewBufferString("")
-			errOut := bytes.NewBufferString("")
-			cmd.SetOut(out)
-			cmd.SetErr(errOut)
-			cmd.SetArgs([]string{"show", "list"})
-			err := cmd.Execute()
-			So(err, ShouldBeNil)
-			So(out.String(), ShouldContainSubstring, "https://test-url.com")
-		})
-
-		Convey("get", func() {
-			cmd := client.NewConfigCommand()
-			out := bytes.NewBufferString("")
-			errOut := bytes.NewBufferString("")
-			cmd.SetOut(out)
-			cmd.SetErr(errOut)
-			cmd.SetArgs([]string{"get", "list", "url"})
-			err := cmd.Execute()
-			So(err, ShouldBeNil)
-			So(out.String(), ShouldContainSubstring, "https://test-url.com")
-		})
-
-		Convey("remove", func() {
-			cmd := client.NewConfigCommand()
-			out := bytes.NewBufferString("")
-			errOut := bytes.NewBufferString("")
-			cmd.SetOut(out)
-			cmd.SetErr(errOut)
-			cmd.SetArgs([]string{"remove", "list"})
-			err := cmd.Execute()
-			So(err, ShouldBeNil)
-		})
 	})
 
 	Convey("Test error on home directory", t, func() {
@@ -178,7 +122,7 @@ func TestConfigCmdMain(t *testing.T) {
 	})
 
 	Convey("Test list config with invalid format", t, func() {
-		args := []string{"list"}
+		args := []string{"--list"}
 
 		_ = makeConfigFile(t, `{"configs":{"_name":"configtest","url":"https://test-url.com","showspinner":false}}`)
 
@@ -293,8 +237,26 @@ func TestConfigCmdMain(t *testing.T) {
 		So(buff.String(), ShouldContainSubstring, "permission denied")
 	})
 
-	Convey("Test config list", t, func() {
-		Convey("prints profile names and URLs", func() {
+	Convey("Test fetch all config", t, func() {
+		args := []string{"--list"}
+
+		_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
+
+		cmd := client.NewConfigCommand()
+		outBuff := bytes.NewBufferString("")
+		errBuff := bytes.NewBufferString("")
+		cmd.SetOut(outBuff)
+		cmd.SetErr(errBuff)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+
+		So(outBuff.String(), ShouldContainSubstring, "https://test-url.com")
+		So(errBuff.String(), ShouldContainSubstring, "`zli config list`")
+		So(err, ShouldBeNil)
+
+		Convey("with the shorthand", func() {
+			args := []string{"-l"}
+
 			_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 			cmd := client.NewConfigCommand()
@@ -302,13 +264,18 @@ func TestConfigCmdMain(t *testing.T) {
 			errBuff := bytes.NewBufferString("")
 			cmd.SetOut(outBuff)
 			cmd.SetErr(errBuff)
-			cmd.SetArgs([]string{"list"})
-			So(cmd.Execute(), ShouldBeNil)
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+			So(err, ShouldBeNil)
+
 			So(outBuff.String(), ShouldContainSubstring, "https://test-url.com")
-			So(errBuff.String(), ShouldEqual, "")
+			So(errBuff.String(), ShouldContainSubstring, "`zli config list`")
 		})
 
-		Convey("from empty config file", func() {
+		Convey("From empty file", func() {
+			args := []string{"-l"}
+
 			_ = makeConfigFile(t, ``)
 
 			cmd := client.NewConfigCommand()
@@ -316,15 +283,38 @@ func TestConfigCmdMain(t *testing.T) {
 			errBuff := bytes.NewBufferString("")
 			cmd.SetOut(outBuff)
 			cmd.SetErr(errBuff)
-			cmd.SetArgs([]string{"list"})
-			So(cmd.Execute(), ShouldBeNil)
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+			So(err, ShouldBeNil)
+
 			So(strings.TrimSpace(outBuff.String()), ShouldEqual, "")
-			So(errBuff.String(), ShouldEqual, "")
+			So(errBuff.String(), ShouldContainSubstring, "`zli config list`")
 		})
 	})
 
-	Convey("Test config show", t, func() {
-		Convey("prints variables for the profile", func() {
+	Convey("Test fetch a config", t, func() {
+		args := []string{"configtest", "--list"}
+
+		_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
+
+		cmd := client.NewConfigCommand()
+		outBuff := bytes.NewBufferString("")
+		errBuff := bytes.NewBufferString("")
+		cmd.SetOut(outBuff)
+		cmd.SetErr(errBuff)
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+		So(err, ShouldBeNil)
+
+		So(outBuff.String(), ShouldContainSubstring, "url = https://test-url.com")
+		So(outBuff.String(), ShouldContainSubstring, "showspinner = false")
+		So(errBuff.String(), ShouldContainSubstring, "`zli config show <name>`")
+
+		Convey("with the shorthand", func() {
+			args := []string{"configtest", "-l"}
+
 			_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
 			cmd := client.NewConfigCommand()
@@ -332,14 +322,19 @@ func TestConfigCmdMain(t *testing.T) {
 			errBuff := bytes.NewBufferString("")
 			cmd.SetOut(outBuff)
 			cmd.SetErr(errBuff)
-			cmd.SetArgs([]string{"show", "configtest"})
-			So(cmd.Execute(), ShouldBeNil)
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+			So(err, ShouldBeNil)
+
 			So(outBuff.String(), ShouldContainSubstring, "url = https://test-url.com")
 			So(outBuff.String(), ShouldContainSubstring, "showspinner = false")
-			So(errBuff.String(), ShouldEqual, "")
+			So(errBuff.String(), ShouldContainSubstring, "`zli config show <name>`")
 		})
 
-		Convey("from empty config file", func() {
+		Convey("From empty file", func() {
+			args := []string{"configtest", "-l"}
+
 			_ = makeConfigFile(t, ``)
 
 			cmd := client.NewConfigCommand()
@@ -347,66 +342,36 @@ func TestConfigCmdMain(t *testing.T) {
 			errBuff := bytes.NewBufferString("")
 			cmd.SetOut(outBuff)
 			cmd.SetErr(errBuff)
-			cmd.SetArgs([]string{"show", "configtest"})
-			So(cmd.Execute(), ShouldBeNil)
-			So(strings.TrimSpace(outBuff.String()), ShouldEqual, "")
-			So(errBuff.String(), ShouldEqual, "")
-		})
-	})
+			cmd.SetArgs(args)
 
-	Convey("Test config get", t, func() {
-		Convey("prints one key", func() {
-			_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
-
-			cmd := client.NewConfigCommand()
-			outBuff := bytes.NewBufferString("")
-			errBuff := bytes.NewBufferString("")
-			cmd.SetOut(outBuff)
-			cmd.SetErr(errBuff)
-			cmd.SetArgs([]string{"get", "configtest", "url"})
-			So(cmd.Execute(), ShouldBeNil)
-			So(outBuff.String(), ShouldEqual, "https://test-url.com\n")
-			So(errBuff.String(), ShouldEqual, "")
-		})
-
-		Convey("from empty config file", func() {
-			_ = makeConfigFile(t, ``)
-
-			cmd := client.NewConfigCommand()
-			outBuff := bytes.NewBufferString("")
-			errBuff := bytes.NewBufferString("")
-			cmd.SetOut(outBuff)
-			cmd.SetErr(errBuff)
-			cmd.SetArgs([]string{"get", "configtest", "url"})
-			So(cmd.Execute(), ShouldNotBeNil)
-
-			combined := errBuff.String() + outBuff.String()
-			So(combined, ShouldContainSubstring, "does not exist")
-		})
-	})
-
-	Convey("Test config set", t, func() {
-		Convey("adds a variable", func() {
-			configPath := makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com"}]}`)
-
-			cmd := client.NewConfigCommand()
-			outBuff := bytes.NewBufferString("")
-			errBuff := bytes.NewBufferString("")
-			cmd.SetOut(outBuff)
-			cmd.SetErr(errBuff)
-			cmd.SetArgs([]string{"set", "configtest", "showspinner", "false"})
-			So(cmd.Execute(), ShouldBeNil)
-			So(outBuff.String(), ShouldEqual, "")
-			So(errBuff.String(), ShouldEqual, "")
-
-			actual, err := os.ReadFile(configPath)
+			err := cmd.Execute()
 			So(err, ShouldBeNil)
-			actualStr := string(actual)
-			So(actualStr, ShouldContainSubstring, "https://test-url.com")
-			So(actualStr, ShouldContainSubstring, `"showspinner": false`)
-		})
 
-		Convey("to an empty config file", func() {
+			So(strings.TrimSpace(outBuff.String()), ShouldEqual, "")
+			So(errBuff.String(), ShouldContainSubstring, "`zli config show <name>`")
+		})
+	})
+
+	Convey("Test fetch a config val", t, func() {
+		args := []string{"configtest", "url"}
+
+		_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
+
+		cmd := client.NewConfigCommand()
+		outBuff := bytes.NewBufferString("")
+		errBuff := bytes.NewBufferString("")
+		cmd.SetOut(outBuff)
+		cmd.SetErr(errBuff)
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+		So(err, ShouldBeNil)
+		So(outBuff.String(), ShouldEqual, "https://test-url.com\n")
+		So(errBuff.String(), ShouldContainSubstring, "deprecated invocation")
+
+		Convey("From empty file", func() {
+			args := []string{"configtest", "url"}
+
 			_ = makeConfigFile(t, ``)
 
 			cmd := client.NewConfigCommand()
@@ -414,15 +379,63 @@ func TestConfigCmdMain(t *testing.T) {
 			errBuff := bytes.NewBufferString("")
 			cmd.SetOut(outBuff)
 			cmd.SetErr(errBuff)
-			cmd.SetArgs([]string{"set", "configtest", "showspinner", "false"})
-			So(cmd.Execute(), ShouldNotBeNil)
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+			So(err, ShouldNotBeNil)
 
 			combined := errBuff.String() + outBuff.String()
 			So(combined, ShouldContainSubstring, "does not exist")
 		})
 	})
 
-	Convey("Test config set overwrites URL", t, func() {
+	Convey("Test add a config val", t, func() {
+		args := []string{"configtest", "showspinner", "false"}
+
+		configPath := makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com"}]}`)
+
+		cmd := client.NewConfigCommand()
+		outBuff := bytes.NewBufferString("")
+		errBuff := bytes.NewBufferString("")
+		cmd.SetOut(outBuff)
+		cmd.SetErr(errBuff)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		So(err, ShouldBeNil)
+
+		actual, err := os.ReadFile(configPath)
+		if err != nil {
+			panic(err)
+		}
+		actualStr := string(actual)
+		So(actualStr, ShouldContainSubstring, "https://test-url.com")
+		So(actualStr, ShouldContainSubstring, `"showspinner": false`)
+		So(outBuff.String(), ShouldEqual, "")
+		So(errBuff.String(), ShouldContainSubstring, "deprecated invocation")
+
+		Convey("To an empty file", func() {
+			args := []string{"configtest", "showspinner", "false"}
+
+			_ = makeConfigFile(t, ``)
+
+			cmd := client.NewConfigCommand()
+			outBuff := bytes.NewBufferString("")
+			errBuff := bytes.NewBufferString("")
+			cmd.SetOut(outBuff)
+			cmd.SetErr(errBuff)
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+			So(err, ShouldNotBeNil)
+
+			combined := errBuff.String() + outBuff.String()
+			So(combined, ShouldContainSubstring, "does not exist")
+		})
+	})
+
+	Convey("Test overwrite a config", t, func() {
+		args := []string{"configtest", "url", "https://new-url.com"}
+
 		configPath := makeConfigFile(t,
 			`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
@@ -431,56 +444,66 @@ func TestConfigCmdMain(t *testing.T) {
 		errBuff := bytes.NewBufferString("")
 		cmd.SetOut(outBuff)
 		cmd.SetErr(errBuff)
-		cmd.SetArgs([]string{"set", "configtest", "url", "https://new-url.com"})
-		So(cmd.Execute(), ShouldBeNil)
-		So(outBuff.String(), ShouldEqual, "")
-		So(errBuff.String(), ShouldEqual, "")
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		So(err, ShouldBeNil)
 
 		actual, err := os.ReadFile(configPath)
-		So(err, ShouldBeNil)
+		if err != nil {
+			panic(err)
+		}
 		actualStr := string(actual)
 		So(actualStr, ShouldContainSubstring, `https://new-url.com`)
 		So(actualStr, ShouldContainSubstring, `"showspinner": false`)
 		So(actualStr, ShouldNotContainSubstring, `https://test-url.com`)
+		So(outBuff.String(), ShouldEqual, "")
+		So(errBuff.String(), ShouldContainSubstring, "deprecated invocation")
 	})
 
-	Convey("Test config reset", t, func() {
-		Convey("clears an optional variable", func() {
-			configPath := makeConfigFile(t,
-				`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
+	Convey("Test reset a config val", t, func() {
+		args := []string{"configtest", "showspinner", "--reset"}
 
-			cmd := client.NewConfigCommand()
-			outBuff := bytes.NewBufferString("")
-			errBuff := bytes.NewBufferString("")
-			cmd.SetOut(outBuff)
-			cmd.SetErr(errBuff)
-			cmd.SetArgs([]string{"reset", "configtest", "showspinner"})
-			So(cmd.Execute(), ShouldBeNil)
-			So(outBuff.String(), ShouldEqual, "")
-			So(errBuff.String(), ShouldEqual, "")
+		configPath := makeConfigFile(t,
+			`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
-			actual, err := os.ReadFile(configPath)
-			So(err, ShouldBeNil)
-			actualStr := string(actual)
-			So(actualStr, ShouldNotContainSubstring, "showspinner")
-			So(actualStr, ShouldContainSubstring, `"url": "https://test-url.com"`)
-		})
+		cmd := client.NewConfigCommand()
+		outBuff := bytes.NewBufferString("")
+		errBuff := bytes.NewBufferString("")
+		cmd.SetOut(outBuff)
+		cmd.SetErr(errBuff)
+		cmd.SetArgs(args)
+		err := cmd.Execute()
+		So(err, ShouldBeNil)
 
-		Convey("rejects resetting url", func() {
-			_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
+		actual, err := os.ReadFile(configPath)
+		if err != nil {
+			panic(err)
+		}
+		actualStr := string(actual)
+		So(actualStr, ShouldNotContainSubstring, "showspinner")
+		So(actualStr, ShouldContainSubstring, `"url": "https://test-url.com"`)
+		So(outBuff.String(), ShouldEqual, "")
+		So(errBuff.String(), ShouldContainSubstring, "`zli config reset <name> <key>`")
+	})
 
-			cmd := client.NewConfigCommand()
-			outBuff := bytes.NewBufferString("")
-			errBuff := bytes.NewBufferString("")
-			cmd.SetOut(outBuff)
-			cmd.SetErr(errBuff)
-			cmd.SetArgs([]string{"reset", "configtest", "url"})
+	Convey("Test reset a url", t, func() {
+		args := []string{"configtest", "url", "--reset"}
 
-			So(cmd.Execute(), ShouldNotBeNil)
+		_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
 
-			combined := errBuff.String() + outBuff.String()
-			So(combined, ShouldContainSubstring, "cannot reset")
-		})
+		cmd := client.NewConfigCommand()
+		outBuff := bytes.NewBufferString("")
+		errBuff := bytes.NewBufferString("")
+		cmd.SetOut(outBuff)
+		cmd.SetErr(errBuff)
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+		So(err, ShouldNotBeNil)
+
+		combined := errBuff.String() + outBuff.String()
+		So(combined, ShouldContainSubstring, "cannot reset")
+		So(combined, ShouldContainSubstring, "`zli config reset <name> <key>`")
 	})
 
 	Convey("Test add a config with an existing saved name", t, func() {
@@ -498,5 +521,22 @@ func TestConfigCmdMain(t *testing.T) {
 		So(err, ShouldNotBeNil)
 
 		So(buff.String(), ShouldContainSubstring, "cli config name already added")
+	})
+
+	Convey("Test deprecated config invalid args (too many args)", t, func() {
+		args := []string{"configtest", "url", "x", "y"}
+
+		_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
+
+		cmd := client.NewConfigCommand()
+		outBuff := bytes.NewBufferString("")
+		errBuff := bytes.NewBufferString("")
+		cmd.SetOut(outBuff)
+		cmd.SetErr(errBuff)
+		cmd.SetArgs(args)
+
+		err := cmd.Execute()
+		So(err, ShouldNotBeNil)
+		So(errors.Is(err, zerr.ErrInvalidArgs), ShouldBeTrue)
 	})
 }

--- a/pkg/cli/server/verify_retention_test.go
+++ b/pkg/cli/server/verify_retention_test.go
@@ -1445,6 +1445,10 @@ func TestRetentionCheckWithSubpaths(t *testing.T) {
 			},
 		}
 
+		// The command returns after its timeout; ensure we have all expected decisions in the log
+		// before validating, to avoid flakes from buffered writes.
+		logContent = readLogUntilRetentionDecisions(t, logFile, len(expectedResults), 2*time.Second)
+		logStr = string(logContent)
 		validateRetentionDecisions(t, logContent, expectedResults)
 	})
 }
@@ -1712,6 +1716,56 @@ func validateRetentionDecisions(t *testing.T, logContent []byte, expectedResults
 		_, exists := expectedMap[key]
 		So(exists, ShouldBeTrue)
 	}
+}
+
+func readLogUntilRetentionDecisions(
+	t *testing.T,
+	logFile string,
+	expectedCount int,
+	timeout time.Duration,
+) []byte {
+	t.Helper()
+
+	deadline := time.Now().Add(timeout)
+
+	var (
+		lastContent []byte
+		lastReadErr error
+	)
+
+	for time.Now().Before(deadline) {
+		content, err := os.ReadFile(logFile)
+		if err != nil {
+			lastReadErr = err
+			time.Sleep(50 * time.Millisecond)
+
+			continue
+		}
+
+		lastReadErr = nil
+		lastContent = content
+		if len(parseRetentionDecisions(content)) >= expectedCount {
+			return content
+		}
+
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if lastContent == nil && lastReadErr != nil {
+		t.Fatalf("failed to read log file %q: %v", logFile, lastReadErr)
+	}
+
+	if lastReadErr != nil {
+		t.Logf("last log read error for %q: %v", logFile, lastReadErr)
+	}
+
+	observed := len(parseRetentionDecisions(lastContent))
+	if observed < expectedCount {
+		t.Fatalf("timed out waiting for retention decisions in %q: observed=%d expected>=%d",
+			logFile, observed, expectedCount)
+	}
+
+	return lastContent
 }
 
 func logRetentionDecisions(t *testing.T, actualDecisions []RetentionDecision) {


### PR DESCRIPTION
Introduce first-class subcommands for listing profiles, showing a profile, getting and setting keys, and resetting optional keys (alongside existing add/remove). The parent command now resolves ~/.zot via zliUserConfigPath(), documents that profile names must not clash with subcommand names, and states that positional/--list/--reset usage is deprecated and will be removed soon.

Legacy behavior is delegated to config_cmd_deprecated.go with stderr warnings for old flags and positional get/set. Examples and inline help point users at the new commands. FormatNames/FormatListedVars comments reference config list/show.

Tests are split, so config_cmd_test.go exercises the supported subcommands while config_cmd_deprecated_test.go retains coverage for the deprecated paths under renamed TestConfigCmdDeprecated* entries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
