### PR TITLE
refactor(build): move build metadata to pkg/buildinfo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,11 @@ GREP_BIN_PATH ?= $(shell which grep)
 BLACKBOX_DOCKER_ENV = BUILDX_NO_DEFAULT_ATTESTATIONS=1 DOCKER_DEFAULT_PLATFORM=linux/amd64
 
 MODULE_PATH := $(shell go list -m)
-CONFIG_PACKAGE := $(MODULE_PATH)/pkg/api/config
-CONFIG_RELEASE_TAG := $(CONFIG_PACKAGE).ReleaseTag
-CONFIG_COMMIT := $(CONFIG_PACKAGE).Commit
-CONFIG_BINARY_TYPE := $(CONFIG_PACKAGE).BinaryType
-CONFIG_GO_VERSION := $(CONFIG_PACKAGE).GoVersion
+BUILDINFO_PACKAGE := $(MODULE_PATH)/pkg/buildinfo
+BUILDINFO_RELEASE_TAG := $(BUILDINFO_PACKAGE).ReleaseTag
+BUILDINFO_COMMIT := $(BUILDINFO_PACKAGE).Commit
+BUILDINFO_BINARY_TYPE := $(BUILDINFO_PACKAGE).BinaryType
+BUILDINFO_GO_VERSION := $(BUILDINFO_PACKAGE).GoVersion
 
 PROTOC := $(TOOLSDIR)/bin/protoc
 PROTOC_VERSION := 24.4
@@ -184,25 +184,25 @@ gen-protobuf: $(PROTOC)
 .PHONY: binary-minimal
 binary-minimal: EXTENSIONS=
 binary-minimal: build-metadata
-	env CGO_ENABLED=0 GOEXPERIMENT=jsonv2 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-minimal$(BIN_EXT) $(BUILDMODE_FLAGS) -v -trimpath -ldflags "-X $(CONFIG_RELEASE_TAG)=${RELEASE_TAG} -X $(CONFIG_COMMIT)=${COMMIT} -X $(CONFIG_BINARY_TYPE)=minimal -X $(CONFIG_GO_VERSION)=${GO_VERSION} -s -w" ./cmd/zot
+	env CGO_ENABLED=0 GOEXPERIMENT=jsonv2 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-minimal$(BIN_EXT) $(BUILDMODE_FLAGS) -v -trimpath -ldflags "-X $(BUILDINFO_RELEASE_TAG)=${RELEASE_TAG} -X $(BUILDINFO_COMMIT)=${COMMIT} -X $(BUILDINFO_BINARY_TYPE)=minimal -X $(BUILDINFO_GO_VERSION)=${GO_VERSION} -s -w" ./cmd/zot
 
 .PHONY: binary
 binary: $(if $(findstring ui,$(BUILD_LABELS)), ui)
 binary: build-metadata
-	env CGO_ENABLED=0 GOEXPERIMENT=jsonv2 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)$(BIN_EXT) $(BUILDMODE_FLAGS) $(GO_CMD_TAGS) -v -trimpath -ldflags "-X $(CONFIG_RELEASE_TAG)=${RELEASE_TAG} -X $(CONFIG_COMMIT)=${COMMIT} -X $(CONFIG_BINARY_TYPE)=$(extended-name) -X $(CONFIG_GO_VERSION)=${GO_VERSION} -s -w" ./cmd/zot
+	env CGO_ENABLED=0 GOEXPERIMENT=jsonv2 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)$(BIN_EXT) $(BUILDMODE_FLAGS) $(GO_CMD_TAGS) -v -trimpath -ldflags "-X $(BUILDINFO_RELEASE_TAG)=${RELEASE_TAG} -X $(BUILDINFO_COMMIT)=${COMMIT} -X $(BUILDINFO_BINARY_TYPE)=$(extended-name) -X $(BUILDINFO_GO_VERSION)=${GO_VERSION} -s -w" ./cmd/zot
 
 .PHONY: binary-debug
 binary-debug: $(if $(findstring ui,$(BUILD_LABELS)), ui)
 binary-debug: swaggercheck build-metadata
-	env CGO_ENABLED=0 GOEXPERIMENT=jsonv2 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-debug$(BIN_EXT) $(BUILDMODE_FLAGS) -tags $(BUILD_LABELS),debug -v -gcflags all='-N -l' -ldflags "-X $(CONFIG_RELEASE_TAG)=${RELEASE_TAG} -X $(CONFIG_COMMIT)=${COMMIT} -X $(CONFIG_BINARY_TYPE)=$(extended-name) -X $(CONFIG_GO_VERSION)=${GO_VERSION}" ./cmd/zot
+	env CGO_ENABLED=0 GOEXPERIMENT=jsonv2 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zot-$(OS)-$(ARCH)-debug$(BIN_EXT) $(BUILDMODE_FLAGS) -tags $(BUILD_LABELS),debug -v -gcflags all='-N -l' -ldflags "-X $(BUILDINFO_RELEASE_TAG)=${RELEASE_TAG} -X $(BUILDINFO_COMMIT)=${COMMIT} -X $(BUILDINFO_BINARY_TYPE)=$(extended-name) -X $(BUILDINFO_GO_VERSION)=${GO_VERSION}" ./cmd/zot
 
 .PHONY: cli
 cli: build-metadata
-	env CGO_ENABLED=0 GOEXPERIMENT=jsonv2 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zli-$(OS)-$(ARCH)$(BIN_EXT) $(BUILDMODE_FLAGS) -tags $(BUILD_LABELS),search -v -trimpath -ldflags "-X $(CONFIG_COMMIT)=${COMMIT} -X $(CONFIG_BINARY_TYPE)=$(extended-name) -X $(CONFIG_GO_VERSION)=${GO_VERSION} -s -w" ./cmd/zli
+	env CGO_ENABLED=0 GOEXPERIMENT=jsonv2 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zli-$(OS)-$(ARCH)$(BIN_EXT) $(BUILDMODE_FLAGS) -tags $(BUILD_LABELS),search -v -trimpath -ldflags "-X $(BUILDINFO_COMMIT)=${COMMIT} -X $(BUILDINFO_BINARY_TYPE)=$(extended-name) -X $(BUILDINFO_GO_VERSION)=${GO_VERSION} -s -w" ./cmd/zli
 
 .PHONY: bench
 bench: build-metadata
-	env CGO_ENABLED=0 GOEXPERIMENT=jsonv2 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zb-$(OS)-$(ARCH)$(BIN_EXT) $(BUILDMODE_FLAGS) $(GO_CMD_TAGS) -v -trimpath -ldflags "-X $(CONFIG_COMMIT)=${COMMIT} -X $(CONFIG_BINARY_TYPE)=$(extended-name) -X $(CONFIG_GO_VERSION)=${GO_VERSION} -s -w" ./cmd/zb
+	env CGO_ENABLED=0 GOEXPERIMENT=jsonv2 GOOS=$(OS) GOARCH=$(ARCH) go build -o bin/zb-$(OS)-$(ARCH)$(BIN_EXT) $(BUILDMODE_FLAGS) $(GO_CMD_TAGS) -v -trimpath -ldflags "-X $(BUILDINFO_COMMIT)=${COMMIT} -X $(BUILDINFO_BINARY_TYPE)=$(extended-name) -X $(BUILDINFO_GO_VERSION)=${GO_VERSION} -s -w" ./cmd/zb
 
 .PHONY: exporter-minimal
 exporter-minimal: EXTENSIONS=

--- a/cmd/zb/main.go
+++ b/cmd/zb/main.go
@@ -7,7 +7,7 @@ import (
 	distspec "github.com/opencontainers/distribution-spec/specs-go"
 	"github.com/spf13/cobra"
 
-	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/buildinfo"
 	"zotregistry.dev/zot/v2/pkg/log"
 )
 
@@ -28,8 +28,8 @@ func NewPerfRootCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			if showVersion {
 				logger := log.NewLogger("info", "")
-				logger.Info().Str("distribution-spec", distspec.Version).Str("commit", config.Commit).
-					Str("binary-type", config.BinaryType).Str("go version", config.GoVersion).Msg("version")
+				logger.Info().Str("distribution-spec", distspec.Version).Str("commit", buildinfo.Commit).
+					Str("binary-type", buildinfo.BinaryType).Str("go version", buildinfo.GoVersion).Msg("version")
 			}
 
 			if len(args) == 0 {

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -11,20 +11,15 @@ import (
 	distspec "github.com/opencontainers/distribution-spec/specs-go"
 	"github.com/tiendc/go-deepcopy"
 
+	"zotregistry.dev/zot/v2/pkg/buildinfo"
 	"zotregistry.dev/zot/v2/pkg/compat"
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
 )
 
 var (
-	Commit     string //nolint: gochecknoglobals
-	ReleaseTag string //nolint: gochecknoglobals
-	BinaryType string //nolint: gochecknoglobals
-	GoVersion  string //nolint: gochecknoglobals
-
 	openIDSupportedProviders = [...]string{"google", "gitlab", "oidc"} //nolint: gochecknoglobals
 	oauth2SupportedProviders = [...]string{"github"}                   //nolint: gochecknoglobals
-
 )
 
 type StorageConfig struct {
@@ -660,10 +655,10 @@ type Config struct {
 func New() *Config {
 	return &Config{
 		DistSpecVersion: distspec.Version,
-		GoVersion:       GoVersion,
-		Commit:          Commit,
-		ReleaseTag:      ReleaseTag,
-		BinaryType:      BinaryType,
+		GoVersion:       buildinfo.GoVersion,
+		Commit:          buildinfo.Commit,
+		ReleaseTag:      buildinfo.ReleaseTag,
+		BinaryType:      buildinfo.BinaryType,
 		Storage: GlobalStorageConfig{
 			StorageConfig: StorageConfig{
 				Dedupe:     true,

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -1,0 +1,18 @@
+package buildinfo
+
+// This package intentionally stays tiny and dependency-free because it is
+// imported by CLI binaries that should not pull in server-only deps.
+
+var (
+	// Commit is the git commit hash, injected at build time via -ldflags.
+	Commit string //nolint:gochecknoglobals
+
+	// ReleaseTag is the git tag for the release, injected at build time via -ldflags.
+	ReleaseTag string //nolint:gochecknoglobals
+
+	// BinaryType is a short identifier like "server", "cli", etc, injected at build time.
+	BinaryType string //nolint:gochecknoglobals
+
+	// GoVersion is the Go toolchain version used to build the binary, injected at build time.
+	GoVersion string //nolint:gochecknoglobals
+)

--- a/pkg/cli/client/root.go
+++ b/pkg/cli/client/root.go
@@ -6,7 +6,7 @@ import (
 	distspec "github.com/opencontainers/distribution-spec/specs-go"
 	"github.com/spf13/cobra"
 
-	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/buildinfo"
 	"zotregistry.dev/zot/v2/pkg/log"
 )
 
@@ -21,8 +21,8 @@ func NewCliRootCmd() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			if showVersion {
 				logger := log.NewLogger("info", "")
-				logger.Info().Str("distribution-spec", distspec.Version).Str("commit", config.Commit).
-					Str("binary-type", config.BinaryType).Str("go version", config.GoVersion).Msg("version")
+				logger.Info().Str("distribution-spec", distspec.Version).Str("commit", buildinfo.Commit).
+					Str("binary-type", buildinfo.BinaryType).Str("go version", buildinfo.GoVersion).Msg("version")
 			} else {
 				_ = cmd.Usage()
 				cmd.SilenceErrors = false

--- a/pkg/cli/client/server_info_cmd_test.go
+++ b/pkg/cli/client/server_info_cmd_test.go
@@ -17,6 +17,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api"
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
+	"zotregistry.dev/zot/v2/pkg/buildinfo"
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
 	test "zotregistry.dev/zot/v2/pkg/test/common"
 )
@@ -54,8 +55,8 @@ func TestServerStatusCommand(t *testing.T) {
 		space := regexp.MustCompile(`\s+`)
 		str := space.ReplaceAllString(buff.String(), " ")
 		actual := strings.TrimSpace(str)
-		So(actual, ShouldContainSubstring, config.ReleaseTag)
-		So(actual, ShouldContainSubstring, config.BinaryType)
+		So(actual, ShouldContainSubstring, buildinfo.ReleaseTag)
+		So(actual, ShouldContainSubstring, buildinfo.BinaryType)
 
 		// JSON
 		args = []string{"status", "--config", "status-test", "--format", "json"}
@@ -69,8 +70,8 @@ func TestServerStatusCommand(t *testing.T) {
 		space = regexp.MustCompile(`\s+`)
 		str = space.ReplaceAllString(buff.String(), " ")
 		actual = strings.TrimSpace(str)
-		So(actual, ShouldContainSubstring, config.ReleaseTag)
-		So(actual, ShouldContainSubstring, config.BinaryType)
+		So(actual, ShouldContainSubstring, buildinfo.ReleaseTag)
+		So(actual, ShouldContainSubstring, buildinfo.BinaryType)
 
 		// YAML
 		args = []string{"status", "--config", "status-test", "--format", "yaml"}
@@ -84,8 +85,8 @@ func TestServerStatusCommand(t *testing.T) {
 		space = regexp.MustCompile(`\s+`)
 		str = space.ReplaceAllString(buff.String(), " ")
 		actual = strings.TrimSpace(str)
-		So(actual, ShouldContainSubstring, config.ReleaseTag)
-		So(actual, ShouldContainSubstring, config.BinaryType)
+		So(actual, ShouldContainSubstring, buildinfo.ReleaseTag)
+		So(actual, ShouldContainSubstring, buildinfo.BinaryType)
 
 		// bad type
 		args = []string{"status", "--config", "status-test", "--format", "badType"}

--- a/pkg/extensions/get_extensions.go
+++ b/pkg/extensions/get_extensions.go
@@ -5,6 +5,7 @@ import (
 
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
+	"zotregistry.dev/zot/v2/pkg/buildinfo"
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/scheduler"
@@ -40,7 +41,7 @@ func GetExtensions(config *config.Config) distext.ExtensionList {
 	if len(endpoints) > 0 {
 		extensions = append(extensions, distext.Extension{
 			Name:        constants.BaseExtension,
-			URL:         "https://github.com/project-zot/zot/blob/" + config.ReleaseTag + "/pkg/extensions/_zot.md",
+			URL:         "https://github.com/project-zot/zot/blob/" + buildinfo.ReleaseTag + "/pkg/extensions/_zot.md",
 			Description: "zot registry extensions",
 			Endpoints:   endpoints,
 		})


### PR DESCRIPTION
Keep CLI binaries from importing pkg/api/config just for version strings by centralizing Commit/ReleaseTag/BinaryType/GoVersion in a tiny buildinfo package. Update ldflags targets and callers accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
