### PR TITLE
ci: sync go 1.26 images to ghcr.io/project-zot/golang

### DIFF
--- a/.github/workflows/sync-3rdparty-images.yaml
+++ b/.github/workflows/sync-3rdparty-images.yaml
@@ -18,8 +18,8 @@ jobs:
     strategy:
       matrix:
         golang_version:
-          - "1.24"
           - "1.25"
+          - "1.26"
     runs-on: ubuntu-latest
     steps:
       - name: Log in to GitHub Docker Registry


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
