### PR TITLE
ci: fix golangci-lint install URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -341,7 +341,7 @@ $(GOLINTER): $(TOOLSDIR)/.golangci-lint-$(GOLINTER_VERSION)
 $(TOOLSDIR)/.golangci-lint-$(GOLINTER_VERSION):
 	mkdir -p $(TOOLSDIR)/bin
 	rm -f $(TOOLSDIR)/.golangci-lint-*
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(TOOLSDIR)/bin $(GOLINTER_VERSION)
+	curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(TOOLSDIR)/bin $(GOLINTER_VERSION)
 	$(GOLINTER) version
 	touch $@
 


### PR DESCRIPTION
1. Cause SBOM assets were added to the release checksum file, so you get two lines that contain the same substring, e.g. …linux-amd64.tar.gz and …linux-amd64.tar.gz.sbom.json. The old install.sh logic used something like grep "${BASENAME}", so both lines matched. That breaks want (wrong or ambiguous hash) and shows up as checksum verification errors (including the 8df… vs fd3… style mismatch you debugged).

2. The upstream fix is in https://github.com/golangci/golangci-lint/pull/6539 The matcher was changed so the checksum line must end with the archive name — i.e. grep "${BASENAME}$" — so the .sbom.json line no longer matches.

3. In the same thread they say master on raw.githubusercontent.com is not the right branch anymore and recommend the canonical installer URL: https://golangci-lint.run/install.sh
(see the PR description and local install / binaries.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
