### PR TITLE
fix: skip DynamoDB table creation when tables exist

### DIFF
--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -63,33 +63,59 @@ func New(client *dynamodb.Client, params DBDriverParameters, log log.Logger,
 		return nil, err
 	}
 
-	err = dynamoWrapper.createTable(dynamoWrapper.RepoMetaTablename)
+	err = dynamoWrapper.createTableIfNotExists(dynamoWrapper.RepoMetaTablename, func() error {
+		return dynamoWrapper.createTable(dynamoWrapper.RepoMetaTablename)
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	err = dynamoWrapper.createTable(dynamoWrapper.RepoBlobsTablename)
+	err = dynamoWrapper.createTableIfNotExists(dynamoWrapper.RepoBlobsTablename, func() error {
+		return dynamoWrapper.createTable(dynamoWrapper.RepoBlobsTablename)
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	err = dynamoWrapper.createTable(dynamoWrapper.ImageMetaTablename)
+	err = dynamoWrapper.createTableIfNotExists(dynamoWrapper.ImageMetaTablename, func() error {
+		return dynamoWrapper.createTable(dynamoWrapper.ImageMetaTablename)
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	err = dynamoWrapper.createTable(dynamoWrapper.UserDataTablename)
+	err = dynamoWrapper.createTableIfNotExists(dynamoWrapper.UserDataTablename, func() error {
+		return dynamoWrapper.createTable(dynamoWrapper.UserDataTablename)
+	})
 	if err != nil {
 		return nil, err
 	}
 
-	err = dynamoWrapper.createTable(dynamoWrapper.APIKeyTablename)
+	err = dynamoWrapper.createTableIfNotExists(dynamoWrapper.APIKeyTablename, func() error {
+		return dynamoWrapper.createTable(dynamoWrapper.APIKeyTablename)
+	})
 	if err != nil {
 		return nil, err
 	}
 
 	// Using the Config value, create the DynamoDB client
 	return &dynamoWrapper, nil
+}
+
+func (dwr *DynamoDB) createTableIfNotExists(tableName string, createTable func() error) error {
+	_, err := dwr.Client.DescribeTable(context.Background(), &dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
+	})
+	if err == nil {
+		return nil
+	}
+
+	var notFoundErr *types.ResourceNotFoundException
+	if !errors.As(err, &notFoundErr) {
+		return err
+	}
+
+	return createTable()
 }
 
 func (dwr *DynamoDB) GetAllRepoNames() ([]string, error) {

--- a/pkg/meta/dynamodb/dynamodb_internal_test.go
+++ b/pkg/meta/dynamodb/dynamodb_internal_test.go
@@ -147,6 +147,54 @@ func TestWrapperErrors(t *testing.T) {
 			So(actualVersion, ShouldEqual, version.CurrentVersion)
 		})
 
+		Convey("New sets version when version table already exists but version doesn't", func() {
+			uuid, err := guuid.NewV4()
+			So(err, ShouldBeNil)
+
+			client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+				o.BaseEndpoint = aws.String(endpoint)
+			})
+
+			params := DBDriverParameters{
+				RepoMetaTablename:      "RepoMetadataTable" + uuid.String(),
+				RepoBlobsInfoTablename: "RepoBlobsTable" + uuid.String(),
+				ImageMetaTablename:     "ImageMetaTable" + uuid.String(),
+				UserDataTablename:      "UserDataTable" + uuid.String(),
+				APIKeyTablename:        "ApiKeyTable" + uuid.String(),
+				VersionTablename:       "Version" + uuid.String(),
+			}
+
+			dynamoWrapper := DynamoDB{
+				Client:           client,
+				VersionTablename: params.VersionTablename,
+				Patches:          version.GetDynamoDBPatches(),
+				Log:              log.NewTestLogger(),
+			}
+
+			err = dynamoWrapper.createTable(params.VersionTablename)
+			So(err, ShouldBeNil)
+
+			defer func() {
+				for _, tableName := range []string{
+					params.RepoMetaTablename,
+					params.RepoBlobsInfoTablename,
+					params.ImageMetaTablename,
+					params.UserDataTablename,
+					params.APIKeyTablename,
+					params.VersionTablename,
+				} {
+					_ = dynamoWrapper.deleteTable(tableName)
+				}
+			}()
+
+			_, err = New(client, params, log.NewTestLogger())
+			So(err, ShouldBeNil)
+
+			actualVersion, err := getVersion(client, params.VersionTablename)
+			So(err, ShouldBeNil)
+			So(actualVersion, ShouldEqual, version.CurrentVersion)
+		})
+
 		Convey("createVersionTable does not overwrite existing version", func() {
 			uuid, err := guuid.NewV4()
 			So(err, ShouldBeNil)


### PR DESCRIPTION
## Summary
- check whether DynamoDB tables already exist before attempting creation
- skip CreateTable when DescribeTable confirms the table is present
- keep create behavior for missing tables

Fixes #4066.

## Tests
- go test ./pkg/meta/dynamodb -run TestWrapperErrors/Create -count=1
- go test ./pkg/meta/dynamodb -count=1