### PR TITLE
fix(lint): silence deprecated gomodguard linter warning

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -12,6 +12,7 @@ linters:
     - funlen
     - gocognit
     - goconst
+    - gomodguard
     - gosmopolitan
     - iface
     - inamedparam


### PR DESCRIPTION


**What type of PR is this?**

cleanup

**Which issue does this PR fix**:

None

**What does this PR do / Why do we need it**:

Remove warning:

```
WARN The linter 'gomodguard' is deprecated (since v2.12.0) due to: new major version. Replaced by gomodguard_v2.
WARN Suggested new configuration:
linters:
  enable:
    - gomodguard_v2
```

`gomodguard_v2` is enabled by default https://github.com/golangci/golangci-lint/blob/8c90a87d9c9839599f0391fbf296009799165b12/.golangci.reference.yml#L69

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
