### PR TITLE
feat: redirect to download urls of blobs

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -212,4 +212,5 @@ var (
 	ErrCertificateWatcherAlreadyRunning = errors.New("certificate watcher is already running")
 	ErrInvalidEndSessionEndpoint        = errors.New("end_session_endpoint must be an absolute http(s) URL")
 	ErrPolicyConditionNotCompiled       = errors.New("policy condition not compiled")
+	ErrBlobRedirectURLNotSupported      = errors.New("blob redirect url not supported")
 )

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -35,6 +35,8 @@ type StorageConfig struct {
 	Retention     ImageRetention
 	StorageDriver map[string]any `mapstructure:",omitempty"`
 	CacheDriver   map[string]any `mapstructure:",omitempty"`
+	// Redirect allows storage backends to hand out redirect URLs
+	Redirect bool
 
 	// GCMaxSchedulerDelay is the maximum random delay for GC task scheduling
 	// This field is not configurable by the end user

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1450,6 +1450,7 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 
 	digest := godigest.Digest(digestStr)
 
+	redirect := rh.c.Config.Storage.StorageConfig.Redirect
 	contentRange := request.Header.Get("Range")
 	_, rangeHeaderPresent := request.Header["Range"]
 
@@ -1552,19 +1553,34 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 		return
 	}
 
-	var repo io.ReadCloser
-
-	var blen int64
-
 	// Resolve the response Content-Type from the blob's OCI descriptor
 	// (if any), with a fallback to application/octet-stream. This lookup
 	// may require an additional repo index/manifest walk before we read
 	// the blob, but preserves a more specific Content-Type when available.
 	mediaType := resolveBlobResponseMediaType(imgStore, name, digest, rh.c.Log)
 
-	repo, blen, err := imgStore.GetBlob(name, digest, mediaType)
+	var (
+		repo        io.ReadCloser
+		blen        int64
+		err         error
+		redirectURL string
+	)
+	if !redirect {
+		repo, blen, err = imgStore.GetBlob(name, digest, mediaType)
+	} else {
+		redirectURL, err = imgStore.GetBlobURL(request, name, digest, mediaType)
+		if errors.Is(err, zerr.ErrBlobRedirectURLNotSupported) {
+			repo, blen, err = imgStore.GetBlob(name, digest, mediaType)
+		}
+	}
 	if err != nil {
 		writeBlobError(err)
+
+		return
+	}
+	if redirectURL != "" {
+		// #nosec G710 - RedirectURL is from storage driver
+		http.Redirect(response, request, redirectURL, http.StatusTemporaryRedirect)
 
 		return
 	}

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -2033,15 +2033,23 @@ func descriptorTestDigests() (godigest.Digest, godigest.Digest, godigest.Digest)
 	return godigest.FromString("layer"), godigest.FromString("manifest"), godigest.FromString("config")
 }
 
-// newBlobTestRouteHandler returns a fresh RouteHandler whose default
+// newBlobTestRouteHandler calls newBlobTestRouteHandlerWithConfig with the default config.
+func newBlobTestRouteHandler(t *testing.T, store mocks.MockedImageStore) *api.RouteHandler {
+	t.Helper()
+
+	return newBlobTestRouteHandlerWithConfig(t, store, config.New())
+}
+
+// newBlobTestRouteHandlerWithConfig returns a fresh RouteHandler whose default
 // store is the supplied mock. It does not start a server; handlers are
 // invoked directly via httptest. The Router is initialized manually
 // because NewRouteHandler->SetupRoutes dereferences it but the server
 // (which would normally do that) is never started here.
-func newBlobTestRouteHandler(t *testing.T, store mocks.MockedImageStore) *api.RouteHandler {
+func newBlobTestRouteHandlerWithConfig(t *testing.T, store mocks.MockedImageStore, cfg *config.Config,
+) *api.RouteHandler {
 	t.Helper()
 
-	ctlr := api.NewController(config.New())
+	ctlr := api.NewController(cfg)
 	ctlr.Router = mux.NewRouter()
 	ctlr.StoreController.DefaultStore = store
 
@@ -3220,4 +3228,73 @@ func TestGetBlobMultipartReaderCloseError(t *testing.T) {
 	body := drainResponseBody(t, resp)
 	assert.Less(t, int64(len(body)), advertisedLen,
 		"a Close() error on the second range must truncate the body")
+}
+
+func TestGetBlobRedirectURL(t *testing.T) {
+	cfg := config.New()
+	cfg.Storage.Redirect = true
+
+	handler := newBlobTestRouteHandlerWithConfig(t, mocks.MockedImageStore{
+		GetBlobURLFn: func(request *http.Request, repo string, digest godigest.Digest, mediaType string) (string, error) {
+			return "http://example.com/foo", nil
+		},
+	}, cfg)
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"http://example.com/v2/test/blobs/sha256:test",
+		http.NoBody,
+	)
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621",
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusTemporaryRedirect, resp.StatusCode)
+	assert.Equal(t, "http://example.com/foo", resp.Header.Get("Location"))
+}
+
+func TestGetBlobRedirectFallback(t *testing.T) {
+	cfg := config.New()
+	cfg.Storage.Redirect = true
+
+	var getBlobCalled bool
+
+	handler := newBlobTestRouteHandlerWithConfig(t, mocks.MockedImageStore{
+		GetBlobURLFn: func(request *http.Request, repo string, digest godigest.Digest, mediaType string) (string, error) {
+			return "", zerr.ErrBlobRedirectURLNotSupported
+		},
+		GetBlobFn: func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
+			getBlobCalled = true
+
+			return io.NopCloser(strings.NewReader("")), 0, nil
+		},
+	}, cfg)
+
+	req := httptest.NewRequestWithContext(
+		context.Background(),
+		http.MethodGet,
+		"http://example.com/v2/test/blobs/sha256:test",
+		http.NoBody,
+	)
+	req = mux.SetURLVars(req, map[string]string{
+		"name":   "test",
+		"digest": "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621",
+	})
+
+	rec := httptest.NewRecorder()
+	handler.GetBlob(rec, req)
+
+	resp := rec.Result()
+	defer resp.Body.Close()
+
+	require.NotEqual(t, http.StatusTemporaryRedirect, resp.StatusCode)
+	assert.True(t, getBlobCalled)
 }

--- a/pkg/storage/gcs/driver.go
+++ b/pkg/storage/gcs/driver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"strings"
 
 	// Add gcs support.
@@ -174,6 +175,10 @@ func (driver *Driver) SameFile(path1, path2 string) bool {
 // from cache.
 func (driver *Driver) Link(src, dest string) error {
 	return driver.formatErr(driver.store.PutContent(context.Background(), dest, []byte{}), dest)
+}
+
+func (driver *Driver) URLFor(r *http.Request, path string) (string, error) {
+	return driver.store.RedirectURL(r, path)
 }
 
 // formatErr converts GCS-specific 404/not found errors to PathNotFoundError.

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"path"
 	"path/filepath"
 	"slices"
@@ -1637,7 +1638,8 @@ func (is *ImageStore) originalBlobInfo(repo string, digest godigest.Digest) (dri
 
 // GetBlob returns a stream to read the blob.
 // blob selector instead of directly downloading the blob.
-func (is *ImageStore) GetBlob(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
+func (is *ImageStore) GetBlob(repo string, digest godigest.Digest, mediaType string,
+) (io.ReadCloser, int64, error) {
 	var lockLatency time.Time
 
 	if err := digest.Validate(); err != nil {
@@ -1661,6 +1663,25 @@ func (is *ImageStore) GetBlob(repo string, digest godigest.Digest, mediaType str
 
 	// The caller function is responsible for calling Close()
 	return blobReadCloser, binfo.Size(), nil
+}
+
+func (is *ImageStore) GetBlobURL(request *http.Request, repo string, digest godigest.Digest, mediaType string,
+) (string, error) {
+	var lockLatency time.Time
+
+	if err := digest.Validate(); err != nil {
+		return "", err
+	}
+
+	is.RLock(&lockLatency)
+	defer is.RUnlock(&lockLatency)
+
+	binfo, err := is.originalBlobInfo(repo, digest)
+	if err != nil {
+		return "", err
+	}
+
+	return is.storeDriver.URLFor(request, binfo.Path())
 }
 
 // GetBlobContent returns blob contents, the caller function MUST lock from outside.

--- a/pkg/storage/local/driver.go
+++ b/pkg/storage/local/driver.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"path"
 	"sort"
@@ -291,6 +292,10 @@ func (driver *Driver) Link(src, dest string) error {
 	}
 
 	return nil
+}
+
+func (driver *Driver) URLFor(_ *http.Request, _ string) (string, error) {
+	return "", zerr.ErrBlobRedirectURLNotSupported
 }
 
 func (driver *Driver) formatErr(err error) error {

--- a/pkg/storage/s3/driver.go
+++ b/pkg/storage/s3/driver.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	"io"
+	"net/http"
 
 	// Add s3 support.
 	"github.com/distribution/distribution/v3/registry/storage/driver"
@@ -109,4 +110,8 @@ func (driver *Driver) SameFile(path1, path2 string) bool {
 // from cache.
 func (driver *Driver) Link(src, dest string) error {
 	return driver.store.PutContent(context.Background(), dest, []byte{})
+}
+
+func (driver *Driver) URLFor(r *http.Request, path string) (string, error) {
+	return driver.store.RedirectURL(r, path)
 }

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -3,6 +3,7 @@ package types
 import (
 	"context"
 	"io"
+	"net/http"
 	"time"
 
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
@@ -54,6 +55,7 @@ type ImageStore interface { //nolint:interfacebloat
 	CheckBlob(repo string, digest godigest.Digest) (bool, int64, error)
 	StatBlob(repo string, digest godigest.Digest) (bool, int64, time.Time, error)
 	GetBlob(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error)
+	GetBlobURL(r *http.Request, repo string, digest godigest.Digest, mediaType string) (string, error)
 	GetBlobPartial(repo string, digest godigest.Digest, mediaType string, from, to int64,
 	) (io.ReadCloser, int64, int64, error)
 	DeleteBlob(repo string, digest godigest.Digest) error
@@ -87,4 +89,5 @@ type Driver interface { //nolint:interfacebloat
 	Move(sourcePath string, destPath string) error
 	SameFile(path1, path2 string) bool
 	Link(src, dest string) error
+	URLFor(request *http.Request, path string) (string, error)
 }

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -3,6 +3,7 @@ package mocks
 import (
 	"context"
 	"io"
+	"net/http"
 	"time"
 
 	godigest "github.com/opencontainers/go-digest"
@@ -44,6 +45,7 @@ type MockedImageStore struct {
 	GetBlobPartialFn       func(repo string, digest godigest.Digest, mediaType string, from, to int64,
 	) (io.ReadCloser, int64, int64, error)
 	GetBlobFn            func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error)
+	GetBlobURLFn         func(request *http.Request, repo string, digest godigest.Digest, mediaType string) (string, error)
 	DeleteBlobFn         func(repo string, digest godigest.Digest) error
 	GetIndexContentFn    func(repo string) ([]byte, error)
 	GetBlobContentFn     func(repo string, digest godigest.Digest) ([]byte, error)
@@ -338,6 +340,15 @@ func (is MockedImageStore) GetBlob(repo string, digest godigest.Digest, mediaTyp
 	}
 
 	return io.NopCloser(&io.LimitedReader{}), 0, nil
+}
+
+func (is MockedImageStore) GetBlobURL(request *http.Request, repo string, digest godigest.Digest, mediaType string,
+) (string, error) {
+	if is.GetBlobURLFn != nil {
+		return is.GetBlobURLFn(request, repo, digest, mediaType)
+	}
+
+	return "", nil
 }
 
 func (is MockedImageStore) DeleteBlobUpload(repo string, uuid string) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:
#2752 

**What does this PR do / Why do we need it**:
redirects clients to a presigned urls for blob downloads, which significantly reduces load of the zot server, since the blobs no longer need to go through the server.

Upstream distribution spec has moved with opencontainers/distribution-spec#607 to allow redirects.
> Registries MAY respond to any request with a redirect per [RFC 9110 (section 15.4)](https://www.rfc-editor.org/rfc/rfc9110#section-15.4); clients SHOULD follow such redirects, and MUST NOT forward Authorization headers across host boundaries unless explicitly configured to do so.

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
support redirect clients to S3 URLs when fetching blobs
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.