### PR TITLE
feat(cli): support default config name

### DIFF
--- a/pkg/cli/client/config.go
+++ b/pkg/cli/client/config.go
@@ -21,14 +21,16 @@ const (
 	defaultConfigPerms = 0o644
 	defaultFilePerms   = 0o600
 
-	nameKey           = "_name"
-	showspinnerConfig = "showspinner"
-	verifyTLSConfig   = "verify-tls"
+	defaultConfigNameKey = "defaultConfigName"
+	nameKey              = "_name"
+	showspinnerConfig    = "showspinner"
+	verifyTLSConfig      = "verify-tls"
 )
 
 // ZliConfigFile is the on-disk JSON shape for ~/.zot (zli CLI registry profiles).
 type ZliConfigFile struct {
-	Configs []ZliConfig `json:"configs"`
+	Configs           []ZliConfig `json:"configs"`
+	DefaultConfigName string      `json:"defaultConfigName,omitempty"`
 }
 
 // ZliConfig is one named registry profile inside ZliConfigFile.Configs.
@@ -88,6 +90,17 @@ func ReadZliConfigFile(filePath string) (*ZliConfigFile, error) {
 	}
 
 	out := &ZliConfigFile{Configs: make([]ZliConfig, 0, len(configsAny))}
+
+	if defaultNameRaw, ok := jsonMap[defaultConfigNameKey]; ok && defaultNameRaw != nil {
+		defaultName, ok := defaultNameRaw.(string)
+		if !ok {
+			return nil, fmt.Errorf(
+				`%w: field "%s" must be a string, got %T`,
+				zerr.ErrCliBadConfig, defaultConfigNameKey, defaultNameRaw)
+		}
+
+		out.DefaultConfigName = defaultName
+	}
 
 	for i, v := range configsAny {
 		configMap, ok := v.(map[string]any)
@@ -182,6 +195,37 @@ func (f *ZliConfigFile) HasEntry(configName string) bool {
 	})
 }
 
+// SetDefault validates and stores the default profile name.
+func (f *ZliConfigFile) SetDefault(configName string) error {
+	if !f.HasEntry(configName) {
+		return zerr.ErrConfigNotFound
+	}
+
+	f.DefaultConfigName = configName
+
+	return nil
+}
+
+// ClearDefault clears the stored default profile name.
+func (f *ZliConfigFile) ClearDefault() {
+	f.DefaultConfigName = ""
+}
+
+// DefaultName returns the configured default profile name, validating that it still exists.
+func (f *ZliConfigFile) DefaultName() (string, error) {
+	if f.DefaultConfigName == "" {
+		return "", nil
+	}
+
+	if !f.HasEntry(f.DefaultConfigName) {
+		return "", fmt.Errorf(
+			"%w: %s %q does not match any profile",
+			zerr.ErrConfigNotFound, defaultConfigNameKey, f.DefaultConfigName)
+	}
+
+	return f.DefaultConfigName, nil
+}
+
 // AddEntry appends a new profile after validating URL and duplicate names.
 func (f *ZliConfigFile) AddEntry(configName, urlStr string) error {
 	if err := validateURL(urlStr); err != nil {
@@ -210,6 +254,9 @@ func (f *ZliConfigFile) RemoveEntry(configName string) error {
 		}
 
 		f.Configs = append(f.Configs[:i], f.Configs[i+1:]...)
+		if f.DefaultConfigName == configName {
+			f.ClearDefault()
+		}
 
 		return nil
 	}
@@ -224,7 +271,12 @@ func (f *ZliConfigFile) FormatNames() (string, error) {
 	writer := tabwriter.NewWriter(&builder, 0, 8, 1, '\t', tabwriter.AlignRight) //nolint:mnd
 
 	for _, c := range f.Configs {
-		fmt.Fprintf(writer, "%s\t%s\n", c.Name, c.URL)
+		name := c.Name
+		if c.Name == f.DefaultConfigName {
+			name += " (default)"
+		}
+
+		fmt.Fprintf(writer, "%s\t%s\n", name, c.URL)
 	}
 
 	if err := writer.Flush(); err != nil {
@@ -319,11 +371,18 @@ func (c *ZliConfig) ResetVar(key string) error {
 
 // FormatListedVars renders lines for `zli config show <name>`.
 func (c *ZliConfig) FormatListedVars() string {
+	return c.formatListedVars(false)
+}
+
+func (c *ZliConfig) formatListedVars(isDefault bool) string {
 	var builder strings.Builder
 
 	fmt.Fprintf(&builder, "%s = %v\n", URLFlag, c.URL)
 	fmt.Fprintf(&builder, "%s = %v\n", showspinnerConfig, c.ShowSpinner)
 	fmt.Fprintf(&builder, "%s = %v\n", verifyTLSConfig, c.VerifyTLS)
+	if isDefault {
+		fmt.Fprintln(&builder, "default = true")
+	}
 
 	return builder.String()
 }

--- a/pkg/cli/client/config_cmd.go
+++ b/pkg/cli/client/config_cmd.go
@@ -55,12 +55,14 @@ func NewConfigCommand() *cobra.Command {
 	configCmd.AddCommand(NewConfigGetCommand())
 	configCmd.AddCommand(NewConfigSetCommand())
 	configCmd.AddCommand(NewConfigResetCommand())
+	configCmd.AddCommand(NewConfigSetDefaultCommand())
+	configCmd.AddCommand(NewConfigClearDefaultCommand())
 
 	// Build this from actual subcommands to avoid drift.
 	reserved := strings.Join(reservedProfileNames(configCmd), ", ")
 	configCmd.Long = fmt.Sprintf(`Configure zot registry parameters for CLI.
 
-Use the list, show, get, set, and reset subcommands for inspecting and editing profiles.
+Use the list, show, get, set, reset, set-default, and clear-default subcommands for inspecting and editing profiles.
 Profile names must not collide with subcommand names (%s).
 
 Older positional syntax on this command is deprecated and will soon be removed.`, reserved)
@@ -165,7 +167,7 @@ func NewConfigRemoveCommand() *cobra.Command {
 		Use:          "remove <config-name>",
 		Example:      "  zli config remove main",
 		Short:        "Remove configuration for a zot registry",
-		Long:         "Remove configuration for a zot registry",
+		Long:         "Remove configuration for a zot registry. Removing the default profile also clears the default.",
 		SilenceUsage: true,
 		Args:         exactArgsOrHelp(oneArg),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -324,6 +326,52 @@ func NewConfigResetCommand() *cobra.Command {
 	return resetCmd
 }
 
+func NewConfigSetDefaultCommand() *cobra.Command {
+	setDefaultCmd := &cobra.Command{
+		Use:          "set-default <name>",
+		Example:      "  zli config set-default main",
+		Short:        "Set the default configuration profile",
+		Long:         "Set the default profile used when neither --url nor --config is provided.",
+		SilenceUsage: true,
+		Args:         exactArgsOrHelp(oneArg),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := zliUserConfigPath()
+			if err != nil {
+				return err
+			}
+
+			return setDefaultConfig(configPath, args[0])
+		},
+	}
+
+	setDefaultCmd.SetUsageTemplate(setDefaultCmd.UsageTemplate())
+
+	return setDefaultCmd
+}
+
+func NewConfigClearDefaultCommand() *cobra.Command {
+	clearDefaultCmd := &cobra.Command{
+		Use:          "clear-default",
+		Example:      "  zli config clear-default",
+		Short:        "Clear the default configuration profile",
+		Long:         "Clear the default profile. Commands will again require --url or --config.",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := zliUserConfigPath()
+			if err != nil {
+				return err
+			}
+
+			return clearDefaultConfig(configPath)
+		},
+	}
+
+	clearDefaultCmd.SetUsageTemplate(clearDefaultCmd.UsageTemplate())
+
+	return clearDefaultCmd
+}
+
 func getConfigNames(configPath string) (string, error) {
 	cfg, err := ReadZliConfigFile(configPath)
 	if err != nil {
@@ -367,6 +415,38 @@ func removeConfig(configPath, configName string) error {
 	if err := cfg.RemoveEntry(configName); err != nil {
 		return err
 	}
+
+	return cfg.WriteFile(configPath)
+}
+
+func setDefaultConfig(configPath, configName string) error {
+	cfg, err := ReadZliConfigFile(configPath)
+	if err != nil {
+		if isConfigUnavailable(err) {
+			return zerr.ErrConfigNotFound
+		}
+
+		return err
+	}
+
+	if err := cfg.SetDefault(configName); err != nil {
+		return err
+	}
+
+	return cfg.WriteFile(configPath)
+}
+
+func clearDefaultConfig(configPath string) error {
+	cfg, err := ReadZliConfigFile(configPath)
+	if err != nil {
+		if isConfigUnavailable(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	cfg.ClearDefault()
 
 	return cfg.WriteFile(configPath)
 }
@@ -456,7 +536,7 @@ func getAllConfig(configPath, configName string) (string, error) {
 		return "", err
 	}
 
-	return c.FormatListedVars(), nil
+	return c.formatListedVars(cfg.DefaultConfigName == configName), nil
 }
 
 const (
@@ -466,6 +546,8 @@ const (
   zli config get main url
   zli config set main showspinner false
   zli config reset main showspinner
+  zli config set-default main
+  zli config clear-default
   zli config remove main`
 
 	supportedOptions = `

--- a/pkg/cli/client/config_cmd_internal_test.go
+++ b/pkg/cli/client/config_cmd_internal_test.go
@@ -306,6 +306,74 @@ func TestSetConfigValue(t *testing.T) {
 	})
 }
 
+func TestDefaultConfigValue(t *testing.T) {
+	t.Parallel()
+
+	validProfile := `{"configs":[{"_name":"a","url":"https://example.com"}]}`
+
+	t.Run("setDefaultConfig_success", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		cfgPath := writeTestZotFile(t, dir, validProfile)
+
+		require.NoError(t, setDefaultConfig(cfgPath, "a"))
+
+		cfg, err := ReadZliConfigFile(cfgPath)
+		require.NoError(t, err)
+		require.Equal(t, "a", cfg.DefaultConfigName)
+	})
+
+	t.Run("setDefaultConfig_missing_profile", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		cfgPath := writeTestZotFile(t, dir, validProfile)
+
+		err := setDefaultConfig(cfgPath, "missing")
+		require.ErrorIs(t, err, zerr.ErrConfigNotFound)
+	})
+
+	t.Run("clearDefaultConfig_success", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		cfgPath := writeTestZotFile(t, dir,
+			`{"configs":[{"_name":"a","url":"https://example.com"}],"defaultConfigName":"a"}`)
+
+		require.NoError(t, clearDefaultConfig(cfgPath))
+
+		cfg, err := ReadZliConfigFile(cfgPath)
+		require.NoError(t, err)
+		require.Empty(t, cfg.DefaultConfigName)
+	})
+
+	t.Run("getDefaultConfigName_missing_profile", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		cfgPath := writeTestZotFile(t, dir,
+			`{"configs":[{"_name":"a","url":"https://example.com"}],"defaultConfigName":"missing"}`)
+
+		_, err := getDefaultConfigName(cfgPath)
+		require.ErrorIs(t, err, zerr.ErrConfigNotFound)
+		require.Contains(t, err.Error(), "defaultConfigName")
+	})
+
+	t.Run("getDefaultConfigName_missing_file", func(t *testing.T) {
+		t.Parallel()
+
+		cfgPath := tempConfigPath(t, false, "")
+
+		defaultName, err := getDefaultConfigName(cfgPath)
+		require.NoError(t, err)
+		require.Empty(t, defaultName)
+
+		_, err = os.Stat(cfgPath)
+		require.ErrorIs(t, err, os.ErrNotExist)
+	})
+}
+
 func TestConfigCmd_listFreshAndFindErrors(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/cli/client/config_cmd_test.go
+++ b/pkg/cli/client/config_cmd_test.go
@@ -323,6 +323,96 @@ func TestConfigCmdMain(t *testing.T) {
 		})
 	})
 
+	Convey("Test config default profile commands", t, func() {
+		Convey("sets and displays the default profile", func() {
+			configPath := makeConfigFile(t,
+				`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
+
+			cmd := client.NewConfigCommand()
+			outBuff := bytes.NewBufferString("")
+			errBuff := bytes.NewBufferString("")
+			cmd.SetOut(outBuff)
+			cmd.SetErr(errBuff)
+			cmd.SetArgs([]string{"set-default", "configtest"})
+			So(cmd.Execute(), ShouldBeNil)
+
+			actual, err := os.ReadFile(configPath)
+			So(err, ShouldBeNil)
+			So(string(actual), ShouldContainSubstring, `"defaultConfigName": "configtest"`)
+
+			listCmd := client.NewConfigCommand()
+			listOut := bytes.NewBufferString("")
+			listErr := bytes.NewBufferString("")
+			listCmd.SetOut(listOut)
+			listCmd.SetErr(listErr)
+			listCmd.SetArgs([]string{"list"})
+			So(listCmd.Execute(), ShouldBeNil)
+			So(listOut.String(), ShouldContainSubstring, "configtest (default)")
+			So(listErr.String(), ShouldEqual, "")
+
+			showCmd := client.NewConfigCommand()
+			showOut := bytes.NewBufferString("")
+			showErr := bytes.NewBufferString("")
+			showCmd.SetOut(showOut)
+			showCmd.SetErr(showErr)
+			showCmd.SetArgs([]string{"show", "configtest"})
+			So(showCmd.Execute(), ShouldBeNil)
+			So(showOut.String(), ShouldContainSubstring, "default = true")
+			So(showErr.String(), ShouldEqual, "")
+		})
+
+		Convey("rejects a missing default profile", func() {
+			_ = makeConfigFile(t,
+				`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)
+
+			cmd := client.NewConfigCommand()
+			buff := bytes.NewBufferString("")
+			cmd.SetOut(buff)
+			cmd.SetErr(buff)
+			cmd.SetArgs([]string{"set-default", "missing"})
+			err := cmd.Execute()
+
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrConfigNotFound), ShouldBeTrue)
+		})
+
+		Convey("clears the default profile", func() {
+			configPath := makeConfigFile(t,
+				`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}],"defaultConfigName":"configtest"}`)
+
+			cmd := client.NewConfigCommand()
+			outBuff := bytes.NewBufferString("")
+			errBuff := bytes.NewBufferString("")
+			cmd.SetOut(outBuff)
+			cmd.SetErr(errBuff)
+			cmd.SetArgs([]string{"clear-default"})
+			So(cmd.Execute(), ShouldBeNil)
+			So(outBuff.String(), ShouldEqual, "")
+			So(errBuff.String(), ShouldEqual, "")
+
+			actual, err := os.ReadFile(configPath)
+			So(err, ShouldBeNil)
+			So(string(actual), ShouldNotContainSubstring, "defaultConfigName")
+		})
+
+		Convey("remove clears the default profile", func() {
+			configPath := makeConfigFile(t,
+				`{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}],"defaultConfigName":"configtest"}`)
+
+			cmd := client.NewConfigCommand()
+			outBuff := bytes.NewBufferString("")
+			errBuff := bytes.NewBufferString("")
+			cmd.SetOut(outBuff)
+			cmd.SetErr(errBuff)
+			cmd.SetArgs([]string{"remove", "configtest"})
+			So(cmd.Execute(), ShouldBeNil)
+
+			actual, err := os.ReadFile(configPath)
+			So(err, ShouldBeNil)
+			So(string(actual), ShouldNotContainSubstring, "defaultConfigName")
+		})
+	})
+
 	Convey("Test config show", t, func() {
 		Convey("prints variables for the profile", func() {
 			_ = makeConfigFile(t, `{"configs":[{"_name":"configtest","url":"https://test-url.com","showspinner":false}]}`)

--- a/pkg/cli/client/config_test.go
+++ b/pkg/cli/client/config_test.go
@@ -86,6 +86,12 @@ func TestReadZliConfigFile_errors(t *testing.T) {
 			wantSubs:    "",
 			wantErrIs:   []error{zerr.ErrCliBadConfig, zerr.ErrCliMissingConfigsField},
 		},
+		{
+			name:        "default_config_name_not_string",
+			cfgContents: `{"configs":[],"defaultConfigName":1}`,
+			wantSubs:    `field "defaultConfigName" must be a string`,
+			wantErrIs:   []error{zerr.ErrCliBadConfig},
+		},
 	}
 
 	for _, tableCase := range tests {
@@ -117,6 +123,42 @@ func TestZliConfigFile_RemoveEntry_NotFound(t *testing.T) {
 
 	err := f.RemoveEntry("missing")
 	assert.ErrorIs(t, err, zerr.ErrConfigNotFound)
+}
+
+func TestZliConfigFile_DefaultConfigName(t *testing.T) {
+	t.Parallel()
+
+	f := client.ZliConfigFile{
+		Configs: []client.ZliConfig{
+			{Name: "main", URL: "https://example.com"},
+			{Name: "other", URL: "https://other.example.com"},
+		},
+	}
+
+	require.NoError(t, f.SetDefault("main"))
+	assert.Equal(t, "main", f.DefaultConfigName)
+
+	defaultName, err := f.DefaultName()
+	require.NoError(t, err)
+	assert.Equal(t, "main", defaultName)
+
+	assert.ErrorIs(t, f.SetDefault("missing"), zerr.ErrConfigNotFound)
+
+	require.NoError(t, f.RemoveEntry("main"))
+	assert.Empty(t, f.DefaultConfigName)
+}
+
+func TestZliConfigFile_DefaultNameMissingProfile(t *testing.T) {
+	t.Parallel()
+
+	f := client.ZliConfigFile{
+		DefaultConfigName: "missing",
+		Configs:           []client.ZliConfig{{Name: "main", URL: "https://example.com"}},
+	}
+
+	_, err := f.DefaultName()
+	assert.ErrorIs(t, err, zerr.ErrConfigNotFound)
+	assert.Contains(t, err.Error(), "defaultConfigName")
 }
 
 func TestZliConfig_GetVar(t *testing.T) {

--- a/pkg/cli/client/search_functions_internal_test.go
+++ b/pkg/cli/client/search_functions_internal_test.go
@@ -955,6 +955,17 @@ func TestUtils(t *testing.T) {
 		So(err, ShouldNotBeNil)
 		So(isSpinner, ShouldBeFalse)
 		So(verifyTLS, ShouldBeFalse)
+
+		// default profile when --config and --url are absent
+		_ = makeConfigFile(t,
+			`{"configs":[{"_name":"imagetest","url":"https://test-url.com","showspinner":false, "verify-tls": false}],"defaultConfigName":"imagetest"}`)
+		cmd = &cobra.Command{}
+		cmd.Flags().String(ConfigFlag, "", "")
+		cmd.Flags().String(URLFlag, "", "")
+		isSpinner, verifyTLS, err = GetCliConfigOptions(cmd)
+		So(err, ShouldBeNil)
+		So(isSpinner, ShouldBeFalse)
+		So(verifyTLS, ShouldBeFalse)
 	})
 
 	Convey("GetServerURLFromFlags", t, func() {
@@ -985,6 +996,43 @@ func TestUtils(t *testing.T) {
 		url, err = GetServerURLFromFlags(cmd)
 		So(url, ShouldResemble, "")
 		So(err, ShouldNotBeNil)
+
+		// default profile when --config and --url are absent
+		_ = makeConfigFile(t,
+			`{"configs":[{"_name":"main","url":"https://default.example.com"},{"_name":"other","url":"https://other.example.com"}],"defaultConfigName":"main"}`)
+		cmd = &cobra.Command{}
+		cmd.Flags().String(URLFlag, "", "")
+		cmd.Flags().String(ConfigFlag, "", "")
+		url, err = GetServerURLFromFlags(cmd)
+		So(url, ShouldResemble, "https://default.example.com")
+		So(err, ShouldBeNil)
+
+		// explicit --url overrides default
+		cmd = &cobra.Command{}
+		cmd.Flags().String(URLFlag, "https://flag.example.com", "")
+		cmd.Flags().String(ConfigFlag, "", "")
+		url, err = GetServerURLFromFlags(cmd)
+		So(url, ShouldResemble, "https://flag.example.com")
+		So(err, ShouldBeNil)
+
+		// explicit --config overrides default
+		cmd = &cobra.Command{}
+		cmd.Flags().String(URLFlag, "", "")
+		cmd.Flags().String(ConfigFlag, "other", "")
+		url, err = GetServerURLFromFlags(cmd)
+		So(url, ShouldResemble, "https://other.example.com")
+		So(err, ShouldBeNil)
+
+		// invalid default profile has a clear error
+		_ = makeConfigFile(t,
+			`{"configs":[{"_name":"main","url":"https://default.example.com"}],"defaultConfigName":"missing"}`)
+		cmd = &cobra.Command{}
+		cmd.Flags().String(URLFlag, "", "")
+		cmd.Flags().String(ConfigFlag, "", "")
+		url, err = GetServerURLFromFlags(cmd)
+		So(url, ShouldResemble, "")
+		So(err, ShouldNotBeNil)
+		So(err.Error(), ShouldContainSubstring, "defaultConfigName")
 	})
 
 	Convey("CheckExtEndPointQuery", t, func() {

--- a/pkg/cli/client/utils.go
+++ b/pkg/cli/client/utils.go
@@ -4,10 +4,10 @@ package client
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -449,15 +449,30 @@ func GetCliConfigOptions(cmd *cobra.Command) (bool, bool, error) {
 	}
 
 	if configName == "" {
-		return false, false, nil
+		serverURL, urlErr := cmd.Flags().GetString(URLFlag)
+		if urlErr == nil && serverURL != "" {
+			return false, false, nil
+		}
+
+		configPath, err := zliUserConfigPath()
+		if err != nil {
+			return false, false, err
+		}
+
+		configName, err = getDefaultConfigName(configPath)
+		if err != nil {
+			return false, false, err
+		}
+
+		if configName == "" {
+			return false, false, nil
+		}
 	}
 
-	home, err := os.UserHomeDir()
+	configPath, err := zliUserConfigPath()
 	if err != nil {
 		return false, false, err
 	}
-
-	configPath := filepath.Join(home, ".zot")
 
 	isSpinner, err := parseBooleanConfig(configPath, configName, showspinnerConfig)
 	if err != nil {
@@ -484,7 +499,21 @@ func GetServerURLFromFlags(cmd *cobra.Command) (string, error) {
 	}
 
 	if configName == "" {
-		return "", fmt.Errorf("%w: specify either '--%s' or '--%s' flags", zerr.ErrNoURLProvided, URLFlag, ConfigFlag)
+		configPath, err := zliUserConfigPath()
+		if err != nil {
+			return "", err
+		}
+
+		configName, err = getDefaultConfigName(configPath)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	if configName == "" {
+		return "", fmt.Errorf(
+			"%w: specify either '--%s' or '--%s' flags, or set a default with 'zli config set-default <name>'",
+			zerr.ErrNoURLProvided, URLFlag, ConfigFlag)
 	}
 
 	serverURL, err = ReadServerURLFromConfig(configName)
@@ -500,12 +529,10 @@ func GetServerURLFromFlags(cmd *cobra.Command) (string, error) {
 }
 
 func ReadServerURLFromConfig(configName string) (string, error) {
-	home, err := os.UserHomeDir()
+	configPath, err := zliUserConfigPath()
 	if err != nil {
 		return "", err
 	}
-
-	configPath := filepath.Join(home, ".zot")
 
 	urlFromConfig, err := getConfigValue(configPath, configName, URLFlag)
 	if err != nil {
@@ -513,6 +540,27 @@ func ReadServerURLFromConfig(configName string) (string, error) {
 	}
 
 	return urlFromConfig, nil
+}
+
+func getDefaultConfigName(configPath string) (string, error) {
+	if _, err := os.Stat(configPath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", nil
+		}
+
+		return "", err
+	}
+
+	cfg, err := ReadZliConfigFile(configPath)
+	if err != nil {
+		if isConfigUnavailable(err) {
+			return "", nil
+		}
+
+		return "", err
+	}
+
+	return cfg.DefaultName()
 }
 
 func GetSuggestionsString(suggestions []string) string {


### PR DESCRIPTION
## Summary
- add top-level `defaultConfigName` support to the zli `~/.zot` config file
- add `zli config set-default <name>` and `zli config clear-default`
- use the default profile only when neither `--url` nor `--config` is provided
- show the default in `zli config list` / `zli config show`, and clear it automatically when removing that profile

Supersedes #3996.
Fixes #129.

## Validation
- `git diff --check`
- `GOEXPERIMENT=jsonv2 go test -tags search ./pkg/cli/client -run 'TestConfig'`\n- `GOEXPERIMENT=jsonv2 go test -tags search ./pkg/cli/client -run 'Test(ReadZliConfigFile_errors|ZliConfigFile_DefaultConfigName|ZliConfigFile_DefaultNameMissingProfile|ConfigCmdMain|ConfigCmdBasics|GetConfigValue|ResetConfigValue|SetConfigValue|DefaultConfigValue|ConfigCmd_listFreshAndFindErrors|Utils)$'`