### PR TITLE
ci: Update GH runner labels

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   benchmark:
     name: Performance regression check
-    runs-on: oracle-vm-8cpu-32gb-x86-64
+    runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   client-tools:
     name: Check client tools
-    runs-on: cncf-ubuntu-16-64-x86
+    runs-on: cncf-ubuntu-32-128-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   client-tools:
     name: Check client tools
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/gc-stress-test.yaml
+++ b/.github/workflows/gc-stress-test.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   gc-referrers-stress-local:
     name: GC(with referrers) on filesystem with short interval
-    runs-on: oracle-vm-8cpu-32gb-x86-64
+    runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -56,7 +56,7 @@ jobs:
 
   gc-stress-local:
     name: GC(without referrers) on filesystem with short interval
-    runs-on: oracle-vm-8cpu-32gb-x86-64
+    runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -98,7 +98,7 @@ jobs:
 
   gc-referrers-stress-s3:
     name: GC(with referrers) on S3(minio) with short interval
-    runs-on: oracle-vm-8cpu-32gb-x86-64
+    runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -185,7 +185,7 @@ jobs:
 
   gc-stress-s3:
     name: GC(without referrers) on S3(minio) with short interval
-    runs-on: oracle-vm-8cpu-32gb-x86-64
+    runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -72,7 +72,7 @@ jobs:
 
   gc-referrers-stress-s3:
     name: GC(with referrers) on S3(localstack) with short interval
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -118,7 +118,7 @@ jobs:
 
   gc-stress-s3:
     name: GC(without referrers) on S3(localstack) with short interval
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -264,7 +264,7 @@ jobs:
 
   cloud-scale-out:
     name: s3+dynamodb scale-out
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -335,7 +335,7 @@ jobs:
 
   cloud-scale-out-redis:
     name: s3+redis scale-out
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,7 @@ jobs:
       - uses: ./.github/actions/teardown-localstack
   test-run-extensions:
     name: Run zot with extensions tests
-    runs-on: oracle-vm-16cpu-64gb-x86-64
+    runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION

1. Switch CI jobs from oracle-vm-* runner labels to cncf-ubuntu-* as the oracle-cm-* CNCF runner labels are deprecated.
2. Increase resources available for ecosystem tools tests
3. 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
