### PR TITLE
fix(storage): treat dedupe-candidate cache miss as no candidates, not an error

### DIFF
--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -1388,6 +1388,16 @@ func (is *ImageStore) GetAllDedupeReposCandidates(digest godigest.Digest) ([]str
 
 	blobsPaths, err := is.cache.GetAllBlobs(digest)
 	if err != nil {
+		// A cache miss means the digest is not present in the cache yet, so there
+		// are simply no dedupe/mount candidates for it — that is the normal case
+		// for a not-yet-cached blob, not a failure. Treat it like the nil-cache
+		// case above and return no candidates rather than propagating the error
+		// (which callers log as an "unexpected error", spamming the logs on every
+		// fresh blob during pushes/cross-repo mount checks).
+		if errors.Is(err, zerr.ErrCacheMiss) {
+			return nil, nil //nolint:nilnil
+		}
+
 		return nil, err
 	}
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -644,6 +644,18 @@ func TestGetAllDedupeReposCandidates(t *testing.T) {
 				slices.Sort(repos)
 				So(repoNames, ShouldResemble, repos)
 			})
+
+			Convey("A digest with no cached blob returns no candidates and no error", t, func(c C) {
+				// A cache miss is the normal case for a not-yet-cached blob (e.g. the
+				// first push of a new blob, or a cross-repo mount check during a push).
+				// It must surface as "no dedupe/mount candidates", NOT as an error the
+				// caller logs as "unexpected error".
+				uncachedDigest := godigest.FromBytes([]byte("blob that was never pushed to any repo"))
+
+				repos, err := imgStore.GetAllDedupeReposCandidates(uncachedDigest)
+				So(err, ShouldBeNil)
+				So(repos, ShouldBeEmpty)
+			})
 		})
 	}
 }


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

No existing issue — repro steps + logs below.

**What does this PR do / Why do we need it**:

`ImageStore.GetAllDedupeReposCandidates` propagates `zerr.ErrCacheMiss` from the cache's `GetAllBlobs` verbatim. A cache miss is the *normal* case for a not-yet-cached blob digest — the first push of a new blob, or a cross-repo mount check during a push — and semantically means "no dedupe/mount candidates", not a failure.

Because `canMount()` (used by both the `CheckBlob` `HEAD /v2/.../blobs/<digest>` handler and the `CreateBlobUpload` `POST /v2/.../blobs/uploads/` handler) returns that error to the route handler, every fresh blob digest produces an `error`-level `"unexpected error"` log line. With remote storage (e.g. S3) a cache is always created — setting `storage.dedupe: false` does **not** disable it — so this fires for essentially every blob on every push: substantial error-level log spam during bulk pushes and cross-repo mounts, despite the push succeeding normally (the client just falls back to a regular upload).

The fix treats `ErrCacheMiss` exactly like the existing `is.cache == nil` branch a few lines above: return no candidates and no error.

**If an issue # is not available please add repro steps and logs showing the issue**:

Config: zot v2.1.x with an S3 storage driver + `storage.dedupe: false` (any config where a cache is present). Push a multi-arch image, or `skopeo copy` an image into a second repo. zot logs, per blob digest:

```
{"level":"error","message":"unexpected error","error":"cache miss","caller":"zotregistry.dev/zot/v2/pkg/api/routes.go:1103","func":"zotregistry.dev/zot/v2/pkg/api.(*RouteHandler).CheckBlob"}
{"level":"error","message":"unexpected error","error":"cache miss","caller":"zotregistry.dev/zot/v2/pkg/api/routes.go:1688","func":"zotregistry.dev/zot/v2/pkg/api.(*RouteHandler).CreateBlobUpload"}
```

All HTTP responses are 2xx/404 (the push succeeds) — the error log is spurious.

**Testing done on this change**:

- Extended the existing `TestGetAllDedupeReposCandidates` (`pkg/storage/storage_test.go`) with a case asserting a digest never written to the cache returns `(empty, nil)` rather than an error. Runs across the boltdb / redis / dynamodb local cache backends in the existing table.
- Verified the test **fails without the fix** (uncached digest → `ErrCacheMiss` → non-nil error) and **passes with it**.
- `go build ./pkg/storage/...`, `go vet ./pkg/storage/imagestore/`, and `gofmt` are clean.
- Observed against a live deployment (S3 + `dedupe:false`): before — an error line per blob with all-2xx/404 HTTP; after — the spurious logs are gone, push/mount behaviour unchanged.

**Automation added to e2e**:

No e2e change — this is a storage-layer concern covered by the unit test above. Happy to file an enhancement/testing issue if an e2e case is preferred.

**Will this break upgrades or downgrades?**

No. Pure error-handling change in a single storage method; no schema, API, or on-disk/format change.

**Does this PR introduce any user-facing change?**:

Yes — removes spurious `error`-level "unexpected error" / "cache miss" log lines emitted on every fresh blob during pushes and cross-repo mount checks.

```release-note
Fix spurious "unexpected error: cache miss" error logs emitted on every fresh blob during pushes and cross-repo mount checks (GetAllDedupeReposCandidates now treats a cache miss as "no candidates").
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
