### PR TITLE
feat(auth): fetch github teams for oidc groups claim and access control

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -387,6 +387,7 @@ zot can be configured to use the above providers with:
   }
 ```
 
+
 To login with either provider use http://127.0.0.1:8080/zot/auth/login?provider=\<provider\>&callback_ui=/home
 for example to login with github use http://127.0.0.1:8080/zot/auth/login?provider=github&callback_ui=/home
 
@@ -412,6 +413,28 @@ The callback url which should be used when making oauth2 provider setup is http:
 for example github callback url would be http://127.0.0.1:8080/zot/auth/callback/github
 
 If network policy doesn't allow inbound connections, this callback wont work!
+
+#### GitHub Teams in Access Control
+
+When authenticating with the GitHub provider, if you include the `read:org` scope, zot will fetch both the user's Organization memberships and their Team memberships.
+Team memberships are formatted as `<organization>/<team-slug>` and added to the user's groups. You can use these in your access control policies. For example, if a user belongs to the `Infra` team in the `MyOrg` organization, the group name will be `myorg/infra`.
+
+```json
+{
+  "accessControl": {
+    "repositories": {
+      "myorg/infrastructure/**": {
+        "policies": [
+          {
+            "groups": ["myorg/infra"],
+            "actions": ["read", "create", "update", "delete"]
+          }
+        ]
+      }
+    }
+  }
+}
+```
 
 dex is an identity service that uses OpenID Connect to drive authentication for other apps https://github.com/dexidp/dex
 To setup dex service see https://dexidp.io/docs/getting-started/

--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -1062,11 +1062,15 @@ func GetGithubUserInfo(ctx context.Context, client *github.Client, log log.Logge
 	}
 
 	teams, _, err := client.Teams.ListUserTeams(ctx, nil)
-	if err == nil {
-		for _, team := range teams {
-			if team.Organization != nil && team.Organization.Login != nil && team.Slug != nil {
-				groups = append(groups, fmt.Sprintf("%s/%s", *team.Organization.Login, *team.Slug))
-			}
+	if err != nil {
+		log.Error().Msg("failed to fetch user teams")
+
+		return "", []string{}, err
+	}
+
+	for _, team := range teams {
+		if team.Organization != nil && team.Organization.Login != nil && team.Slug != nil {
+			groups = append(groups, fmt.Sprintf("%s/%s", *team.Organization.Login, *team.Slug))
 		}
 	}
 

--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -1061,6 +1061,15 @@ func GetGithubUserInfo(ctx context.Context, client *github.Client, log log.Logge
 		groups = append(groups, *org.Login)
 	}
 
+	teams, _, err := client.Teams.ListUserTeams(ctx, nil)
+	if err == nil {
+		for _, team := range teams {
+			if team.Organization != nil && team.Organization.Login != nil && team.Slug != nil {
+				groups = append(groups, fmt.Sprintf("%s/%s", *team.Organization.Login, *team.Slug))
+			}
+		}
+	}
+
 	return primaryEmail, groups, nil
 }
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -13015,12 +13015,25 @@ func TestGetGithubUserInfo(t *testing.T) {
 					},
 				},
 			),
+			mock.WithRequestMatchHandler(
+				mock.EndpointPattern{
+					Pattern: "/user/teams",
+					Method:  "GET",
+				},
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.Write([]byte(`[{"slug": "infra", "organization": {"login": "myorg"}}]`))
+				}),
+			),
 		)
 
 		client := github.NewClient(mockedHTTPClient)
 
-		_, _, err := api.GetGithubUserInfo(context.Background(), client, log.NewTestLogger())
+		email, groups, err := api.GetGithubUserInfo(context.Background(), client, log.NewTestLogger())
 		So(err, ShouldBeNil)
+		So(email, ShouldEqual, "test@test")
+		So(groups, ShouldContain, "testOrg")
+		So(groups, ShouldContain, "myorg/infra")
 	})
 
 	Convey("github ListEmails error", t, func() {
@@ -13056,6 +13069,46 @@ func TestGetGithubUserInfo(t *testing.T) {
 			),
 			mock.WithRequestMatchHandler(
 				mock.GetUserOrgs,
+				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					mock.WriteError(
+						w,
+						http.StatusInternalServerError,
+						"github error",
+					)
+				}),
+			),
+		)
+
+		client := github.NewClient(mockedHTTPClient)
+
+		_, _, err := api.GetGithubUserInfo(context.Background(), client, log.NewTestLogger())
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("github ListUserTeams error", t, func() {
+		mockedHTTPClient := mock.NewMockedHTTPClient(
+			mock.WithRequestMatch(
+				mock.GetUserEmails,
+				[]github.UserEmail{
+					{
+						Email:   new("test@test"),
+						Primary: new(true),
+					},
+				},
+			),
+			mock.WithRequestMatch(
+				mock.GetUserOrgs,
+				[]github.Organization{
+					{
+						Login: new("testOrg"),
+					},
+				},
+			),
+			mock.WithRequestMatchHandler(
+				mock.EndpointPattern{
+					Pattern: "/user/teams",
+					Method:  "GET",
+				},
 				http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					mock.WriteError(
 						w,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

feature


**Which issue does this PR fix**:

Inability to grant permissions via assigned GitHub Teams.


**What does this PR do / Why do we need it**:

When authenticating with the GitHub provider, if you include the `read:org` scope, zot will fetch both the user's Organization memberships and their Team memberships.
Team memberships are formatted as `<organization>/<team-slug>` and added to the user's groups. You can use these in your access control policies alongside the organisation names. For example, if a user belongs to the `Infra` team in the `MyOrg` organization, the group name will be `myorg/infra`.

```json
{
  "accessControl": {
    "repositories": {
      "myorg/infrastructure/**": {
        "policies": [
          {
            "groups": ["myorg/infra"],
            "actions": ["read", "create", "update", "delete"]
          },
          {
            "groups": ["myorg"],
            "actions": ["read"]
          }
        ]
      }
    }
  }
}
```


**Testing done on this change**:

Unit testing added 

Manual testing done using my production zot instance to my github org.

Check access controls work for wildcard and specific repos

- myorg/infrastructure/**
- myorg/infrastructure/test-container

Checked group allocations
- added github user to Team - repos started showing, plus push, create delete allowed
- remove github user from Team - actions denied and repo in zot UI hidden

Checked Org group
- logged in with a github user in no Teams - read-only privilages given via Org group e.g `myorg`
```json
{
  "myorg/infrastructure/**": {
    "policies": [
      {
        "groups": ["myorg"],
         "actions": ["read"]
       }
     ]
}
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
When authenticating with the GitHub provider, if you include the `read:org` scope, zot will fetch both the user's Organization memberships and their Team memberships.
Team memberships are formatted as `<organization>/<team-slug>` and added to the user's groups. You can use these in your access control policies alongside the organisation names. For example, if a user belongs to the `Infra` team in the `MyOrg` organization, the group name will be `myorg/infra`.

```json
{
  "accessControl": {
    "repositories": {
      "myorg/infrastructure/**": {
        "policies": [
          {
            "groups": ["myorg/infra"],
            "actions": ["read", "create", "update", "delete"]
          },
          {
            "groups": ["myorg"],
            "actions": ["read"]
          }
        ]
      }
    }
  }
}
```

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
