### PR TITLE
feat: config: validate metrics config

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -212,4 +212,7 @@ var (
 	ErrCertificateWatcherAlreadyRunning = errors.New("certificate watcher is already running")
 	ErrInvalidEndSessionEndpoint        = errors.New("end_session_endpoint must be an absolute http(s) URL")
 	ErrPolicyConditionNotCompiled       = errors.New("policy condition not compiled")
+	ErrDisallowedMetricsPath            = errors.New("provided metrics path is disallowed")
+	ErrInvalidMetricsPathPrefix         = errors.New("metrics path must start with /")
+	ErrInvalidMetricsPath               = errors.New("invalid metrics path")
 )

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -536,6 +536,32 @@ func validateRemoteSessionStoreConfig(cfg *config.Config, logger zlog.Logger) er
 	return nil
 }
 
+func validateMetricsConfig(cfg *extconf.ExtensionConfig) error {
+	metricsCfg := cfg.GetMetricsPrometheusConfig()
+	if metricsCfg == nil {
+		return nil
+	}
+
+	cleanedPath := path.Clean(metricsCfg.Path)
+	// The path when cleaned should be exactly the same as in config
+	// to avoid invalid paths from being used for metrics.
+	if metricsCfg.Path != cleanedPath {
+		return zerr.ErrInvalidMetricsPath
+	}
+
+	if !strings.HasPrefix(metricsCfg.Path, "/") {
+		return zerr.ErrInvalidMetricsPathPrefix
+	}
+
+	disallowedMetricsPaths := []string{"/", "/v2"}
+
+	if slices.Contains(disallowedMetricsPaths, metricsCfg.Path) {
+		return zerr.ErrDisallowedMetricsPath
+	}
+
+	return nil
+}
+
 func validateExtensionsConfig(cfg *config.Config, logger zlog.Logger) error {
 	extensionsConfig := cfg.CopyExtensionsConfig()
 	if extensionsConfig != nil && extensionsConfig.Mgmt != nil {
@@ -545,6 +571,15 @@ func validateExtensionsConfig(cfg *config.Config, logger zlog.Logger) error {
 	if extensionsConfig != nil && extensionsConfig.APIKey != nil {
 		logger.Warn().Msg("apikey extension configuration will be ignored as API keys " +
 			"are now configurable in the HTTP settings.")
+	}
+
+	if extensionsConfig != nil {
+		if metricsValErr := validateMetricsConfig(extensionsConfig); metricsValErr != nil {
+			joinedErr := errors.Join(zerr.ErrBadConfig, metricsValErr)
+			logger.Error().Err(joinedErr).Msg("invalid metrics config")
+
+			return joinedErr
+		}
 	}
 
 	if extensionsConfig.IsUIEnabled() {

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -3446,3 +3446,216 @@ func TestBearerASMConfigValidation(t *testing.T) {
 		})
 	})
 }
+
+func TestMetricsConfigurationValidation(t *testing.T) {
+	Convey("Test metrics config", t, func() {
+		Convey("Allow no metrics config", func() {
+			content := `{
+				"storage": {"rootDirectory": "/tmp/zot"},
+				"http": {
+					"address": "127.0.0.1", "port": "8080"
+				},
+				"extensions": {}
+			}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Allow empty metrics config", func() {
+			content := `{
+				"storage": {"rootDirectory": "/tmp/zot"},
+				"http": {
+					"address": "127.0.0.1", "port": "8080"
+				},
+				"extensions": {
+					"metrics": {}
+				}
+			}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Allow only metrics enabled", func() {
+			content := `{
+				"storage": {"rootDirectory": "/tmp/zot"},
+				"http": {
+					"address": "127.0.0.1", "port": "8080"
+				},
+				"extensions": {
+					"metrics": {
+						"enable": true
+					}
+				}
+			}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldBeNil)
+		})
+	})
+
+	Convey("Test metrics path validation", t, func() {
+		Convey("Reject / as metrics path", func() {
+			content := `{
+				"storage": {"rootDirectory": "/tmp/zot"},
+				"http": {
+					"address": "127.0.0.1", "port": "8080"
+				},
+				"extensions": {
+					"metrics": {
+						"enable": true,
+						"prometheus": {
+							"path": "/"
+						}
+					}
+				}
+			}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldWrap, zerr.ErrBadConfig)
+			So(err, ShouldWrap, zerr.ErrDisallowedMetricsPath)
+		})
+
+		Convey("Reject /v2 as metrics path", func() {
+			content := `{
+				"storage": {"rootDirectory": "/tmp/zot"},
+				"http": {
+					"address": "127.0.0.1", "port": "8080"
+				},
+				"extensions": {
+					"metrics": {
+						"enable": true,
+						"prometheus": {
+							"path": "/v2"
+						}
+					}
+				}
+			}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldWrap, zerr.ErrBadConfig)
+			So(err, ShouldWrap, zerr.ErrDisallowedMetricsPath)
+		})
+
+		Convey("Reject /v2/ as metrics path", func() {
+			content := `{
+				"storage": {"rootDirectory": "/tmp/zot"},
+				"http": {
+					"address": "127.0.0.1", "port": "8080"
+				},
+				"extensions": {
+					"metrics": {
+						"enable": true,
+						"prometheus": {
+							"path": "/v2/"
+						}
+					}
+				}
+			}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldWrap, zerr.ErrBadConfig)
+			So(err, ShouldWrap, zerr.ErrInvalidMetricsPath)
+		})
+
+		Convey("Reject /abcd/.. as metrics path", func() {
+			content := `{
+				"storage": {"rootDirectory": "/tmp/zot"},
+				"http": {
+					"address": "127.0.0.1", "port": "8080"
+				},
+				"extensions": {
+					"metrics": {
+						"enable": true,
+						"prometheus": {
+							"path": "/abcd/.."
+						}
+					}
+				}
+			}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldWrap, zerr.ErrBadConfig)
+			So(err, ShouldWrap, zerr.ErrInvalidMetricsPath)
+		})
+
+		Convey("Reject abcd as metrics path", func() {
+			content := `{
+				"storage": {"rootDirectory": "/tmp/zot"},
+				"http": {
+					"address": "127.0.0.1", "port": "8080"
+				},
+				"extensions": {
+					"metrics": {
+						"enable": true,
+						"prometheus": {
+							"path": "abcd"
+						}
+					}
+				}
+			}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldWrap, zerr.ErrBadConfig)
+			So(err, ShouldWrap, zerr.ErrInvalidMetricsPathPrefix)
+		})
+
+		Convey("Reject blank metrics path", func() {
+			content := `{
+				"storage": {"rootDirectory": "/tmp/zot"},
+				"http": {
+					"address": "127.0.0.1", "port": "8080"
+				},
+				"extensions": {
+					"metrics": {
+						"enable": true,
+						"prometheus": {
+							"path": ""
+						}
+					}
+				}
+			}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldWrap, zerr.ErrBadConfig)
+			So(err, ShouldWrap, zerr.ErrInvalidMetricsPath)
+		})
+
+		Convey("Allow valid metrics path", func() {
+			content := `{
+				"storage": {"rootDirectory": "/tmp/zot"},
+				"http": {
+					"address": "127.0.0.1", "port": "8080"
+				},
+				"extensions": {
+					"metrics": {
+						"enable": true,
+						"prometheus": {
+							"path": "/abcd"
+						}
+					}
+				}
+			}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldBeNil)
+		})
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
No issue filed

**What does this PR do / Why do we need it**:
Adds validation for the metrics config to ensure it is:
- clean
- starts with a /
- is not one of 2 disallowed metrics paths.

**If an issue # is not available please add repro steps and logs showing the issue**:
N/A

**Testing done on this change**:
Config related validation has been tested via unit tests.

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades?**
N/A - this only affects invalid metrics path configurations.

**Does this PR introduce any user-facing change?**:
No, this is just an additional validation that shouldn't affect existing configs provided that they are valid.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
