### PR TITLE
fix(authz): metrics: deny authenticated users not in ACL even with anonymous read

### DIFF
--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -741,21 +741,6 @@ func MetricsAuthzHandler(ctlr *Controller) mux.MiddlewareFunc {
 				return
 			}
 
-			metricsConfig := accessControlConfig.GetMetrics()
-			if slices.Contains(metricsConfig.AnonymousPolicy, constants.ReadPermission) {
-				next.ServeHTTP(response, request)
-
-				return
-			}
-
-			if len(metricsConfig.Users) == 0 {
-				log := ctlr.Log
-				log.Warn().Msg("auth is enabled but no metrics users in accessControl: /metrics is unaccesible")
-				common.AuthzFail(response, request, "", realm, failDelay)
-
-				return
-			}
-
 			// get access control context made in authn.go
 			userAc, err := reqCtx.UserAcFromContext(request.Context())
 			if err != nil { // should never happen
@@ -764,11 +749,31 @@ func MetricsAuthzHandler(ctlr *Controller) mux.MiddlewareFunc {
 				return
 			}
 
-			username := userAc.GetUsername()
-			if !slices.Contains(metricsConfig.Users, username) {
-				common.AuthzFail(response, request, username, realm, failDelay)
+			metricsAccessConfig := accessControlConfig.GetMetrics()
 
-				return
+			username := userAc.GetUsername()
+			if username == "" {
+				// If anonymous read is not specified in access control, deny.
+				if !slices.Contains(metricsAccessConfig.AnonymousPolicy, constants.ReadPermission) {
+					common.AuthzFail(response, request, "", realm, failDelay)
+
+					return
+				}
+			} else {
+				if len(metricsAccessConfig.Users) == 0 {
+					log := ctlr.Log
+					log.Warn().Msg("auth is enabled and a metrics request with a user received " +
+						"but no metrics users configured in accessControl")
+					common.AuthzFail(response, request, "", realm, failDelay)
+
+					return
+				}
+
+				if !slices.Contains(metricsAccessConfig.Users, username) {
+					common.AuthzFail(response, request, username, realm, failDelay)
+
+					return
+				}
 			}
 
 			next.ServeHTTP(response, request) //nolint:contextcheck

--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -762,8 +762,8 @@ func MetricsAuthzHandler(ctlr *Controller) mux.MiddlewareFunc {
 				username := userAc.GetUsername()
 				if len(metricsAccessConfig.Users) == 0 {
 					log := ctlr.Log
-					log.Warn().Msg("auth is enabled and a metrics request with a user received " +
-						"but no metrics users configured in accessControl")
+					log.Warn().Msg("no users configured in metrics user list; " +
+						"metrics are not accessible to any authenticated user.")
 					common.AuthzFail(response, request, username, realm, failDelay)
 
 					return

--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -751,8 +751,7 @@ func MetricsAuthzHandler(ctlr *Controller) mux.MiddlewareFunc {
 
 			metricsAccessConfig := accessControlConfig.GetMetrics()
 
-			username := userAc.GetUsername()
-			if username == "" {
+			if userAc.IsAnonymous() {
 				// If anonymous read is not specified in access control, deny.
 				if !slices.Contains(metricsAccessConfig.AnonymousPolicy, constants.ReadPermission) {
 					common.AuthzFail(response, request, "", realm, failDelay)
@@ -760,11 +759,12 @@ func MetricsAuthzHandler(ctlr *Controller) mux.MiddlewareFunc {
 					return
 				}
 			} else {
+				username := userAc.GetUsername()
 				if len(metricsAccessConfig.Users) == 0 {
 					log := ctlr.Log
 					log.Warn().Msg("auth is enabled and a metrics request with a user received " +
 						"but no metrics users configured in accessControl")
-					common.AuthzFail(response, request, "", realm, failDelay)
+					common.AuthzFail(response, request, username, realm, failDelay)
 
 					return
 				}

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -280,14 +280,14 @@ func TestMetricsAuthorization(t *testing.T) {
 			resp, err := client.R().Get(baseURL + "/metrics")
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
-			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+			So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
 
 			// authenticated but not authorized user should not have access to/metrics
 			client.SetBasicAuth(metricsuser, metricspass)
 			resp, err = client.R().Get(baseURL + "/metrics")
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
-			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+			So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
 		})
 		Convey("with basic auth: metrics users in accessControl", func() {
 			conf.HTTP.AccessControl = &config.AccessControlConfig{
@@ -450,13 +450,23 @@ func TestMetricsAuthorization(t *testing.T) {
 			So(resp, ShouldNotBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
 
-			// valid credentials should not work as user is not in the users list
-			client := resty.New()
-			client.SetBasicAuth(metricsuser, metricspass)
-			resp, err = client.R().Get(baseURL + "/metrics")
+			// Scrape should not be allowed for the metrics user when allowed metrics users
+			// is not configured.
+			metricsUserClient := resty.New()
+			metricsUserClient.SetBasicAuth(metricsuser, metricspass)
+			resp, err = metricsUserClient.R().Get(baseURL + "/metrics")
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
-			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+			So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
+
+			// Scrape should not be allowed for a valid user when allowed metrics users
+			// is not configured.
+			normalUserClient := resty.New()
+			normalUserClient.SetBasicAuth(username, password)
+			resp, err = normalUserClient.R().Get(baseURL + "/metrics")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
 
 			// anonymous access to registry endpoints should remain protected
 			resp, err = resty.R().Get(baseURL + "/v2/")
@@ -490,13 +500,21 @@ func TestMetricsAuthorization(t *testing.T) {
 			So(resp, ShouldNotBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
 
-			// valid credentials should work as user is in the users list
-			client := resty.New()
-			client.SetBasicAuth(metricsuser, metricspass)
-			resp, err = client.R().Get(baseURL + "/metrics")
+			// scrape should be allowed for a valid user in the metrics users list
+			metricsUserClient := resty.New()
+			metricsUserClient.SetBasicAuth(metricsuser, metricspass)
+			resp, err = metricsUserClient.R().Get(baseURL + "/metrics")
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			// scrape should not be allowed for a valid user who is not in the metrics users list
+			normalUserClient := resty.New()
+			normalUserClient.SetBasicAuth(username, password)
+			resp, err = normalUserClient.R().Get(baseURL + "/metrics")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
 
 			// anonymous access to registry endpoints should remain protected
 			resp, err = resty.R().Get(baseURL + "/v2/")

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -450,7 +450,47 @@ func TestMetricsAuthorization(t *testing.T) {
 			So(resp, ShouldNotBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
 
-			// valid credentials should also work
+			// valid credentials should not work as user is not in the users list
+			client := resty.New()
+			client.SetBasicAuth(metricsuser, metricspass)
+			resp, err = client.R().Get(baseURL + "/metrics")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+
+			// anonymous access to registry endpoints should remain protected
+			resp, err = resty.R().Get(baseURL + "/v2/")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+		})
+		Convey("with basic auth: metrics.anonymousPolicy and users list, allow permitted user", func() {
+			conf.HTTP.AccessControl = &config.AccessControlConfig{
+				Metrics: config.Metrics{
+					Users:           []string{metricsuser},
+					AnonymousPolicy: []string{"read"},
+				},
+			}
+			ctlr := api.NewController(conf)
+			ctlr.Config.Storage.RootDirectory = t.TempDir()
+
+			cm := test.NewControllerManager(ctlr)
+			cm.StartAndWait(port)
+			defer cm.StopServer()
+
+			// unauthenticated client should be allowed to scrape /metrics
+			resp, err := resty.R().Get(baseURL + "/metrics")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			// wrong credentials should still be rejected at authn
+			resp, err = resty.R().SetBasicAuth("hacker", "wrongpass").Get(baseURL + "/metrics")
+			So(err, ShouldBeNil)
+			So(resp, ShouldNotBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+
+			// valid credentials should work as user is in the users list
 			client := resty.New()
 			client.SetBasicAuth(metricsuser, metricspass)
 			resp, err = client.R().Get(baseURL + "/metrics")

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -451,7 +451,7 @@ func TestMetricsAuthorization(t *testing.T) {
 			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
 
 			// Scrape should not be allowed for the metrics user when allowed metrics users
-			// is not configured.
+			// are not configured.
 			metricsUserClient := resty.New()
 			metricsUserClient.SetBasicAuth(metricsuser, metricspass)
 			resp, err = metricsUserClient.R().Get(baseURL + "/metrics")
@@ -460,7 +460,7 @@ func TestMetricsAuthorization(t *testing.T) {
 			So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
 
 			// Scrape should not be allowed for a valid user when allowed metrics users
-			// is not configured.
+			// are not configured.
 			normalUserClient := resty.New()
 			normalUserClient.SetBasicAuth(username, password)
 			resp, err = normalUserClient.R().Get(baseURL + "/metrics")


### PR DESCRIPTION
**What type of PR is this?**
bugfix

**Which issue does this PR fix**:
N/A not tracked by an issue.

**What does this PR do / Why do we need it**:
- Even when anonymous access is enabled for metrics, if a disallowed authenticated user makes a request, access should be denied.
- This PR also refactors the MetricsAuthzHandler to better fit this logic.

**If an issue # is not available please add repro steps and logs showing the issue**:
Reproducible in Unit tests.

**Testing done on this change**:
Tested in Unit tests.

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades?**
No change.

**Does this PR introduce any user-facing change?**:
Yes. When access control is configured, authenticated users not in the metrics allow list will receive 403 Forbidden when the metrics URL is accessed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
