### PR TITLE
feat(cli): add zli config set-default / clear-default commands

### DIFF
--- a/pkg/cli/client/config.go
+++ b/pkg/cli/client/config.go
@@ -28,7 +28,8 @@ const (
 
 // ZliConfigFile is the on-disk JSON shape for ~/.zot (zli CLI registry profiles).
 type ZliConfigFile struct {
-	Configs []ZliConfig `json:"configs"`
+	Configs       []ZliConfig `json:"configs"`
+	DefaultConfig string      `json:"defaultConfigName,omitempty"`
 }
 
 // ZliConfig is one named registry profile inside ZliConfigFile.Configs.
@@ -217,14 +218,34 @@ func (f *ZliConfigFile) RemoveEntry(configName string) error {
 	return zerr.ErrConfigNotFound
 }
 
-// FormatNames renders name and URL columns for `zli config list`.
+// SetDefault marks a named profile as the default; returns ErrConfigNotFound when absent.
+func (f *ZliConfigFile) SetDefault(name string) error {
+	if !f.HasEntry(name) {
+		return zerr.ErrConfigNotFound
+	}
+
+	f.DefaultConfig = name
+
+	return nil
+}
+
+// ClearDefault removes the default profile designation.
+func (f *ZliConfigFile) ClearDefault() {
+	f.DefaultConfig = ""
+}
+
+// FormatNames renders name and URL columns for `zli config list`, marking the default profile.
 func (f *ZliConfigFile) FormatNames() (string, error) {
 	var builder strings.Builder
 
 	writer := tabwriter.NewWriter(&builder, 0, 8, 1, '\t', tabwriter.AlignRight) //nolint:mnd
 
 	for _, c := range f.Configs {
-		fmt.Fprintf(writer, "%s\t%s\n", c.Name, c.URL)
+		if c.Name == f.DefaultConfig {
+			fmt.Fprintf(writer, "%s\t%s\t(default)\n", c.Name, c.URL)
+		} else {
+			fmt.Fprintf(writer, "%s\t%s\n", c.Name, c.URL)
+		}
 	}
 
 	if err := writer.Flush(); err != nil {

--- a/pkg/cli/client/config_cmd.go
+++ b/pkg/cli/client/config_cmd.go
@@ -55,6 +55,8 @@ func NewConfigCommand() *cobra.Command {
 	configCmd.AddCommand(NewConfigGetCommand())
 	configCmd.AddCommand(NewConfigSetCommand())
 	configCmd.AddCommand(NewConfigResetCommand())
+	configCmd.AddCommand(NewConfigSetDefaultCommand())
+	configCmd.AddCommand(NewConfigClearDefaultCommand())
 
 	// Build this from actual subcommands to avoid drift.
 	reserved := strings.Join(reservedProfileNames(configCmd), ", ")
@@ -324,6 +326,53 @@ func NewConfigResetCommand() *cobra.Command {
 	return resetCmd
 }
 
+func NewConfigSetDefaultCommand() *cobra.Command {
+	setDefaultCmd := &cobra.Command{
+		Use:          "set-default <name>",
+		Example:      "  zli config set-default main",
+		Short:        "Set the default configuration profile",
+		Long: "Mark a named profile as the default so that commands needing a registry URL\n" +
+			"use it automatically when --config is not specified.",
+		SilenceUsage: true,
+		Args:         exactArgsOrHelp(oneArg),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := zliUserConfigPath()
+			if err != nil {
+				return err
+			}
+
+			return setDefaultConfig(configPath, args[0])
+		},
+	}
+
+	setDefaultCmd.SetUsageTemplate(setDefaultCmd.UsageTemplate())
+
+	return setDefaultCmd
+}
+
+func NewConfigClearDefaultCommand() *cobra.Command {
+	clearDefaultCmd := &cobra.Command{
+		Use:          "clear-default",
+		Example:      "  zli config clear-default",
+		Short:        "Remove the default configuration profile designation",
+		Long:         "Clear the default profile so that commands always require an explicit --config flag.",
+		SilenceUsage: true,
+		Args:         cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			configPath, err := zliUserConfigPath()
+			if err != nil {
+				return err
+			}
+
+			return clearDefaultConfig(configPath)
+		},
+	}
+
+	clearDefaultCmd.SetUsageTemplate(clearDefaultCmd.UsageTemplate())
+
+	return clearDefaultCmd
+}
+
 func getConfigNames(configPath string) (string, error) {
 	cfg, err := ReadZliConfigFile(configPath)
 	if err != nil {
@@ -441,6 +490,38 @@ func setConfigValue(configPath, configName, key, value string) error {
 	return cfg.WriteFile(configPath)
 }
 
+func setDefaultConfig(configPath, name string) error {
+	cfg, err := ReadZliConfigFile(configPath)
+	if err != nil {
+		if isConfigUnavailable(err) {
+			return zerr.ErrConfigNotFound
+		}
+
+		return err
+	}
+
+	if err := cfg.SetDefault(name); err != nil {
+		return err
+	}
+
+	return cfg.WriteFile(configPath)
+}
+
+func clearDefaultConfig(configPath string) error {
+	cfg, err := ReadZliConfigFile(configPath)
+	if err != nil {
+		if isConfigUnavailable(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	cfg.ClearDefault()
+
+	return cfg.WriteFile(configPath)
+}
+
 func getAllConfig(configPath, configName string) (string, error) {
 	cfg, err := ReadZliConfigFile(configPath)
 	if err != nil {
@@ -466,7 +547,9 @@ const (
   zli config get main url
   zli config set main showspinner false
   zli config reset main showspinner
-  zli config remove main`
+  zli config remove main
+  zli config set-default main
+  zli config clear-default`
 
 	supportedOptions = `
 Useful variables:

--- a/pkg/cli/client/utils.go
+++ b/pkg/cli/client/utils.go
@@ -449,6 +449,10 @@ func GetCliConfigOptions(cmd *cobra.Command) (bool, bool, error) {
 	}
 
 	if configName == "" {
+		configName = readDefaultConfigName()
+	}
+
+	if configName == "" {
 		return false, false, nil
 	}
 
@@ -484,6 +488,10 @@ func GetServerURLFromFlags(cmd *cobra.Command) (string, error) {
 	}
 
 	if configName == "" {
+		configName = readDefaultConfigName()
+	}
+
+	if configName == "" {
 		return "", fmt.Errorf("%w: specify either '--%s' or '--%s' flags", zerr.ErrNoURLProvided, URLFlag, ConfigFlag)
 	}
 
@@ -497,6 +505,21 @@ func GetServerURLFromFlags(cmd *cobra.Command) (string, error) {
 	}
 
 	return serverURL, nil
+}
+
+// readDefaultConfigName returns the defaultConfigName field from ~/.zot, or "" when unset.
+func readDefaultConfigName() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	cfg, err := ReadZliConfigFile(filepath.Join(home, ".zot"))
+	if err != nil {
+		return ""
+	}
+
+	return cfg.DefaultConfig
 }
 
 func ReadServerURLFromConfig(configName string) (string, error) {


### PR DESCRIPTION
﻿## Problem

Users who work primarily against a single zot registry must pass `--config <name>` on every `zli` command. There is no way to designate one profile as the default so that commands "just work" without a flag.

Issue: #129

## Solution

Add a `defaultConfigName` field to the `~/.zot` JSON file and two new subcommands:

```
zli config set-default <name>   # mark a profile as default
zli config clear-default        # remove the default designation
```

When `--url` and `--config` are both absent, `GetServerURLFromFlags` and `GetCliConfigOptions` now fall back to the default profile automatically.

`zli config list` appends `(default)` to the designated profile so users can see which one is active at a glance.

## Changes

| File | What changed |
|------|-------------|
| `pkg/cli/client/config.go` | `ZliConfigFile` gets `DefaultConfig string` (`defaultConfigName` JSON key, omitempty). Added `SetDefault(name)` / `ClearDefault()` methods. `FormatNames()` marks the default entry. |
| `pkg/cli/client/config_cmd.go` | `NewConfigSetDefaultCommand()`, `NewConfigClearDefaultCommand()`, `setDefaultConfig()`, `clearDefaultConfig()` helpers. Commands registered in `NewConfigCommand()`. Examples updated. |
| `pkg/cli/client/utils.go` | `GetServerURLFromFlags` and `GetCliConfigOptions` call `readDefaultConfigName()` when `--config` is not given. New `readDefaultConfigName()` reads the `defaultConfigName` field from `~/.zot`. |

## Example

```
$ zli config add main https://zot.example.com:8080
$ zli config set-default main
$ zli config list
main    https://zot.example.com:8080    (default)

$ zli image list          # no --config needed
...
```

Signed-off-by: B R GOVIND <brgovind2005@gmail.com>
