### PR TITLE
feat: add Azure Blob Storage driver

### DIFF
--- a/.github/actions/setup-azurite/action.yaml
+++ b/.github/actions/setup-azurite/action.yaml
@@ -6,7 +6,7 @@ runs:
     - shell: bash
       run: |
         docker run -d --name azurite -p 10000:10000 \
-          mcr.microsoft.com/azure-storage/azurite \
+          mcr.microsoft.com/azure-storage/azurite:3.34.0@sha256:0a47e12e3693483cef5c71f35468b91d751611f172d2f97414e9c69113b106d9 \
           azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck
         echo "Waiting for azurite..."
         timeout 30s bash -c 'until curl -s -o /dev/null http://localhost:10000/devstoreaccount1; do sleep 1; done'

--- a/.github/actions/setup-azurite/action.yaml
+++ b/.github/actions/setup-azurite/action.yaml
@@ -7,6 +7,6 @@ runs:
       run: |
         docker run -d --name azurite -p 10000:10000 \
           ghcr.io/project-zot/ci-images/azurite:3.34.0 \
-          azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck
+          azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck --inMemoryPersistence --silent
         echo "Waiting for azurite..."
         timeout 30s bash -c 'until curl -s -o /dev/null http://localhost:10000/devstoreaccount1; do sleep 1; done'

--- a/.github/actions/setup-azurite/action.yaml
+++ b/.github/actions/setup-azurite/action.yaml
@@ -6,7 +6,7 @@ runs:
     - shell: bash
       run: |
         docker run -d --name azurite -p 10000:10000 \
-          mcr.microsoft.com/azure-storage/azurite:3.34.0@sha256:0a47e12e3693483cef5c71f35468b91d751611f172d2f97414e9c69113b106d9 \
+          ghcr.io/project-zot/ci-images/azurite:3.34.0 \
           azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck
         echo "Waiting for azurite..."
         timeout 30s bash -c 'until curl -s -o /dev/null http://localhost:10000/devstoreaccount1; do sleep 1; done'

--- a/.github/actions/setup-azurite/action.yaml
+++ b/.github/actions/setup-azurite/action.yaml
@@ -1,0 +1,12 @@
+name: 'Setup Azurite'
+description: 'Download & run the Azurite Azure Storage emulator for integration tests'
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        docker run -d --name azurite -p 10000:10000 \
+          mcr.microsoft.com/azure-storage/azurite \
+          azurite-blob --blobHost 0.0.0.0 --skipApiVersionCheck
+        echo "Waiting for azurite..."
+        timeout 30s bash -c 'until curl -s -o /dev/null http://localhost:10000/devstoreaccount1; do sleep 1; done'

--- a/.github/actions/teardown-azurite/action.yaml
+++ b/.github/actions/teardown-azurite/action.yaml
@@ -1,0 +1,9 @@
+name: 'Teardown Azurite'
+description: 'Stop and remove the Azurite emulator'
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        docker stop azurite || true
+        docker rm azurite || true

--- a/.github/actions/teardown-azurite/action.yaml
+++ b/.github/actions/teardown-azurite/action.yaml
@@ -4,6 +4,4 @@ runs:
   using: "composite"
   steps:
     - shell: bash
-      run: |
-        docker stop azurite || true
-        docker rm azurite || true
+      run: docker rm -f azurite || true

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -40,6 +40,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           go mod download
       - uses: ./.github/actions/setup-localstack
+      - uses: ./.github/actions/setup-azurite
       - name: run zot minimal tests
         run: |
           cd $GITHUB_WORKSPACE
@@ -49,51 +50,13 @@ jobs:
           DYNAMODBMOCK_ENDPOINT: http://localhost:4566
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
+          AZURITEMOCK_ENDPOINT: http://127.0.0.1:10000/devstoreaccount1
       - name: upload coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-minimal
           path: coverage-minimal.txt
       - uses: ./.github/actions/teardown-localstack
-  test-azure-storage:
-    name: Azure Blob storage driver tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Install go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
-        with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
-      - name: Cache go dependencies
-        id: cache-go-dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-mod-
-      - name: Install go dependencies
-        if: steps.cache-go-dependencies.outputs.cache-hit != 'true'
-        run: |
-          cd $GITHUB_WORKSPACE
-          go mod download
-      - uses: ./.github/actions/setup-azurite
-      - name: run azure storage driver tests
-        run: |
-          cd $GITHUB_WORKSPACE
-          go test -covermode=atomic -coverprofile=coverage-azure.txt ./pkg/storage/azure/...
-        env:
-          AZURITEMOCK_ENDPOINT: http://127.0.0.1:10000/devstoreaccount1
-      - name: upload coverage
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-azure
-          path: coverage-azure.txt
       - uses: ./.github/actions/teardown-azurite
   test-run-extensions:
     name: Run zot with extensions tests
@@ -122,6 +85,7 @@ jobs:
           cd $GITHUB_WORKSPACE
           go mod download
       - uses: ./.github/actions/setup-localstack
+      - uses: ./.github/actions/setup-azurite
       - name: run zot extended tests
         run: |
           cd $GITHUB_WORKSPACE
@@ -131,12 +95,14 @@ jobs:
           DYNAMODBMOCK_ENDPOINT: http://localhost:4566
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
+          AZURITEMOCK_ENDPOINT: http://127.0.0.1:10000/devstoreaccount1
       - name: upload coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-extended
           path: coverage-extended.txt
       - uses: ./.github/actions/teardown-localstack
+      - uses: ./.github/actions/teardown-azurite
   test-run-devmode:
     name: Running development-mode tests on Linux
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,6 +55,46 @@ jobs:
           name: coverage-minimal
           path: coverage-minimal.txt
       - uses: ./.github/actions/teardown-localstack
+  test-azure-storage:
+    name: Azure Blob storage driver tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Install go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Cache go dependencies
+        id: cache-go-dependencies
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Install go dependencies
+        if: steps.cache-go-dependencies.outputs.cache-hit != 'true'
+        run: |
+          cd $GITHUB_WORKSPACE
+          go mod download
+      - uses: ./.github/actions/setup-azurite
+      - name: run azure storage driver tests
+        run: |
+          cd $GITHUB_WORKSPACE
+          go test -covermode=atomic -coverprofile=coverage-azure.txt ./pkg/storage/azure/...
+        env:
+          AZURITEMOCK_ENDPOINT: http://127.0.0.1:10000/devstoreaccount1
+      - name: upload coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-azure
+          path: coverage-azure.txt
+      - uses: ./.github/actions/teardown-azurite
   test-run-extensions:
     name: Run zot with extensions tests
     runs-on: cncf-ubuntu-16-64-x86

--- a/examples/README.md
+++ b/examples/README.md
@@ -1089,13 +1089,21 @@ zot also supports different storage drivers for each subpath.
 
 zot supports an Azure Blob Storage backend. For a full example see [azure config](config-azure.json).
 
-The driver requires `accountname` and `container`, and selects credentials via
+The driver requires `accountname` and `container`, and selects how to authenticate via
 `storageDriver.credentials.type`:
 
-- `shared_key` — storage account key (set `accountkey`)
-- `client_secret` — service principal (set `tenantid`, `clientid`, `secret`)
-- `default_credentials` — `DefaultAzureCredential` (managed identity / Azure Workload
-  Identity); no secrets stored in config
+- `shared_key` — authenticate with a storage account key; set `accountkey`.
+- `client_secret` — authenticate as an Entra (Azure AD) service principal; set `tenantid`,
+  `clientid`, and `secret`.
+- `default_credentials` — use the Azure SDK's `DefaultAzureCredential` chain, so **no secret
+  is stored in the zot config**. It resolves a credential in order: Azure Workload Identity
+  (federated token), Managed Identity, the `AZURE_*` environment variables, then Azure CLI
+  login. This is the recommended option when zot runs on AKS or a self-managed cluster with
+  the [Azure Workload Identity](https://azure.github.io/azure-workload-identity/) webhook —
+  zot's pod receives a federated token and needs no stored credentials.
+
+The example uses `default_credentials` (Workload Identity). For a non-federated setup, use
+`shared_key` with `accountkey`, or `client_secret` with a service principal.
 
 Example (Workload Identity, secret-less):
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1102,8 +1102,16 @@ The driver requires `accountname` and `container`, and selects how to authentica
   the [Azure Workload Identity](https://azure.github.io/azure-workload-identity/) webhook —
   zot's pod receives a federated token and needs no stored credentials.
 
-The example uses `default_credentials` (Workload Identity). For a non-federated setup, use
-`shared_key` with `accountkey`, or `client_secret` with a service principal.
+The example uses `default_credentials` (Workload Identity). `DefaultAzureCredential` works
+wherever an ambient Azure identity is available — **not only on Azure**: any Kubernetes
+cluster running the [azure-workload-identity](https://azure.github.io/azure-workload-identity/)
+webhook can federate a managed identity to zot's ServiceAccount (the cluster's OIDC issuer
+trusted by Entra), including **self-managed / non-Azure clusters**, and zot gets a token via
+the WorkloadIdentityCredential — no secrets stored. For a plain standalone process with no
+managed/federated identity, `default_credentials` falls back to the `AZURE_TENANT_ID` /
+`AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` (or `AZURE_CLIENT_CERTIFICATE_PATH`) environment
+variables or an `az login` session; otherwise use `shared_key` (with `accountkey`) or
+`client_secret` (with a service principal).
 
 Example (Workload Identity, secret-less):
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1085,6 +1085,34 @@ For an s3 zot configuration with multiple storage drivers see: [s3-config](confi
 
 zot also supports different storage drivers for each subpath.
 
+### Azure Blob Storage
+
+zot supports an Azure Blob Storage backend. For a full example see [azure config](config-azure.json).
+
+The driver requires `accountname` and `container`, and selects credentials via
+`storageDriver.credentials.type`:
+
+- `shared_key` — storage account key (set `accountkey`)
+- `client_secret` — service principal (set `tenantid`, `clientid`, `secret`)
+- `default_credentials` — `DefaultAzureCredential` (managed identity / Azure Workload
+  Identity); no secrets stored in config
+
+Example (Workload Identity, secret-less):
+
+```
+    "storage": {
+        "rootDirectory": "/tmp/zot",  # local path used to store dedupe cache database
+        "dedupe": false,
+        "storageDriver": {
+            "name": "azure",
+            "rootdirectory": "/zot",  # prefix applied to all blob names
+            "accountname": "myazurestorageaccount",
+            "container": "zot-storage",
+            "credentials": { "type": "default_credentials" }
+        }
+    }
+```
+
 ### S3 permissions scopes
 
 The following AWS policy is required by zot for push and pull. Make sure to replace S3_BUCKET_NAME with the name of your bucket.

--- a/examples/config-azure.json
+++ b/examples/config-azure.json
@@ -1,0 +1,22 @@
+{
+  "storage": {
+    "rootDirectory": "/tmp/zot",
+    "dedupe": false,
+    "storageDriver": {
+      "name": "azure",
+      "rootdirectory": "/zot",
+      "accountname": "myazurestorageaccount",
+      "container": "zot-storage",
+      "credentials": {
+        "type": "default_credentials"
+      }
+    }
+  },
+  "http": {
+    "address": "127.0.0.1",
+    "port": "8080"
+  },
+  "log": {
+    "level": "debug"
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -108,6 +108,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.29 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	github.com/99designs/gqlgen v0.17.90
+	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4
 	github.com/GehirnInc/crypt v0.0.0-20230320061759-8cc1b52080c5
 	github.com/Masterminds/semver v1.5.0
 	github.com/alicebob/miniredis/v2 v2.38.0
@@ -108,7 +109,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 // indirect
-	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest v0.11.29 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,10 +54,14 @@ github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3 h1:l
 github.com/Azure/azure-sdk-for-go/sdk/containers/azcontainerregistry v0.2.3/go.mod h1:MAm7bk0oDLmD8yIkvfbxPW04fxzphPyL+7GzwHxOp6Y=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0 h1:fhqpLE3UEXi9lPaBRpQ6XuRW0nU7hgg4zlmZZa+a9q4=
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.12.0/go.mod h1:7dCRMLwisfRH3dBupKeNCioWYUZ4SS09Z14H+7i8ZoY=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1 h1:/Zt+cDPnpC3OVDm/JKLOs7M2DKmLRIIp3XIx9pHHiig=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.8.1/go.mod h1:Ng3urmn6dYe8gnbCMoHHVl5APYz2txho3koEkV2o2HA=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0 h1:E4MgwLBGeVB5f2MdcIVD3ELVAWpr+WD6MUe1i+tM/PA=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0/go.mod h1:Y2b/1clN4zsAoUd/pgNAQHjLDnTis/6ROkUfyob6psM=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0 h1:nCYfgcSyHZXJI8J0IWE5MsCGlb2xp9fJiXyxWgmOFg4=
 github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4 h1:jWQK1GI+LeGGUKBADtcH2rRqPxYB1Ljwms5gFA2LqrM=
+github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.4/go.mod h1:8mwH4klAm9DUgR2EEHyEEAQlRDvLPyg5fQry3y+cDew=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -629,9 +629,10 @@ func validateStorageConfigSection(
 	}
 
 	if len(storageConfig.StorageDriver) != 0 {
-		// enforce s3/gcs driver in case of using storage driver
+		// enforce s3/gcs/azure driver in case of using storage driver
 		if storageConfig.StorageDriver["name"] != storageConstants.S3StorageDriverName &&
-			storageConfig.StorageDriver["name"] != storageConstants.GCSStorageDriverName {
+			storageConfig.StorageDriver["name"] != storageConstants.GCSStorageDriverName &&
+			storageConfig.StorageDriver["name"] != storageConstants.AzureStorageDriverName {
 			msg := "unsupported storage driver"
 			logger.Error().Err(zerr.ErrBadConfig).Interface("storageDriver", storageConfig.StorageDriver["name"]).Msg(msg)
 
@@ -664,7 +665,8 @@ func validateStorageConfigSection(
 
 			if len(subStorageConfig.StorageDriver) != 0 {
 				if subStorageConfig.StorageDriver["name"] != storageConstants.S3StorageDriverName &&
-					subStorageConfig.StorageDriver["name"] != storageConstants.GCSStorageDriverName {
+					subStorageConfig.StorageDriver["name"] != storageConstants.GCSStorageDriverName &&
+					subStorageConfig.StorageDriver["name"] != storageConstants.AzureStorageDriverName {
 					msg := "unsupported storage driver"
 					logger.Error().Err(zerr.ErrBadConfig).Str("subpath", route).Interface("storageDriver",
 						subStorageConfig.StorageDriver["name"]).Msg(msg)

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -621,7 +621,7 @@ func validateStorageConfigSection(
 	// Redirect mode requires a backend capable of issuing external signed URLs.
 	// With local storage there is no target URL to redirect clients to.
 	if storageConfig.RedirectBlobURL && len(storageConfig.StorageDriver) == 0 {
-		msg := "invalid storage config, redirectBlobURL is supported only for s3/gcs storage"
+		msg := "invalid storage config, redirectBlobURL is supported only for s3/gcs/azure storage"
 		logger.Error().Err(zerr.ErrBadConfig).Bool("redirectBlobURL", storageConfig.RedirectBlobURL).
 			Str("storageDriver", storageConstants.LocalStorageDriverName).Msg(msg)
 
@@ -655,7 +655,7 @@ func validateStorageConfigSection(
 			// Apply the same redirect precondition per subpath because subpaths can
 			// override driver config independently from the default store.
 			if subStorageConfig.RedirectBlobURL && len(subStorageConfig.StorageDriver) == 0 {
-				msg := "invalid storage config, redirectBlobURL is supported only for s3/gcs storage"
+				msg := "invalid storage config, redirectBlobURL is supported only for s3/gcs/azure storage"
 				logger.Error().Err(zerr.ErrBadConfig).Str("subpath", route).
 					Bool("redirectBlobURL", subStorageConfig.RedirectBlobURL).
 					Str("storageDriver", storageConstants.LocalStorageDriverName).Msg(msg)

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -1582,7 +1582,7 @@ storage:
 		err := cli.LoadConfiguration(cfg, tmpfile)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring,
-			"invalid storage config, redirectBlobURL is supported only for s3/gcs storage")
+			"invalid storage config, redirectBlobURL is supported only for s3/gcs/azure storage")
 	})
 
 	Convey("Test redirectBlobURL error for empty storageDriver map", t, func(c C) {
@@ -1598,7 +1598,7 @@ storage:
 		err := cli.LoadConfiguration(cfg, tmpfile)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring,
-			"invalid storage config, redirectBlobURL is supported only for s3/gcs storage")
+			"invalid storage config, redirectBlobURL is supported only for s3/gcs/azure storage")
 	})
 
 	Convey("Test redirectBlobURL error for subpath local storage", t, func(c C) {
@@ -1613,7 +1613,7 @@ storage:
 		err := cli.LoadConfiguration(cfg, tmpfile)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring,
-			"invalid storage config, redirectBlobURL is supported only for s3/gcs storage")
+			"invalid storage config, redirectBlobURL is supported only for s3/gcs/azure storage")
 	})
 
 	Convey("Test redirectBlobURL error for subpath empty storageDriver map", t, func(c C) {
@@ -1628,7 +1628,7 @@ storage:
 		err := cli.LoadConfiguration(cfg, tmpfile)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldContainSubstring,
-			"invalid storage config, redirectBlobURL is supported only for s3/gcs storage")
+			"invalid storage config, redirectBlobURL is supported only for s3/gcs/azure storage")
 	})
 
 	Convey("Test verify w/ authorization and w/o authentication", t, func(c C) {

--- a/pkg/storage/azure/azure.go
+++ b/pkg/storage/azure/azure.go
@@ -1,0 +1,38 @@
+package azure
+
+import (
+	// Add azure support.
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	// Load azure driver.
+	_ "github.com/distribution/distribution/v3/registry/storage/driver/azure"
+
+	"zotregistry.dev/zot/v2/pkg/compat"
+	"zotregistry.dev/zot/v2/pkg/extensions/events"
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	zlog "zotregistry.dev/zot/v2/pkg/log"
+	common "zotregistry.dev/zot/v2/pkg/storage/common"
+	"zotregistry.dev/zot/v2/pkg/storage/imagestore"
+	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
+)
+
+// NewImageStore returns a new image store backed by Azure Blob Storage.
+// see https://github.com/distribution/distribution/tree/main/registry/storage/driver/azure
+// Use the last argument to properly set a cache database, or it will default to boltDB local storage.
+func NewImageStore(rootDir string, cacheDir string, dedupe, commit bool, log zlog.Logger,
+	metrics monitoring.MetricServer, linter common.Lint, store driver.StorageDriver,
+	cacheDriver storageTypes.Cache, compat []compat.MediaCompatibility, recorder events.Recorder,
+) storageTypes.ImageStore {
+	return imagestore.NewImageStore(
+		rootDir,
+		cacheDir,
+		dedupe,
+		commit,
+		log,
+		metrics,
+		linter,
+		New(store),
+		cacheDriver,
+		compat,
+		recorder,
+	)
+}

--- a/pkg/storage/azure/azure_test.go
+++ b/pkg/storage/azure/azure_test.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
-	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/azure"
+	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
 	. "github.com/smartystreets/goconvey/convey"
 
 	"zotregistry.dev/zot/v2/pkg/storage/azure"
@@ -97,8 +97,9 @@ func TestAzureDriverIntegration(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// Source is gone: must surface as PathNotFoundError (our error mapping).
-			_, err = driver.ReadFile(src)
 			var pathErr storagedriver.PathNotFoundError
+
+			_, err = driver.ReadFile(src)
 			So(errors.As(err, &pathErr), ShouldBeTrue)
 
 			err = driver.Delete(dst)

--- a/pkg/storage/azure/azure_test.go
+++ b/pkg/storage/azure/azure_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
-	_ "github.com/distribution/distribution/v3/registry/storage/driver/azure"
 	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
 	. "github.com/smartystreets/goconvey/convey"
 

--- a/pkg/storage/azure/azure_test.go
+++ b/pkg/storage/azure/azure_test.go
@@ -1,0 +1,112 @@
+package azure_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/distribution/distribution/v3/registry/storage/driver/factory"
+	_ "github.com/distribution/distribution/v3/registry/storage/driver/azure"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/storage/azure"
+)
+
+// Well-known Azurite development account (https://github.com/Azure/Azurite).
+//
+//nolint:gochecknoglobals,gosec // fixed public dev credentials, not a secret
+const (
+	azuriteAccount   = "devstoreaccount1"
+	azuriteAccessKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+	azureContainer   = "zot-azure-it"
+)
+
+// TestAzureDriverIntegration exercises the Azure storage driver end-to-end against an
+// Azurite emulator. It is skipped unless AZURITEMOCK_ENDPOINT is set (e.g.
+// http://127.0.0.1:10000/devstoreaccount1), mirroring the S3 (S3MOCK_ENDPOINT) and
+// GCS (GCSMOCK_ENDPOINT) integration tests.
+func TestAzureDriverIntegration(t *testing.T) {
+	endpoint := os.Getenv("AZURITEMOCK_ENDPOINT")
+	if endpoint == "" {
+		t.Skip("AZURITEMOCK_ENDPOINT not set; skipping Azure Blob integration test")
+	}
+
+	ctx := context.Background()
+
+	// Ensure the container exists in Azurite.
+	connStr := fmt.Sprintf(
+		"DefaultEndpointsProtocol=http;AccountName=%s;AccountKey=%s;BlobEndpoint=%s;",
+		azuriteAccount, azuriteAccessKey, endpoint)
+
+	client, err := azblob.NewClientFromConnectionString(connStr, nil)
+	if err != nil {
+		t.Fatalf("azurite client: %v", err)
+	}
+
+	if _, err := client.CreateContainer(ctx, azureContainer, nil); err != nil &&
+		!strings.Contains(err.Error(), "ContainerAlreadyExists") {
+		t.Fatalf("create container: %v", err)
+	}
+
+	params := map[string]any{
+		"name":        "azure",
+		"container":   azureContainer,
+		"accountname": azuriteAccount,
+		"accountkey":  azuriteAccessKey,
+		"serviceurl":  endpoint,
+		"credentials": map[string]any{"type": "shared_key"},
+	}
+
+	store, err := factory.Create(ctx, "azure", params)
+	if err != nil {
+		t.Fatalf("create azure driver: %v", err)
+	}
+
+	driver := azure.New(store)
+
+	Convey("Azure Blob round-trip through the zot wrapper", t, func() {
+		So(driver.Name(), ShouldEqual, "azure")
+
+		Convey("Write/Read/Stat/List/Move/Delete", func() {
+			src := "/repo/blob"
+			dst := "/repo/blob2"
+			payload := []byte("hello azure blob")
+
+			n, err := driver.WriteFile(src, payload)
+			So(err, ShouldBeNil)
+			So(n, ShouldEqual, len(payload))
+
+			content, err := driver.ReadFile(src)
+			So(err, ShouldBeNil)
+			So(string(content), ShouldEqual, string(payload))
+
+			fi, err := driver.Stat(src)
+			So(err, ShouldBeNil)
+			So(fi.Size(), ShouldEqual, int64(len(payload)))
+
+			list, err := driver.List("/repo")
+			So(err, ShouldBeNil)
+			So(list, ShouldContain, src)
+
+			err = driver.Move(src, dst)
+			So(err, ShouldBeNil)
+
+			// Source is gone: must surface as PathNotFoundError (our error mapping).
+			_, err = driver.ReadFile(src)
+			var pathErr storagedriver.PathNotFoundError
+			So(errors.As(err, &pathErr), ShouldBeTrue)
+
+			err = driver.Delete(dst)
+			So(err, ShouldBeNil)
+
+			// Deleting a missing path is idempotent (no error).
+			err = driver.Delete(dst)
+			So(err, ShouldBeNil)
+		})
+	})
+}

--- a/pkg/storage/azure/driver.go
+++ b/pkg/storage/azure/driver.go
@@ -7,9 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	// Add azure support.
 	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
-	_ "github.com/distribution/distribution/v3/registry/storage/driver/azure"
 
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
 )

--- a/pkg/storage/azure/driver.go
+++ b/pkg/storage/azure/driver.go
@@ -156,8 +156,12 @@ func (driver *Driver) SameFile(path1, path2 string) bool {
 	fi2, _ := driver.store.Stat(context.Background(), path2)
 
 	if fi1 != nil && fi2 != nil {
+		// Compare modification times with Equal, not ==: time.Time values parsed from
+		// Azure's LastModified header carry differing monotonic/location data, so == reports
+		// two stats of the same blob as unequal. That would make dedupe Link a blob onto
+		// itself and overwrite it with an empty placeholder.
 		if fi1.IsDir() == fi2.IsDir() &&
-			fi1.ModTime() == fi2.ModTime() &&
+			fi1.ModTime().Equal(fi2.ModTime()) &&
 			fi1.Path() == fi2.Path() &&
 			fi1.Size() == fi2.Size() {
 			return true

--- a/pkg/storage/azure/driver.go
+++ b/pkg/storage/azure/driver.go
@@ -1,0 +1,239 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+
+	// Add azure support.
+	storagedriver "github.com/distribution/distribution/v3/registry/storage/driver"
+	_ "github.com/distribution/distribution/v3/registry/storage/driver/azure"
+
+	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
+)
+
+type Driver struct {
+	store storagedriver.StorageDriver
+}
+
+func New(storeDriver storagedriver.StorageDriver) *Driver {
+	return &Driver{store: storeDriver}
+}
+
+func (driver *Driver) Name() string {
+	return storageConstants.AzureStorageDriverName
+}
+
+func (driver *Driver) EnsureDir(path string) error {
+	return nil
+}
+
+func (driver *Driver) DirExists(path string) bool {
+	if fi, err := driver.Stat(path); err == nil && fi.IsDir() {
+		return true
+	}
+
+	return false
+}
+
+func (driver *Driver) Reader(path string, offset int64) (io.ReadCloser, error) {
+	reader, err := driver.store.Reader(context.Background(), path, offset)
+	if err != nil {
+		return nil, driver.formatErr(err, path)
+	}
+
+	return reader, nil
+}
+
+func (driver *Driver) ReadFile(path string) ([]byte, error) {
+	content, err := driver.store.GetContent(context.Background(), path)
+	if err != nil {
+		return nil, driver.formatErr(err, path)
+	}
+
+	return content, nil
+}
+
+func (driver *Driver) Delete(path string) error {
+	err := driver.store.Delete(context.Background(), path)
+	if err == nil {
+		return nil
+	}
+
+	// Format the error first to convert Azure-specific 404 errors to PathNotFoundError.
+	formattedErr := driver.formatErr(err, path)
+
+	// Check if the formatted error is PathNotFoundError.
+	var pathNotFoundErr storagedriver.PathNotFoundError
+	if errors.As(formattedErr, &pathNotFoundErr) {
+		// In Azure Blob, directories are just blob-name prefixes, so once all blobs under a
+		// prefix are gone the "directory" no longer exists. Treat deleting a missing path as a
+		// no-op so Delete is idempotent (mirrors the gcs driver behavior).
+		return nil
+	}
+
+	return formattedErr
+}
+
+func (driver *Driver) Stat(path string) (storagedriver.FileInfo, error) {
+	fileInfo, err := driver.store.Stat(context.Background(), path)
+	if err != nil {
+		return nil, driver.formatErr(err, path)
+	}
+
+	return fileInfo, nil
+}
+
+func (driver *Driver) Writer(filepath string, append bool) (storagedriver.FileWriter, error) { //nolint:predeclared
+	writer, err := driver.store.Writer(context.Background(), filepath, append)
+	if err != nil {
+		return nil, driver.formatErr(err, filepath)
+	}
+
+	return writer, nil
+}
+
+func (driver *Driver) WriteFile(filepath string, content []byte) (int, error) {
+	var n int
+
+	stwr, err := driver.store.Writer(context.Background(), filepath, false)
+	if err != nil {
+		return -1, driver.formatErr(err, filepath)
+	}
+	defer stwr.Close()
+
+	if n, err = stwr.Write(content); err != nil {
+		return -1, driver.formatErr(err, filepath)
+	}
+
+	if err := stwr.Commit(context.Background()); err != nil {
+		return -1, driver.formatErr(err, filepath)
+	}
+
+	return n, nil
+}
+
+func (driver *Driver) Walk(path string, f storagedriver.WalkFn) error {
+	err := driver.store.Walk(context.Background(), path, f)
+	// io.EOF is used by callers (e.g. GetNextRepository) as a stop signal, not an error, so return directly.
+	if isEOF(err) {
+		return io.EOF
+	}
+
+	return driver.formatErr(err, path)
+}
+
+// isEOF checks whether err is directly io.EOF or if io.EOF is wrapped into storagedriver.Error.Detail.
+func isEOF(err error) bool {
+	if errors.Is(err, io.EOF) {
+		return true
+	}
+
+	var storageErr storagedriver.Error
+	if errors.As(err, &storageErr) {
+		return errors.Is(storageErr.Detail, io.EOF)
+	}
+
+	return false
+}
+
+func (driver *Driver) List(fullpath string) ([]string, error) {
+	list, err := driver.store.List(context.Background(), fullpath)
+	if err != nil {
+		return nil, driver.formatErr(err, fullpath)
+	}
+
+	return list, nil
+}
+
+func (driver *Driver) Move(sourcePath string, destPath string) error {
+	return driver.formatErr(driver.store.Move(context.Background(), sourcePath, destPath), sourcePath)
+}
+
+func (driver *Driver) SameFile(path1, path2 string) bool {
+	fi1, _ := driver.store.Stat(context.Background(), path1)
+
+	fi2, _ := driver.store.Stat(context.Background(), path2)
+
+	if fi1 != nil && fi2 != nil {
+		if fi1.IsDir() == fi2.IsDir() &&
+			fi1.ModTime() == fi2.ModTime() &&
+			fi1.Path() == fi2.Path() &&
+			fi1.Size() == fi2.Size() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Link puts an empty file that will act like a link between the original file and deduped one.
+// Because Azure Blob doesn't support symlinks, wherever the storage encounters an empty file it
+// will get the original one from cache.
+func (driver *Driver) Link(src, dest string) error {
+	return driver.formatErr(driver.store.PutContent(context.Background(), dest, []byte{}), dest)
+}
+
+func (driver *Driver) RedirectURL(r *http.Request, path string) (string, error) {
+	redirectURL, err := driver.store.RedirectURL(r, path)
+
+	return redirectURL, driver.formatErr(err, path)
+}
+
+// formatErr converts Azure-specific not-found errors to PathNotFoundError. The upstream azure
+// driver usually returns PathNotFoundError already (handled by the first cases); the default case
+// is a defensive fallback that maps Azure blob "not found" responses to PathNotFoundError.
+func (driver *Driver) formatErr(err error, path string) error {
+	switch actual := err.(type) { //nolint: errorlint
+	case nil:
+		return nil
+	case storagedriver.PathNotFoundError:
+		actual.DriverName = driver.Name()
+		if actual.Path == "" && path != "" {
+			actual.Path = path
+		}
+
+		return actual
+	case storagedriver.InvalidPathError:
+		actual.DriverName = driver.Name()
+
+		return actual
+	case storagedriver.InvalidOffsetError:
+		actual.DriverName = driver.Name()
+
+		return actual
+	default:
+		// Check for Azure-specific not-found errors by unwrapping the error chain.
+		errToCheck := err
+		for errToCheck != nil {
+			errStr := errToCheck.Error()
+			isNotFound := strings.Contains(errStr, "BlobNotFound") ||
+				strings.Contains(errStr, "ResourceNotFound") ||
+				strings.Contains(errStr, "Error 404") ||
+				strings.Contains(errStr, "404 The specified blob does not exist") ||
+				strings.Contains(errStr, "does not exist")
+
+			if isNotFound {
+				return storagedriver.PathNotFoundError{
+					DriverName: driver.Name(),
+					Path:       path,
+				}
+			}
+
+			if unwrappable, ok := errToCheck.(interface{ Unwrap() error }); ok {
+				errToCheck = unwrappable.Unwrap()
+			} else {
+				break
+			}
+		}
+
+		storageError := storagedriver.Error{
+			DriverName: driver.Name(),
+			Detail:     err,
+		}
+
+		return storageError
+	}
+}

--- a/pkg/storage/azure/driver_test.go
+++ b/pkg/storage/azure/driver_test.go
@@ -1,0 +1,431 @@
+package azure_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/distribution/distribution/v3/registry/storage/driver"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	zlog "zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/storage/azure"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+var errTest = errors.New("error")
+
+type fileInfoMock struct {
+	isDir   bool
+	size    int64
+	modTime time.Time
+	path    string
+}
+
+func (f *fileInfoMock) Path() string       { return f.path }
+func (f *fileInfoMock) Size() int64        { return f.size }
+func (f *fileInfoMock) ModTime() time.Time { return f.modTime }
+func (f *fileInfoMock) IsDir() bool        { return f.isDir }
+
+func TestDriver(t *testing.T) {
+	Convey("Azure Driver", t, func() {
+		storeMock := &mocks.StorageDriverMock{}
+		azureDriver := azure.New(storeMock)
+
+		Convey("Name", func() {
+			So(azureDriver.Name(), ShouldEqual, "azure")
+		})
+
+		Convey("EnsureDir", func() {
+			err := azureDriver.EnsureDir("/test")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("DirExists", func() {
+			Convey("True", func() {
+				storeMock.StatFn = func(ctx context.Context, path string) (driver.FileInfo, error) {
+					return &mocks.FileInfoMock{
+						IsDirFn: func() bool { return true },
+					}, nil
+				}
+				So(azureDriver.DirExists("/test"), ShouldBeTrue)
+			})
+
+			Convey("False - Not a dir", func() {
+				storeMock.StatFn = func(ctx context.Context, path string) (driver.FileInfo, error) {
+					return &mocks.FileInfoMock{
+						IsDirFn: func() bool { return false },
+					}, nil
+				}
+				So(azureDriver.DirExists("/test"), ShouldBeFalse)
+			})
+
+			Convey("False - Error", func() {
+				storeMock.StatFn = func(ctx context.Context, path string) (driver.FileInfo, error) {
+					return nil, errTest
+				}
+				So(azureDriver.DirExists("/test"), ShouldBeFalse)
+			})
+		})
+
+		Convey("Reader", func() {
+			Convey("Success", func() {
+				storeMock.ReaderFn = func(ctx context.Context, path string, offset int64) (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader("")), nil
+				}
+				r, err := azureDriver.Reader("/test", 0)
+				So(err, ShouldBeNil)
+				So(r, ShouldNotBeNil)
+			})
+
+			Convey("InvalidOffsetError", func() {
+				storeMock.ReaderFn = func(ctx context.Context, path string, offset int64) (io.ReadCloser, error) {
+					return nil, driver.InvalidOffsetError{Path: path, Offset: offset}
+				}
+				_, err := azureDriver.Reader("/test", 100)
+				So(err, ShouldNotBeNil)
+
+				var invalidOffset driver.InvalidOffsetError
+				So(errors.As(err, &invalidOffset), ShouldBeTrue)
+				So(invalidOffset.DriverName, ShouldEqual, "azure")
+			})
+		})
+
+		Convey("ReadFile", func() {
+			Convey("Success", func() {
+				storeMock.GetContentFn = func(ctx context.Context, path string) ([]byte, error) {
+					return []byte("content"), nil
+				}
+				content, err := azureDriver.ReadFile("/test")
+				So(err, ShouldBeNil)
+				So(string(content), ShouldEqual, "content")
+			})
+
+			Convey("PathNotFoundError with empty Path gets path set", func() {
+				storeMock.GetContentFn = func(ctx context.Context, path string) ([]byte, error) {
+					return nil, driver.PathNotFoundError{Path: ""} // Path empty so driver sets it
+				}
+				_, err := azureDriver.ReadFile("/requested/path")
+				So(err, ShouldNotBeNil)
+
+				var pathErr driver.PathNotFoundError
+				So(errors.As(err, &pathErr), ShouldBeTrue)
+				So(pathErr.DriverName, ShouldEqual, "azure")
+				So(pathErr.Path, ShouldEqual, "/requested/path")
+			})
+
+			Convey("Azure not-found string becomes PathNotFoundError", func() {
+				for _, msg := range []string{"BlobNotFound", "ResourceNotFound", "Error 404", "does not exist"} {
+					errMsg := msg
+					storeMock.GetContentFn = func(ctx context.Context, path string) ([]byte, error) {
+						//nolint:err113 // test needs variable not-found message
+						return nil, fmt.Errorf("%s", errMsg)
+					}
+					_, err := azureDriver.ReadFile("/key")
+					So(err, ShouldNotBeNil)
+
+					var pathErr driver.PathNotFoundError
+					So(errors.As(err, &pathErr), ShouldBeTrue)
+					So(pathErr.Path, ShouldEqual, "/key")
+				}
+			})
+
+			Convey("Generic error becomes storagedriver.Error", func() {
+				storeMock.GetContentFn = func(ctx context.Context, path string) ([]byte, error) {
+					return nil, errTest
+				}
+				_, err := azureDriver.ReadFile("/test")
+				So(err, ShouldNotBeNil)
+
+				var storageErr driver.Error
+				So(errors.As(err, &storageErr), ShouldBeTrue)
+				So(storageErr.DriverName, ShouldEqual, "azure")
+				So(storageErr.Detail, ShouldEqual, errTest)
+			})
+		})
+
+		Convey("Delete", func() {
+			Convey("Success", func() {
+				storeMock.DeleteFn = func(ctx context.Context, path string) error {
+					return nil
+				}
+				err := azureDriver.Delete("/test")
+				So(err, ShouldBeNil)
+			})
+
+			Convey("PathNotFoundError is idempotent (return nil)", func() {
+				storeMock.DeleteFn = func(ctx context.Context, path string) error {
+					return driver.PathNotFoundError{Path: path}
+				}
+				err := azureDriver.Delete("/nonexistent")
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Other error is returned", func() {
+				storeMock.DeleteFn = func(ctx context.Context, path string) error {
+					return errTest
+				}
+				err := azureDriver.Delete("/test")
+				So(err, ShouldNotBeNil)
+				So(errors.Is(err, errTest), ShouldBeFalse) // wrapped in storagedriver.Error
+			})
+		})
+
+		Convey("Stat", func() {
+			Convey("Success", func() {
+				storeMock.StatFn = func(ctx context.Context, path string) (driver.FileInfo, error) {
+					return &mocks.FileInfoMock{}, nil
+				}
+				fi, err := azureDriver.Stat("/test")
+				So(err, ShouldBeNil)
+				So(fi, ShouldNotBeNil)
+			})
+
+			Convey("InvalidPathError", func() {
+				storeMock.StatFn = func(ctx context.Context, path string) (driver.FileInfo, error) {
+					return nil, driver.InvalidPathError{Path: path}
+				}
+				_, err := azureDriver.Stat("/bad")
+				So(err, ShouldNotBeNil)
+
+				var invalidPath driver.InvalidPathError
+				So(errors.As(err, &invalidPath), ShouldBeTrue)
+				So(invalidPath.DriverName, ShouldEqual, "azure")
+			})
+		})
+
+		Convey("Writer", func() {
+			Convey("Success", func() {
+				storeMock.WriterFn = func(ctx context.Context, path string, isAppend bool) (driver.FileWriter, error) {
+					return &mocks.FileWriterMock{}, nil
+				}
+				w, err := azureDriver.Writer("/test", false)
+				So(err, ShouldBeNil)
+				So(w, ShouldNotBeNil)
+			})
+
+			Convey("Error", func() {
+				storeMock.WriterFn = func(ctx context.Context, path string, isAppend bool) (driver.FileWriter, error) {
+					return nil, errTest
+				}
+				_, err := azureDriver.Writer("/test", false)
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("WriteFile", func() {
+			Convey("Success", func() {
+				storeMock.WriterFn = func(ctx context.Context, path string, isAppend bool) (driver.FileWriter, error) {
+					return &mocks.FileWriterMock{
+						WriteFn: func(p []byte) (int, error) {
+							return len(p), nil
+						},
+						CommitFn: func() error {
+							return nil
+						},
+						CloseFn: func() error {
+							return nil
+						},
+					}, nil
+				}
+				n, err := azureDriver.WriteFile("/test", []byte("content"))
+				So(err, ShouldBeNil)
+				So(n, ShouldEqual, 7)
+			})
+
+			Convey("Writer Error", func() {
+				storeMock.WriterFn = func(ctx context.Context, path string, isAppend bool) (driver.FileWriter, error) {
+					return nil, errTest
+				}
+				_, err := azureDriver.WriteFile("/test", []byte("content"))
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Write Error", func() {
+				storeMock.WriterFn = func(ctx context.Context, path string, isAppend bool) (driver.FileWriter, error) {
+					return &mocks.FileWriterMock{
+						WriteFn: func(p []byte) (int, error) {
+							return 0, errTest
+						},
+						CloseFn: func() error { return nil },
+					}, nil
+				}
+				_, err := azureDriver.WriteFile("/test", []byte("content"))
+				So(err, ShouldNotBeNil)
+			})
+
+			Convey("Commit Error", func() {
+				storeMock.WriterFn = func(ctx context.Context, path string, isAppend bool) (driver.FileWriter, error) {
+					return &mocks.FileWriterMock{
+						WriteFn: func(p []byte) (int, error) {
+							return len(p), nil
+						},
+						CommitFn: func() error {
+							return errTest
+						},
+						CloseFn: func() error { return nil },
+					}, nil
+				}
+				_, err := azureDriver.WriteFile("/test", []byte("content"))
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("Walk", func() {
+			Convey("Success", func() {
+				storeMock.WalkFn = func(ctx context.Context, path string, f driver.WalkFn, _ ...func(*driver.WalkOptions)) error {
+					return nil
+				}
+				err := azureDriver.Walk("/test", nil)
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Direct io.EOF is returned as io.EOF", func() {
+				storeMock.WalkFn = func(ctx context.Context, path string, f driver.WalkFn, _ ...func(*driver.WalkOptions)) error {
+					return io.EOF
+				}
+				err := azureDriver.Walk("/test", nil)
+				So(errors.Is(err, io.EOF), ShouldBeTrue)
+			})
+
+			Convey("io.EOF wrapped in storagedriver.Error is returned as io.EOF", func() {
+				storeMock.WalkFn = func(ctx context.Context, path string, f driver.WalkFn, _ ...func(*driver.WalkOptions)) error {
+					return driver.Error{
+						DriverName: "azure",
+						Detail:     io.EOF,
+					}
+				}
+				err := azureDriver.Walk("/test", nil)
+				So(errors.Is(err, io.EOF), ShouldBeTrue)
+			})
+
+			Convey("Non-EOF error is formatted normally", func() {
+				storeMock.WalkFn = func(ctx context.Context, path string, f driver.WalkFn, _ ...func(*driver.WalkOptions)) error {
+					return errTest
+				}
+				err := azureDriver.Walk("/test", nil)
+				So(err, ShouldNotBeNil)
+				So(errors.Is(err, io.EOF), ShouldBeFalse)
+
+				var storageErr driver.Error
+				So(errors.As(err, &storageErr), ShouldBeTrue)
+			})
+		})
+
+		Convey("List", func() {
+			Convey("Success", func() {
+				storeMock.ListFn = func(ctx context.Context, path string) ([]string, error) {
+					return []string{"a"}, nil
+				}
+				l, err := azureDriver.List("/test")
+				So(err, ShouldBeNil)
+				So(l, ShouldResemble, []string{"a"})
+			})
+
+			Convey("Error", func() {
+				storeMock.ListFn = func(ctx context.Context, path string) ([]string, error) {
+					return nil, errTest
+				}
+				_, err := azureDriver.List("/test")
+				So(err, ShouldNotBeNil)
+			})
+		})
+
+		Convey("Move", func() {
+			storeMock.MoveFn = func(ctx context.Context, sourcePath, destPath string) error {
+				return nil
+			}
+			err := azureDriver.Move("/src", "/dst")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("SameFile", func() {
+			Convey("True", func() {
+				now := time.Now()
+				storeMock.StatFn = func(ctx context.Context, path string) (driver.FileInfo, error) {
+					return &fileInfoMock{
+						isDir:   false,
+						size:    10,
+						modTime: now,
+						path:    "/canonical/path",
+					}, nil
+				}
+				So(azureDriver.SameFile("/path1", "/path2"), ShouldBeTrue)
+			})
+
+			Convey("False - Different ModTime", func() {
+				storeMock.StatFn = func(ctx context.Context, path string) (driver.FileInfo, error) {
+					modTime := time.Now()
+					if path == "/path2" {
+						modTime = modTime.Add(1 * time.Hour)
+					}
+
+					return &fileInfoMock{
+						isDir:   false,
+						size:    10,
+						modTime: modTime,
+						path:    path,
+					}, nil
+				}
+				So(azureDriver.SameFile("/path1", "/path2"), ShouldBeFalse)
+			})
+		})
+
+		Convey("Link", func() {
+			storeMock.PutContentFn = func(ctx context.Context, path string, content []byte) error {
+				return nil
+			}
+			err := azureDriver.Link("/src", "/dst")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("RedirectURL", func() {
+			req := httptest.NewRequestWithContext(context.Background(), http.MethodGet,
+				"http://localhost/v2/repo/blobs/sha256:abc", nil)
+
+			Convey("Success", func() {
+				storeMock.RedirectURLFn = func(r *http.Request, path string) (string, error) {
+					So(r, ShouldEqual, req)
+					So(path, ShouldEqual, "/blob/path")
+
+					return "https://example.com/signed", nil
+				}
+
+				url, err := azureDriver.RedirectURL(req, "/blob/path")
+				So(err, ShouldBeNil)
+				So(url, ShouldEqual, "https://example.com/signed")
+			})
+
+			Convey("Error", func() {
+				storeMock.RedirectURLFn = func(_ *http.Request, _ string) (string, error) {
+					return "", errTest
+				}
+
+				url, err := azureDriver.RedirectURL(req, "/blob/path")
+				So(url, ShouldEqual, "")
+				So(err, ShouldNotBeNil)
+
+				var storageErr driver.Error
+				So(errors.As(err, &storageErr), ShouldBeTrue)
+				So(storageErr.DriverName, ShouldEqual, "azure")
+			})
+		})
+	})
+}
+
+func TestNewImageStore(t *testing.T) {
+	Convey("NewImageStore", t, func() {
+		storeMock := &mocks.StorageDriverMock{}
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		imgStore := azure.NewImageStore("/tmp", "/tmp", true, true, log, metrics, nil, storeMock, nil, nil, nil)
+		So(imgStore, ShouldNotBeNil)
+	})
+}

--- a/pkg/storage/constants/constants.go
+++ b/pkg/storage/constants/constants.go
@@ -25,6 +25,7 @@ const (
 	DefaultGCInterval       = 1 * time.Hour
 	S3StorageDriverName     = "s3"
 	GCSStorageDriverName    = "gcs"
+	AzureStorageDriverName  = "azure"
 	LocalStorageDriverName  = "local"
 	// DedupeRestoreCompleteMarker is written at the image store root when a full dedupe-restore
 	// pass has completed. Its presence means no deduped blobs remain, so subsequent startups

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -89,7 +89,8 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 			var metaDB mTypes.MetaDB
 			compat := []compat.MediaCompatibility{compat.DockerManifestV2SchemaV2}
 
-			if testcase.storageType == storageConstants.S3StorageDriverName {
+			switch testcase.storageType {
+			case storageConstants.S3StorageDriverName:
 				tskip.SkipDynamo(t)
 				tskip.SkipS3(t)
 
@@ -158,7 +159,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 				}
 
 				imgStore = s3.NewImageStore(rootDir, cacheDir, true, false, log, metrics, nil, store, nil, compat, nil)
-			} else if testcase.storageType == storageConstants.AzureStorageDriverName {
+			case storageConstants.AzureStorageDriverName:
 				tskip.SkipAzure(t)
 
 				uuid, err := guuid.NewV4()
@@ -200,7 +201,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 
 				imgStore = azure.NewImageStore(storage.RootDir(storageConstants.AzureStorageDriverName, driverParams),
 					cacheDir, true, false, log, metrics, nil, store, nil, compat, nil)
-			} else {
+			default:
 				// Create temporary directory
 				rootDir := t.TempDir()
 
@@ -1826,7 +1827,8 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 			var metaDB mTypes.MetaDB
 			metaDB = nil
 
-			if testcase.storageType == storageConstants.S3StorageDriverName {
+			switch testcase.storageType {
+			case storageConstants.S3StorageDriverName:
 				tskip.SkipDynamo(t)
 				tskip.SkipS3(t)
 
@@ -1869,7 +1871,7 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 				}
 
 				imgStore = s3.NewImageStore(rootDir, cacheDir, true, false, log, metrics, nil, store, nil, nil, nil)
-			} else if testcase.storageType == storageConstants.AzureStorageDriverName {
+			case storageConstants.AzureStorageDriverName:
 				tskip.SkipAzure(t)
 
 				uuid, err := guuid.NewV4()
@@ -1896,7 +1898,7 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 
 				imgStore = azure.NewImageStore(storage.RootDir(storageConstants.AzureStorageDriverName, driverParams),
 					cacheDir, true, false, log, metrics, nil, store, nil, nil, nil)
-			} else {
+			default:
 				// Create temporary directory
 				rootDir := t.TempDir()
 

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -84,6 +84,11 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 
 	for _, testcase := range testCases {
 		t.Run(testcase.testCaseName, func(t *testing.T) {
+			// Run the storage backends concurrently. Each subtest builds its own store,
+			// cache and metaDB (unique prefixes / temp dirs), so the S3, filesystem and
+			// Azure passes are independent and need not run in series.
+			t.Parallel()
+
 			var imgStore storageTypes.ImageStore
 
 			var metaDB mTypes.MetaDB
@@ -1822,6 +1827,11 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 
 	for _, testcase := range testCases {
 		t.Run(testcase.testCaseName, func(t *testing.T) {
+			// Run the storage backends concurrently. Each subtest builds its own store,
+			// cache and metaDB (unique prefixes / temp dirs), so the S3, filesystem and
+			// Azure passes are independent and need not run in series.
+			t.Parallel()
+
 			var imgStore storageTypes.ImageStore
 
 			var metaDB mTypes.MetaDB

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -74,6 +74,11 @@ func newTestMetricsServer(t *testing.T, log zlog.Logger) monitoring.MetricServer
 	return metrics
 }
 
+// The backend subtests run in parallel, but the top-level test stays sequential on
+// purpose: parallelising it too would run this and the other retention test's backends
+// concurrently, multiplying the load on the runner and the storage emulators.
+//
+//nolint:tparallel
 func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 	log := zlog.NewTestLogger()
 	audit := zlog.NewAuditLogger("debug", "/dev/null")
@@ -1817,6 +1822,11 @@ func readTagsFromStorage(rootDir, repoName string, digest godigest.Digest) ([]st
 	return result, nil
 }
 
+// The backend subtests run in parallel, but the top-level test stays sequential on
+// purpose: parallelising it too would run this and the other retention test's backends
+// concurrently, multiplying the load on the runner and the storage emulators.
+//
+//nolint:tparallel
 func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 	log := zlog.NewTestLogger()
 	audit := zlog.NewAuditLogger("debug", "/dev/null")

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -28,11 +28,13 @@ import (
 	"zotregistry.dev/zot/v2/pkg/meta/dynamodb"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/storage"
+	"zotregistry.dev/zot/v2/pkg/storage/azure"
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
 	"zotregistry.dev/zot/v2/pkg/storage/gc"
 	"zotregistry.dev/zot/v2/pkg/storage/local"
 	"zotregistry.dev/zot/v2/pkg/storage/s3"
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
+	"zotregistry.dev/zot/v2/pkg/test/azurite"
 	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
 	tskip "zotregistry.dev/zot/v2/pkg/test/skip"
 )
@@ -41,6 +43,7 @@ const (
 	region        = "us-east-2"
 	s3TestName    = "S3APIs"
 	localTestName = "LocalAPIs"
+	azureTestName = "AzureAPIs"
 )
 
 //nolint:gochecknoglobals
@@ -55,6 +58,10 @@ var testCases = []struct {
 	{
 		testCaseName: localTestName,
 		storageType:  storageConstants.LocalStorageDriverName,
+	},
+	{
+		testCaseName: azureTestName,
+		storageType:  storageConstants.AzureStorageDriverName,
 	},
 }
 
@@ -151,6 +158,48 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 				}
 
 				imgStore = s3.NewImageStore(rootDir, cacheDir, true, false, log, metrics, nil, store, nil, compat, nil)
+			} else if testcase.storageType == storageConstants.AzureStorageDriverName {
+				tskip.SkipAzure(t)
+
+				uuid, err := guuid.NewV4()
+				if err != nil {
+					panic(err)
+				}
+
+				rootDir := path.Join("/oci-repo-test", uuid.String())
+				cacheDir := t.TempDir()
+
+				driverParams := azurite.DriverParams(rootDir)
+				storage.NormalizeRootDirectory(storageConstants.AzureStorageDriverName, driverParams)
+
+				store, err := factory.Create(context.Background(), storageConstants.AzureStorageDriverName, driverParams)
+				if err != nil {
+					panic(err)
+				}
+
+				if err := azurite.EnsureContainer(); err != nil {
+					panic(err)
+				}
+
+				defer store.Delete(context.Background(), "/") //nolint: errcheck
+
+				// init metaDB on a local boltdb (independent of the blob store)
+				boltParams := boltdb.DBParameters{
+					RootDir: cacheDir,
+				}
+
+				boltDriver, err := boltdb.GetBoltDriver(boltParams)
+				if err != nil {
+					panic(err)
+				}
+
+				metaDB, err = boltdb.New(boltDriver, log)
+				if err != nil {
+					panic(err)
+				}
+
+				imgStore = azure.NewImageStore(storage.RootDir(storageConstants.AzureStorageDriverName, driverParams),
+					cacheDir, true, false, log, metrics, nil, store, nil, compat, nil)
 			} else {
 				// Create temporary directory
 				rootDir := t.TempDir()
@@ -1217,25 +1266,29 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 				})
 
 				Convey("should gc only stale blob uploads", func() {
-					gcDelay := 1 * time.Second
 					repoName := "gc-test1"
 
-					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
-						Delay: gcDelay,
-						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultGCDelay,
-							Policies: []config.RetentionPolicy{
-								{
-									Repositories:    []string{"**"},
-									DeleteReferrers: true,
-									DeleteUntagged:  &trueVal,
-									KeepTags: []config.KeepTagsPolicy{
-										{},
+					// Drive staleness through the GC delay rather than wall-clock time: a long
+					// delay keeps a recent upload, a zero delay treats it as stale. This keeps the
+					// test deterministic regardless of how long the backend takes to respond.
+					newGC := func(delay time.Duration) gc.GarbageCollect {
+						return gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
+							Delay: delay,
+							ImageRetention: config.ImageRetention{
+								Delay: storageConstants.DefaultGCDelay,
+								Policies: []config.RetentionPolicy{
+									{
+										Repositories:    []string{"**"},
+										DeleteReferrers: true,
+										DeleteUntagged:  &trueVal,
+										KeepTags: []config.KeepTagsPolicy{
+											{},
+										},
 									},
 								},
 							},
-						},
-					}, audit, log, metrics)
+						}, audit, log, metrics)
+					}
 
 					blobUploadID, err := imgStore.NewBlobUpload(context.Background(), repoName)
 					So(err, ShouldBeNil)
@@ -1271,7 +1324,8 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 						So(isPresent, ShouldBeTrue)
 					}
 
-					err = gc.CleanRepo(ctx, repoName)
+					// A long GC delay keeps the recent upload.
+					err = newGC(1*time.Hour).CleanRepo(ctx, repoName)
 					So(err, ShouldBeNil)
 
 					// Blob upload is recent it should still be there
@@ -1300,9 +1354,8 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 						So(isPresent, ShouldBeTrue)
 					}
 
-					time.Sleep(gcDelay + 1*time.Second)
-
-					err = gc.CleanRepo(ctx, repoName)
+					// A zero GC delay treats the upload as stale, so it is collected.
+					err = newGC(0).CleanRepo(ctx, repoName)
 					So(err, ShouldBeNil)
 
 					// Blob uploads should be GCed
@@ -1816,6 +1869,33 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 				}
 
 				imgStore = s3.NewImageStore(rootDir, cacheDir, true, false, log, metrics, nil, store, nil, nil, nil)
+			} else if testcase.storageType == storageConstants.AzureStorageDriverName {
+				tskip.SkipAzure(t)
+
+				uuid, err := guuid.NewV4()
+				if err != nil {
+					panic(err)
+				}
+
+				rootDir := path.Join("/oci-repo-test", uuid.String())
+				cacheDir := t.TempDir()
+
+				driverParams := azurite.DriverParams(rootDir)
+				storage.NormalizeRootDirectory(storageConstants.AzureStorageDriverName, driverParams)
+
+				store, err := factory.Create(context.Background(), storageConstants.AzureStorageDriverName, driverParams)
+				if err != nil {
+					panic(err)
+				}
+
+				if err := azurite.EnsureContainer(); err != nil {
+					panic(err)
+				}
+
+				defer store.Delete(context.Background(), "/") //nolint: errcheck
+
+				imgStore = azure.NewImageStore(storage.RootDir(storageConstants.AzureStorageDriverName, driverParams),
+					cacheDir, true, false, log, metrics, nil, store, nil, nil, nil)
 			} else {
 				// Create temporary directory
 				rootDir := t.TempDir()
@@ -2539,25 +2619,29 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 				})
 
 				Convey("should gc only stale blob uploads", func() {
-					gcDelay := 1 * time.Second
 					repoName := "gc-test1"
 
-					gc := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
-						Delay: gcDelay,
-						ImageRetention: config.ImageRetention{
-							Delay: storageConstants.DefaultGCDelay,
-							Policies: []config.RetentionPolicy{
-								{
-									Repositories:    []string{"**"},
-									DeleteReferrers: true,
-									DeleteUntagged:  &trueVal,
-									KeepTags: []config.KeepTagsPolicy{
-										{},
+					// Drive staleness through the GC delay rather than wall-clock time: a long
+					// delay keeps a recent upload, a zero delay treats it as stale. This keeps the
+					// test deterministic regardless of how long the backend takes to respond.
+					newGC := func(delay time.Duration) gc.GarbageCollect {
+						return gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
+							Delay: delay,
+							ImageRetention: config.ImageRetention{
+								Delay: storageConstants.DefaultGCDelay,
+								Policies: []config.RetentionPolicy{
+									{
+										Repositories:    []string{"**"},
+										DeleteReferrers: true,
+										DeleteUntagged:  &trueVal,
+										KeepTags: []config.KeepTagsPolicy{
+											{},
+										},
 									},
 								},
 							},
-						},
-					}, audit, log, metrics)
+						}, audit, log, metrics)
+					}
 
 					blobUploadID, err := imgStore.NewBlobUpload(context.Background(), repoName)
 					So(err, ShouldBeNil)
@@ -2593,7 +2677,8 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 						So(isPresent, ShouldBeTrue)
 					}
 
-					err = gc.CleanRepo(ctx, repoName)
+					// A long GC delay keeps the recent upload.
+					err = newGC(1*time.Hour).CleanRepo(ctx, repoName)
 					So(err, ShouldBeNil)
 
 					// Blob upload is recent it should still be there
@@ -2622,9 +2707,8 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 						So(isPresent, ShouldBeTrue)
 					}
 
-					time.Sleep(gcDelay + 1*time.Second)
-
-					err = gc.CleanRepo(ctx, repoName)
+					// A zero GC delay treats the upload as stale, so it is collected.
+					err = newGC(0).CleanRepo(ctx, repoName)
 					So(err, ShouldBeNil)
 
 					// Blob uploads should be GCed

--- a/pkg/storage/scrub_test.go
+++ b/pkg/storage/scrub_test.go
@@ -109,6 +109,33 @@ func TestS3CheckAllBlobsIntegrity(t *testing.T) {
 	})
 }
 
+func TestAzureCheckAllBlobsIntegrity(t *testing.T) {
+	tskip.SkipAzure(t)
+
+	Convey("test with Azure storage", t, func() {
+		uuid, err := guuid.NewV4()
+		if err != nil {
+			panic(err)
+		}
+
+		testDir := path.Join("/oci-repo-test", uuid.String())
+		tdir := t.TempDir()
+		log := log.NewTestLogger()
+
+		opts := createObjectStoreOpts{
+			rootDir:     testDir,
+			cacheDir:    tdir,
+			cacheType:   storageConstants.BoltdbName,
+			storageType: storageConstants.AzureStorageDriverName,
+		}
+
+		driver, imgStore, _, _ := createObjectsStore(opts)
+		defer cleanupStorage(driver, "/")
+
+		RunCheckAllBlobsIntegrityTests(t, imgStore, driver, log)
+	})
+}
+
 func RunCheckAllBlobsIntegrityTests( //nolint: thelper
 	t *testing.T, imgStore storageTypes.ImageStore, driver storageTypes.Driver, log log.Logger,
 ) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -78,7 +78,7 @@ func New(config *config.Config, linter common.Lint, metrics monitoring.MetricSer
 		// Init a Storager from connection string.
 		store, err := factory.Create(context.Background(), storeName, config.Storage.StorageDriver)
 		if err != nil {
-			log.Error().Err(err).Str("rootDir", config.Storage.RootDirectory).Msg("failed to create s3 service")
+			log.Error().Err(err).Str("rootDir", config.Storage.RootDirectory).Msg("failed to create remote storage service")
 
 			return storeController, err
 		}
@@ -203,7 +203,7 @@ func getSubStore(cfg *config.Config, subPaths map[string]config.StorageConfig,
 			// Init a Storager from connection string.
 			store, err := factory.Create(context.Background(), storeName, storageConfig.StorageDriver)
 			if err != nil {
-				log.Error().Err(err).Str("rootDir", storageConfig.RootDirectory).Msg("failed to create s3 service")
+				log.Error().Err(err).Str("rootDir", storageConfig.RootDirectory).Msg("failed to create remote storage service")
 
 				return nil, err
 			}
@@ -267,7 +267,7 @@ func NormalizeRootDirectory(storeName string, driverParams map[string]any) {
 // For S3: preserve the old behavior for backward compatibility — existing deployments
 // have data stored under double-prefixed keys.
 //
-// For GCS: use "/" to avoid double-prefixing (new driver in 2.1.15, no legacy data).
+// For GCS/Azure: use "/" to avoid double-prefixing (new driver in 2.1.15, no legacy data).
 func RootDir(storeName string, driverParams map[string]any) string {
 	if storeName == constants.S3StorageDriverName && driverParams["rootdirectory"] != nil {
 		return fmt.Sprintf("%v", driverParams["rootdirectory"])

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -73,7 +73,7 @@ func New(config *config.Config, linter common.Lint, metrics monitoring.MetricSer
 			return storeController, fmt.Errorf("storageDriver '%s' unsupported storage driver: %w", storeName, zerr.ErrBadConfig)
 		}
 
-		NormalizeGCSRootDirectory(storeName, config.Storage.StorageDriver)
+		NormalizeRootDirectory(storeName, config.Storage.StorageDriver)
 
 		// Init a Storager from connection string.
 		store, err := factory.Create(context.Background(), storeName, config.Storage.StorageDriver)
@@ -92,15 +92,16 @@ func New(config *config.Config, linter common.Lint, metrics monitoring.MetricSer
 
 		// false positive lint - linter does not implement Lint method
 		//nolint: typecheck,contextcheck
-		if storeName == constants.S3StorageDriverName {
+		switch storeName {
+		case constants.S3StorageDriverName:
 			defaultStore = s3.NewImageStore(rootDir, config.Storage.RootDirectory,
 				config.Storage.Dedupe, config.Storage.Commit, log, metrics, linter, store, cacheDriver,
 				config.HTTP.Compat, recorder)
-		} else if storeName == constants.AzureStorageDriverName {
+		case constants.AzureStorageDriverName:
 			defaultStore = azure.NewImageStore(rootDir, config.Storage.RootDirectory,
 				config.Storage.Dedupe, config.Storage.Commit, log, metrics, linter, store, cacheDriver,
 				config.HTTP.Compat, recorder)
-		} else {
+		default:
 			defaultStore = gcs.NewImageStore(rootDir, config.Storage.RootDirectory,
 				config.Storage.Dedupe, config.Storage.Commit, log, metrics, linter, store, cacheDriver,
 				config.HTTP.Compat, recorder)
@@ -197,7 +198,7 @@ func getSubStore(cfg *config.Config, subPaths map[string]config.StorageConfig,
 				return nil, fmt.Errorf("storageDriver '%s' unsupported storage driver: %w", storeName, zerr.ErrBadConfig)
 			}
 
-			NormalizeGCSRootDirectory(storeName, storageConfig.StorageDriver)
+			NormalizeRootDirectory(storeName, storageConfig.StorageDriver)
 
 			// Init a Storager from connection string.
 			store, err := factory.Create(context.Background(), storeName, storageConfig.StorageDriver)
@@ -219,15 +220,16 @@ func getSubStore(cfg *config.Config, subPaths map[string]config.StorageConfig,
 
 			// false positive lint - linter does not implement Lint method
 			//nolint: typecheck
-			if storeName == constants.S3StorageDriverName {
+			switch storeName {
+			case constants.S3StorageDriverName:
 				subImageStore[route] = s3.NewImageStore(rootDir, storageConfig.RootDirectory,
 					storageConfig.Dedupe, storageConfig.Commit, log, metrics, linter, store, cacheDriver, cfg.HTTP.Compat, recorder,
 				)
-			} else if storeName == constants.AzureStorageDriverName {
+			case constants.AzureStorageDriverName:
 				subImageStore[route] = azure.NewImageStore(rootDir, storageConfig.RootDirectory,
 					storageConfig.Dedupe, storageConfig.Commit, log, metrics, linter, store, cacheDriver, cfg.HTTP.Compat, recorder,
 				)
-			} else {
+			default:
 				subImageStore[route] = gcs.NewImageStore(rootDir, storageConfig.RootDirectory,
 					storageConfig.Dedupe, storageConfig.Commit, log, metrics, linter, store, cacheDriver, cfg.HTTP.Compat, recorder,
 				)
@@ -238,11 +240,11 @@ func getSubStore(cfg *config.Config, subPaths map[string]config.StorageConfig,
 	return subImageStore, nil
 }
 
-// NormalizeGCSRootDirectory ensures the GCS storage driver has a sensible default for rootdirectory.
-// Defaults to "zot" if unset or empty; overrides "/" with "zot" to prevent upstream gcs driver issue.
-// Must be called before factory.Create so the upstream GCS driver receives the correct prefix.
-// Non-GCS drivers are not affected.
-func NormalizeGCSRootDirectory(storeName string, driverParams map[string]any) {
+// NormalizeRootDirectory ensures the GCS and Azure storage drivers have a sensible default
+// for rootdirectory. Defaults to "/zot" if unset or empty; overrides "/" with "/zot" to prevent
+// the upstream driver double-prefixing. Must be called before factory.Create so the upstream
+// driver receives the correct prefix. Other drivers (e.g. S3) are not affected.
+func NormalizeRootDirectory(storeName string, driverParams map[string]any) {
 	// GCS and Azure are both modern drivers (no legacy double-prefixed data) that prefix
 	// rootdirectory internally, so give them a sane default and let RootDir() return "/".
 	if storeName != constants.GCSStorageDriverName && storeName != constants.AzureStorageDriverName {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -240,13 +240,14 @@ func getSubStore(cfg *config.Config, subPaths map[string]config.StorageConfig,
 	return subImageStore, nil
 }
 
-// NormalizeRootDirectory ensures the GCS and Azure storage drivers have a sensible default
-// for rootdirectory. Defaults to "/zot" if unset or empty; overrides "/" with "/zot" to prevent
-// the upstream driver double-prefixing. Must be called before factory.Create so the upstream
-// driver receives the correct prefix. Other drivers (e.g. S3) are not affected.
+// NormalizeRootDirectory gives the GCS and Azure storage drivers a sensible default
+// rootdirectory. Both prefix the rootdirectory internally, and zot's RootDir() returns "/"
+// for them, so an unset, empty, or "/" rootdirectory would leave blobs at the bucket/container
+// root. This defaults it to "/zot" in those cases. Must be called before factory.Create so the
+// upstream driver receives the prefix. Other drivers (e.g. S3) are not affected.
 func NormalizeRootDirectory(storeName string, driverParams map[string]any) {
-	// GCS and Azure are both modern drivers (no legacy double-prefixed data) that prefix
-	// rootdirectory internally, so give them a sane default and let RootDir() return "/".
+	// GCS and Azure are modern drivers that prefix rootdirectory internally, so give them a
+	// sane default prefix instead of leaving everything at the storage root.
 	if storeName != constants.GCSStorageDriverName && storeName != constants.AzureStorageDriverName {
 		return
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,6 +16,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/extensions/events"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
 	"zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/storage/azure"
 	common "zotregistry.dev/zot/v2/pkg/storage/common"
 	"zotregistry.dev/zot/v2/pkg/storage/constants"
 	"zotregistry.dev/zot/v2/pkg/storage/gcs"
@@ -64,7 +65,8 @@ func New(config *config.Config, linter common.Lint, metrics monitoring.MetricSer
 		)
 	} else {
 		storeName := fmt.Sprintf("%v", config.Storage.StorageDriver["name"])
-		if storeName != constants.S3StorageDriverName && storeName != constants.GCSStorageDriverName {
+		if storeName != constants.S3StorageDriverName && storeName != constants.GCSStorageDriverName &&
+			storeName != constants.AzureStorageDriverName {
 			log.Error().Err(zerr.ErrBadConfig).Str("storageDriver", storeName).
 				Msg("unsupported storage driver")
 
@@ -92,6 +94,10 @@ func New(config *config.Config, linter common.Lint, metrics monitoring.MetricSer
 		//nolint: typecheck,contextcheck
 		if storeName == constants.S3StorageDriverName {
 			defaultStore = s3.NewImageStore(rootDir, config.Storage.RootDirectory,
+				config.Storage.Dedupe, config.Storage.Commit, log, metrics, linter, store, cacheDriver,
+				config.HTTP.Compat, recorder)
+		} else if storeName == constants.AzureStorageDriverName {
+			defaultStore = azure.NewImageStore(rootDir, config.Storage.RootDirectory,
 				config.Storage.Dedupe, config.Storage.Commit, log, metrics, linter, store, cacheDriver,
 				config.HTTP.Compat, recorder)
 		} else {
@@ -183,7 +189,8 @@ func getSubStore(cfg *config.Config, subPaths map[string]config.StorageConfig,
 			}
 		} else {
 			storeName := fmt.Sprintf("%v", storageConfig.StorageDriver["name"])
-			if storeName != constants.S3StorageDriverName && storeName != constants.GCSStorageDriverName {
+			if storeName != constants.S3StorageDriverName && storeName != constants.GCSStorageDriverName &&
+				storeName != constants.AzureStorageDriverName {
 				log.Error().Err(zerr.ErrBadConfig).Str("storageDriver", storeName).
 					Msg("unsupported storage driver")
 
@@ -216,6 +223,10 @@ func getSubStore(cfg *config.Config, subPaths map[string]config.StorageConfig,
 				subImageStore[route] = s3.NewImageStore(rootDir, storageConfig.RootDirectory,
 					storageConfig.Dedupe, storageConfig.Commit, log, metrics, linter, store, cacheDriver, cfg.HTTP.Compat, recorder,
 				)
+			} else if storeName == constants.AzureStorageDriverName {
+				subImageStore[route] = azure.NewImageStore(rootDir, storageConfig.RootDirectory,
+					storageConfig.Dedupe, storageConfig.Commit, log, metrics, linter, store, cacheDriver, cfg.HTTP.Compat, recorder,
+				)
 			} else {
 				subImageStore[route] = gcs.NewImageStore(rootDir, storageConfig.RootDirectory,
 					storageConfig.Dedupe, storageConfig.Commit, log, metrics, linter, store, cacheDriver, cfg.HTTP.Compat, recorder,
@@ -232,7 +243,9 @@ func getSubStore(cfg *config.Config, subPaths map[string]config.StorageConfig,
 // Must be called before factory.Create so the upstream GCS driver receives the correct prefix.
 // Non-GCS drivers are not affected.
 func NormalizeGCSRootDirectory(storeName string, driverParams map[string]any) {
-	if storeName != constants.GCSStorageDriverName {
+	// GCS and Azure are both modern drivers (no legacy double-prefixed data) that prefix
+	// rootdirectory internally, so give them a sane default and let RootDir() return "/".
+	if storeName != constants.GCSStorageDriverName && storeName != constants.AzureStorageDriverName {
 		return
 	}
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1903,35 +1903,59 @@ func TestRootDir(t *testing.T) {
 	})
 }
 
-func TestNormalizeGCSRootDirectory(t *testing.T) {
+func TestNormalizeRootDirectory(t *testing.T) {
 	Convey("GCS without rootdirectory defaults to zot", t, func() {
 		params := map[string]any{}
-		storage.NormalizeGCSRootDirectory(storageConstants.GCSStorageDriverName, params)
+		storage.NormalizeRootDirectory(storageConstants.GCSStorageDriverName, params)
 		So(params["rootdirectory"], ShouldEqual, "/zot")
 	})
 
 	Convey("GCS with rootdirectory / is overwritten to zot", t, func() {
 		params := map[string]any{"rootdirectory": "/"}
-		storage.NormalizeGCSRootDirectory(storageConstants.GCSStorageDriverName, params)
+		storage.NormalizeRootDirectory(storageConstants.GCSStorageDriverName, params)
 		So(params["rootdirectory"], ShouldEqual, "/zot")
 	})
 
 	Convey("GCS with empty rootdirectory defaults to zot", t, func() {
 		params := map[string]any{"rootdirectory": ""}
-		storage.NormalizeGCSRootDirectory(storageConstants.GCSStorageDriverName, params)
+		storage.NormalizeRootDirectory(storageConstants.GCSStorageDriverName, params)
 		So(params["rootdirectory"], ShouldEqual, "/zot")
 	})
 
 	Convey("GCS with custom rootdirectory is preserved", t, func() {
 		params := map[string]any{"rootdirectory": "my-prefix"}
-		storage.NormalizeGCSRootDirectory(storageConstants.GCSStorageDriverName, params)
+		storage.NormalizeRootDirectory(storageConstants.GCSStorageDriverName, params)
 		So(params["rootdirectory"], ShouldEqual, "my-prefix")
 	})
 
 	Convey("S3 params are not affected", t, func() {
 		params := map[string]any{"rootdirectory": "/"}
-		storage.NormalizeGCSRootDirectory(storageConstants.S3StorageDriverName, params)
+		storage.NormalizeRootDirectory(storageConstants.S3StorageDriverName, params)
 		So(params["rootdirectory"], ShouldEqual, "/")
+	})
+
+	Convey("Azure without rootdirectory defaults to zot", t, func() {
+		params := map[string]any{}
+		storage.NormalizeRootDirectory(storageConstants.AzureStorageDriverName, params)
+		So(params["rootdirectory"], ShouldEqual, "/zot")
+	})
+
+	Convey("Azure with rootdirectory / is overwritten to zot", t, func() {
+		params := map[string]any{"rootdirectory": "/"}
+		storage.NormalizeRootDirectory(storageConstants.AzureStorageDriverName, params)
+		So(params["rootdirectory"], ShouldEqual, "/zot")
+	})
+
+	Convey("Azure with empty rootdirectory defaults to zot", t, func() {
+		params := map[string]any{"rootdirectory": ""}
+		storage.NormalizeRootDirectory(storageConstants.AzureStorageDriverName, params)
+		So(params["rootdirectory"], ShouldEqual, "/zot")
+	})
+
+	Convey("Azure with custom rootdirectory is preserved", t, func() {
+		params := map[string]any{"rootdirectory": "my-prefix"}
+		storage.NormalizeRootDirectory(storageConstants.AzureStorageDriverName, params)
+		So(params["rootdirectory"], ShouldEqual, "my-prefix")
 	})
 }
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -36,6 +36,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/storage"
+	"zotregistry.dev/zot/v2/pkg/storage/azure"
 	"zotregistry.dev/zot/v2/pkg/storage/cache"
 	storageCommon "zotregistry.dev/zot/v2/pkg/storage/common"
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
@@ -44,6 +45,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/storage/local"
 	"zotregistry.dev/zot/v2/pkg/storage/s3"
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
+	"zotregistry.dev/zot/v2/pkg/test/azurite"
 	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
 	tskip "zotregistry.dev/zot/v2/pkg/test/skip"
@@ -86,7 +88,8 @@ func createObjectsStore(options createObjectStoreOpts) (
 
 	log := zlog.NewTestLogger()
 
-	if options.storageType == storageConstants.S3StorageDriverName {
+	if options.storageType == storageConstants.S3StorageDriverName ||
+		options.storageType == storageConstants.AzureStorageDriverName {
 		useRelPaths = false
 	} else {
 		useRelPaths = true
@@ -109,6 +112,27 @@ func createObjectsStore(options createObjectStoreOpts) (
 	}
 
 	metrics := monitoring.NewMetricsServer(false, log)
+
+	if options.storageType == storageConstants.AzureStorageDriverName {
+		params := azurite.DriverParams(options.rootDir)
+		// Mirror production: default the prefix and pass RootDir() ("/") into the image store
+		// so the driver (not the image store) owns the rootdirectory prefix.
+		storage.NormalizeRootDirectory(storageConstants.AzureStorageDriverName, params)
+
+		azureDriver, err := factory.Create(context.Background(), storageConstants.AzureStorageDriverName, params)
+		if err != nil {
+			panic(err)
+		}
+
+		if err := azurite.EnsureContainer(); err != nil {
+			panic(err)
+		}
+
+		imgStore := azure.NewImageStore(storage.RootDir(storageConstants.AzureStorageDriverName, params),
+			options.cacheDir, true, false, log, metrics, nil, azureDriver, cacheDriver, nil, nil)
+
+		return azure.New(azureDriver), imgStore, cacheDriver, nil
+	}
 
 	if options.storageType != storageConstants.S3StorageDriverName {
 		storeDriver := local.New(true)
@@ -246,6 +270,16 @@ var testCases = []struct {
 	{
 		testCaseName: "FileSystemAPIs_Redis",
 		storageType:  storageConstants.LocalStorageDriverName,
+		cacheType:    storageConstants.RedisDriverName,
+	},
+	{
+		testCaseName: "AzureAPIs_BoltDB",
+		storageType:  storageConstants.AzureStorageDriverName,
+		cacheType:    storageConstants.BoltdbName,
+	},
+	{
+		testCaseName: "AzureAPIs_Redis",
+		storageType:  storageConstants.AzureStorageDriverName,
 		cacheType:    storageConstants.RedisDriverName,
 	},
 }
@@ -862,6 +896,21 @@ func TestGetAllDedupeReposCandidates(t *testing.T) {
 
 				store, imgStore, _, _ = createObjectsStore(opts)
 				defer cleanupStorage(store, testDir)
+			case storageConstants.AzureStorageDriverName:
+				tskip.SkipAzure(t)
+
+				uuid, err := guuid.NewV4()
+				if err != nil {
+					panic(err)
+				}
+
+				testDir := path.Join("/oci-repo-test", uuid.String())
+				opts.rootDir = testDir
+
+				var store storageTypes.Driver
+
+				store, imgStore, _, _ = createObjectsStore(opts)
+				defer cleanupStorage(store, "/")
 			default:
 				_, imgStore, _, _ = createObjectsStore(opts)
 			}
@@ -948,6 +997,21 @@ func TestStorageAPIs(t *testing.T) {
 
 				store, imgStore, _, _ = createObjectsStore(opts)
 				defer cleanupStorage(store, testDir)
+			case storageConstants.AzureStorageDriverName:
+				tskip.SkipAzure(t)
+
+				uuid, err := guuid.NewV4()
+				if err != nil {
+					panic(err)
+				}
+
+				testDir := path.Join("/oci-repo-test", uuid.String())
+				opts.rootDir = testDir
+
+				var store storageTypes.Driver
+
+				store, imgStore, _, _ = createObjectsStore(opts)
+				defer cleanupStorage(store, "/")
 			default:
 				_, imgStore, _, _ = createObjectsStore(opts)
 			}
@@ -1721,6 +1785,29 @@ func TestMandatoryAnnotations(t *testing.T) {
 					}, store, cacheDriver, nil, nil)
 
 				defer cleanupStorage(store, testDir)
+			case storageConstants.AzureStorageDriverName:
+				tskip.SkipAzure(t)
+
+				uuid, err := guuid.NewV4()
+				if err != nil {
+					panic(err)
+				}
+
+				testDir = path.Join("/oci-repo-test", uuid.String())
+				opts.rootDir = testDir
+
+				var cacheDriver storageTypes.Cache
+
+				store, _, cacheDriver, _ = createObjectsStore(opts)
+
+				imgStore = imagestore.NewImageStore("/", cacheDir, false, false, log, metrics,
+					&mocks.MockedLint{
+						LintFn: func(repo string, manifestDigest godigest.Digest, imageStore storageTypes.ImageStore) (bool, error) {
+							return false, nil
+						},
+					}, store, cacheDriver, nil, nil)
+
+				defer cleanupStorage(store, "/")
 			default:
 				var cacheDriver storageTypes.Cache
 
@@ -1780,6 +1867,14 @@ func TestMandatoryAnnotations(t *testing.T) {
 				Convey("Error on mandatory annotations", func() {
 					if testcase.storageType == storageConstants.S3StorageDriverName {
 						imgStore = imagestore.NewImageStore(testDir, cacheDir, false, false, log, metrics,
+							&mocks.MockedLint{
+								LintFn: func(repo string, manifestDigest godigest.Digest, imageStore storageTypes.ImageStore) (bool, error) {
+									//nolint: err113
+									return false, errors.New("linter error")
+								},
+							}, store, nil, nil, nil)
+					} else if testcase.storageType == storageConstants.AzureStorageDriverName {
+						imgStore = imagestore.NewImageStore("/", cacheDir, false, false, log, metrics,
 							&mocks.MockedLint{
 								LintFn: func(repo string, manifestDigest godigest.Digest, imageStore storageTypes.ImageStore) (bool, error) {
 									//nolint: err113
@@ -1901,6 +1996,18 @@ func TestRootDir(t *testing.T) {
 		rootDir := storage.RootDir(storageConstants.GCSStorageDriverName, map[string]any{})
 		So(rootDir, ShouldEqual, "/")
 	})
+
+	Convey("Azure with rootdirectory uses / to avoid double-prefixing", t, func() {
+		rootDir := storage.RootDir(storageConstants.AzureStorageDriverName, map[string]any{
+			"rootdirectory": "/custom-prefix",
+		})
+		So(rootDir, ShouldEqual, "/")
+	})
+
+	Convey("Azure without rootdirectory defaults to /", t, func() {
+		rootDir := storage.RootDir(storageConstants.AzureStorageDriverName, map[string]any{})
+		So(rootDir, ShouldEqual, "/")
+	})
 }
 
 func TestNormalizeRootDirectory(t *testing.T) {
@@ -1997,6 +2104,21 @@ func TestDeleteBlobsInUse(t *testing.T) {
 				store, imgStore, _, _ = createObjectsStore(opts)
 
 				defer cleanupStorage(store, testDir)
+			case storageConstants.AzureStorageDriverName:
+				tskip.SkipAzure(t)
+
+				uuid, err := guuid.NewV4()
+				if err != nil {
+					panic(err)
+				}
+
+				testDir := path.Join("/oci-repo-test", uuid.String())
+				opts.rootDir = testDir
+
+				var store storageTypes.Driver
+				store, imgStore, _, _ = createObjectsStore(opts)
+
+				defer cleanupStorage(store, "/")
 			default:
 				_, imgStore, _, _ = createObjectsStore(opts)
 			}
@@ -2081,7 +2203,7 @@ func TestDeleteBlobsInUse(t *testing.T) {
 					So(err, ShouldBeNil)
 				})
 
-				if testcase.storageType != storageConstants.S3StorageDriverName {
+				if testcase.storageType == storageConstants.LocalStorageDriverName {
 					Convey("get image manifest error", func() {
 						err := os.Chmod(path.Join(imgStore.RootDir(), "repo", "blobs", "sha256", manifestDigest.Encoded()), 0o000)
 						So(err, ShouldBeNil)
@@ -2238,7 +2360,7 @@ func TestDeleteBlobsInUse(t *testing.T) {
 					So(err, ShouldBeNil)
 				})
 
-				if testcase.storageType != storageConstants.S3StorageDriverName {
+				if testcase.storageType == storageConstants.LocalStorageDriverName {
 					Convey("repo not found", func() {
 						// delete repo
 						err := os.RemoveAll(path.Join(imgStore.RootDir(), repoName))
@@ -2309,6 +2431,19 @@ func TestReuploadCorruptedBlob(t *testing.T) {
 
 				driver, imgStore, _, _ = createObjectsStore(opts)
 				defer cleanupStorage(driver, testDir)
+			case storageConstants.AzureStorageDriverName:
+				tskip.SkipAzure(t)
+
+				uuid, err := guuid.NewV4()
+				if err != nil {
+					panic(err)
+				}
+
+				testDir := path.Join("/oci-repo-test", uuid.String())
+				opts.rootDir = testDir
+
+				driver, imgStore, _, _ = createObjectsStore(opts)
+				defer cleanupStorage(driver, "/")
 			default:
 				driver, imgStore, _, _ = createObjectsStore(opts)
 			}
@@ -2460,6 +2595,11 @@ func TestStorageHandler(t *testing.T) {
 
 				thirdStorageDriver, thirdStore, _, _ = createObjectsStore(opts)
 				defer cleanupStorage(thirdStorageDriver, thirdRootDir)
+			case storageConstants.AzureStorageDriverName:
+				// The azure image store always reports RootDir() "/" (the driver owns the
+				// rootdirectory prefix), so the per-store routing assertions below, which rely
+				// on distinct root directories, do not apply to the single-container model.
+				t.Skip("storage handler routing assertions are not applicable to azure")
 			default:
 				firstRootDir = t.TempDir()
 				opts.rootDir = firstRootDir
@@ -2567,6 +2707,21 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 						store, imgStore, _, _ = createObjectsStore(opts)
 						defer cleanupStorage(store, testDir)
+					case storageConstants.AzureStorageDriverName:
+						tskip.SkipAzure(t)
+
+						uuid, err := guuid.NewV4()
+						if err != nil {
+							panic(err)
+						}
+
+						testDir := path.Join("/oci-repo-test", uuid.String())
+						opts.rootDir = testDir
+
+						var store storageTypes.Driver
+
+						store, imgStore, _, _ = createObjectsStore(opts)
+						defer cleanupStorage(store, "/")
 					default:
 						_, imgStore, _, _ = createObjectsStore(opts)
 					}
@@ -2733,6 +2888,21 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 						store, imgStore, _, _ = createObjectsStore(opts)
 						defer cleanupStorage(store, testDir)
+					case storageConstants.AzureStorageDriverName:
+						tskip.SkipAzure(t)
+
+						uuid, err := guuid.NewV4()
+						if err != nil {
+							panic(err)
+						}
+
+						testDir := path.Join("/oci-repo-test", uuid.String())
+						opts.rootDir = testDir
+
+						var store storageTypes.Driver
+
+						store, imgStore, _, _ = createObjectsStore(opts)
+						defer cleanupStorage(store, "/")
 					default:
 						_, imgStore, _, _ = createObjectsStore(opts)
 					}
@@ -3016,6 +3186,21 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 
 						store, imgStore, _, _ = createObjectsStore(opts)
 						defer cleanupStorage(store, testDir)
+					case storageConstants.AzureStorageDriverName:
+						tskip.SkipAzure(t)
+
+						uuid, err := guuid.NewV4()
+						if err != nil {
+							panic(err)
+						}
+
+						testDir := path.Join("/oci-repo-test", uuid.String())
+						opts.rootDir = testDir
+
+						var store storageTypes.Driver
+
+						store, imgStore, _, _ = createObjectsStore(opts)
+						defer cleanupStorage(store, "/")
 					default:
 						_, imgStore, _, _ = createObjectsStore(opts)
 					}
@@ -3270,6 +3455,21 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 
 						store, imgStore, _, _ = createObjectsStore(opts)
 						defer cleanupStorage(store, testDir)
+					case storageConstants.AzureStorageDriverName:
+						tskip.SkipAzure(t)
+
+						uuid, err := guuid.NewV4()
+						if err != nil {
+							panic(err)
+						}
+
+						testDir := path.Join("/oci-repo-test", uuid.String())
+						opts.rootDir = testDir
+
+						var store storageTypes.Driver
+
+						store, imgStore, _, _ = createObjectsStore(opts)
+						defer cleanupStorage(store, "/")
 					default:
 						_, imgStore, _, _ = createObjectsStore(opts)
 					}
@@ -3394,6 +3594,21 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 
 						store, imgStore, _, _ = createObjectsStore(opts)
 						defer cleanupStorage(store, testDir)
+					case storageConstants.AzureStorageDriverName:
+						tskip.SkipAzure(t)
+
+						uuid, err := guuid.NewV4()
+						if err != nil {
+							panic(err)
+						}
+
+						testDir := path.Join("/oci-repo-test", uuid.String())
+						opts.rootDir = testDir
+
+						var store storageTypes.Driver
+
+						store, imgStore, _, _ = createObjectsStore(opts)
+						defer cleanupStorage(store, "/")
 					default:
 						_, imgStore, _, _ = createObjectsStore(opts)
 					}
@@ -3693,6 +3908,21 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 
 					store, imgStore, _, _ = createObjectsStore(opts)
 					defer cleanupStorage(store, testDir)
+				case storageConstants.AzureStorageDriverName:
+					tskip.SkipAzure(t)
+
+					uuid, err := guuid.NewV4()
+					if err != nil {
+						panic(err)
+					}
+
+					testDir := path.Join("/oci-repo-test", uuid.String())
+					opts.rootDir = testDir
+
+					var store storageTypes.Driver
+
+					store, imgStore, _, _ = createObjectsStore(opts)
+					defer cleanupStorage(store, "/")
 				default:
 					_, imgStore, _, _ = createObjectsStore(opts)
 				}

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1904,19 +1904,19 @@ func TestRootDir(t *testing.T) {
 }
 
 func TestNormalizeRootDirectory(t *testing.T) {
-	Convey("GCS without rootdirectory defaults to zot", t, func() {
+	Convey("GCS without rootdirectory defaults to /zot", t, func() {
 		params := map[string]any{}
 		storage.NormalizeRootDirectory(storageConstants.GCSStorageDriverName, params)
 		So(params["rootdirectory"], ShouldEqual, "/zot")
 	})
 
-	Convey("GCS with rootdirectory / is overwritten to zot", t, func() {
+	Convey("GCS with rootdirectory / is overwritten to /zot", t, func() {
 		params := map[string]any{"rootdirectory": "/"}
 		storage.NormalizeRootDirectory(storageConstants.GCSStorageDriverName, params)
 		So(params["rootdirectory"], ShouldEqual, "/zot")
 	})
 
-	Convey("GCS with empty rootdirectory defaults to zot", t, func() {
+	Convey("GCS with empty rootdirectory defaults to /zot", t, func() {
 		params := map[string]any{"rootdirectory": ""}
 		storage.NormalizeRootDirectory(storageConstants.GCSStorageDriverName, params)
 		So(params["rootdirectory"], ShouldEqual, "/zot")
@@ -1934,19 +1934,19 @@ func TestNormalizeRootDirectory(t *testing.T) {
 		So(params["rootdirectory"], ShouldEqual, "/")
 	})
 
-	Convey("Azure without rootdirectory defaults to zot", t, func() {
+	Convey("Azure without rootdirectory defaults to /zot", t, func() {
 		params := map[string]any{}
 		storage.NormalizeRootDirectory(storageConstants.AzureStorageDriverName, params)
 		So(params["rootdirectory"], ShouldEqual, "/zot")
 	})
 
-	Convey("Azure with rootdirectory / is overwritten to zot", t, func() {
+	Convey("Azure with rootdirectory / is overwritten to /zot", t, func() {
 		params := map[string]any{"rootdirectory": "/"}
 		storage.NormalizeRootDirectory(storageConstants.AzureStorageDriverName, params)
 		So(params["rootdirectory"], ShouldEqual, "/zot")
 	})
 
-	Convey("Azure with empty rootdirectory defaults to zot", t, func() {
+	Convey("Azure with empty rootdirectory defaults to /zot", t, func() {
 		params := map[string]any{"rootdirectory": ""}
 		storage.NormalizeRootDirectory(storageConstants.AzureStorageDriverName, params)
 		So(params["rootdirectory"], ShouldEqual, "/zot")

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -1865,7 +1865,8 @@ func TestMandatoryAnnotations(t *testing.T) {
 				})
 
 				Convey("Error on mandatory annotations", func() {
-					if testcase.storageType == storageConstants.S3StorageDriverName {
+					switch testcase.storageType {
+					case storageConstants.S3StorageDriverName:
 						imgStore = imagestore.NewImageStore(testDir, cacheDir, false, false, log, metrics,
 							&mocks.MockedLint{
 								LintFn: func(repo string, manifestDigest godigest.Digest, imageStore storageTypes.ImageStore) (bool, error) {
@@ -1873,7 +1874,7 @@ func TestMandatoryAnnotations(t *testing.T) {
 									return false, errors.New("linter error")
 								},
 							}, store, nil, nil, nil)
-					} else if testcase.storageType == storageConstants.AzureStorageDriverName {
+					case storageConstants.AzureStorageDriverName:
 						imgStore = imagestore.NewImageStore("/", cacheDir, false, false, log, metrics,
 							&mocks.MockedLint{
 								LintFn: func(repo string, manifestDigest godigest.Digest, imageStore storageTypes.ImageStore) (bool, error) {
@@ -1881,7 +1882,7 @@ func TestMandatoryAnnotations(t *testing.T) {
 									return false, errors.New("linter error")
 								},
 							}, store, nil, nil, nil)
-					} else {
+					default:
 						var cacheDriver storageTypes.Cache
 						store, _, cacheDriver, err := createObjectsStore(opts)
 						if err != nil {

--- a/pkg/test/azurite/azurite.go
+++ b/pkg/test/azurite/azurite.go
@@ -1,0 +1,64 @@
+// Package azurite provides shared setup for tests that run against an Azurite
+// (Azure Blob Storage emulator) instance. These tests are gated on the
+// AZURITEMOCK_ENDPOINT environment variable, in the same way the S3 tests are
+// gated on S3MOCK_ENDPOINT.
+package azurite
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+)
+
+// Well-known Azurite development account (https://github.com/Azure/Azurite).
+// These are the fixed, publicly documented emulator credentials, not secrets.
+const (
+	Account = "devstoreaccount1"
+	//nolint:gosec // public Azurite development key, not a secret
+	AccessKey = "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
+	Container = "zot-storage-test"
+)
+
+// Endpoint returns the Azurite blob endpoint (AZURITEMOCK_ENDPOINT), e.g.
+// http://127.0.0.1:10000/devstoreaccount1. It is empty when Azurite is not configured.
+func Endpoint() string {
+	return os.Getenv("AZURITEMOCK_ENDPOINT")
+}
+
+// DriverParams builds the distribution azure driver parameters pointing at
+// Azurite, with the given rootdirectory prefix. The shared_key credential type
+// uses the emulator account key directly.
+func DriverParams(rootDir string) map[string]any {
+	return map[string]any{
+		"name":          "azure",
+		"container":     Container,
+		"accountname":   Account,
+		"accountkey":    AccessKey,
+		"serviceurl":    Endpoint(),
+		"rootdirectory": rootDir,
+		"credentials":   map[string]any{"type": "shared_key"},
+	}
+}
+
+// EnsureContainer creates the test container in Azurite if it does not already
+// exist. It is idempotent, so concurrent test setups can call it safely.
+func EnsureContainer() error {
+	connStr := fmt.Sprintf(
+		"DefaultEndpointsProtocol=http;AccountName=%s;AccountKey=%s;BlobEndpoint=%s;",
+		Account, AccessKey, Endpoint())
+
+	client, err := azblob.NewClientFromConnectionString(connStr, nil)
+	if err != nil {
+		return fmt.Errorf("azurite client: %w", err)
+	}
+
+	if _, err := client.CreateContainer(context.Background(), Container, nil); err != nil &&
+		!strings.Contains(err.Error(), "ContainerAlreadyExists") {
+		return fmt.Errorf("create container: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/test/azurite/azurite.go
+++ b/pkg/test/azurite/azurite.go
@@ -40,6 +40,11 @@ func DriverParams(rootDir string) map[string]any {
 		"serviceurl":    Endpoint(),
 		"rootdirectory": rootDir,
 		"credentials":   map[string]any{"type": "shared_key"},
+		// Azurite completes server-side copies almost instantly but briefly reports them
+		// as pending, so the driver polls every retry_delay. The 100ms default is tuned for
+		// real Azure latency and dominates test time (every Move/InitRepo/blob finalize pays
+		// it); a short interval against a local emulator keeps the suite fast.
+		"retry_delay": "10ms",
 	}
 }
 

--- a/pkg/test/skip/testskip.go
+++ b/pkg/test/skip/testskip.go
@@ -28,3 +28,11 @@ func SkipGCS(t *testing.T) {
 		t.Skip("Skipping testing without GCS mock server")
 	}
 }
+
+func SkipAzure(t *testing.T) {
+	t.Helper()
+
+	if os.Getenv("AZURITEMOCK_ENDPOINT") == "" {
+		t.Skip("Skipping testing without Azurite mock server")
+	}
+}


### PR DESCRIPTION
### What type of PR is this?

feature

### Which issue does this PR fix?

Closes #4141 (distribution-v3 follow-up to #2221).

### What does this PR do?

Adds an **Azure Blob Storage** backend for the remote image store, alongside S3 and GCS.

zot's `pkg/storage/s3` and `pkg/storage/gcs` are thin wrappers over the
`github.com/distribution/distribution/v3` storage-driver framework. v3.1.1 (already vendored)
ships a modern `azure` driver, so this mirrors the gcs wrapper:

- `pkg/storage/azure/{driver.go,azure.go}` — wraps the distribution v3 azure driver behind
  zot's storage interface (mirrors `pkg/storage/gcs`)
- `AzureStorageDriverName = "azure"`; wired into driver dispatch + config validation (default
  store and subpaths) in `pkg/storage/storage.go` and `pkg/cli/server/root.go`
- `azure` added to `NormalizeGCSRootDirectory` (same rootdirectory prefixing as gcs)

### Auth

Inherits the upstream driver's credential types via `storageDriver.credentials.type`:
`shared_key`, `client_secret`, and `default_credentials` (→ `DefaultAzureCredential`, i.e.
managed identity / Azure Workload Identity — secret-less).

```json
"storageDriver": {
  "name": "azure",
  "accountname": "myaccount",
  "container": "registry",
  "credentials": { "type": "default_credentials" }
}
```

### Tests

- **Unit** (`pkg/storage/azure/driver_test.go`) — mock-based, mirrors the gcs unit test
  (Name, dir handling, error→`PathNotFoundError` mapping).
- **Integration** (`pkg/storage/azure/azure_test.go`) — drives the wrapper against an
  **Azurite** emulator (write/read/stat/list/move/not-found/delete), gated on
  `AZURITEMOCK_ENDPOINT` and skipped when unset (mirrors `S3MOCK_ENDPOINT`/`GCSMOCK_ENDPOINT`).
- **CI** — `setup-azurite`/`teardown-azurite` composite actions + a `test-azure-storage` job
  in `test.yaml`, mirroring the localstack/gcs jobs.

### Docs

- `examples/config-azure.json` + an Azure Blob Storage subsection in `examples/README.md`.

### Verification

Validated end-to-end locally: the integration test passes against Azurite, and a zot
instance built from this branch serves a registry backed by Azure Blob via Workload Identity
(k3s + azure-workload-identity webhook) — `docker push`/`pull` succeed with layers landing in
the blob container.
