### PR TITLE
fix: stream blob bodies with per-chunk deadlines

### DIFF
--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -417,11 +417,13 @@ type HTTPConfig struct {
 	AllowOrigin string // comma separated
 	// ReadTimeout controls maximum duration for reading the entire request (including body).
 	// When unset (nil), server-level defaults may apply. When explicitly set to <= 0,
-	// the HTTP server treats it as no timeout.
+	// the HTTP server treats it as no timeout. Blob uploads extend this deadline per read,
+	// so it acts as an idle timeout for them rather than a cap on total upload time.
 	ReadTimeout *time.Duration `mapstructure:"readTimeout,omitempty"`
 	// WriteTimeout controls maximum duration before timing out response writes.
 	// When unset (nil), server-level defaults may apply. When explicitly set to <= 0,
-	// the HTTP server treats it as no timeout.
+	// the HTTP server treats it as no timeout. Blob downloads extend this deadline per write,
+	// so it acts as an idle timeout for them rather than a cap on total download time.
 	WriteTimeout  *time.Duration `mapstructure:"writeTimeout,omitempty"`
 	TLS           *TLSConfig
 	Auth          *AuthConfig

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1381,6 +1381,7 @@ func writeMultipartRanges(
 	bsize int64,
 	mediaType string,
 	openRange openRangeFunc,
+	writeTimeout time.Duration,
 	logger log.Logger,
 ) {
 	pipeReader, pipeWriter := io.Pipe()
@@ -1434,7 +1435,7 @@ func writeMultipartRanges(
 		pipeErr = writer.Close()
 	}()
 
-	if _, err := io.CopyN(response, pipeReader, contentLength); err != nil {
+	if _, err := io.Copy(newStreamDeadlineWriter(response, writeTimeout, logger), pipeReader); err != nil {
 		logger.Error().Err(err).Msg("failed to copy multipart range data into http response")
 	}
 }
@@ -1593,7 +1594,7 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 
 					return reader, err
 				},
-				rh.c.Log,
+				rh.c.Config.GetHTTPWriteTimeout(), rh.c.Log,
 			)
 
 			return
@@ -1625,7 +1626,8 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 		response.Header().Set(constants.DistContentDigestKey, digest.String())
 		response.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.start, rng.end, bsize))
 		WriteDataFromReader(
-			response, http.StatusPartialContent, rng.length(), mediaType, reader, rh.c.Log,
+			response, http.StatusPartialContent, rng.length(), mediaType, reader,
+			rh.c.Config.GetHTTPWriteTimeout(), rh.c.Log,
 		)
 
 		return
@@ -1653,7 +1655,7 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 	response.Header().Set("Content-Length", strconv.FormatInt(blen, 10))
 	response.Header().Set(constants.DistContentDigestKey, digest.String())
 
-	WriteDataFromReader(response, http.StatusOK, blen, mediaType, repo, rh.c.Log)
+	WriteDataFromReader(response, http.StatusOK, blen, mediaType, repo, rh.c.Config.GetHTTPWriteTimeout(), rh.c.Log)
 }
 
 // DeleteBlob godoc
@@ -1868,7 +1870,7 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 			return
 		}
 
-		sessionID, size, err := imgStore.FullBlobUpload(ctx, name, request.Body, digest)
+		sessionID, size, err := imgStore.FullBlobUpload(ctx, name, rh.uploadBody(request, response), digest)
 		if err != nil {
 			if errors.Is(err, zerr.ErrBadBlobDigest) {
 				details := zerr.GetDetails(err)
@@ -2031,7 +2033,7 @@ func (rh *RouteHandler) PatchBlobUpload(response http.ResponseWriter, request *h
 
 	if request.Header.Get("Content-Length") == "" || request.Header.Get("Content-Range") == "" {
 		// streamed blob upload
-		clen, err = imgStore.PutBlobChunkStreamed(ctx, name, sessionID, request.Body)
+		clen, err = imgStore.PutBlobChunkStreamed(ctx, name, sessionID, rh.uploadBody(request, response))
 	} else {
 		// chunked blob upload
 		var contentLength int64
@@ -2050,7 +2052,7 @@ func (rh *RouteHandler) PatchBlobUpload(response http.ResponseWriter, request *h
 			return
 		}
 
-		clen, err = imgStore.PutBlobChunk(ctx, name, sessionID, from, to, request.Body)
+		clen, err = imgStore.PutBlobChunk(ctx, name, sessionID, from, to, rh.uploadBody(request, response))
 	}
 
 	if err != nil { //nolint: dupl
@@ -2189,7 +2191,7 @@ func (rh *RouteHandler) UpdateBlobUpload(response http.ResponseWriter, request *
 	}
 
 	if shouldPutBlobChunk {
-		_, err = imgStore.PutBlobChunk(ctx, name, sessionID, from, to, request.Body)
+		_, err = imgStore.PutBlobChunk(ctx, name, sessionID, from, to, rh.uploadBody(request, response))
 		if err != nil { //nolint:dupl
 			details := zerr.GetDetails(err)
 			if errors.Is(err, zerr.ErrBadUploadRange) { //nolint:gocritic // errorslint conflicts with gocritic:IfElseChain
@@ -2221,7 +2223,7 @@ func (rh *RouteHandler) UpdateBlobUpload(response http.ResponseWriter, request *
 	}
 
 	// blob chunks already transferred, just finish
-	if err := imgStore.FinishBlobUpload(name, sessionID, request.Body, digest); err != nil {
+	if err := imgStore.FinishBlobUpload(name, sessionID, rh.uploadBody(request, response), digest); err != nil {
 		details := zerr.GetDetails(err)
 		if errors.Is(err, zerr.ErrBadBlobDigest) { //nolint:gocritic // errorslint conflicts with gocritic:IfElseChain
 			details["digest"] = digest.String()
@@ -2716,25 +2718,94 @@ func getContentRange(r *http.Request) (int64 /* from */, int64 /* to */, error) 
 }
 
 func WriteDataFromReader(response http.ResponseWriter, status int, length int64, mediaType string,
-	reader io.Reader, logger log.Logger,
+	reader io.Reader, writeTimeout time.Duration, logger log.Logger,
 ) {
 	response.Header().Set("Content-Type", mediaType)
 	response.Header().Set("Content-Length", strconv.FormatInt(length, 10))
 	response.WriteHeader(status)
 
-	const maxSize = 10 * 1024 * 1024
-
-	for {
-		_, err := io.CopyN(response, reader, maxSize)
-		if errors.Is(err, io.EOF) {
-			break
-		} else if err != nil {
-			// other kinds of intermittent errors can occur, e.g, io.ErrShortWrite
-			logger.Error().Err(err).Msg("failed to copy data into http response")
-
-			return
-		}
+	if _, err := io.Copy(newStreamDeadlineWriter(response, writeTimeout, logger), reader); err != nil {
+		// other kinds of intermittent errors can occur, e.g, io.ErrShortWrite
+		logger.Error().Err(err).Msg("failed to copy data into http response")
 	}
+}
+
+// streamDeadlineWriter extends the connection write deadline before each Write.
+// http.Server.WriteTimeout is a deadline on the whole response, so without this a large or slow
+// download is aborted mid-stream even while data is still flowing. io.Copy writes in ~32KiB
+// chunks, so resetting the deadline per Write turns it into an idle deadline regardless of link
+// speed: a transfer that keeps making progress completes, a stalled one still times out. A zero
+// timeout returns the writer unwrapped, preserving the "0 means no timeout" configuration.
+type streamDeadlineWriter struct {
+	writer             io.Writer
+	responseController *http.ResponseController
+	timeout            time.Duration
+	logger             log.Logger
+}
+
+func newStreamDeadlineWriter(response http.ResponseWriter, timeout time.Duration,
+	logger log.Logger,
+) io.Writer {
+	if timeout <= 0 {
+		return response
+	}
+
+	return &streamDeadlineWriter{
+		writer:             response,
+		responseController: http.NewResponseController(response),
+		timeout:            timeout,
+		logger:             logger,
+	}
+}
+
+func (w *streamDeadlineWriter) Write(buf []byte) (int, error) {
+	if err := w.responseController.SetWriteDeadline(time.Now().Add(w.timeout)); err != nil &&
+		!errors.Is(err, http.ErrNotSupported) {
+		w.logger.Error().Err(err).Msg("failed to extend response write deadline")
+	}
+
+	return w.writer.Write(buf)
+}
+
+// streamDeadlineReader extends the connection read deadline before each Read. As with the
+// write side, http.Server.ReadTimeout is a deadline on reading the entire request, so a large
+// or slow upload is aborted mid-stream without this. Resetting per Read makes it an idle
+// deadline. A zero timeout returns the body unwrapped, preserving "0 means no timeout".
+type streamDeadlineReader struct {
+	reader             io.Reader
+	responseController *http.ResponseController
+	timeout            time.Duration
+	logger             log.Logger
+}
+
+func newStreamDeadlineReader(body io.Reader, response http.ResponseWriter, timeout time.Duration,
+	logger log.Logger,
+) io.Reader {
+	if timeout <= 0 {
+		return body
+	}
+
+	return &streamDeadlineReader{
+		reader:             body,
+		responseController: http.NewResponseController(response),
+		timeout:            timeout,
+		logger:             logger,
+	}
+}
+
+func (r *streamDeadlineReader) Read(buf []byte) (int, error) {
+	if err := r.responseController.SetReadDeadline(time.Now().Add(r.timeout)); err != nil &&
+		!errors.Is(err, http.ErrNotSupported) {
+		r.logger.Error().Err(err).Msg("failed to extend request read deadline")
+	}
+
+	return r.reader.Read(buf)
+}
+
+// uploadBody wraps the request body so the configured ReadTimeout applies per read instead of
+// to the whole upload, so large or slow blob uploads stream without being cut off mid-transfer.
+func (rh *RouteHandler) uploadBody(request *http.Request, response http.ResponseWriter) io.Reader {
+	return newStreamDeadlineReader(request.Body, response, rh.c.Config.GetHTTPReadTimeout(), rh.c.Log)
 }
 
 // will return image storage corresponding to subpath provided in config.

--- a/pkg/api/routes_internal_test.go
+++ b/pkg/api/routes_internal_test.go
@@ -1,11 +1,17 @@
 package api
 
 import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/storage"
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 )
@@ -202,3 +208,69 @@ func TestIsBlobRedirectEnabled(t *testing.T) {
 		t.Fatal("expected redirect to be disabled for default storage")
 	}
 }
+
+// readDeadlineRecorder is an http.ResponseWriter that records SetReadDeadline calls so the
+// read side of the streaming deadline handling can be asserted. http.ResponseController calls
+// SetReadDeadline directly when the writer implements it, so no Unwrap is needed.
+type readDeadlineRecorder struct {
+	*httptest.ResponseRecorder
+
+	readDeadlines int
+	deadlineErr   error
+}
+
+func (r *readDeadlineRecorder) SetReadDeadline(_ time.Time) error {
+	r.readDeadlines++
+
+	return r.deadlineErr
+}
+
+func TestStreamDeadlineReader(t *testing.T) {
+	t.Run("extends the read deadline before each read", func(t *testing.T) {
+		recorder := &readDeadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+		reader := newStreamDeadlineReader(bytes.NewReader([]byte("upload-body")), recorder,
+			time.Minute, log.NewTestLogger())
+
+		got, err := reader.Read(make([]byte, 4))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if got == 0 {
+			t.Fatal("expected to read some bytes")
+		}
+
+		if recorder.readDeadlines < 1 {
+			t.Fatalf("expected the read deadline to be set at least once, got %d", recorder.readDeadlines)
+		}
+	})
+
+	t.Run("reads through when setting the deadline errors", func(t *testing.T) {
+		recorder := &readDeadlineRecorder{
+			ResponseRecorder: httptest.NewRecorder(),
+			deadlineErr:      errors.New("deadline not supported"), //nolint:err113
+		}
+		reader := newStreamDeadlineReader(bytes.NewReader([]byte("upload-body")), recorder,
+			time.Minute, log.NewTestLogger())
+
+		if _, err := reader.Read(make([]byte, 4)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("zero timeout returns the body unwrapped", func(t *testing.T) {
+		recorder := &readDeadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+		reader := newStreamDeadlineReader(bytes.NewReader([]byte("upload-body")), recorder,
+			0, log.NewTestLogger())
+
+		if _, err := reader.Read(make([]byte, 4)); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if recorder.readDeadlines != 0 {
+			t.Fatalf("expected no read deadline calls with a zero timeout, got %d", recorder.readDeadlines)
+		}
+	})
+}
+
+var _ http.ResponseWriter = (*readDeadlineRecorder)(nil)

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -2326,13 +2327,64 @@ func (r readerThatFails) Read(p []byte) (int, error) {
 	return 0, zerr.ErrInjected
 }
 
+// deadlineRecorder records SetWriteDeadline calls so tests can assert the streaming write
+// deadline is being extended. http.ResponseController calls SetWriteDeadline directly when the
+// writer implements it, so no Unwrap is needed here.
+type deadlineRecorder struct {
+	*httptest.ResponseRecorder
+
+	writeDeadlines int
+}
+
+func (d *deadlineRecorder) SetWriteDeadline(_ time.Time) error {
+	d.writeDeadlines++
+
+	return nil
+}
+
 func TestWriteDataFromReader(t *testing.T) {
-	Convey("", t, func() {
+	Convey("reader error is handled", t, func() {
 		response := httptest.NewRecorder()
 		api.WriteDataFromReader(response, 200, 100, ispec.MediaTypeImageManifest, readerThatFails{},
-			log.NewTestLogger())
+			0, log.NewTestLogger())
 
 		So(response.Code, ShouldEqual, 200)
+	})
+
+	Convey("data is streamed when the writer lacks deadline support", t, func() {
+		response := httptest.NewRecorder()
+		payload := []byte("some-blob-content")
+
+		// httptest.NewRecorder does not support SetWriteDeadline; the deadline error is
+		// http.ErrNotSupported and must be ignored, so the body still streams in full.
+		api.WriteDataFromReader(response, 200, int64(len(payload)), ispec.MediaTypeImageLayer,
+			bytes.NewReader(payload), time.Minute, log.NewTestLogger())
+
+		So(response.Code, ShouldEqual, 200)
+		So(response.Body.Bytes(), ShouldResemble, payload)
+	})
+
+	Convey("write deadline is extended while streaming", t, func() {
+		recorder := &deadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+		payload := []byte("some-blob-content")
+
+		api.WriteDataFromReader(recorder, 200, int64(len(payload)), ispec.MediaTypeImageLayer,
+			bytes.NewReader(payload), time.Minute, log.NewTestLogger())
+
+		So(recorder.Code, ShouldEqual, 200)
+		So(recorder.Body.Bytes(), ShouldResemble, payload)
+		So(recorder.writeDeadlines, ShouldBeGreaterThanOrEqualTo, 1)
+	})
+
+	Convey("write deadline is not set when the timeout is zero", t, func() {
+		recorder := &deadlineRecorder{ResponseRecorder: httptest.NewRecorder()}
+		payload := []byte("some-blob-content")
+
+		api.WriteDataFromReader(recorder, 200, int64(len(payload)), ispec.MediaTypeImageLayer,
+			bytes.NewReader(payload), 0, log.NewTestLogger())
+
+		So(recorder.Code, ShouldEqual, 200)
+		So(recorder.writeDeadlines, ShouldEqual, 0)
 	})
 }
 

--- a/pkg/api/session.go
+++ b/pkg/api/session.go
@@ -36,6 +36,13 @@ func (w *statusWriter) Write(b []byte) (int, error) {
 	return n, err
 }
 
+// Unwrap exposes the wrapped ResponseWriter so http.ResponseController can reach the
+// underlying connection (e.g. to set read/write deadlines while streaming blobs). Without it
+// the controller stops at this wrapper and reports http.ErrNotSupported.
+func (w *statusWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 // RateLimiter limits handling of incoming requests.
 func RateLimiter(ctlr *Controller, rate int) mux.MiddlewareFunc {
 	ctlr.Log.Info().Int("rate", rate).Msg("ratelimiter enabled")


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**: Fixes #4140

**What does this PR do / Why do we need it**:

`http.Server`'s `ReadTimeout` and `WriteTimeout` (added in #3984) are deadlines on the whole request and response, set when it starts. A blob upload or download that runs longer than the timeout is therefore cut off mid-stream once it passes the deadline, even while data is still flowing. It shows up as a TCP `i/o timeout` (`WriteDataFromReader` in `pkg/api/routes.go`) and a truncated body for the client, and as an occasional failure in the `GC-on-S3` stress job.

This resets the deadline per chunk via `http.NewResponseController`, so the timeout behaves as an idle deadline: a transfer that keeps making progress completes, a stalled one still times out. It covers the blob serve paths (`WriteDataFromReader` and the multipart-range path) and the blob receive paths (`FullBlobUpload`, `PutBlobChunk`, `PutBlobChunkStreamed`, `FinishBlobUpload`). A zero timeout leaves deadlines off, so `readTimeout`/`writeTimeout` set to `0` still disables them.

`statusWriter` (the session-logging middleware wrapper) now implements `Unwrap`, otherwise the `ResponseController` stops at the wrapper and the deadline calls return `http.ErrNotSupported` and do nothing.

**If an issue # is not available please add repro steps and logs showing the issue**:

```
failed to copy data into http response: write tcp ...: i/o timeout   (pkg/api/routes.go)
```
Triggered by uploading or downloading a blob that takes longer than `writeTimeout`/`readTimeout` (default 60s), e.g. a multi-GB layer over a slow link, or a blob read under load in the GC-on-S3 stress test.

**Testing done on this change**:

Extended `TestWriteDataFromReader` to cover streaming with a deadline set, the `http.ErrNotSupported` path (recorder without deadline support), and the zero-timeout case. Existing blob GET, multipart-range and upload handler tests pass. Built and linted with `golangci-lint v2.12.2`.

**Automation added to e2e**:

No new e2e. The existing `GC-on-S3` stress job exercises the serve path under load and acts as a regression check.

**Will this break upgrades or downgrades?**

No.

**Does this PR introduce any user-facing change?**:

```release-note
HTTP readTimeout/writeTimeout now act as idle timeouts during blob upload and download: a transfer that keeps making progress is no longer aborted once it exceeds the configured timeout. They still bound idle connections, and setting either to 0 disables them. Note this means writeTimeout/readTimeout no longer cap the total time of a blob transfer.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

