### PR TITLE
ci: pull test images from ghcr mirror

### DIFF
--- a/.github/workflows/cluster.yaml
+++ b/.github/workflows/cluster.yaml
@@ -52,7 +52,7 @@ jobs:
                 -v /tmp/data:/data \
                 -v /tmp/config:/root/.minio \
                 --health-cmd "curl http://localhost:9000/minio/health/live" \
-                minio/minio:RELEASE.2024-07-16T23-46-41Z server /data
+                ghcr.io/project-zot/ci-images/minio:RELEASE.2024-07-16T23-46-41Z server /data
       - name: Install py minio
         run: pip3 install minio==7.2.18
 
@@ -310,7 +310,7 @@ jobs:
                 -v /tmp/data:/data \
                 -v /tmp/config:/root/.minio \
                 --health-cmd "curl http://localhost:9000/minio/health/live" \
-                minio/minio:RELEASE.2024-07-16T23-46-41Z server /data
+                ghcr.io/project-zot/ci-images/minio:RELEASE.2024-07-16T23-46-41Z server /data
       - name: Install py minio
         run: pip3 install minio==7.2.18
 
@@ -329,7 +329,7 @@ jobs:
                 --health-interval 10s \
                 --health-timeout 5s \
                 --health-retries 5 \
-                redis:7.4.2
+                ghcr.io/project-zot/ci-images/redis:7.4.2
 
       - name: Create minio bucket
         run: |

--- a/.github/workflows/gc-stress-test.yaml
+++ b/.github/workflows/gc-stress-test.yaml
@@ -117,7 +117,7 @@ jobs:
                 -v /tmp/data:/data \
                 -v /tmp/config:/root/.minio \
                 --health-cmd "curl http://localhost:9000/minio/health/live" \
-                minio/minio:RELEASE.2024-07-16T23-46-41Z server /data
+                ghcr.io/project-zot/ci-images/minio:RELEASE.2024-07-16T23-46-41Z server /data
       - name: Install py minio
         run: pip3 install minio==7.2.18
 
@@ -204,7 +204,7 @@ jobs:
                 -v /tmp/data:/data \
                 -v /tmp/config:/root/.minio \
                 --health-cmd "curl http://localhost:9000/minio/health/live" \
-                minio/minio:RELEASE.2024-07-16T23-46-41Z server /data
+                ghcr.io/project-zot/ci-images/minio:RELEASE.2024-07-16T23-46-41Z server /data
       - name: Install py minio
         run: pip3 install minio==7.2.18
 

--- a/test/blackbox/helpers_events.bash
+++ b/test/blackbox/helpers_events.bash
@@ -1,7 +1,7 @@
 function nats_server_start() {
   local cname="$1" # container name
   local free_port="$2"
-  docker run -d --name ${cname} -p ${free_port}:4222 nats:2.11.1 --user jane.joe --pass opensesame
+  docker run -d --name ${cname} -p ${free_port}:4222 ghcr.io/project-zot/ci-images/nats:2.11.1 --user jane.joe --pass opensesame
 }
 
 function nats_server_stop() {
@@ -18,7 +18,7 @@ function wait_event_on_subject() {
 
     mkdir -p "${dir}"
 
-    docker run -d --rm --network host --user "$(id -u):$(id -g)" -v "${dir}":/data natsio/nats-box:latest  \
+    docker run -d --rm --network host --user "$(id -u):$(id -g)" -v "${dir}":/data ghcr.io/project-zot/ci-images/nats-box:0.19.7  \
         nats sub ${subject} --user jane.joe --password opensesame \
         --server nats://127.0.0.1:${port} --count=${count} --wait=5s --raw --dump=/data
 
@@ -40,7 +40,7 @@ function http_server_start() {
     docker run -d --rm --name "${cname}" \
         -p "${port}:8080" \
         -v "${dir}":/data \
-        python:3 sh -c ' \
+        ghcr.io/project-zot/ci-images/python:3.11 sh -c ' \
             echo "Installing Flask..." >&2 && \
             pip install flask > /dev/null 2>&1 && \
             echo "Flask installed, starting server..." >&2 && \

--- a/test/blackbox/setup_images.sh
+++ b/test/blackbox/setup_images.sh
@@ -9,10 +9,10 @@ echo "Pre-downloading Docker images for blackbox tests..."
 
 # List of images used in the tests
 IMAGES=(
-    "nats:2.11.1"
-    "natsio/nats-box:latest"
-    "python:3"
-    "redis:latest"
+    "ghcr.io/project-zot/ci-images/nats:2.11.1"
+    "ghcr.io/project-zot/ci-images/nats-box:0.19.7"
+    "ghcr.io/project-zot/ci-images/python:3.11"
+    "ghcr.io/project-zot/ci-images/redis:7.4.2"
     "ghcr.io/project-zot/test-images/busybox-docker:1.37"
 )
 


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**: Fixes #4154

**What does this PR do / Why do we need it**:

CI intermittently fails when Docker Hub rate-limits or times out pulling images. PRs #4142 and #4149 both failed at the same time on `context deadline exceeded` for `minio/minio` and `natsio/nats-box`.

This points the remaining external CI images at the `ghcr.io/project-zot/ci-images` mirror, matching how localstack, azurite and the gcs testbench already avoid Docker Hub:

- `minio:RELEASE.2024-07-16T23-46-41Z` (`gc-stress-test.yaml`, `cluster.yaml`)
- `nats-box:0.19.7`, was `natsio/nats-box:latest` (`helpers_events.bash`, `setup_images.sh`)
- `nats:2.11.1` (`helpers_events.bash`, `setup_images.sh`)
- `python:3.11`, was `python:3`; matches the `python-version: '3.11'` the workflows use (`helpers_events.bash`, `setup_images.sh`)
- `redis:7.4.2`, was `redis:latest` in the blackbox setup; standardised on `7.4.2` (`setup_images.sh`, `cluster.yaml`)

Floating tags are pinned so CI runs are reproducible.

> [!IMPORTANT]
> Blocked: depends on these images being mirrored to `ghcr.io/project-zot/ci-images` first. CI here stays red until they exist. The branch is ready to merge once the mirror lands. If any final path or tag differs, I will update the references to match.

**If an issue # is not available please add repro steps and logs showing the issue**:

```
Head "https://registry-1.docker.io/v2/minio/minio/manifests/..." : context deadline exceeded
```

**Testing done on this change**:

None yet; the reference paths can only be exercised once the images exist in ghcr. CI on this branch validates them after that.

**Will this break upgrades or downgrades?**

No, CI-only change.

**Does this PR introduce any user-facing change?**:

```release-note
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
