### PR TITLE
fix(api): align blob, manifest, and referrers handling with OCI conformance

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -8039,10 +8039,15 @@ func TestArtifactReferences(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(resp.StatusCode(), ShouldEqual, http.StatusBadRequest)
 
-				// unknown repo will return status not found
+				// unknown repo returns empty referrers index
 				resp, err = resty.R().Get(baseURL + fmt.Sprintf("/v2/%s/referrers/%s", "unknown", digest.String()))
 				So(err, ShouldBeNil)
-				So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+				So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+				var emptyReferrers ispec.Index
+				err = json.Unmarshal(resp.Body(), &emptyReferrers)
+				So(err, ShouldBeNil)
+				So(emptyReferrers.Manifests, ShouldBeEmpty)
 
 				resp, err = resty.R().Get(baseURL + fmt.Sprintf("/v2/%s/referrers/%s", repoName, digest.String()))
 				So(err, ShouldBeNil)

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -610,14 +610,16 @@ func getReferrers(ctx context.Context, routeHandler *RouteHandler,
 
 // GetReferrers godoc
 // @Summary Get referrers for a given digest
-// @Description Get referrers given a digest
+// @Description Returns referrers for a subject digest as an OCI image index. Missing repositories and
+// @Description subjects with no referrers return 200 with an empty manifests list.
 // @Accept  json
 // @Produce application/vnd.oci.image.index.v1+json
 // @Param   name       path    string     true        "repository name"
 // @Param   digest     path    string     true        "digest"
 // @Param artifactType query string false "artifact type"
 // @Success 200 {object} api.ImageIndex
-// @Failure 404 {string} string "not found"
+// @Failure 400 {string} string "bad request (invalid digest)"
+// @Failure 404 {string} string "not found (manifest unknown)"
 // @Failure 500 {string} string "internal server error"
 // @Router /v2/{name}/referrers/{digest} [get].
 func (rh *RouteHandler) GetReferrers(response http.ResponseWriter, request *http.Request) {
@@ -652,7 +654,7 @@ func (rh *RouteHandler) GetReferrers(response http.ResponseWriter, request *http
 
 	referrers, err := getReferrers(request.Context(), rh, imgStore, name, digest, artifactTypes)
 	if err != nil {
-		if errors.Is(err, zerr.ErrManifestNotFound) || errors.Is(err, zerr.ErrRepoNotFound) {
+		if errors.Is(err, zerr.ErrManifestNotFound) {
 			rh.c.Log.Error().Err(err).Str("name", name).Str("digest", digest.String()).
 				Msg("failed to get manifest")
 			response.WriteHeader(http.StatusNotFound)
@@ -715,6 +717,13 @@ func (rh *RouteHandler) UpdateManifest(response http.ResponseWriter, request *ht
 	if !ok || reference == "" {
 		err := apiErr.NewError(apiErr.MANIFEST_INVALID).AddDetail(map[string]string{"reference": reference})
 		zcommon.WriteJSON(response, http.StatusNotFound, apiErr.NewErrorList(err))
+
+		return
+	}
+
+	if zcommon.LooksLikeDigestReference(reference) {
+		e := apiErr.NewError(apiErr.DIGEST_INVALID).AddDetail(map[string]string{"reference": reference})
+		zcommon.WriteJSON(response, http.StatusBadRequest, apiErr.NewErrorList(e))
 
 		return
 	}
@@ -1703,13 +1712,17 @@ func (rh *RouteHandler) DeleteBlob(response http.ResponseWriter, request *http.R
 
 // CreateBlobUpload godoc
 // @Summary Create image blob/layer upload
-// @Description Create a new image blob/layer upload
+// @Description Create a new image blob/layer upload. A `digest` query parameter requests a monolithic upload
+// @Description and returns 201 on success; otherwise a new upload session is started and 202 is returned.
 // @Accept  json
 // @Produce json
 // @Param   name    path    string     true        "repository name"
+// @Success 201 "created"
+// @Header  201 {string} Location "/v2/{name}/blobs/{digest}"
 // @Success 202 "accepted"
 // @Header  202 {string} Location "/v2/{name}/blobs/uploads/{session_id}"
 // @Header  202 {string} Range "0-0"
+// @Failure 400 {string} string "bad request (invalid digest or upload)"
 // @Failure 401 {string} string "unauthorized"
 // @Failure 404 {string} string "not found"
 // @Failure 500 {string} string "internal server error"
@@ -1815,11 +1828,17 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 
 		digestStr := digests[0]
 
-		digest := godigest.Digest(digestStr)
+		digest, err := godigest.Parse(digestStr)
+		if err != nil {
+			e := apiErr.NewError(apiErr.DIGEST_INVALID).AddDetail(map[string]string{"digest": digestStr})
+			zcommon.WriteJSON(response, http.StatusBadRequest, apiErr.NewErrorList(e))
+
+			return
+		}
 
 		var contentLength int64
 
-		contentLength, err := strconv.ParseInt(request.Header.Get("Content-Length"), 10, 64)
+		contentLength, err = strconv.ParseInt(request.Header.Get("Content-Length"), 10, 64)
 		if err != nil || contentLength <= 0 {
 			rh.c.Log.Warn().Str("actual", request.Header.Get("Content-Length")).Msg("invalid content length")
 
@@ -1839,6 +1858,15 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 
 		sessionID, size, err := imgStore.FullBlobUpload(ctx, name, request.Body, digest)
 		if err != nil {
+			if errors.Is(err, zerr.ErrBadBlobDigest) {
+				details := zerr.GetDetails(err)
+				details["digest"] = digest.String()
+				e := apiErr.NewError(apiErr.DIGEST_INVALID).AddDetail(details)
+				zcommon.WriteJSON(response, http.StatusBadRequest, apiErr.NewErrorList(e))
+
+				return
+			}
+
 			rh.c.Log.Error().Err(err).Int64("actual", size).Int64("expected", contentLength).
 				Msg("failed to full blob upload")
 			response.WriteHeader(http.StatusInternalServerError)

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1719,6 +1719,7 @@ func (rh *RouteHandler) DeleteBlob(response http.ResponseWriter, request *http.R
 // @Param   name    path    string     true        "repository name"
 // @Success 201 "created"
 // @Header  201 {string} Location "/v2/{name}/blobs/{digest}"
+// @Header  201 {string} Blob-Upload-UUID "Opaque blob upload session identifier"
 // @Success 202 "accepted"
 // @Header  202 {string} Location "/v2/{name}/blobs/uploads/{session_id}"
 // @Header  202 {string} Range "0-0"

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1712,11 +1712,15 @@ func (rh *RouteHandler) DeleteBlob(response http.ResponseWriter, request *http.R
 
 // CreateBlobUpload godoc
 // @Summary Create image blob/layer upload
-// @Description Create a new image blob/layer upload. A `digest` query parameter requests a monolithic upload
-// @Description and returns 201 on success; otherwise a new upload session is started and 202 is returned.
+// @Description Create a new image blob/layer upload. With no query parameters, starts an upload session
+// @Description and returns 202.
+// @Description A `digest` query parameter requests a monolithic upload and returns 201 on success.
+// @Description A `mount` query parameter requests a cross-repository blob mount and returns 201 or 202.
 // @Accept  json
 // @Produce json
 // @Param   name    path    string     true        "repository name"
+// @Param   digest  query   string     false       "blob digest for monolithic upload"
+// @Param   mount   query   string     false       "blob digest to mount into the repository"
 // @Success 201 "created"
 // @Header  201 {string} Location "/v2/{name}/blobs/{digest}"
 // @Header  201 {string} Blob-Upload-UUID "Opaque blob upload session identifier"
@@ -1726,6 +1730,7 @@ func (rh *RouteHandler) DeleteBlob(response http.ResponseWriter, request *http.R
 // @Failure 400 {string} string "bad request (invalid digest or upload)"
 // @Failure 401 {string} string "unauthorized"
 // @Failure 404 {string} string "not found"
+// @Failure 415 {string} string "unsupported media type (monolithic upload requires application/octet-stream)"
 // @Failure 500 {string} string "internal server error"
 // @Router /v2/{name}/blobs/uploads [post].
 func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *http.Request) {

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -554,6 +554,15 @@ func TestRoutes(t *testing.T) {
 				})
 			So(statusCode, ShouldEqual, http.StatusBadRequest)
 
+			// malformed digest-shaped manifest reference
+			statusCode = testUpdateManifest(
+				map[string]string{
+					"name":      "test",
+					"reference": "sha256:baddigeststring",
+				},
+				&mocks.MockedImageStore{})
+			So(statusCode, ShouldEqual, http.StatusBadRequest)
+
 			// ErrRepoBadVersion
 			statusCode = testUpdateManifest(
 				map[string]string{
@@ -1300,7 +1309,7 @@ func TestRoutes(t *testing.T) {
 			// digest prezent imgStore err
 			statusCode = testCreateBlobUpload(
 				[]struct{ k, v string }{
-					{"digest", "1234"},
+					{"digest", "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621"},
 				},
 				map[string]string{
 					"Content-Type":   constants.BinaryMediaType,
@@ -1313,12 +1322,11 @@ func TestRoutes(t *testing.T) {
 						return sessionStr, 0, zerr.ErrBadBlobDigest
 					},
 				})
-			So(statusCode, ShouldEqual, http.StatusInternalServerError)
+			So(statusCode, ShouldEqual, http.StatusBadRequest)
 
-			// digest prezent bad length
 			statusCode = testCreateBlobUpload(
 				[]struct{ k, v string }{
-					{"digest", "1234"},
+					{"digest", "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621"},
 				},
 				map[string]string{
 					"Content-Type":   constants.BinaryMediaType,

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -1306,6 +1306,18 @@ func TestRoutes(t *testing.T) {
 				})
 			So(statusCode, ShouldEqual, http.StatusUnsupportedMediaType)
 
+			// invalid digest query value
+			statusCode = testCreateBlobUpload(
+				[]struct{ k, v string }{
+					{"digest", "sha256:invalid_digest_format"},
+				},
+				map[string]string{
+					"Content-Type":   constants.BinaryMediaType,
+					"Content-Length": "10",
+				},
+				&mocks.MockedImageStore{})
+			So(statusCode, ShouldEqual, http.StatusBadRequest)
+
 			// digest prezent imgStore err
 			statusCode = testCreateBlobUpload(
 				[]struct{ k, v string }{

--- a/pkg/common/oci.go
+++ b/pkg/common/oci.go
@@ -126,6 +126,25 @@ func IsDigest(ref string) bool {
 	return err == nil
 }
 
+// LooksLikeDigestReference reports whether ref uses digest syntax (algorithm:encoded) but
+// fails digest.Parse, e.g. sha256:baddigeststring.
+func LooksLikeDigestReference(ref string) bool {
+	if IsDigest(ref) {
+		return false
+	}
+
+	algo, encoded, ok := strings.Cut(ref, ":")
+	if !ok || algo == "" || encoded == "" {
+		return false
+	}
+
+	if !digest.Algorithm(algo).Available() {
+		return false
+	}
+
+	return true
+}
+
 func IsTag(ref string) bool {
 	return !IsDigest(ref)
 }

--- a/pkg/common/oci_test.go
+++ b/pkg/common/oci_test.go
@@ -1,6 +1,7 @@
 package common_test
 
 import (
+	"strings"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -13,5 +14,12 @@ func TestOCI(t *testing.T) {
 		repo, digest := common.GetImageDirAndDigest("image")
 		So(repo, ShouldResemble, "image")
 		So(digest, ShouldResemble, "")
+	})
+
+	Convey("LooksLikeDigestReference", t, func() {
+		So(common.LooksLikeDigestReference("sha256:baddigeststring"), ShouldBeTrue)
+		So(common.LooksLikeDigestReference("sha256:"+strings.Repeat("a", 64)), ShouldBeFalse)
+		So(common.LooksLikeDigestReference("1.0"), ShouldBeFalse)
+		So(common.LooksLikeDigestReference("latest"), ShouldBeFalse)
 	})
 }

--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -681,7 +681,7 @@ func GetReferrers(imgStore storageTypes.ImageStore, repo string, gdigest godiges
 
 	dir := path.Join(imgStore.RootDir(), repo)
 	if !imgStore.DirExists(dir) {
-		return nilIndex, zerr.ErrRepoNotFound
+		return newEmptyReferrersIndex(), nil
 	}
 
 	index, err := GetIndex(imgStore, repo, log)
@@ -773,14 +773,21 @@ func GetReferrers(imgStore storageTypes.ImageStore, repo string, gdigest godiges
 		}
 	}
 
-	index = ispec.Index{
+	return ispec.Index{
 		Versioned:   imeta.Versioned{SchemaVersion: storageConstants.SchemaVersion},
 		MediaType:   ispec.MediaTypeImageIndex,
 		Manifests:   result,
 		Annotations: map[string]string{},
-	}
+	}, nil
+}
 
-	return index, nil
+func newEmptyReferrersIndex() ispec.Index {
+	return ispec.Index{
+		Versioned:   imeta.Versioned{SchemaVersion: storageConstants.SchemaVersion},
+		MediaType:   ispec.MediaTypeImageIndex,
+		Manifests:   []ispec.Descriptor{},
+		Annotations: map[string]string{},
+	}
 }
 
 // GetBlobDescriptorFromRepo gets blob descriptor from it's manifest contents,

--- a/pkg/storage/common/common_test.go
+++ b/pkg/storage/common/common_test.go
@@ -221,10 +221,12 @@ func TestGetReferrersErrors(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Trigger repo not found error", func(c C) {
-			_, err := common.GetReferrers(imgStore, "zot-test", validDigest,
+		Convey("repo not found returns empty index", func(c C) {
+			idx, err := common.GetReferrers(imgStore, "zot-test", validDigest,
 				[]string{artifactType}, log)
-			So(err, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+			So(idx.Manifests, ShouldBeEmpty)
+			So(idx.MediaType, ShouldEqual, ispec.MediaTypeImageIndex)
 		})
 
 		storageCtlr := storage.StoreController{DefaultStore: imgStore}

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -292,7 +292,7 @@ const docTemplate = `{
         },
         "/v2/{name}/blobs/uploads": {
             "post": {
-                "description": "Create a new image blob/layer upload",
+                "description": "Create a new image blob/layer upload. A ` + "`" + `digest` + "`" + ` query parameter requests a monolithic upload\nand returns 201 on success; otherwise a new upload session is started and 202 is returned.",
                 "consumes": [
                     "application/json"
                 ],
@@ -310,6 +310,15 @@ const docTemplate = `{
                     }
                 ],
                 "responses": {
+                    "201": {
+                        "description": "created",
+                        "headers": {
+                            "Location": {
+                                "type": "string",
+                                "description": "/v2/{name}/blobs/{digest}"
+                            }
+                        }
+                    },
                     "202": {
                         "description": "accepted",
                         "headers": {
@@ -321,6 +330,12 @@ const docTemplate = `{
                                 "type": "string",
                                 "description": "0-0"
                             }
+                        }
+                    },
+                    "400": {
+                        "description": "bad request (invalid digest or upload)",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     "401": {
@@ -946,7 +961,7 @@ const docTemplate = `{
         },
         "/v2/{name}/referrers/{digest}": {
             "get": {
-                "description": "Get referrers given a digest",
+                "description": "Returns referrers for a subject digest as an OCI image index. Missing repositories and\nsubjects with no referrers return 200 with an empty manifests list.",
                 "consumes": [
                     "application/json"
                 ],
@@ -983,8 +998,14 @@ const docTemplate = `{
                             "$ref": "#/definitions/api.ImageIndex"
                         }
                     },
+                    "400": {
+                        "description": "bad request (invalid digest)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "404": {
-                        "description": "not found",
+                        "description": "not found (manifest unknown)",
                         "schema": {
                             "type": "string"
                         }

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -292,7 +292,7 @@ const docTemplate = `{
         },
         "/v2/{name}/blobs/uploads": {
             "post": {
-                "description": "Create a new image blob/layer upload. A ` + "`" + `digest` + "`" + ` query parameter requests a monolithic upload\nand returns 201 on success; otherwise a new upload session is started and 202 is returned.",
+                "description": "Create a new image blob/layer upload. With no query parameters, starts an upload session\nand returns 202.\nA ` + "`" + `digest` + "`" + ` query parameter requests a monolithic upload and returns 201 on success.\nA ` + "`" + `mount` + "`" + ` query parameter requests a cross-repository blob mount and returns 201 or 202.",
                 "consumes": [
                     "application/json"
                 ],
@@ -307,6 +307,18 @@ const docTemplate = `{
                         "name": "name",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "blob digest for monolithic upload",
+                        "name": "digest",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "blob digest to mount into the repository",
+                        "name": "mount",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -350,6 +362,12 @@ const docTemplate = `{
                     },
                     "404": {
                         "description": "not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "415": {
+                        "description": "unsupported media type (monolithic upload requires application/octet-stream)",
                         "schema": {
                             "type": "string"
                         }

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -313,6 +313,10 @@ const docTemplate = `{
                     "201": {
                         "description": "created",
                         "headers": {
+                            "Blob-Upload-UUID": {
+                                "type": "string",
+                                "description": "Opaque blob upload session identifier"
+                            },
                             "Location": {
                                 "type": "string",
                                 "description": "/v2/{name}/blobs/{digest}"

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -284,7 +284,7 @@
         },
         "/v2/{name}/blobs/uploads": {
             "post": {
-                "description": "Create a new image blob/layer upload",
+                "description": "Create a new image blob/layer upload. A `digest` query parameter requests a monolithic upload\nand returns 201 on success; otherwise a new upload session is started and 202 is returned.",
                 "consumes": [
                     "application/json"
                 ],
@@ -302,6 +302,15 @@
                     }
                 ],
                 "responses": {
+                    "201": {
+                        "description": "created",
+                        "headers": {
+                            "Location": {
+                                "type": "string",
+                                "description": "/v2/{name}/blobs/{digest}"
+                            }
+                        }
+                    },
                     "202": {
                         "description": "accepted",
                         "headers": {
@@ -313,6 +322,12 @@
                                 "type": "string",
                                 "description": "0-0"
                             }
+                        }
+                    },
+                    "400": {
+                        "description": "bad request (invalid digest or upload)",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     "401": {
@@ -938,7 +953,7 @@
         },
         "/v2/{name}/referrers/{digest}": {
             "get": {
-                "description": "Get referrers given a digest",
+                "description": "Returns referrers for a subject digest as an OCI image index. Missing repositories and\nsubjects with no referrers return 200 with an empty manifests list.",
                 "consumes": [
                     "application/json"
                 ],
@@ -975,8 +990,14 @@
                             "$ref": "#/definitions/api.ImageIndex"
                         }
                     },
+                    "400": {
+                        "description": "bad request (invalid digest)",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
                     "404": {
-                        "description": "not found",
+                        "description": "not found (manifest unknown)",
                         "schema": {
                             "type": "string"
                         }

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -305,6 +305,10 @@
                     "201": {
                         "description": "created",
                         "headers": {
+                            "Blob-Upload-UUID": {
+                                "type": "string",
+                                "description": "Opaque blob upload session identifier"
+                            },
                             "Location": {
                                 "type": "string",
                                 "description": "/v2/{name}/blobs/{digest}"

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -284,7 +284,7 @@
         },
         "/v2/{name}/blobs/uploads": {
             "post": {
-                "description": "Create a new image blob/layer upload. A `digest` query parameter requests a monolithic upload\nand returns 201 on success; otherwise a new upload session is started and 202 is returned.",
+                "description": "Create a new image blob/layer upload. With no query parameters, starts an upload session\nand returns 202.\nA `digest` query parameter requests a monolithic upload and returns 201 on success.\nA `mount` query parameter requests a cross-repository blob mount and returns 201 or 202.",
                 "consumes": [
                     "application/json"
                 ],
@@ -299,6 +299,18 @@
                         "name": "name",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "blob digest for monolithic upload",
+                        "name": "digest",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "blob digest to mount into the repository",
+                        "name": "mount",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -342,6 +354,12 @@
                     },
                     "404": {
                         "description": "not found",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "415": {
+                        "description": "unsupported media type (monolithic upload requires application/octet-stream)",
                         "schema": {
                             "type": "string"
                         }

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -506,7 +506,9 @@ paths:
     post:
       consumes:
       - application/json
-      description: Create a new image blob/layer upload
+      description: |-
+        Create a new image blob/layer upload. A `digest` query parameter requests a monolithic upload
+        and returns 201 on success; otherwise a new upload session is started and 202 is returned.
       parameters:
       - description: repository name
         in: path
@@ -516,6 +518,12 @@ paths:
       produces:
       - application/json
       responses:
+        "201":
+          description: created
+          headers:
+            Location:
+              description: /v2/{name}/blobs/{digest}
+              type: string
         "202":
           description: accepted
           headers:
@@ -525,6 +533,10 @@ paths:
             Range:
               description: 0-0
               type: string
+        "400":
+          description: bad request (invalid digest or upload)
+          schema:
+            type: string
         "401":
           description: unauthorized
           schema:
@@ -878,7 +890,9 @@ paths:
     get:
       consumes:
       - application/json
-      description: Get referrers given a digest
+      description: |-
+        Returns referrers for a subject digest as an OCI image index. Missing repositories and
+        subjects with no referrers return 200 with an empty manifests list.
       parameters:
       - description: repository name
         in: path
@@ -901,8 +915,12 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/api.ImageIndex'
+        "400":
+          description: bad request (invalid digest)
+          schema:
+            type: string
         "404":
-          description: not found
+          description: not found (manifest unknown)
           schema:
             type: string
         "500":

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -521,6 +521,9 @@ paths:
         "201":
           description: created
           headers:
+            Blob-Upload-UUID:
+              description: Opaque blob upload session identifier
+              type: string
             Location:
               description: /v2/{name}/blobs/{digest}
               type: string

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -507,13 +507,23 @@ paths:
       consumes:
       - application/json
       description: |-
-        Create a new image blob/layer upload. A `digest` query parameter requests a monolithic upload
-        and returns 201 on success; otherwise a new upload session is started and 202 is returned.
+        Create a new image blob/layer upload. With no query parameters, starts an upload session
+        and returns 202.
+        A `digest` query parameter requests a monolithic upload and returns 201 on success.
+        A `mount` query parameter requests a cross-repository blob mount and returns 201 or 202.
       parameters:
       - description: repository name
         in: path
         name: name
         required: true
+        type: string
+      - description: blob digest for monolithic upload
+        in: query
+        name: digest
+        type: string
+      - description: blob digest to mount into the repository
+        in: query
+        name: mount
         type: string
       produces:
       - application/json
@@ -546,6 +556,10 @@ paths:
             type: string
         "404":
           description: not found
+          schema:
+            type: string
+        "415":
+          description: unsupported media type (monolithic upload requires application/octet-stream)
           schema:
             type: string
         "500":


### PR DESCRIPTION
1. Reject malformed digest-shaped manifest references with 400 instead of treating them as tags.
2. Return an empty referrers index for missing repos rather than 404 (spec is ambigous but tests expect it, and it is mentioned in https://github.com/opencontainers/distribution-spec/issues/359#issuecomment-1294840948).
3. Map monolithic blob upload digest mismatches and invalid digest query parameters to 400 DIGEST_INVALID instead of 500.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
