### PR TITLE
fix(api): use repo-local blob stat on HEAD and ranged GET reads

### DIFF
--- a/examples/config-conformance.json
+++ b/examples/config-conformance.json
@@ -3,7 +3,7 @@
   "storage": {
     "rootDirectory": "/tmp/zot",
     "gc": true,
-    "dedupe": false
+    "dedupe": true
   },
   "http": {
     "address": "0.0.0.0",

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -5811,11 +5811,16 @@ func TestAuthorizationMountBlob(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
 
-		/* a HEAD request by user1 on blob digest (found in user1Repo) should return 200
-		because user1 has permission to read user1Repo */
-		resp, err = userClient1.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", username1+"/"+"mysecondrepo", blobDigest))
+		/* a HEAD request by user1 on the blob in repoName1 should return 200;
+		blob reads are repo-local (StatBlob), not satisfied via cross-repo cache */
+		resp, err = userClient1.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", repoName1, blobDigest))
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		/* the same digest is not known to a different repository until mounted there */
+		resp, err = userClient1.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", username1+"/"+"mysecondrepo", blobDigest))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
 
 		// user2 can upload without dedupe
 		err = UploadImageWithBasicAuth(img, baseURL, repoName2, tag, username2, password2)
@@ -6934,10 +6939,16 @@ func TestCrossRepoMount(t *testing.T) {
 
 		So(os.SameFile(cacheFi, linkFi), ShouldEqual, true)
 
+		// Blob reads are repo-local: HEAD succeeds only where the blob was mounted.
+		headResponse, err = client.R().SetBasicAuth(username, password).
+			Head(fmt.Sprintf("%s/v2/zot-mount-test/blobs/%s", baseURL, manifestDigest))
+		So(err, ShouldBeNil)
+		So(headResponse.StatusCode(), ShouldEqual, http.StatusOK)
+
 		headResponse, err = client.R().SetBasicAuth(username, password).
 			Head(fmt.Sprintf("%s/v2/zot-cv-test/blobs/%s", baseURL, manifestDigest))
 		So(err, ShouldBeNil)
-		So(headResponse.StatusCode(), ShouldEqual, http.StatusOK)
+		So(headResponse.StatusCode(), ShouldEqual, http.StatusNotFound)
 
 		// Invalid request
 		params = make(map[string]string)
@@ -6997,6 +7008,98 @@ func TestCrossRepoMount(t *testing.T) {
 			Head(fmt.Sprintf("%s/v2/%s/blobs/%s", baseURL, name, digest))
 		So(err, ShouldBeNil)
 		So(headResponse.StatusCode(), ShouldEqual, http.StatusNotFound)
+	})
+}
+
+func TestBlobReadRepoLocalAfterMountDelete(t *testing.T) {
+	Convey("blob HEAD and GET are repo-local after cross-repo mount and delete", t, func() {
+		port := test.GetFreePort()
+		baseURL := test.GetBaseURL(port)
+
+		conf := config.New()
+		conf.HTTP.Port = port
+
+		dir := t.TempDir()
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.Dedupe = true
+		ctlr.Config.Storage.GC = false
+
+		cm := test.NewControllerManager(ctlr)
+		cm.StartAndWait(port)
+
+		defer cm.StopServer()
+
+		client := resty.New()
+
+		const (
+			repoDest = "oci-conformance/distribution-test"
+			repoSrc  = "oci-conformance/crossmount-test"
+		)
+
+		blob := []byte("mount-atomic-delete-test")
+		digest := godigest.FromBytes(blob).String()
+
+		resp, err := client.R().
+			SetHeader("Content-Type", "application/octet-stream").
+			SetHeader("Content-Length", strconv.Itoa(len(blob))).
+			SetQueryParam("digest", digest).
+			SetBody(blob).
+			Post(baseURL + "/v2/" + repoSrc + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		resp, err = client.R().
+			SetQueryParam("mount", digest).
+			Post(baseURL + "/v2/" + repoDest + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		headBlob := func(repo string) int {
+			head, headErr := client.R().Head(baseURL + "/v2/" + repo + "/blobs/" + digest)
+			So(headErr, ShouldBeNil)
+
+			return head.StatusCode()
+		}
+
+		getBlob := func(repo string, rangeHeader string) (int, []byte) {
+			req := client.R()
+			if rangeHeader != "" {
+				req.SetHeader("Range", rangeHeader)
+			}
+
+			get, getErr := req.Get(baseURL + "/v2/" + repo + "/blobs/" + digest)
+			So(getErr, ShouldBeNil)
+
+			return get.StatusCode(), get.Body()
+		}
+
+		So(headBlob(repoDest), ShouldEqual, http.StatusOK)
+
+		status, body := getBlob(repoDest, "")
+		So(status, ShouldEqual, http.StatusOK)
+		So(body, ShouldResemble, blob)
+
+		status, body = getBlob(repoDest, "bytes=0-4")
+		So(status, ShouldEqual, http.StatusPartialContent)
+		So(body, ShouldResemble, blob[:5])
+
+		resp, err = client.R().Delete(baseURL + "/v2/" + repoDest + "/blobs/" + digest)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+		So(headBlob(repoDest), ShouldEqual, http.StatusNotFound)
+		So(headBlob(repoSrc), ShouldEqual, http.StatusOK)
+
+		status, _ = getBlob(repoDest, "")
+		So(status, ShouldEqual, http.StatusNotFound)
+
+		status, _ = getBlob(repoDest, "bytes=0-4")
+		So(status, ShouldEqual, http.StatusNotFound)
+
+		status, body = getBlob(repoSrc, "")
+		So(status, ShouldEqual, http.StatusOK)
+		So(body, ShouldResemble, blob)
 	})
 }
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -5695,11 +5695,16 @@ func TestAuthorizationMountBlob(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
 
-		/* a HEAD request by user1 on blob digest (found in user1Repo) should return 200
-		because user1 has permission to read user1Repo */
-		resp, err = userClient1.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", username1+"/"+"mysecondrepo", blobDigest))
+		/* a HEAD request by user1 on the blob in repoName1 should return 200;
+		blob reads are repo-local (StatBlob), not satisfied via cross-repo cache */
+		resp, err = userClient1.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", repoName1, blobDigest))
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		/* the same digest is not known to a different repository until mounted there */
+		resp, err = userClient1.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", username1+"/"+"mysecondrepo", blobDigest))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
 
 		// user2 can upload without dedupe
 		err = UploadImageWithBasicAuth(img, baseURL, repoName2, tag, username2, password2)
@@ -7366,10 +7371,16 @@ func TestCrossRepoMount(t *testing.T) {
 
 		So(os.SameFile(cacheFi, linkFi), ShouldEqual, true)
 
+		// Blob reads are repo-local: HEAD succeeds only where the blob was mounted.
+		headResponse, err = client.R().SetBasicAuth(username, password).
+			Head(fmt.Sprintf("%s/v2/zot-mount-test/blobs/%s", baseURL, manifestDigest))
+		So(err, ShouldBeNil)
+		So(headResponse.StatusCode(), ShouldEqual, http.StatusOK)
+
 		headResponse, err = client.R().SetBasicAuth(username, password).
 			Head(fmt.Sprintf("%s/v2/zot-cv-test/blobs/%s", baseURL, manifestDigest))
 		So(err, ShouldBeNil)
-		So(headResponse.StatusCode(), ShouldEqual, http.StatusOK)
+		So(headResponse.StatusCode(), ShouldEqual, http.StatusNotFound)
 
 		// Invalid request
 		params = make(map[string]string)
@@ -7426,6 +7437,95 @@ func TestCrossRepoMount(t *testing.T) {
 			Head(fmt.Sprintf("%s/v2/%s/blobs/%s", baseURL, name, digest))
 		So(err, ShouldBeNil)
 		So(headResponse.StatusCode(), ShouldEqual, http.StatusNotFound)
+	})
+}
+
+func TestBlobReadRepoLocalAfterMountDelete(t *testing.T) {
+	Convey("blob HEAD and GET are repo-local after cross-repo mount and delete", t, func() {
+		conf := config.New()
+		conf.HTTP.Port = "0"
+
+		dir := t.TempDir()
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.Dedupe = true
+		ctlr.Config.Storage.GC = false
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+
+		defer cm.StopServer()
+
+		client := resty.New()
+
+		const (
+			repoDest = "oci-conformance/distribution-test"
+			repoSrc  = "oci-conformance/crossmount-test"
+		)
+
+		blob := []byte("mount-atomic-delete-test")
+		digest := godigest.FromBytes(blob).String()
+
+		resp, err := client.R().
+			SetHeader("Content-Type", "application/octet-stream").
+			SetHeader("Content-Length", strconv.Itoa(len(blob))).
+			SetQueryParam("digest", digest).
+			SetBody(blob).
+			Post(baseURL + "/v2/" + repoSrc + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		resp, err = client.R().
+			SetQueryParam("mount", digest).
+			Post(baseURL + "/v2/" + repoDest + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		headBlob := func(repo string) int {
+			head, headErr := client.R().Head(baseURL + "/v2/" + repo + "/blobs/" + digest)
+			So(headErr, ShouldBeNil)
+
+			return head.StatusCode()
+		}
+
+		getBlob := func(repo string, rangeHeader string) (int, []byte) {
+			req := client.R()
+			if rangeHeader != "" {
+				req.SetHeader("Range", rangeHeader)
+			}
+
+			get, getErr := req.Get(baseURL + "/v2/" + repo + "/blobs/" + digest)
+			So(getErr, ShouldBeNil)
+
+			return get.StatusCode(), get.Body()
+		}
+
+		So(headBlob(repoDest), ShouldEqual, http.StatusOK)
+
+		status, body := getBlob(repoDest, "")
+		So(status, ShouldEqual, http.StatusOK)
+		So(body, ShouldResemble, blob)
+
+		status, body = getBlob(repoDest, "bytes=0-4")
+		So(status, ShouldEqual, http.StatusPartialContent)
+		So(body, ShouldResemble, blob[:5])
+
+		resp, err = client.R().Delete(baseURL + "/v2/" + repoDest + "/blobs/" + digest)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+		So(headBlob(repoDest), ShouldEqual, http.StatusNotFound)
+		So(headBlob(repoSrc), ShouldEqual, http.StatusOK)
+
+		status, _ = getBlob(repoDest, "")
+		So(status, ShouldEqual, http.StatusNotFound)
+
+		status, _ = getBlob(repoDest, "bytes=0-4")
+		So(status, ShouldEqual, http.StatusNotFound)
+
+		status, body = getBlob(repoSrc, "")
+		So(status, ShouldEqual, http.StatusOK)
+		So(body, ShouldResemble, blob)
 	})
 }
 

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1101,38 +1101,7 @@ func (rh *RouteHandler) CheckBlob(response http.ResponseWriter, request *http.Re
 
 	digest := godigest.Digest(digestStr)
 
-	userAc, err := reqCtx.UserAcFromContext(request.Context())
-	if err != nil {
-		response.WriteHeader(http.StatusInternalServerError)
-
-		return
-	}
-
-	userCanMount := true
-	accessControlConfig := rh.c.Config.CopyAccessControlConfig()
-
-	if accessControlConfig.IsAuthzEnabled() {
-		userCanMount, err = canMount(userAc, imgStore, digest)
-		if err != nil {
-			rh.c.Log.Error().Err(err).Msg("unexpected error")
-		}
-	}
-
-	var blen int64
-
-	if userCanMount {
-		ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
-		ok, blen, err = imgStore.CheckBlob(ctx, name, digest)
-	} else {
-		var lockLatency time.Time
-
-		imgStore.RLock(&lockLatency)
-		defer imgStore.RUnlock(&lockLatency)
-
-		ok, blen, _, err = imgStore.StatBlob(name, digest)
-	}
-
-	if err != nil {
+	respondBlobError := func(err error) {
 		details := zerr.GetDetails(err)
 		if errors.Is(err, zerr.ErrBadBlobDigest) { //nolint:gocritic,dupl // errorslint conflicts with gocritic:IfElseChain
 			details["digest"] = digest.String()
@@ -1150,6 +1119,22 @@ func (rh *RouteHandler) CheckBlob(response http.ResponseWriter, request *http.Re
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			response.WriteHeader(http.StatusInternalServerError)
 		}
+	}
+
+	if err := digest.Validate(); err != nil {
+		respondBlobError(zerr.ErrBadBlobDigest)
+
+		return
+	}
+
+	var lockLatency time.Time
+
+	imgStore.RLock(&lockLatency)
+	ok, blen, _, err := imgStore.StatBlob(name, digest)
+	imgStore.RUnlock(&lockLatency)
+
+	if err != nil {
+		respondBlobError(err)
 
 		return
 	}
@@ -1367,7 +1352,7 @@ func (c *byteCountingWriter) Write(p []byte) (int, error) {
 // layer's metadata path (e.g. a deleted blob) would historically have
 // produced a 4xx; under this design they too truncate. The 16-range
 // cap and coalesceRanges already bound the worst case, and the eager
-// CheckBlob earlier in GetBlob still rejects the obvious "blob does
+// StatBlob earlier in GetBlob still rejects the obvious "blob does
 // not exist" case before we get here.
 func writeMultipartRanges(
 	response http.ResponseWriter,
@@ -1546,8 +1531,12 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 	}
 
 	if rangeHeaderPresent {
-		ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
-		ok, bsize, err := imgStore.CheckBlob(ctx, name, digest)
+		var lockLatency time.Time
+
+		imgStore.RLock(&lockLatency)
+		ok, bsize, _, err := imgStore.StatBlob(name, digest)
+		imgStore.RUnlock(&lockLatency)
+
 		if err != nil {
 			writeBlobError(err)
 

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1083,38 +1083,7 @@ func (rh *RouteHandler) CheckBlob(response http.ResponseWriter, request *http.Re
 
 	digest := godigest.Digest(digestStr)
 
-	userAc, err := reqCtx.UserAcFromContext(request.Context())
-	if err != nil {
-		response.WriteHeader(http.StatusInternalServerError)
-
-		return
-	}
-
-	userCanMount := true
-	accessControlConfig := rh.c.Config.CopyAccessControlConfig()
-
-	if accessControlConfig.IsAuthzEnabled() {
-		userCanMount, err = canMount(userAc, imgStore, digest)
-		if err != nil {
-			rh.c.Log.Error().Err(err).Msg("unexpected error")
-		}
-	}
-
-	var blen int64
-
-	if userCanMount {
-		ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
-		ok, blen, err = imgStore.CheckBlob(ctx, name, digest)
-	} else {
-		var lockLatency time.Time
-
-		imgStore.RLock(&lockLatency)
-		defer imgStore.RUnlock(&lockLatency)
-
-		ok, blen, _, err = imgStore.StatBlob(name, digest)
-	}
-
-	if err != nil {
+	respondBlobError := func(err error) {
 		details := zerr.GetDetails(err)
 		if errors.Is(err, zerr.ErrBadBlobDigest) { //nolint:gocritic,dupl // errorslint conflicts with gocritic:IfElseChain
 			details["digest"] = digest.String()
@@ -1132,6 +1101,22 @@ func (rh *RouteHandler) CheckBlob(response http.ResponseWriter, request *http.Re
 			rh.c.Log.Error().Err(err).Msg("unexpected error")
 			response.WriteHeader(http.StatusInternalServerError)
 		}
+	}
+
+	if err := digest.Validate(); err != nil {
+		respondBlobError(zerr.ErrBadBlobDigest)
+
+		return
+	}
+
+	var lockLatency time.Time
+
+	imgStore.RLock(&lockLatency)
+	ok, blen, _, err := imgStore.StatBlob(name, digest)
+	imgStore.RUnlock(&lockLatency)
+
+	if err != nil {
+		respondBlobError(err)
 
 		return
 	}
@@ -1349,7 +1334,7 @@ func (c *byteCountingWriter) Write(p []byte) (int, error) {
 // layer's metadata path (e.g. a deleted blob) would historically have
 // produced a 4xx; under this design they too truncate. The 16-range
 // cap and coalesceRanges already bound the worst case, and the eager
-// CheckBlob earlier in GetBlob still rejects the obvious "blob does
+// StatBlob earlier in GetBlob still rejects the obvious "blob does
 // not exist" case before we get here.
 func writeMultipartRanges(
 	response http.ResponseWriter,
@@ -1529,8 +1514,12 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 	}
 
 	if rangeHeaderPresent {
-		ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
-		ok, bsize, err := imgStore.CheckBlob(ctx, name, digest)
+		var lockLatency time.Time
+
+		imgStore.RLock(&lockLatency)
+		ok, bsize, _, err := imgStore.StatBlob(name, digest)
+		imgStore.RUnlock(&lockLatency)
+
 		if err != nil {
 			writeBlobError(err)
 

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -823,6 +824,8 @@ func TestRoutes(t *testing.T) {
 
 		// Check Blob
 		Convey("CheckBlob", func() {
+			const validDigest = "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621"
+
 			testCheckBlob := func(urlVars map[string]string, ism *mocks.MockedImageStore) int {
 				ctlr.StoreController.DefaultStore = ism
 				request, _ := http.NewRequestWithContext(context.TODO(), http.MethodHead, baseURL, nil)
@@ -837,15 +840,28 @@ func TestRoutes(t *testing.T) {
 				return resp.StatusCode
 			}
 
-			// ErrBadBlobDigest
+			// invalid digest format is rejected before StatBlob
 			statusCode := testCheckBlob(
 				map[string]string{
 					"name":   "ErrBadBlobDigest",
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, zerr.ErrBadBlobDigest
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						panic("StatBlob must not be called for invalid digest format")
+					},
+				})
+			So(statusCode, ShouldEqual, http.StatusBadRequest)
+
+			// ErrBadBlobDigest from storage
+			statusCode = testCheckBlob(
+				map[string]string{
+					"name":   "ErrBadBlobDigest",
+					"digest": validDigest,
+				},
+				&mocks.MockedImageStore{
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, zerr.ErrBadBlobDigest
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusBadRequest)
@@ -854,11 +870,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrRepoNotFound",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, zerr.ErrRepoNotFound
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, zerr.ErrRepoNotFound
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusNotFound)
@@ -867,11 +883,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrBlobNotFound",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, zerr.ErrBlobNotFound
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, zerr.ErrBlobNotFound
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusNotFound)
@@ -880,11 +896,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrUnexpectedError",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, ErrUnexpectedError
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, ErrUnexpectedError
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusInternalServerError)
@@ -893,11 +909,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "Check Blob Not Ok",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return false, 0, nil
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return false, 0, time.Time{}, nil
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusNotFound)
@@ -1034,8 +1050,8 @@ func TestRoutes(t *testing.T) {
 
 						return "https://storage.example.com/zot/repo/blobs/sha256/layer", nil
 					},
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 4, nil
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 4, time.Time{}, nil
 					},
 					GetBlobPartialFn: func(repo string, digest godigest.Digest, mediaType string,
 						from, to int64,
@@ -2425,12 +2441,12 @@ func descriptorStore(t *testing.T) mocks.MockedImageStore {
 
 	return mocks.MockedImageStore{
 		RootDirFn: func() string { return t.TempDir() },
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
 			if digest == layerDigest {
-				return true, 4, nil
+				return true, 4, time.Time{}, nil
 			}
 
-			return true, 0, nil
+			return true, 0, time.Time{}, nil
 		},
 		GetIndexContentFn: func(repo string) ([]byte, error) {
 			return indexJSON, nil
@@ -2445,8 +2461,8 @@ func descriptorStore(t *testing.T) mocks.MockedImageStore {
 
 func TestCheckBlobUsesDescriptorContentType(t *testing.T) {
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, 42, nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, 42, time.Time{}, nil
 	}
 
 	handler := newBlobTestRouteHandler(t, store)
@@ -2482,8 +2498,8 @@ func TestCheckBlobFallsBackToBinaryContentType(t *testing.T) {
 	// must fall back to application/octet-stream so OCI clients get a
 	// well-formed Content-Type.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 1024, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 1024, time.Time{}, nil
 		},
 		GetIndexContentFn: func(repo string) ([]byte, error) {
 			return nil, zerr.ErrManifestNotFound
@@ -2690,8 +2706,8 @@ func TestGetBlobPartialFallsBackToBinaryContentType(t *testing.T) {
 	// Single-range request for a blob whose repo has no index — same
 	// fallback behaviour as the full-GET case.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -2739,8 +2755,8 @@ func TestGetBlobMultipartPartHasDescriptorContentType(t *testing.T) {
 	const blobBody = "0123456789"
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -2900,8 +2916,8 @@ func TestGetBlobMultipartContentLengthMatchesBody(t *testing.T) {
 	const blobBody = "0123456789abcdef" // 16 bytes
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -2973,8 +2989,8 @@ func TestGetBlobMultipartOpensOneReaderAtATime(t *testing.T) {
 	var opens partialReaderOpenTracker
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -3031,8 +3047,8 @@ func TestGetBlobMultipartTruncatesOnReaderError(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -3092,8 +3108,8 @@ func TestGetBlobRangeUnsatisfiable(t *testing.T) {
 	// retry with a valid range. parseRangeHeader rejects the header
 	// before the handler reaches GetBlobPartial.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetIndexContentFn: func(repo string) ([]byte, error) {
 			return nil, zerr.ErrManifestNotFound
@@ -3123,11 +3139,11 @@ func TestGetBlobRangeUnsatisfiable(t *testing.T) {
 }
 
 func TestGetBlobRangeCheckBlobError(t *testing.T) {
-	// CheckBlob returning a non-zerr error must surface as 500 via
+	// StatBlob returning a non-zerr error must surface as 500 via
 	// writeBlobError's default branch.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return false, 0, ErrUnexpectedError
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return false, 0, time.Time{}, ErrUnexpectedError
 		},
 	})
 
@@ -3153,12 +3169,12 @@ func TestGetBlobRangeCheckBlobError(t *testing.T) {
 }
 
 func TestGetBlobRangeCheckBlobMissing(t *testing.T) {
-	// CheckBlob succeeding with ok=false (e.g. a deleted blob whose
+	// StatBlob succeeding with ok=false (e.g. a deleted blob whose
 	// repo still exists) must short-circuit to 404 BLOB_UNKNOWN before
 	// any range parsing or descriptor lookup.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return false, 0, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return false, 0, time.Time{}, nil
 		},
 	})
 
@@ -3191,14 +3207,14 @@ func TestGetBlobRangeCheckBlobMissing(t *testing.T) {
 
 func TestGetBlobSingleRangePartialBlobNotFound(t *testing.T) {
 	// Single-range path: GetBlobPartial returning ErrBlobNotFound after
-	// a successful CheckBlob (a blob deleted between the two calls)
-	// must surface as 404 with the BLOB_UNKNOWN error body. CheckBlob
+	// a successful StatBlob (a blob deleted between the two calls)
+	// must surface as 404 with the BLOB_UNKNOWN error body. StatBlob
 	// has already returned ok=true so we get past the length check;
 	// the response is still recoverable because no body bytes have
 	// been written yet.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -3245,8 +3261,8 @@ func TestGetBlobSingleRangePartialUnexpectedError(t *testing.T) {
 	// Single-range path: GetBlobPartial returning a non-zerr error
 	// hits writeBlobError's default branch and produces a 500.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -3292,8 +3308,8 @@ func TestGetBlobSingleRangeLengthMismatch(t *testing.T) {
 	// since on the single-range path the headers haven't been flushed
 	// yet and 5xx is still possible.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -3345,8 +3361,8 @@ func TestGetBlobMultipartShortReaderTruncates(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -3397,7 +3413,7 @@ func TestGetBlobMultipartShortReaderTruncates(t *testing.T) {
 }
 
 func TestGetBlobRangeCheckBlobNamedErrors(t *testing.T) {
-	// CheckBlob is the first storage call on the range branch and the
+	// StatBlob is the first storage call on the range branch and the
 	// only place where named storage errors can be turned into proper
 	// 4xx OCI error responses (once the 206 is in flight on the
 	// multipart path it's too late). Each case in the table maps a
@@ -3429,8 +3445,8 @@ func TestGetBlobRangeCheckBlobNamedErrors(t *testing.T) {
 	for name, testCase := range cases {
 		t.Run(name, func(t *testing.T) {
 			handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-				CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-					return false, 0, testCase.err
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return false, 0, time.Time{}, testCase.err
 				},
 			})
 
@@ -3485,8 +3501,8 @@ func TestGetBlobMultipartReaderCloseError(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -826,6 +827,8 @@ func TestRoutes(t *testing.T) {
 
 		// Check Blob
 		Convey("CheckBlob", func() {
+			const validDigest = "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621"
+
 			testCheckBlob := func(urlVars map[string]string, ism *mocks.MockedImageStore) int {
 				ctlr.StoreController.DefaultStore = ism
 				request, _ := http.NewRequestWithContext(context.TODO(), http.MethodHead, baseURL, nil)
@@ -840,15 +843,28 @@ func TestRoutes(t *testing.T) {
 				return resp.StatusCode
 			}
 
-			// ErrBadBlobDigest
+			// invalid digest format is rejected before StatBlob
 			statusCode := testCheckBlob(
 				map[string]string{
 					"name":   "ErrBadBlobDigest",
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, zerr.ErrBadBlobDigest
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						panic("StatBlob must not be called for invalid digest format")
+					},
+				})
+			So(statusCode, ShouldEqual, http.StatusBadRequest)
+
+			// ErrBadBlobDigest from storage
+			statusCode = testCheckBlob(
+				map[string]string{
+					"name":   "ErrBadBlobDigest",
+					"digest": validDigest,
+				},
+				&mocks.MockedImageStore{
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, zerr.ErrBadBlobDigest
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusBadRequest)
@@ -857,11 +873,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrRepoNotFound",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, zerr.ErrRepoNotFound
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, zerr.ErrRepoNotFound
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusNotFound)
@@ -870,11 +886,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrBlobNotFound",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, zerr.ErrBlobNotFound
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, zerr.ErrBlobNotFound
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusNotFound)
@@ -883,11 +899,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrUnexpectedError",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, ErrUnexpectedError
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, ErrUnexpectedError
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusInternalServerError)
@@ -896,11 +912,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "Check Blob Not Ok",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return false, 0, nil
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return false, 0, time.Time{}, nil
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusNotFound)
@@ -1037,8 +1053,8 @@ func TestRoutes(t *testing.T) {
 
 						return "https://storage.example.com/zot/repo/blobs/sha256/layer", nil
 					},
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 4, nil
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 4, time.Time{}, nil
 					},
 					GetBlobPartialFn: func(repo string, digest godigest.Digest, mediaType string,
 						from, to int64,
@@ -2426,12 +2442,12 @@ func descriptorStore(t *testing.T) mocks.MockedImageStore {
 
 	return mocks.MockedImageStore{
 		RootDirFn: func() string { return t.TempDir() },
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
 			if digest == layerDigest {
-				return true, 4, nil
+				return true, 4, time.Time{}, nil
 			}
 
-			return true, 0, nil
+			return true, 0, time.Time{}, nil
 		},
 		GetIndexContentFn: func(repo string) ([]byte, error) {
 			return indexJSON, nil
@@ -2459,8 +2475,8 @@ func TestCheckBlobAlwaysBinaryContentType(t *testing.T) {
 
 		return []byte("{}"), nil
 	}
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, 42, nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, 42, time.Time{}, nil
 	}
 
 	handler := newBlobTestRouteHandler(t, store)
@@ -2498,8 +2514,8 @@ func TestCheckBlobFallsBackToBinaryContentType(t *testing.T) {
 	// must fall back to application/octet-stream so OCI clients get a
 	// well-formed Content-Type.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 1024, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 1024, time.Time{}, nil
 		},
 		GetIndexContentFn: func(repo string) ([]byte, error) {
 			return nil, zerr.ErrManifestNotFound
@@ -2685,8 +2701,8 @@ func TestGetBlobPartialFallsBackToBinaryContentType(t *testing.T) {
 	// Single-range request for a blob whose repo has no index — same
 	// fallback behaviour as the full-GET case.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -2747,8 +2763,8 @@ func TestGetBlobMultipartPartBinaryContentType(t *testing.T) {
 
 		return []byte("{}"), nil
 	}
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -2910,8 +2926,8 @@ func TestGetBlobMultipartContentLengthMatchesBody(t *testing.T) {
 	const blobBody = "0123456789abcdef" // 16 bytes
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -2983,8 +2999,8 @@ func TestGetBlobMultipartOpensOneReaderAtATime(t *testing.T) {
 	var opens partialReaderOpenTracker
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -3041,8 +3057,8 @@ func TestGetBlobMultipartTruncatesOnReaderError(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -3102,8 +3118,8 @@ func TestGetBlobRangeUnsatisfiable(t *testing.T) {
 	// retry with a valid range. parseRangeHeader rejects the header
 	// before the handler reaches GetBlobPartial.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetIndexContentFn: func(repo string) ([]byte, error) {
 			return nil, zerr.ErrManifestNotFound
@@ -3133,11 +3149,11 @@ func TestGetBlobRangeUnsatisfiable(t *testing.T) {
 }
 
 func TestGetBlobRangeCheckBlobError(t *testing.T) {
-	// CheckBlob returning a non-zerr error must surface as 500 via
+	// StatBlob returning a non-zerr error must surface as 500 via
 	// writeBlobError's default branch.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return false, 0, ErrUnexpectedError
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return false, 0, time.Time{}, ErrUnexpectedError
 		},
 	})
 
@@ -3163,12 +3179,12 @@ func TestGetBlobRangeCheckBlobError(t *testing.T) {
 }
 
 func TestGetBlobRangeCheckBlobMissing(t *testing.T) {
-	// CheckBlob succeeding with ok=false (e.g. a deleted blob whose
+	// StatBlob succeeding with ok=false (e.g. a deleted blob whose
 	// repo still exists) must short-circuit to 404 BLOB_UNKNOWN before
 	// any range parsing or descriptor lookup.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return false, 0, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return false, 0, time.Time{}, nil
 		},
 	})
 
@@ -3201,14 +3217,14 @@ func TestGetBlobRangeCheckBlobMissing(t *testing.T) {
 
 func TestGetBlobSingleRangePartialBlobNotFound(t *testing.T) {
 	// Single-range path: GetBlobPartial returning ErrBlobNotFound after
-	// a successful CheckBlob (a blob deleted between the two calls)
-	// must surface as 404 with the BLOB_UNKNOWN error body. CheckBlob
+	// a successful StatBlob (a blob deleted between the two calls)
+	// must surface as 404 with the BLOB_UNKNOWN error body. StatBlob
 	// has already returned ok=true so we get past the length check;
 	// the response is still recoverable because no body bytes have
 	// been written yet.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -3255,8 +3271,8 @@ func TestGetBlobSingleRangePartialUnexpectedError(t *testing.T) {
 	// Single-range path: GetBlobPartial returning a non-zerr error
 	// hits writeBlobError's default branch and produces a 500.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -3302,8 +3318,8 @@ func TestGetBlobSingleRangeLengthMismatch(t *testing.T) {
 	// since on the single-range path the headers haven't been flushed
 	// yet and 5xx is still possible.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -3355,8 +3371,8 @@ func TestGetBlobMultipartShortReaderTruncates(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -3407,7 +3423,7 @@ func TestGetBlobMultipartShortReaderTruncates(t *testing.T) {
 }
 
 func TestGetBlobRangeCheckBlobNamedErrors(t *testing.T) {
-	// CheckBlob is the first storage call on the range branch and the
+	// StatBlob is the first storage call on the range branch and the
 	// only place where named storage errors can be turned into proper
 	// 4xx OCI error responses (once the 206 is in flight on the
 	// multipart path it's too late). Each case in the table maps a
@@ -3439,8 +3455,8 @@ func TestGetBlobRangeCheckBlobNamedErrors(t *testing.T) {
 	for name, testCase := range cases {
 		t.Run(name, func(t *testing.T) {
 			handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-				CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-					return false, 0, testCase.err
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return false, 0, time.Time{}, testCase.err
 				},
 			})
 
@@ -3495,8 +3511,8 @@ func TestGetBlobMultipartReaderCloseError(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,


### PR DESCRIPTION
When dedupe is enabled, zot can store a blob in one repository and "mount" it into another via POST .../blobs/uploads/?mount=<digest>. The destination repo gets a placeholder; the real bytes live in the global dedupe cache keyed by digest.

`CheckBlob` is the write-oriented path: if the repo-local file is missing or zero-length, it looks up the digest in the dedupe cache and **re-materializes** the blob into that repository via `copyBlob`. That is correct for mount uploads, but wrong for read APIs — a client that DELETEs the blob from the destination repo must see 404 on subsequent reads there, even though the source repo (and cache) still have the content.

OCI distribution-spec v2 conformance exercises exactly this scenario ("atomic delete"): mount blob A→B, DELETE from B, HEAD B must be 404. HEAD (and ranged GET) previously called `CheckBlob`, which silently re-created the blob in B and returned 200.

Switch blob existence checks on read paths to `StatBlob`, which only consults repo-local storage (`originalBlobInfo`). Full GET was already repo-local via `GetBlob` → `originalBlobInfo`; no change needed there.

| Method        | Handler        | Storage call                          | Cross-repo dedupe on read? |
|---------------|----------------|---------------------------------------|----------------------------|
| HEAD          | CheckBlob      | StatBlob → originalBlobInfo           | No                         |
| GET (no Range)| GetBlob        | GetBlob → originalBlobInfo            | No (unchanged)             |
| GET (Range)   | GetBlob        | StatBlob, then GetBlobPartial → …     | No                         |
| POST mount    | CreateBlobUpload | CheckBlob (unchanged)               | Yes (intended)             |

`originalBlobInfo` may follow an in-repo zero-byte dedupe link via `checkCacheBlob`, but only when the repo-local path still exists. If the blob was deleted from that repo, stat fails and the API returns 404 — it does not pull bytes back from another repository.

Add integration test TestBlobReadRepoLocalAfterMountDelete covering HEAD, full GET, and ranged GET across mount + delete.

Fixes OCI distribution-spec v2 conformance failures for Blob/AtomicDelete (HEAD after cross-repo mount and delete).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
