### PR TITLE
feat(notation): Add TSA truststore support to notation policy

### DIFF
--- a/pkg/extensions/README_imagetrust.md
+++ b/pkg/extensions/README_imagetrust.md
@@ -149,9 +149,10 @@ The information above will be included in the ManifestSummary objects returned b
                     "name": "default-config",
                     "registryScopes": [ "*" ],
                     "signatureVerification": {
-                        "level" : "strict" 
+                        "level" : "strict",
+                        "verifyTimestamp": "afterCertExpiry"
                     },
-                    "trustStores": ["ca:default","signingAuthority:default"],
+                    "trustStores": ["ca:default","signingAuthority:default","tsa:default"],
                     "trustedIdentities": [
                         "*"
                     ]
@@ -159,3 +160,5 @@ The information above will be included in the ManifestSummary objects returned b
             ]
         }
         ```
+
+        The default trust policy includes all supported notation truststore types, including CA, signing authority, and TSA stores.

--- a/pkg/extensions/README_imagetrust.md
+++ b/pkg/extensions/README_imagetrust.md
@@ -149,7 +149,8 @@ The information above will be included in the ManifestSummary objects returned b
                     "name": "default-config",
                     "registryScopes": [ "*" ],
                     "signatureVerification": {
-                        "level" : "strict" 
+                        "level" : "strict",
+                        "verifyTimestamp": "afterCertExpiry"
                     },
                     "trustStores": ["ca:default","signingAuthority:default","tsa:default"],
                     "trustedIdentities": [

--- a/pkg/extensions/README_imagetrust.md
+++ b/pkg/extensions/README_imagetrust.md
@@ -149,8 +149,7 @@ The information above will be included in the ManifestSummary objects returned b
                     "name": "default-config",
                     "registryScopes": [ "*" ],
                     "signatureVerification": {
-                        "level" : "strict",
-                        "verifyTimestamp": "afterCertExpiry"
+                        "level" : "strict" 
                     },
                     "trustStores": ["ca:default","signingAuthority:default","tsa:default"],
                     "trustedIdentities": [

--- a/pkg/extensions/README_imagetrust.md
+++ b/pkg/extensions/README_imagetrust.md
@@ -149,7 +149,7 @@ The information above will be included in the ManifestSummary objects returned b
                     "name": "default-config",
                     "registryScopes": [ "*" ],
                     "signatureVerification": {
-                        "level" : "strict",
+                        "level": "strict",
                         "verifyTimestamp": "afterCertExpiry"
                     },
                     "trustStores": ["ca:default","signingAuthority:default","tsa:default"],

--- a/pkg/extensions/imagetrust/image_trust_test.go
+++ b/pkg/extensions/imagetrust/image_trust_test.go
@@ -102,6 +102,39 @@ func TestInitCosignAndNotationDirs(t *testing.T) {
 		So(err, ShouldEqual, zerr.ErrSignConfigDirNotSet)
 	})
 
+	Convey("InitTrustpolicy includes TSA store", t, func() {
+		dir := t.TempDir()
+
+		certStorage, err := imagetrust.NewCertificateLocalStorage(dir)
+		So(err, ShouldBeNil)
+
+		notationDir, err := certStorage.GetNotationDirPath()
+		So(err, ShouldBeNil)
+
+		_, err = os.Stat(path.Join(notationDir, "truststore/x509/tsa/default"))
+		So(err, ShouldBeNil)
+
+		trustPolicyBytes, err := os.ReadFile(path.Join(notationDir, "trustpolicy.json"))
+		So(err, ShouldBeNil)
+
+		trustPolicyDoc := struct {
+			TrustPolicies []struct {
+				TrustStores           []string `json:"trustStores"`
+				SignatureVerification struct {
+					VerifyTimestamp string `json:"verifyTimestamp"`
+				} `json:"signatureVerification"`
+			} `json:"trustPolicies"`
+		}{}
+
+		err = json.Unmarshal(trustPolicyBytes, &trustPolicyDoc)
+		So(err, ShouldBeNil)
+		So(trustPolicyDoc.TrustPolicies, ShouldNotBeEmpty)
+		So(trustPolicyDoc.TrustPolicies[0].TrustStores, ShouldContain, "ca:default")
+		So(trustPolicyDoc.TrustPolicies[0].TrustStores, ShouldContain, "signingAuthority:default")
+		So(trustPolicyDoc.TrustPolicies[0].TrustStores, ShouldContain, "tsa:default")
+		So(trustPolicyDoc.TrustPolicies[0].SignatureVerification.VerifyTimestamp, ShouldEqual, "afterCertExpiry")
+	})
+
 	Convey("UploadCertificate - notationDir is not set", t, func() {
 		rootDir := t.TempDir()
 

--- a/pkg/extensions/imagetrust/notation.go
+++ b/pkg/extensions/imagetrust/notation.go
@@ -80,16 +80,9 @@ func NewCertificateLocalStorage(rootDir string) (*CertificateLocalStorage, error
 	for _, truststoreType := range truststore.Types {
 		defaultTruststore := path.Join(dir, "truststore", "x509", string(truststoreType), truststoreName)
 
-		_, err = os.Stat(defaultTruststore)
+		err = os.MkdirAll(defaultTruststore, defaultDirPerms)
 		if err != nil {
-			if !os.IsNotExist(err) {
-				return nil, err
-			}
-
-			err = os.MkdirAll(defaultTruststore, defaultDirPerms)
-			if err != nil {
-				return nil, err
-			}
+			return nil, err
 		}
 	}
 
@@ -136,7 +129,7 @@ func InitTrustpolicyFile(notationStorage certificateStorage) error {
 			"name": "default-config",
 			"registryScopes": [ "*" ],
 			"signatureVerification": {
-				"level" : "strict",
+				"level": "strict",
 				"verifyTimestamp": "afterCertExpiry"
 			},
 			"trustStores": [` + defaultTruststores + `],

--- a/pkg/extensions/imagetrust/notation.go
+++ b/pkg/extensions/imagetrust/notation.go
@@ -78,17 +78,15 @@ func NewCertificateLocalStorage(rootDir string) (*CertificateLocalStorage, error
 	}
 
 	for _, truststoreType := range truststore.Types {
-		if truststoreType != truststore.TypeTSA {
-			defaultTruststore := path.Join(dir, "truststore", "x509", string(truststoreType), truststoreName)
+		defaultTruststore := path.Join(dir, "truststore", "x509", string(truststoreType), truststoreName)
 
-			_, err = os.Stat(defaultTruststore)
-			if os.IsNotExist(err) {
-				err = os.MkdirAll(defaultTruststore, defaultDirPerms)
-				if err != nil {
-					return nil, err
-				}
+		_, err = os.Stat(defaultTruststore)
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return nil, err
 			}
 
+			err = os.MkdirAll(defaultTruststore, defaultDirPerms)
 			if err != nil {
 				return nil, err
 			}
@@ -118,9 +116,7 @@ func InitTrustpolicyFile(notationStorage certificateStorage) error {
 	truststores := []string{}
 
 	for _, truststoreType := range truststore.Types {
-		if truststoreType != truststore.TypeTSA {
-			truststores = append(truststores, fmt.Sprintf("\"%s:%s\"", string(truststoreType), truststoreName))
-		}
+		truststores = append(truststores, fmt.Sprintf("\"%s:%s\"", string(truststoreType), truststoreName))
 	}
 
 	defaultTruststores := strings.Join(truststores, ",")

--- a/pkg/extensions/imagetrust/notation.go
+++ b/pkg/extensions/imagetrust/notation.go
@@ -136,7 +136,8 @@ func InitTrustpolicyFile(notationStorage certificateStorage) error {
 			"name": "default-config",
 			"registryScopes": [ "*" ],
 			"signatureVerification": {
-				"level" : "strict" 
+				"level" : "strict",
+                                "verifyTimestamp": "afterCertExpiry"
 			},
 			"trustStores": [` + defaultTruststores + `],
 			"trustedIdentities": [

--- a/pkg/extensions/imagetrust/notation.go
+++ b/pkg/extensions/imagetrust/notation.go
@@ -137,7 +137,7 @@ func InitTrustpolicyFile(notationStorage certificateStorage) error {
 			"registryScopes": [ "*" ],
 			"signatureVerification": {
 				"level" : "strict",
-                                "verifyTimestamp": "afterCertExpiry"
+				"verifyTimestamp": "afterCertExpiry"
 			},
 			"trustStores": [` + defaultTruststores + `],
 			"trustedIdentities": [


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Fixes #4167

**What does this PR do / Why do we need it**:
The default notation trust policy generated by the imagetrust extension was missing TSA trust stores, so signatures that rely on TSA validation could not be evaluated against the full set of supported notation truststore types. This change makes the generated trustpolicy.json reflect the same truststore set exposed by notation and preserves existing strict verification behavior for non-timestamped signatures.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
Added to unit tests.

**Automation added to e2e**:
No

**Will this break upgrades or downgrades?**
No.

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
