### PR TITLE
fix(notation): Decouple Signature trust UI processing from scanning

### DIFF
--- a/pkg/extensions/search/convert/convert_test.go
+++ b/pkg/extensions/search/convert/convert_test.go
@@ -186,7 +186,7 @@ func TestGetSignaturesInfo(t *testing.T) {
 		signaturesSummary := convert.GetSignaturesInfo(true, signatures[digest.String()])
 		So(signaturesSummary, ShouldNotBeEmpty)
 		So(*signaturesSummary[0].Author, ShouldEqual, "author")
-		So(*signaturesSummary[0].IsTrusted, ShouldEqual, false)
+		So(*signaturesSummary[0].IsTrusted, ShouldEqual, true)
 		So(*signaturesSummary[0].Tool, ShouldEqual, "notation")
 	})
 }

--- a/pkg/extensions/search/convert/metadb.go
+++ b/pkg/extensions/search/convert/metadb.go
@@ -263,29 +263,10 @@ func GetSignaturesInfo(isSigned bool, signatures mTypes.ManifestSignatures) []*g
 	for sigType, signatures := range signatures {
 		for _, sig := range signatures {
 			for _, layer := range sig.LayersInfo {
-				var (
-					isTrusted bool
-					author    string
-					tool      string
-				)
-
-				if layer.Signer != "" {
-					author = layer.Signer
-
-					if !layer.Date.IsZero() && time.Now().After(layer.Date) {
-						isTrusted = false
-					} else {
-						isTrusted = true
-					}
-				} else {
-					isTrusted = false
-					author = ""
-				}
-
-				tool = sigType
+				isTrusted := layer.Signer != ""
 
 				signaturesInfo = append(signaturesInfo,
-					&gql_generated.SignatureSummary{Tool: &tool, IsTrusted: &isTrusted, Author: &author})
+					&gql_generated.SignatureSummary{Tool: &sigType, IsTrusted: &isTrusted, Author: &layer.Signer})
 			}
 		}
 	}

--- a/pkg/extensions/search/convert/metadb.go
+++ b/pkg/extensions/search/convert/metadb.go
@@ -263,6 +263,8 @@ func GetSignaturesInfo(isSigned bool, signatures mTypes.ManifestSignatures) []*g
 	for sigType, signatures := range signatures {
 		for _, sig := range signatures {
 			for _, layer := range sig.LayersInfo {
+
+				// Signer is only set by UpdateSignaturesValidity when VerifySignature succeeds, so empty Signer means untrusted.
 				tool := sigType
 				author := layer.Signer
 				isTrusted := author != ""

--- a/pkg/extensions/search/convert/metadb.go
+++ b/pkg/extensions/search/convert/metadb.go
@@ -263,10 +263,12 @@ func GetSignaturesInfo(isSigned bool, signatures mTypes.ManifestSignatures) []*g
 	for sigType, signatures := range signatures {
 		for _, sig := range signatures {
 			for _, layer := range sig.LayersInfo {
-				isTrusted := layer.Signer != ""
+				tool := sigType
+				author := layer.Signer
+				isTrusted := author != ""
 
 				signaturesInfo = append(signaturesInfo,
-					&gql_generated.SignatureSummary{Tool: &sigType, IsTrusted: &isTrusted, Author: &layer.Signer})
+					&gql_generated.SignatureSummary{Tool: &tool, IsTrusted: &isTrusted, Author: &author})
 			}
 		}
 	}

--- a/pkg/extensions/search/convert/metadb.go
+++ b/pkg/extensions/search/convert/metadb.go
@@ -263,7 +263,6 @@ func GetSignaturesInfo(isSigned bool, signatures mTypes.ManifestSignatures) []*g
 	for sigType, signatures := range signatures {
 		for _, sig := range signatures {
 			for _, layer := range sig.LayersInfo {
-
 				// Signer is only set by UpdateSignaturesValidity when VerifySignature succeeds, so empty Signer means untrusted.
 				tool := sigType
 				author := layer.Signer

--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -1401,7 +1401,6 @@ func (bdw *BoltDB) UpdateSignaturesValidity(ctx context.Context, repo string, ma
 					}
 
 					if !date.IsZero() {
-						layerInfo.Signer = author
 						layerInfo.Date = timestamppb.New(date)
 					}
 

--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -1398,6 +1398,8 @@ func (bdw *BoltDB) UpdateSignaturesValidity(ctx context.Context, repo string, ma
 
 					if isTrusted {
 						layerInfo.Signer = author
+					} else {
+						layerInfo.Signer = ""
 					}
 
 					if !date.IsZero() {

--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -1317,7 +1317,6 @@ func (dwr *DynamoDB) UpdateSignaturesValidity(ctx context.Context, repo string, 
 				}
 
 				if !date.IsZero() {
-					layerInfo.Signer = author
 					layerInfo.Date = timestamppb.New(date)
 				}
 

--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -1314,6 +1314,8 @@ func (dwr *DynamoDB) UpdateSignaturesValidity(ctx context.Context, repo string, 
 
 				if isTrusted {
 					layerInfo.Signer = author
+				} else {
+					layerInfo.Signer = ""
 				}
 
 				if !date.IsZero() {

--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -1535,7 +1535,6 @@ func (rc *RedisDB) UpdateSignaturesValidity(ctx context.Context, repo string, ma
 					}
 
 					if !date.IsZero() {
-						layerInfo.Signer = author
 						layerInfo.Date = timestamppb.New(date)
 					}
 

--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -1532,6 +1532,8 @@ func (rc *RedisDB) UpdateSignaturesValidity(ctx context.Context, repo string, ma
 
 					if isTrusted {
 						layerInfo.Signer = author
+					} else {
+						layerInfo.Signer = ""
 					}
 
 					if !date.IsZero() {


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
closes #4172 

**What does this PR do / Why do we need it**:
This PR is needed because PR #4168 introduced support for time-stamped signatures. Trusted timestamps allow signatures created with short-lived signing certificates to remain verifiable after the signing certificate has expired, because a trusted third party (the Time Stamping Authority, or TSA) certifies when the signature was created.

Currently, signature trust is determined in two places. The ```UpdateSignaturesValidity``` implementations (BoltDB, DynamoDB, and Redis) populate the database with signature properties, while ```GetSignaturesInfo``` reads those properties and recomputes the trust state for the UI by checking, among other things, whether the signing certificate has expired. This second check is no longer appropriate when time-stamped signatures are supported.

This PR removes the certificate expiration check from ```GetSignaturesInfo```, leaving the trust decision entirely to the signature verification extensions (Notation, Cosign, etc.), which already implement the correct time-stamp-aware validation logic.

One side effect of this change is that certificate expiration is no longer evaluated when the UI is loaded. Previously, expiration could be detected both during the periodic database refresh (every two hours) and on demand by the UI. After this change, an expired certificate will only be reflected after the next database refresh. This behavior has been deemed acceptable for now and can be revisited if it proves problematic.

**Testing done on this change**:
Run test suite

**Automation added to e2e**:
No

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
Yes

```release-note
Trust in timestamped signatures is now correctly displayed.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
