### PR TITLE
fix(gc): break orphan cycle when manifest blobs are missing from storage

### DIFF
--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -164,6 +164,14 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 		return err
 	}
 
+	// prune manifest/index descriptors whose blobs no longer exist in storage
+	if err := gc.removeStaleManifestEntries(repo, &index); err != nil {
+		gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).
+			Msg("failed to prune stale manifest entries")
+
+		return err
+	}
+
 	// update repos's index.json in storage
 	if !gc.opts.ImageRetention.DryRun {
 		/* this will update the index.json with manifests deleted above
@@ -194,6 +202,176 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 	}
 
 	return nil
+}
+
+func (gc GarbageCollect) removeStaleManifestEntries(repo string, index *ispec.Index) error {
+	if gc.opts.ImageRetention.DryRun {
+		return nil
+	}
+
+	allBlobs, err := gc.imgStore.GetAllBlobs(repo)
+	if err != nil {
+		var pathNotFoundErr driver.PathNotFoundError
+		if !errors.As(err, &pathNotFoundErr) {
+			return err
+		}
+
+		allBlobs = []godigest.Digest{}
+	}
+
+	existingBlobs := make(map[string]bool, len(allBlobs))
+	for _, d := range allBlobs {
+		existingBlobs[d.String()] = true
+	}
+
+	kept := make([]ispec.Descriptor, 0, len(index.Manifests))
+
+	for _, desc := range index.Manifests {
+		if !existingBlobs[desc.Digest.String()] {
+			if err := gc.syncStaleManifestRemoval(repo, desc); err != nil {
+				return err
+			}
+
+			continue
+		}
+
+		if desc.MediaType == ispec.MediaTypeImageIndex || compat.IsCompatibleManifestListMediaType(desc.MediaType) {
+			stale, err := gc.imageIndexHasStaleNestedManifests(repo, desc, existingBlobs)
+			if err != nil {
+				return err
+			}
+
+			if stale {
+				if err := gc.syncStaleManifestRemoval(repo, desc); err != nil {
+					return err
+				}
+
+				continue
+			}
+		}
+
+		kept = append(kept, desc)
+	}
+
+	if removed := len(index.Manifests) - len(kept); removed > 0 {
+		gc.log.Info().Str("module", "gc").Str("repository", repo).
+			Int("removed", removed).Int("kept", len(kept)).
+			Msg("pruned stale manifest entries from index")
+	}
+
+	index.Manifests = kept
+
+	return nil
+}
+
+// syncStaleManifestRemoval best-effort syncs metaDB before a stale descriptor is removed from
+// index.Manifests (index.json is persisted later in cleanRepo). metaDB failures are logged but
+// do not abort stale pruning — storage repair must not depend on secondary index consistency.
+// The blob is typically already absent from storage; cosign signatures are cleaned up via tag annotation.
+func (gc GarbageCollect) syncStaleManifestRemoval(repo string, desc ispec.Descriptor) error {
+	tag, hasTag := getDescriptorTag(desc)
+	ref := tag
+	if ref == "" {
+		ref = desc.Digest.String()
+	}
+
+	var subjectDigest godigest.Digest
+
+	isCosignSig := hasTag && zcommon.IsCosignSignature(tag)
+	if isCosignSig {
+		subjectDigest = getSubjectFromCosignTag(tag)
+		if err := subjectDigest.Validate(); err != nil {
+			gc.log.Warn().Err(err).Str("module", "gc").Str("repository", repo).
+				Str("reference", ref).Str("digest", desc.Digest.String()).
+				Msg("invalid cosign tag subject digest, falling back to RemoveRepoReference")
+
+			isCosignSig = false
+			subjectDigest = ""
+		}
+	}
+
+	if gc.metaDB != nil {
+		if isCosignSig {
+			if err := gc.metaDB.DeleteSignature(repo, subjectDigest, mTypes.SignatureMetadata{
+				SignatureDigest: desc.Digest.String(),
+				SignatureType:   storage.CosignType,
+			}); err != nil {
+				gc.log.Error().Err(err).Str("module", "gc").Str("component", "metadb").
+					Str("repository", repo).Str("digest", desc.Digest.String()).Str("reference", ref).
+					Msg("failed to remove stale cosign signature from metaDB, continuing stale prune")
+			}
+		} else if err := gc.metaDB.RemoveRepoReference(repo, ref, desc.Digest); err != nil {
+			gc.log.Error().Err(err).Str("module", "gc").Str("component", "metadb").
+				Str("repository", repo).Str("digest", desc.Digest.String()).Str("reference", ref).
+				Msg("failed to remove stale manifest reference from metaDB, continuing stale prune")
+		}
+	}
+
+	logEvent := gc.log.Info().Str("module", "gc").
+		Str("repository", repo).
+		Str("reference", ref).
+		Str("digest", desc.Digest.String()).
+		Str("decision", "delete").
+		Str("reason", "staleManifestPrune")
+
+	if subjectDigest != "" {
+		logEvent = logEvent.Str("subject", subjectDigest.String())
+	}
+
+	logEvent.Msg("pruned stale manifest entry from index")
+
+	if gc.auditLog != nil {
+		auditEvent := gc.auditLog.Info().Str("module", "gc").
+			Str("repository", repo).
+			Str("reference", ref).
+			Str("digest", desc.Digest.String()).
+			Str("decision", "delete").
+			Str("reason", "staleManifestPrune")
+
+		if subjectDigest != "" {
+			auditEvent = auditEvent.Str("subject", subjectDigest.String())
+		}
+
+		auditEvent.Msg("pruned stale manifest entry from index")
+	}
+
+	return nil
+}
+
+// imageIndexHasStaleNestedManifests reports whether the top-level image index descriptor
+// should be dropped from index.json. The index blob itself is never rewritten.
+// Sparse indexes are supported: if any nested manifest blob still exists, return false
+// (not stale) so the tagged index entry is kept even when other nested manifests are missing.
+// Return true only when every nested manifest blob is gone (or the index blob is missing).
+// Empty manifest lists are valid OCI and are kept when the index blob still exists.
+func (gc GarbageCollect) imageIndexHasStaleNestedManifests(repo string, desc ispec.Descriptor,
+	existingBlobs map[string]bool,
+) (bool, error) {
+	indexImage, err := common.GetImageIndex(gc.imgStore, repo, desc.Digest, gc.log)
+	if err != nil {
+		var pathNotFoundErr driver.PathNotFoundError
+		if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
+			// Index blob missing — top-level descriptor is stale.
+			return true, nil
+		}
+
+		return false, err
+	}
+
+	if len(indexImage.Manifests) == 0 {
+		return false, nil
+	}
+
+	for _, nested := range indexImage.Manifests {
+		if existingBlobs[nested.Digest.String()] {
+			// At least one nested manifest remains; keep this sparse index in index.json.
+			// Early return (not continue): stale=false is decided as soon as one survivor exists.
+			return false, nil
+		}
+	}
+
+	// Every nested manifest blob is missing.
+	return true, nil
 }
 
 func (gc GarbageCollect) removeManifestsPerRepoPolicy(ctx context.Context, repo string, index *ispec.Index) error {

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -854,6 +854,27 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			So(deleted, ShouldEqual, 0)
 		})
 
+		Convey("Error on GetAllBlobs in removeUnreferencedBlobs", func() {
+			returnedIndex := ispec.Index{}
+			returnedIndexBuf, err := json.Marshal(returnedIndex)
+			So(err, ShouldBeNil)
+
+			imgStore := mocks.MockedImageStore{
+				GetIndexContentFn: func(repo string) ([]byte, error) {
+					return returnedIndexBuf, nil
+				},
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return nil, errGC
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			deleted, err := gc.removeUnreferencedBlobs(repoName, time.Hour, log)
+			So(err, ShouldNotBeNil)
+			So(deleted, ShouldEqual, 0)
+		})
+
 		Convey("StatBlobUpload error in removeBlobUploads", func() {
 			imgStore := mocks.MockedImageStore{
 				DirExistsFn: func(d string) bool {
@@ -963,5 +984,679 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrRepoNotFound), ShouldBeTrue)
 		})
+
+		Convey("removeStaleManifestEntries removes entries whose blobs are missing", func() {
+			existingDigest := godigest.FromString("existing-blob")
+			missingDigest := godigest.FromString("missing-blob")
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return []godigest.Digest{existingDigest}, nil
+				},
+			}
+
+			removedRef := ""
+			metaDB := mocks.MetaDBMock{
+				RemoveRepoReferenceFn: func(repo, reference string, manifestDigest godigest.Digest) error {
+					removedRef = reference
+
+					return nil
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    existingDigest,
+						MediaType: ispec.MediaTypeImageManifest,
+					},
+					{
+						Digest:    missingDigest,
+						MediaType: ispec.MediaTypeImageManifest,
+					},
+				},
+			}
+
+			err := gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 1)
+			So(index.Manifests[0].Digest, ShouldEqual, existingDigest)
+			So(removedRef, ShouldEqual, missingDigest.String())
+		})
+
+		Convey("removeStaleManifestEntries uses tag as reference when available", func() {
+			missingDigest := godigest.FromString("missing-blob")
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return nil, nil
+				},
+			}
+
+			removedRef := ""
+			metaDB := mocks.MetaDBMock{
+				RemoveRepoReferenceFn: func(repo, reference string, manifestDigest godigest.Digest) error {
+					removedRef = reference
+
+					return nil
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    missingDigest,
+						MediaType: ispec.MediaTypeImageManifest,
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: "v1.0",
+						},
+					},
+				},
+			}
+
+			err := gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 0)
+			So(removedRef, ShouldEqual, "v1.0")
+		})
+
+		Convey("removeStaleManifestEntries removes cosign signature via DeleteSignature when blob is missing", func() {
+			subjectDigest := godigest.FromString("signed-manifest")
+			missingSigDigest := godigest.FromString("missing-sig")
+			cosignTag := "sha256-" + subjectDigest.Encoded() + ".sig"
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return nil, nil
+				},
+			}
+
+			deletedSig := false
+			removedRef := false
+			metaDB := mocks.MetaDBMock{
+				DeleteSignatureFn: func(repo string, signedManifestDigest godigest.Digest, sm types.SignatureMetadata) error {
+					deletedSig = signedManifestDigest == subjectDigest &&
+						sm.SignatureDigest == missingSigDigest.String() &&
+						sm.SignatureType == storage.CosignType
+
+					return nil
+				},
+				RemoveRepoReferenceFn: func(repo, reference string, manifestDigest godigest.Digest) error {
+					removedRef = true
+
+					return nil
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    missingSigDigest,
+						MediaType: ispec.MediaTypeImageManifest,
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: cosignTag,
+						},
+					},
+				},
+			}
+
+			err := gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 0)
+			So(deletedSig, ShouldBeTrue)
+			So(removedRef, ShouldBeFalse)
+		})
+
+		Convey("removeStaleManifestEntries falls back to RemoveRepoReference for malformed cosign tag", func() {
+			missingSigDigest := godigest.FromString("missing-sig")
+			malformedCosignTag := "sha256-not-a-valid-digest.sig"
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return nil, nil
+				},
+			}
+
+			deletedSig := false
+			removedRef := ""
+			metaDB := mocks.MetaDBMock{
+				DeleteSignatureFn: func(repo string, signedManifestDigest godigest.Digest, sm types.SignatureMetadata) error {
+					deletedSig = true
+
+					return nil
+				},
+				RemoveRepoReferenceFn: func(repo, reference string, manifestDigest godigest.Digest) error {
+					removedRef = reference
+
+					return nil
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    missingSigDigest,
+						MediaType: ispec.MediaTypeImageManifest,
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: malformedCosignTag,
+						},
+					},
+				},
+			}
+
+			err := gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 0)
+			So(deletedSig, ShouldBeFalse)
+			So(removedRef, ShouldEqual, malformedCosignTag)
+		})
+
+		Convey("removeStaleManifestEntries skips in DryRun mode", func() {
+			dryRunOptions := Options{
+				Delay: storageConstants.DefaultGCDelay,
+				ImageRetention: config.ImageRetention{
+					DryRun: true,
+					Delay:  storageConstants.DefaultGCDelay,
+				},
+			}
+
+			gc := NewGarbageCollect(mocks.MockedImageStore{}, mocks.MetaDBMock{}, dryRunOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    godigest.FromString("whatever"),
+						MediaType: ispec.MediaTypeImageManifest,
+					},
+				},
+			}
+
+			err := gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 1)
+		})
+
+		Convey("removeStaleManifestEntries treats GetAllBlobs PathNotFound as empty storage", func() {
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return nil, driver.PathNotFoundError{}
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    godigest.FromString("blob"),
+						MediaType: ispec.MediaTypeImageManifest,
+					},
+				},
+			}
+
+			err := gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 0)
+		})
+
+		Convey("removeStaleManifestEntries continues despite metaDB errors", func() {
+			missingDigest := godigest.FromString("missing-blob")
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return nil, nil
+				},
+			}
+
+			metaDB := mocks.MetaDBMock{
+				RemoveRepoReferenceFn: func(repo, reference string, manifestDigest godigest.Digest) error {
+					return errGC
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    missingDigest,
+						MediaType: ispec.MediaTypeImageManifest,
+					},
+				},
+			}
+
+			err := gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 0)
+		})
+
+		Convey("removeStaleManifestEntries keeps sparse image index when some nested manifests exist", func() {
+			indexDigest := godigest.FromString("image-index-blob")
+			existingNested := godigest.FromString("existing-nested")
+			missingNested := godigest.FromString("missing-nested")
+
+			indexBlob, err := json.Marshal(ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{Digest: existingNested, MediaType: ispec.MediaTypeImageManifest},
+					{Digest: missingNested, MediaType: ispec.MediaTypeImageManifest},
+				},
+			})
+			So(err, ShouldBeNil)
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return []godigest.Digest{indexDigest, existingNested}, nil
+				},
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == indexDigest {
+						return indexBlob, nil
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    indexDigest,
+						MediaType: ispec.MediaTypeImageIndex,
+						Size:      int64(len(indexBlob)),
+					},
+				},
+			}
+
+			err = gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 1)
+			So(index.Manifests[0].Digest, ShouldEqual, indexDigest)
+		})
+
+		Convey("removeStaleManifestEntries drops image index when all nested manifests are missing", func() {
+			indexDigest := godigest.FromString("image-index-blob")
+			missingNested := godigest.FromString("missing-nested")
+
+			indexBlob, err := json.Marshal(ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{Digest: missingNested, MediaType: ispec.MediaTypeImageManifest},
+				},
+			})
+			So(err, ShouldBeNil)
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return []godigest.Digest{indexDigest}, nil
+				},
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == indexDigest {
+						return indexBlob, nil
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    indexDigest,
+						MediaType: ispec.MediaTypeImageIndex,
+						Size:      int64(len(indexBlob)),
+					},
+				},
+			}
+
+			err = gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 0)
+		})
+
+		Convey("removeStaleManifestEntries skips metaDB sync when metaDB is nil", func() {
+			missingDigest := godigest.FromString("missing-blob")
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return nil, nil
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, nil, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    missingDigest,
+						MediaType: ispec.MediaTypeImageManifest,
+					},
+				},
+			}
+
+			err := gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 0)
+		})
+
+		Convey("removeStaleManifestEntries propagates image index read errors", func() {
+			indexDigest := godigest.FromString("image-index-blob")
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return []godigest.Digest{indexDigest}, nil
+				},
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					return nil, errGC
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    indexDigest,
+						MediaType: ispec.MediaTypeImageIndex,
+					},
+				},
+			}
+
+			err := gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldNotBeNil)
+			So(len(index.Manifests), ShouldEqual, 1)
+		})
+
+		Convey("removeStaleManifestEntries drops image index when index blob is missing at read time", func() {
+			indexDigest := godigest.FromString("image-index-blob")
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return []godigest.Digest{indexDigest}, nil
+				},
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					return nil, zerr.ErrBlobNotFound
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    indexDigest,
+						MediaType: ispec.MediaTypeImageIndex,
+					},
+				},
+			}
+
+			err := gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 0)
+		})
+
+		Convey("removeStaleManifestEntries keeps image index when nested list is empty", func() {
+			indexDigest := godigest.FromString("image-index-blob")
+
+			indexBlob, err := json.Marshal(ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{},
+			})
+			So(err, ShouldBeNil)
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return []godigest.Digest{indexDigest}, nil
+				},
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == indexDigest {
+						return indexBlob, nil
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    indexDigest,
+						MediaType: ispec.MediaTypeImageIndex,
+						Size:      int64(len(indexBlob)),
+					},
+				},
+			}
+
+			err = gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 1)
+			So(index.Manifests[0].Digest, ShouldEqual, indexDigest)
+		})
+
+		Convey("removeStaleManifestEntries continues when cosign signature metadata is missing", func() {
+			subjectDigest := godigest.FromString("signed-manifest")
+			missingSigDigest := godigest.FromString("missing-sig")
+			cosignTag := "sha256-" + subjectDigest.Encoded() + ".sig"
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return nil, nil
+				},
+			}
+
+			metaDB := mocks.MetaDBMock{
+				DeleteSignatureFn: func(repo string, signedManifestDigest godigest.Digest, sm types.SignatureMetadata) error {
+					return zerr.ErrImageMetaNotFound
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    missingSigDigest,
+						MediaType: ispec.MediaTypeImageManifest,
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: cosignTag,
+						},
+					},
+				},
+			}
+
+			err := gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 0)
+		})
+
+		Convey("removeStaleManifestEntries syncs metaDB when dropping stale image index", func() {
+			indexDigest := godigest.FromString("image-index-blob")
+			missingNested := godigest.FromString("missing-nested")
+
+			indexBlob, err := json.Marshal(ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{Digest: missingNested, MediaType: ispec.MediaTypeImageManifest},
+				},
+			})
+			So(err, ShouldBeNil)
+
+			removed := false
+			metaDB := mocks.MetaDBMock{
+				RemoveRepoReferenceFn: func(repo, reference string, manifestDigest godigest.Digest) error {
+					if manifestDigest == indexDigest {
+						removed = true
+					}
+
+					return nil
+				},
+			}
+
+			imgStore := mocks.MockedImageStore{
+				GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+					return []godigest.Digest{indexDigest}, nil
+				},
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == indexDigest {
+						return indexBlob, nil
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{
+						Digest:    indexDigest,
+						MediaType: ispec.MediaTypeImageIndex,
+						Size:      int64(len(indexBlob)),
+					},
+				},
+			}
+
+			err = gc.removeStaleManifestEntries(repoName, index)
+			So(err, ShouldBeNil)
+			So(len(index.Manifests), ShouldEqual, 0)
+			So(removed, ShouldBeTrue)
+		})
+	})
+}
+
+func TestCleanRepoWithStaleManifestEntries(t *testing.T) {
+	ctx := context.Background()
+
+	Convey("cleanRepo end-to-end prunes stale manifest entries", t, func() {
+		log := zlog.NewTestLogger()
+		audit := zlog.NewAuditLogger("debug", "")
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		existingDigest := godigest.FromString("existing-blob")
+		missingDigest := godigest.FromString("missing-blob")
+
+		returnedIndex := ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{
+					Digest:    existingDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				},
+				{
+					Digest:    missingDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				},
+			},
+		}
+
+		returnedIndexBuf, err := json.Marshal(returnedIndex)
+		So(err, ShouldBeNil)
+
+		var savedIndex ispec.Index
+
+		imgStore := mocks.MockedImageStore{
+			GetIndexContentFn: func(repo string) ([]byte, error) {
+				return returnedIndexBuf, nil
+			},
+			GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+				return []godigest.Digest{existingDigest}, nil
+			},
+			PutIndexContentFn: func(repo string, index ispec.Index) error {
+				savedIndex = index
+
+				return nil
+			},
+			CleanupRepoFn: func(repo string, blobs []godigest.Digest, removeRepo bool) (int, error) {
+				return 0, nil
+			},
+			GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+				if digest == existingDigest {
+					m := ispec.Manifest{}
+					m.SchemaVersion = 2
+					b, _ := json.Marshal(m)
+
+					return b, nil
+				}
+
+				return nil, zerr.ErrBlobNotFound
+			},
+			StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+				if digest == existingDigest {
+					return true, 100, time.Now().Add(-time.Hour), nil
+				}
+
+				return false, 0, time.Time{}, zerr.ErrBlobNotFound
+			},
+			ListBlobUploadsFn: func(repo string) ([]string, error) {
+				return nil, nil
+			},
+		}
+
+		falseVal := false
+		gcOptions := Options{
+			Delay: storageConstants.DefaultGCDelay,
+			ImageRetention: config.ImageRetention{
+				Delay: storageConstants.DefaultGCDelay,
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:   []string{"**"},
+						DeleteUntagged: &falseVal,
+					},
+				},
+			},
+		}
+
+		gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+		err = gc.cleanRepo(ctx, repoName)
+		So(err, ShouldBeNil)
+		So(len(savedIndex.Manifests), ShouldEqual, 1)
+		So(savedIndex.Manifests[0].Digest, ShouldEqual, existingDigest)
+	})
+}
+
+func TestCleanupRepoMissingBlob(t *testing.T) {
+	Convey("CleanupRepo skips blobs that are already absent", t, func() {
+		dir := t.TempDir()
+
+		log := zlog.NewTestLogger()
+
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
+			RootDir:     dir,
+			Name:        "cache",
+			UseRelPaths: true,
+		}, log)
+		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
+
+		content := []byte("disappearing blob")
+		digest := godigest.FromBytes(content)
+
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(content), digest)
+		So(err, ShouldBeNil)
+
+		blobPath := path.Join(dir, repoName, "blobs", "sha256", digest.Encoded())
+		err = os.Remove(blobPath)
+		So(err, ShouldBeNil)
+
+		count, err := imgStore.CleanupRepo(repoName, []godigest.Digest{digest}, false)
+		So(err, ShouldBeNil)
+		So(count, ShouldEqual, 1)
 	})
 }

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -1921,26 +1921,35 @@ func (is *ImageStore) CleanupRepo(repo string, blobs []godigest.Digest, removeRe
 		is.log.Debug().Str("repository", repo).
 			Str("digest", digest.String()).Msg("perform GC on blob")
 
-		if err := is.deleteBlob(repo, digest); err != nil {
-			if errors.Is(err, zerr.ErrBlobReferenced) {
-				if err := is.deleteImageManifest(context.Background(), repo, digest.String(), true); err != nil {
-					if errors.Is(err, zerr.ErrManifestConflict) || errors.Is(err, zerr.ErrManifestReferenced) {
-						continue
-					}
+		err := is.deleteBlob(repo, digest)
+		if err == nil {
+			count++
 
-					is.log.Error().Err(err).Str("repository", repo).Str("digest", digest.String()).Msg("failed to delete manifest")
+			continue
+		}
 
-					return count, err
+		switch {
+		case errors.Is(err, zerr.ErrBlobReferenced):
+			if err := is.deleteImageManifest(context.Background(), repo, digest.String(), true); err != nil {
+				if errors.Is(err, zerr.ErrManifestConflict) || errors.Is(err, zerr.ErrManifestReferenced) {
+					continue
 				}
 
-				count++
-			} else {
-				is.log.Error().Err(err).Str("repository", repo).Str("digest", digest.String()).Msg("failed to delete blob")
+				is.log.Error().Err(err).Str("repository", repo).Str("digest", digest.String()).Msg("failed to delete manifest")
 
 				return count, err
 			}
-		} else {
+
 			count++
+		case errors.Is(err, zerr.ErrBlobNotFound):
+			is.log.Info().Str("repository", repo).Str("digest", digest.String()).
+				Msg("blob already absent during GC, skipping")
+
+			count++
+		default:
+			is.log.Error().Err(err).Str("repository", repo).Str("digest", digest.String()).Msg("failed to delete blob")
+
+			return count, err
 		}
 	}
 
@@ -1970,9 +1979,14 @@ func (is *ImageStore) deleteBlob(repo string, digest godigest.Digest) error {
 
 	_, err := is.storeDriver.Stat(blobPath)
 	if err != nil {
+		var pathNotFoundErr driver.PathNotFoundError
+		if errors.As(err, &pathNotFoundErr) {
+			return zerr.ErrBlobNotFound
+		}
+
 		is.log.Error().Err(err).Str("blob", blobPath).Msg("failed to stat blob")
 
-		return zerr.ErrBlobNotFound
+		return err
 	}
 
 	// first check if this blob is not currently in use
@@ -2037,6 +2051,14 @@ func (is *ImageStore) deleteBlob(repo string, digest godigest.Digest) error {
 	}
 
 	if err := is.storeDriver.Delete(blobPath); err != nil {
+		var pathNotFoundErr driver.PathNotFoundError
+		if errors.As(err, &pathNotFoundErr) {
+			is.log.Warn().Str("repository", repo).Str("digest", digest.String()).
+				Str("blobPath", blobPath).Msg("blob already removed from storage, skipping")
+
+			return nil
+		}
+
 		is.log.Error().Err(err).Str("blobPath", blobPath).Msg("failed to remove blob path")
 
 		return err

--- a/pkg/storage/imagestore/imagestore_test.go
+++ b/pkg/storage/imagestore/imagestore_test.go
@@ -1,14 +1,19 @@
 package imagestore_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
 	zerr "zotregistry.dev/zot/v2/errors"
@@ -17,8 +22,11 @@ import (
 	"zotregistry.dev/zot/v2/pkg/storage/gcs"
 	"zotregistry.dev/zot/v2/pkg/storage/imagestore"
 	"zotregistry.dev/zot/v2/pkg/storage/local"
+	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
 )
+
+var errDeleteFailed = errors.New("delete failed") //nolint: gochecknoglobals
 
 func TestGetBlobRedirectURL(t *testing.T) {
 	Convey("GetBlobRedirectURL", t, func() {
@@ -96,5 +104,153 @@ func TestGetBlobRedirectURL(t *testing.T) {
 			So(url, ShouldEqual, "")
 			So(errors.Is(err, zerr.ErrBlobNotFound), ShouldBeTrue)
 		})
+	})
+}
+
+func TestCleanupRepoToleratesDeletePathNotFound(t *testing.T) {
+	Convey("CleanupRepo tolerates PathNotFound on delete", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		rootDir := t.TempDir()
+		storeMock := &mocks.StorageDriverMock{}
+		remoteDriver := gcs.New(storeMock)
+		store := imagestore.NewImageStore(rootDir, "", false, false, log, metrics, nil,
+			remoteDriver, nil, nil, nil)
+
+		repo := "repo"
+		ctx := context.Background()
+		So(store.InitRepo(ctx, repo), ShouldBeNil)
+
+		digest := godigest.FromString("blob-content")
+		blobPath := store.BlobPath(repo, digest)
+
+		storeMock.StatFn = func(_ context.Context, path string) (driver.FileInfo, error) {
+			if path == blobPath {
+				return &mocks.FileInfoMock{
+					SizeFn: func() int64 { return 10 },
+				}, nil
+			}
+
+			return &mocks.FileInfoMock{}, nil
+		}
+		storeMock.DeleteFn = func(_ context.Context, path string) error {
+			if path == blobPath {
+				return driver.PathNotFoundError{Path: path}
+			}
+
+			return nil
+		}
+		storeMock.ListFn = func(_ context.Context, path string) ([]string, error) {
+			return nil, nil
+		}
+
+		count, err := store.CleanupRepo(repo, []godigest.Digest{digest}, false)
+		So(err, ShouldBeNil)
+		So(count, ShouldEqual, 1)
+	})
+}
+
+func TestCleanupRepoFailsOnUnexpectedDeleteBlobError(t *testing.T) {
+	Convey("CleanupRepo returns error when deleteBlob fails unexpectedly", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		rootDir := t.TempDir()
+		storeMock := &mocks.StorageDriverMock{}
+		remoteDriver := gcs.New(storeMock)
+		store := imagestore.NewImageStore(rootDir, "", false, false, log, metrics, nil,
+			remoteDriver, nil, nil, nil)
+
+		repo := "repo"
+		ctx := context.Background()
+		So(store.InitRepo(ctx, repo), ShouldBeNil)
+
+		digest := godigest.FromString("blob-content")
+		blobPath := store.BlobPath(repo, digest)
+
+		storeMock.StatFn = func(_ context.Context, path string) (driver.FileInfo, error) {
+			if path == blobPath {
+				return &mocks.FileInfoMock{
+					SizeFn: func() int64 { return 10 },
+				}, nil
+			}
+
+			return &mocks.FileInfoMock{}, nil
+		}
+		storeMock.DeleteFn = func(_ context.Context, path string) error {
+			if path == blobPath {
+				return errDeleteFailed
+			}
+
+			return nil
+		}
+		storeMock.ListFn = func(_ context.Context, path string) ([]string, error) {
+			return nil, nil
+		}
+
+		count, err := store.CleanupRepo(repo, []godigest.Digest{digest}, false)
+		So(err, ShouldNotBeNil)
+		So(count, ShouldEqual, 0)
+	})
+}
+
+func TestCleanupRepoFailsOnDeleteImageManifest(t *testing.T) {
+	Convey("CleanupRepo returns error when deleteImageManifest fails", t, func() {
+		dir := t.TempDir()
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		store := local.NewImageStore(dir, true, true, log, metrics, nil, nil, nil, nil)
+		repo := "repo"
+		ctx := context.Background()
+
+		content := []byte("layer content")
+		digest := godigest.FromBytes(content)
+		_, _, err := store.FullBlobUpload(ctx, repo, bytes.NewReader(content), digest)
+		So(err, ShouldBeNil)
+
+		cblob, cdigest := GetRandomImageConfig()
+		_, _, err = store.FullBlobUpload(ctx, repo, bytes.NewReader(cblob), cdigest)
+		So(err, ShouldBeNil)
+
+		manifest := ispec.Manifest{
+			Config: ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageConfig,
+				Digest:    cdigest,
+				Size:      int64(len(cblob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: ispec.MediaTypeImageLayer,
+					Digest:    digest,
+					Size:      int64(len(content)),
+				},
+			},
+		}
+		manifest.SchemaVersion = 2
+
+		body, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+
+		manifestDigest := godigest.FromBytes(body)
+		_, _, err = store.PutImageManifest(ctx, repo, "1.0", ispec.MediaTypeImageManifest, body, nil)
+		So(err, ShouldBeNil)
+
+		indexPath := path.Join(dir, repo, ispec.ImageIndexFile)
+		err = os.Chmod(indexPath, 0o444)
+		So(err, ShouldBeNil)
+
+		defer func() {
+			err := os.Chmod(indexPath, 0o644)
+			So(err, ShouldBeNil)
+		}()
+
+		count, err := store.CleanupRepo(repo, []godigest.Digest{manifestDigest}, false)
+		So(err, ShouldNotBeNil)
+		So(count, ShouldEqual, 0)
 	})
 }


### PR DESCRIPTION
fix(gc): break orphan cycle when manifest blobs are missing from storage

When manifest blobs disappear from object storage, GC could loop forever:
stale index.json entries kept layers unreferenced, blob deletes failed with
PathNotFound, and the run aborted before index.json was repaired.

Prune stale descriptors from index.json after retention (never rewrite
content-addressable blobs). Support sparse image indexes; keep valid empty
OCI indexes when the blob exists. Best-effort metaDB sync during stale prune
(cosign DeleteSignature or RemoveRepoReference; errors do not block repair).

Tolerate missing blobs in CleanupRepo/deleteBlob; map only Stat not-found to
ErrBlobNotFound.

Supersedes #3825

Signed-off-by: Andrei Aaron <andreifdaaron@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
