### PR TITLE
fix(sync): predict post-OCI digest for on-demand skip checks

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -215,6 +215,33 @@ jobs:
             sudo ./scripts/enable_userns.sh
             ./examples/kind/kind-ci.sh
 
+  kind-sync-ondemand:
+    name: On-demand sync mirror regression (issue 4184)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          make check-blackbox-prerequisites
+          go mod download
+          sudo apt-get update
+          sudo apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap jq
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+      - name: Build zot binary
+        run: make binary
+      - name: Run on-demand sync mirror regression test
+        run: |
+          sudo ./scripts/enable_userns.sh
+          ./examples/kind/kind-sync-ondemand.sh
+
   oidc-workload-identity:
     name: OIDC Workload Identity E2E
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -591,6 +591,10 @@ run-blackbox-sync-nightly: check-blackbox-prerequisites binary binary-minimal be
 	echo running nightly sync tests; \
 	$(BATS) $(BATS_FLAGS) test/blackbox/sync_harness.bats
 
+.PHONY: run-kind-sync-ondemand
+run-kind-sync-ondemand: check-blackbox-prerequisites binary
+	./examples/kind/kind-sync-ondemand.sh
+
 .PHONY: fuzz-all
 fuzz-all: fuzztime=${1}
 fuzz-all:

--- a/examples/kind/kind-sync-ondemand.sh
+++ b/examples/kind/kind-sync-ondemand.sh
@@ -1,0 +1,479 @@
+#!/bin/bash
+# kind-sync-ondemand.sh
+#
+# Regression test for https://github.com/project-zot/zot/issues/4184
+#
+# Docker manifest-list images like registry.k8s.io/pause:3.10.1 used to trigger
+# an endless resync loop because zot's OCI digest prediction did not match
+# regclient's post-conversion digest, causing CanSkipImage to always return false.
+#
+# This test:
+#   1. Builds a minimal Docker image that packages the locally compiled zot binary.
+#   2. Runs the container as a registry that mirrors registry.k8s.io on-demand.
+#   3. Creates a kind cluster with containerd configured to use zot as a mirror
+#      for registry.k8s.io.
+#   4. Evicts any pre-cached pause image, then pulls registry.k8s.io/pause:3.10.1 via zot mirror.
+#   5. Evicts the image from the kind node with crictl rmi.
+#   6. Pulls the same image again (second sync request to zot).
+#   7. Asserts:
+#      - The image appears in zot's catalog after the first sync.
+#      - "skipping image because it's already synced" appears in zot logs on the
+#        second pull only (not after the first).
+#      - "remote image digest changed, syncing again" does NOT appear (no loop).
+#
+# Prerequisites:
+#   make check-blackbox-prerequisites binary
+#
+# Usage:
+#   make run-kind-sync-ondemand
+#   ./examples/kind/kind-sync-ondemand.sh
+
+set -o errexit
+set -o pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+cd "${ROOT_DIR}"
+
+OS=$(go env GOOS)
+ARCH=$(go env GOARCH)
+ZOT_BINARY="${ROOT_DIR}/bin/zot-${OS}-${ARCH}"
+
+# Prefer the project-local kind binary installed by check-blackbox-prerequisites.
+if [ -x "${ROOT_DIR}/hack/tools/bin/kind" ]; then
+    KIND="${ROOT_DIR}/hack/tools/bin/kind"
+elif command -v kind &>/dev/null; then
+    KIND="kind"
+else
+    echo "Error: kind not found. Run 'make check-blackbox-prerequisites' first." >&2
+    exit 1
+fi
+
+ZOT_LISTEN_PORT="5000"
+KIND_NODE_IMAGE="kindest/node:v1.28.7"
+# pause:3.10.1 is a ~20-platform manifest list; first on-demand sync can take 1-3 minutes.
+POD_WAIT_TIMEOUT="180s"
+
+# The image that triggered the issue: a Docker manifest-list with ~20 platforms.
+PAUSE_IMAGE="registry.k8s.io/pause:3.10.1"
+
+COMMIT_HASH=$(git describe --always --tags --long)
+RUN_SUFFIX="$(git rev-parse --short HEAD)-$$"
+CLUSTER_NAME="zot-sync-ondemand-${RUN_SUFFIX}"
+ZOT_CONTAINER_NAME="zot-sync-ondemand-${RUN_SUFFIX}"
+CONTROL_PLANE="${CLUSTER_NAME}-control-plane"
+ZOT_IMAGE="zot-sync-ondemand:${COMMIT_HASH}"
+# Pinned digest for reproducible CI/nightly runs (index digest; docker --platform selects arch).
+DISTROLESS_BASE_IMAGE="gcr.io/distroless/base-debian12@sha256:9c05cfd65f41c93a909ea67eb05b920a3b838780ea55df5421d48295d98ff957"
+
+ZOT_STORAGE=$(mktemp -d /tmp/zot-sync-storage-XXXXX)
+KUBECONFIG_FILE=$(mktemp /tmp/kind-sync-kubeconfig-XXXXX)
+export KUBECONFIG="${KUBECONFIG_FILE}"
+
+log_info()  { echo "[INFO]  $*"; }
+log_warn()  { echo "[WARN]  $*" >&2; }
+log_error() { echo "[ERROR] $*" >&2; }
+
+KUBECTL_CTX="kind-${CLUSTER_NAME}"
+
+wait_for_cluster_ready() {
+    log_info "Waiting for kind node(s) to be Ready..."
+    kubectl --context "${KUBECTL_CTX}" wait --for=condition=Ready nodes --all --timeout=180s
+
+    log_info "Waiting for default service account..."
+    for i in $(seq 1 60); do
+        if kubectl --context "${KUBECTL_CTX}" get serviceaccount default -n default &>/dev/null; then
+            return 0
+        fi
+        sleep 2
+    done
+
+    log_error "default/default service account was not created in time"
+    kubectl --context "${KUBECTL_CTX}" get serviceaccount -A || true
+    exit 1
+}
+
+wait_for_pod() {
+    local pod=$1
+    local purpose=$2
+
+    log_info "Waiting for pod ${pod} (${purpose}, timeout ${POD_WAIT_TIMEOUT})..."
+    if kubectl --context "${KUBECTL_CTX}" wait --for=condition=Ready "pod/${pod}" \
+        --timeout="${POD_WAIT_TIMEOUT}" 2>/dev/null; then
+        return 0
+    fi
+
+    local phase
+    phase=$(kubectl --context "${KUBECTL_CTX}" get pod "${pod}" \
+        -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+    if [ "${phase}" = "Running" ] || [ "${phase}" = "Succeeded" ]; then
+        return 0
+    fi
+
+    log_error "pod ${pod} did not become ready (phase=${phase:-unknown})"
+    kubectl --context "${KUBECTL_CTX}" describe pod "${pod}" || true
+    docker logs "${ZOT_CONTAINER_NAME}" 2>&1 | tail -80 || true
+    exit 1
+}
+
+evict_pause_image_from_node() {
+    log_info "Evicting ${PAUSE_IMAGE} from kind node (kindest/node may pre-cache it)..."
+    docker exec "${CONTROL_PLANE}" crictl rmi "${PAUSE_IMAGE}" 2>/dev/null || \
+        log_info "Image was not cached on node (continuing)"
+}
+
+pause_tag_present() {
+    echo "${1}" | jq -e --arg tag "3.10.1" '.tags | index($tag)' >/dev/null 2>&1
+}
+
+wait_for_pause_in_catalog() {
+    local tags i
+
+    for i in $(seq 1 90); do
+        tags=$(curl -sf "http://localhost:${ZOT_HOST_PORT}/v2/pause/tags/list" 2>/dev/null || echo "")
+        if pause_tag_present "${tags}"; then
+            return 0
+        fi
+        sleep 2
+    done
+    return 1
+}
+
+# Match pause:3.10.1 skip/resync log lines (JSON "image"/"repo" fields or plain text).
+pause_image_log_filter() {
+    grep -E '(pause:3\.10\.1|"repo":"pause"|registry\.k8s\.io/pause)' || true
+}
+
+count_pause_skip_logs() {
+    { grep "skipping image because it's already synced" || true; } \
+        | pause_image_log_filter | wc -l | tr -d ' '
+}
+
+count_pause_resync_logs() {
+    { grep "remote image digest changed, syncing again" || true; } \
+        | pause_image_log_filter | wc -l | tr -d ' '
+}
+
+try_remove_container() {
+    local name=$1
+    local quiet=${2:-false}
+
+    if ! docker container inspect "${name}" &>/dev/null; then
+        return 0
+    fi
+
+    if [ "${quiet}" != "true" ]; then
+        log_info "Removing container ${name}..."
+    fi
+    docker network disconnect kind "${name}" 2>/dev/null || true
+    if docker rm -f "${name}" 2>/dev/null; then
+        return 0
+    fi
+
+    if docker container inspect "${name}" &>/dev/null; then
+        if [ "${quiet}" != "true" ]; then
+            log_warn "Could not remove container ${name} (docker stop/rm failed)."
+            log_warn "Orphans do not block this test (each run uses a unique name)."
+        fi
+        return 1
+    fi
+    return 0
+}
+
+remove_stale_kind_clusters() {
+    local cluster
+
+    while read -r cluster; do
+        [ -n "${cluster}" ] || continue
+        [ "${cluster}" = "${CLUSTER_NAME}" ] && continue
+        case "${cluster}" in
+            zot-sync-ondemand|zot-sync-ondemand-*)
+                log_info "Removing stale kind cluster ${cluster}..."
+                "${KIND}" delete cluster --name "${cluster}" 2>/dev/null || true
+                ;;
+        esac
+    done < <("${KIND}" get clusters 2>/dev/null || true)
+}
+
+remove_stale_zot_containers() {
+    local -a names=()
+    local name count
+
+    while read -r name; do
+        [ -n "${name}" ] || continue
+        [ "${name}" = "${ZOT_CONTAINER_NAME}" ] && continue
+        case "${name}" in
+            zot-sync-ondemand|zot-sync-ondemand-*)
+                names+=("${name}")
+                ;;
+        esac
+    done < <(docker ps -a --filter "name=zot-sync-ondemand" --format '{{.Names}}' 2>/dev/null || true)
+
+    count=${#names[@]}
+    [ "${count}" -eq 0 ] && return 0
+
+    log_info "Removing ${count} leftover zot-sync-ondemand container(s)..."
+    if ! try_remove_container "${names[0]}" true; then
+        log_warn "Could not remove ${count} leftover container(s) (docker stop/rm failed)."
+        log_warn "Orphans do not block this test (each run uses a unique name)."
+        return 0
+    fi
+
+    for name in "${names[@]:1}"; do
+        try_remove_container "${name}" true || true
+    done
+}
+
+remove_stale_resources() {
+    remove_stale_kind_clusters
+    remove_stale_zot_containers
+}
+
+resolve_zot_host_port() {
+    local mapped
+
+    mapped=$(docker port "${ZOT_CONTAINER_NAME}" "${ZOT_LISTEN_PORT}/tcp" | head -1)
+    ZOT_HOST_PORT=${mapped##*:}
+    if [ -z "${ZOT_HOST_PORT}" ]; then
+        log_error "Failed to resolve host port for ${ZOT_CONTAINER_NAME}"
+        exit 1
+    fi
+}
+
+cleanup() {
+    local exit_code=$?
+    set +o errexit
+    log_info "Cleaning up..."
+    if [ -n "${KUBECONFIG:-}" ]; then
+        "${KIND}" delete cluster --name "${CLUSTER_NAME}" 2>/dev/null || true
+    fi
+    try_remove_container "${ZOT_CONTAINER_NAME}" || true
+    docker rmi -f "${ZOT_IMAGE}" 2>/dev/null || true
+    rm -rf "${ZOT_STORAGE}" 2>/dev/null || true
+    rm -f "${KUBECONFIG_FILE}" 2>/dev/null || true
+    exit "${exit_code}"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+for cmd in docker kubectl curl jq git; do
+    if ! command -v "$cmd" &>/dev/null; then
+        log_error "$cmd is required but not found"
+        exit 1
+    fi
+done
+
+# Use an isolated kubeconfig so kind does not modify ~/.kube/config.
+log_info "Using isolated kubeconfig ${KUBECONFIG_FILE}"
+
+# Remove leftovers from an interrupted prior run before doing any work.
+remove_stale_resources
+
+if [ ! -x "${ZOT_BINARY}" ]; then
+    log_error "zot binary not found at ${ZOT_BINARY}."
+    log_error "Build the extended binary (sync extension): make check-blackbox-prerequisites binary"
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Build a minimal zot Docker image from the locally compiled binary and config.
+# Config is baked into the image (not bind-mounted) because single-file bind
+# mounts into distroless often become directories when the parent path is absent.
+# Using gcr.io/distroless/base-debian12 (includes CA certificates) avoids a
+# full recompile while still giving the image the TLS roots it needs to reach
+# registry.k8s.io.
+# ---------------------------------------------------------------------------
+log_info "Building zot Docker image (${ZOT_IMAGE}) from local binary..."
+BUILD_CTX=$(mktemp -d)
+cp "${ZOT_BINARY}" "${BUILD_CTX}/zot"
+cat > "${BUILD_CTX}/config.json" <<EOF
+{
+    "distSpecVersion": "1.1.1",
+    "storage": {
+        "rootDirectory": "/var/lib/registry"
+    },
+    "http": {
+        "address": "0.0.0.0",
+        "port": "${ZOT_LISTEN_PORT}"
+    },
+    "log": {
+        "level": "info"
+    },
+    "extensions": {
+        "sync": {
+            "registries": [
+                {
+                    "urls": ["https://registry.k8s.io"],
+                    "onDemand": true,
+                    "tlsVerify": true,
+                    "content": [{"prefix": "**"}]
+                }
+            ]
+        }
+    }
+}
+EOF
+docker build \
+    --platform "linux/${ARCH}" \
+    -t "${ZOT_IMAGE}" \
+    -f - "${BUILD_CTX}" <<DOCKER
+FROM ${DISTROLESS_BASE_IMAGE}
+COPY zot /usr/bin/zot
+COPY config.json /config/config.json
+ENTRYPOINT ["/usr/bin/zot"]
+EXPOSE 5000
+DOCKER
+rm -rf "${BUILD_CTX}"
+log_info "Image built: ${ZOT_IMAGE}"
+
+mkdir -p "${ZOT_STORAGE}"
+
+# ---------------------------------------------------------------------------
+# Start the zot container (not yet on the kind network).
+# ---------------------------------------------------------------------------
+log_info "Starting zot container (${ZOT_CONTAINER_NAME})..."
+docker run -d \
+    --name "${ZOT_CONTAINER_NAME}" \
+    -p "127.0.0.1::${ZOT_LISTEN_PORT}" \
+    -v "${ZOT_STORAGE}:/var/lib/registry" \
+    "${ZOT_IMAGE}" serve /config/config.json
+
+resolve_zot_host_port
+log_info "Zot listening on host port ${ZOT_HOST_PORT} (container port ${ZOT_LISTEN_PORT})"
+
+log_info "Waiting for zot to be ready..."
+for i in $(seq 1 30); do
+    if curl -sf "http://localhost:${ZOT_HOST_PORT}/v2/" >/dev/null 2>&1; then
+        log_info "Zot is ready"
+        break
+    fi
+    [ "${i}" -lt 30 ] || { log_error "Zot did not start in time"; docker logs "${ZOT_CONTAINER_NAME}"; exit 1; }
+    sleep 1
+done
+
+# ---------------------------------------------------------------------------
+# Create the kind cluster with registry.k8s.io mirrored to the zot container.
+# The mirror references the container by name; DNS resolves after we join the
+# kind network below.
+# ---------------------------------------------------------------------------
+log_info "Creating kind cluster '${CLUSTER_NAME}'..."
+"${KIND}" get clusters 2>/dev/null | grep -qx "${CLUSTER_NAME}" && \
+    "${KIND}" delete cluster --name "${CLUSTER_NAME}"
+
+cat <<EOF | "${KIND}" create cluster --name "${CLUSTER_NAME}" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: ${KIND_NODE_IMAGE}
+containerdConfigPatches:
+- |-
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry.k8s.io"]
+    endpoint = ["http://${ZOT_CONTAINER_NAME}:${ZOT_LISTEN_PORT}"]
+EOF
+
+# Connect the zot container to the kind Docker network so kind nodes can reach
+# it by container name.
+if [ "$(docker inspect -f='{{json .NetworkSettings.Networks.kind}}' "${ZOT_CONTAINER_NAME}")" = 'null' ]; then
+    docker network connect kind "${ZOT_CONTAINER_NAME}"
+fi
+
+log_info "Cluster created; waiting for control plane..."
+kubectl --context "${KUBECTL_CTX}" get nodes
+wait_for_cluster_ready
+
+# ---------------------------------------------------------------------------
+# First pull: deploy a pod whose container image is pause:3.10.1.
+# This causes the kind node's containerd to pull through the zot mirror.
+# kindest/node often pre-loads pause; evict it so the pull must go through zot.
+# ---------------------------------------------------------------------------
+evict_pause_image_from_node
+
+log_info "First pull: creating pod with image ${PAUSE_IMAGE}..."
+kubectl --context "${KUBECTL_CTX}" run pause-first \
+    --image="${PAUSE_IMAGE}" \
+    --restart=Never \
+    --image-pull-policy=Always
+
+wait_for_pod pause-first "first pull; multi-arch sync may take a few minutes"
+log_info "pause-first pod is ready"
+
+log_info "Verifying pause:3.10.1 exists in zot catalog..."
+if ! wait_for_pause_in_catalog; then
+    TAGS=$(curl -sf "http://localhost:${ZOT_HOST_PORT}/v2/pause/tags/list" 2>/dev/null || echo "{}")
+    log_error "pause:3.10.1 was not found in zot after first sync"
+    echo "Tags response: ${TAGS}"
+    docker logs "${ZOT_CONTAINER_NAME}"
+    exit 1
+fi
+log_info "pause:3.10.1 confirmed in zot catalog"
+
+LOGS_AFTER_FIRST=$(docker logs "${ZOT_CONTAINER_NAME}" 2>&1)
+FIRST_PULL_SKIP_COUNT=$(echo "${LOGS_AFTER_FIRST}" | count_pause_skip_logs)
+if [ "${FIRST_PULL_SKIP_COUNT}" -gt 0 ]; then
+    log_error "FAIL: pause:3.10.1 was skipped on the first pull (expected a full sync)"
+    echo "${LOGS_AFTER_FIRST}" \
+        | { grep "skipping image because it's already synced" || true; } \
+        | pause_image_log_filter | tail -10
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Evict the image from the kind node's containerd image store so the next pod
+# creation triggers a fresh pull request to zot (the skip-check path).
+# ---------------------------------------------------------------------------
+log_info "Removing pause-first pod and evicting image from kind node..."
+kubectl --context "${KUBECTL_CTX}" delete pod pause-first --ignore-not-found=true
+# Wait for pod to be fully gone before evicting image
+kubectl --context "${KUBECTL_CTX}" wait --for=delete pod/pause-first --timeout=30s 2>/dev/null || true
+evict_pause_image_from_node
+
+# ---------------------------------------------------------------------------
+# Second pull: re-create the pod.  The kind node pulls from zot again;  zot
+# must recognise the image as already synced and skip re-downloading it from
+# registry.k8s.io.
+# ---------------------------------------------------------------------------
+log_info "Second pull: creating pod with image ${PAUSE_IMAGE} (should be skipped by zot)..."
+kubectl --context "${KUBECTL_CTX}" run pause-second \
+    --image="${PAUSE_IMAGE}" \
+    --restart=Never \
+    --image-pull-policy=Always
+
+wait_for_pod pause-second "second pull; expect zot skip, not upstream resync"
+log_info "pause-second pod is ready"
+
+# Give the zot container a moment to flush log buffers.
+sleep 2
+
+# ---------------------------------------------------------------------------
+# Assert correct sync behaviour from zot logs.
+# ---------------------------------------------------------------------------
+ZOT_LOGS=$(docker logs "${ZOT_CONTAINER_NAME}" 2>&1)
+
+log_info "=== Asserting zot sync behaviour ==="
+
+SECOND_PULL_SKIP_COUNT=$(echo "${ZOT_LOGS}" | count_pause_skip_logs)
+NEW_SKIP_COUNT=$((SECOND_PULL_SKIP_COUNT - FIRST_PULL_SKIP_COUNT))
+
+# 1. The second pull must have been skipped (already synced).
+if [ "${NEW_SKIP_COUNT}" -lt 1 ]; then
+    log_error "FAIL: pause:3.10.1 was not skipped on the second pull"
+    echo "=== Zot log excerpt (pause lines) ==="
+    echo "${ZOT_LOGS}" \
+        | { grep -iE 'pause|skipping image because' || true; } | tail -40
+    exit 1
+fi
+
+# 2. The digest-change resync loop must NOT have occurred.
+RESYNC_COUNT=$(echo "${ZOT_LOGS}" | count_pause_resync_logs)
+if [ "${RESYNC_COUNT}" -gt 0 ]; then
+    log_error "FAIL: pause:3.10.1 triggered a resync loop (issue #4184 regression)"
+    echo "=== Zot log excerpt (resync lines) ==="
+    echo "${ZOT_LOGS}" \
+        | { grep "remote image digest changed" || true; } \
+        | pause_image_log_filter | tail -20
+    exit 1
+fi
+
+log_info "SUCCESS: ${PAUSE_IMAGE} synced without resync loop (issue #4184 verified fixed)"

--- a/pkg/extensions/sync/README_digest_prediction.md
+++ b/pkg/extensions/sync/README_digest_prediction.md
@@ -1,0 +1,204 @@
+# OCI digest prediction for on-demand sync skip checks
+
+This note describes how zot predicts the digest an image will have **after** regclient
+`mod.WithManifestToOCI` + `mod.WithManifestToOCIReferrers`, without running a full sync.
+It compares **remote registry call counts** for:
+
+1. **Pre-`predictOCIDigest`** — hand-rolled `convertDockerManifestToOCI` / `convertDockerListToOCI` in `remote.go` (removed when `predictOCIDigest` landed)
+2. **`predictOCIDigest`** — in-memory mirror of regclient manifest conversion (`oci_digest_predict.go`)
+3. **`mod.Apply`** — what regclient runs during an actual sync conversion
+
+References:
+
+- regclient: [`github.com/regclient/regclient`](https://github.com/regclient/regclient) v0.11.5 (`go.mod`)
+- Conversion mods: `mod.WithManifestToOCI`, `mod.WithManifestToOCIReferrers` ([`mod/manifest.go`](https://github.com/regclient/regclient/blob/v0.11.5/mod/manifest.go))
+
+---
+
+## Why prediction exists
+
+On-demand sync uses `CanSkipImage` to avoid re-copying an image that is already stored with the
+digest regclient would produce after OCI conversion. That requires comparing:
+
+- **Local stored digest** — from `mod.Apply` at commit time (OCI layout in the sync session)
+- **Remote “would-be” digest** — must match post-conversion OCI, not the upstream Docker digest
+
+For Docker images (e.g. `registry.k8s.io/pause:3.10.1`), the upstream manifest-list digest and the
+post-`mod.Apply` OCI index digest differ. Comparing raw remote vs local caused endless resync loops.
+
+`predictOCIDigest` mirrors regclient’s in-memory manifest conversion so skip checks can compare
+OCI-to-OCI without running `ImageCopy` + `mod.Apply` on every tag lookup.
+
+---
+
+## What each approach does
+
+| Approach | When used | Fetches blobs? | Mirrors `WithManifestToOCIReferrers`? |
+|----------|-----------|----------------|----------------------------------------|
+| **Pre-`predictOCIDigest`** | `GetOCIDigest` before this change | Yes — `BlobGetOCIConfig` per Docker platform manifest | No |
+| **`predictOCIDigest`** | `GetOCIDigest` today | No — manifest JSON only; every index child is fetched recursively | Yes |
+| **`mod.Apply`** | Actual sync after `ImageCopy` | Yes — full DAG (configs, layers, referrers) | Yes |
+
+`WithManifestToOCI` does **not** rewrite config or layer **blob** bytes. It rewrites **descriptor
+media types inside manifest JSON** (config + layers). That can change a manifest digest even when
+the manifest envelope already uses OCI media types.
+
+---
+
+## Remote calls for one `GetOCIDigest(repo, tag)` lookup
+
+Let **P** = number of platform manifests in a multi-arch index. Let **N** = total manifest nodes
+in the tree (root + every child index entry, recursively).
+
+| Image shape | Pre-`predictOCIDigest` | `predictOCIDigest` | `mod.Apply` (`dagGet` only, remote) |
+|-------------|------------------------|--------------------|-------------------------------------|
+| OCI single manifest | 1 `ManifestGet` | 1 `ManifestGet` | 1 `ManifestGet` + 1 `BlobGetOCIConfig` + 1 `ReferrerList` |
+| OCI multi-arch index (P platforms) | **1 `ManifestGet`** (root only) | **1 + P** `ManifestGet` | **1 + P** × (`ManifestGet` + `BlobGetOCIConfig` + `ReferrerList`) + referrer recursion |
+| Docker single manifest | 1 `ManifestGet` + 1 `BlobGetOCIConfig` | 1 `ManifestGet` | Same as OCI single row |
+| Docker manifest list (P) | **1 + 2P** (`ManifestGet` + `BlobGetOCIConfig` per child) | **1 + P** `ManifestGet` | **1 + P** × (`ManifestGet` + `BlobGetOCIConfig` + `ReferrerList`) + … |
+| Hybrid: OCI index + Docker children | **1 `ManifestGet`** (root treated as OCI — wrong digest) | **1 + P** `ManifestGet` | Full tree walk (as multi-arch) |
+| Hybrid: Docker list + OCI children | **1 + 2P** (if root is docker list) | **1 + P** `ManifestGet` | Full tree walk |
+| Nested indexes (depth D, N total entries) | Often **1** (root only) | **N** `ManifestGet` | **N** × (`ManifestGet` + `BlobGetOCIConfig` + `ReferrerList`) + … |
+
+In general, `predictOCIDigest` performs **one `ManifestGet` per manifest node** in the tree — the
+same manifest walk as `mod.Apply`’s `dagGet`, but without config blobs, layer blobs, or referrer
+list calls.
+
+### Call types
+
+- **`ManifestGet`** — fetch manifest JSON (index or platform manifest)
+- **`BlobGetOCIConfig`** — fetch image config blob (pre-`predictOCIDigest` + `mod.Apply` `dagGet`; not used by predictor)
+- **`ReferrerList`** — `mod.Apply` `dagGet` only; predictor does not call this
+- **`ManifestPut`** — `mod.Apply` `dagPut` when manifests change (local ocidir after `ImageCopy`; not used for prediction)
+
+---
+
+## `predictOCIDigest` vs pre-`predictOCIDigest` (summary)
+
+| Scenario | Call count | Correctness |
+|----------|------------|-------------|
+| Docker multi-arch | **~half** pre-`predictOCIDigest` (`1+P` vs `1+2P`) | `predictOCIDigest` matches `mod.Apply`; pre-`predictOCIDigest` matched simple docker lists but not referrers |
+| Docker single | **Fewer** (`1` vs `2`) | `predictOCIDigest` matches `mod.Apply` (manifest media-type change only; config blob not needed for digest) |
+| Pure OCI multi-arch | **More** (`1+P` vs `1`) but still cheap (manifest JSON only) | Both correct for skip (no conversion); extra child fetches are required for correctness (see below) |
+| Hybrid indexes | Pre-`predictOCIDigest` often **wrong** (1 call, no child conversion) | `predictOCIDigest` walks all children and matches regclient |
+
+---
+
+## vs `mod.Apply` on the real sync path
+
+Skip checks **do not** call `mod.Apply`. During sync, conversion runs only when
+`isConverted && !skipped && !PreserveDigest` in `syncImage`:
+
+```go
+mod.Apply(ctx, service.rc, localImageRef,
+    mod.WithRefTgt(localImageRef),
+    mod.WithManifestToOCI(),
+    mod.WithManifestToOCIReferrers(),
+)
+```
+
+| Phase | Where | Cost |
+|-------|-------|------|
+| **`ImageCopy`** (`syncRef`) | Remote → local ocidir session | All manifests + all blobs (dominant) |
+| **`mod.Apply`** | Local ocidir | `dagGet` (manifest + config + referrers tree) + `ManifestPut` for changed manifests |
+| **`predictOCIDigest`** | Remote registry | **N** `ManifestGet` calls (full manifest tree); no blobs or referrer lists |
+
+Using `mod.Apply` **for prediction on the remote** (without a prior copy) would require `dagGet`
+on the upstream registry: config blobs, referrer lists, and recursive referrer walks — far heavier
+than `predictOCIDigest`, and would still need `ManifestPut` to materialize converted manifests.
+
+Tests in `oci_digest_predict_internal_test.go` use `ImageCopy` + `mod.Apply` on a **local** ocidir
+as the oracle; that matches the conversion step in `syncImage`, not the remote prediction path.
+
+---
+
+## Worked examples
+
+### Docker manifest list with P ≈ 20
+
+(e.g. `registry.k8s.io/pause:3.10.1`)
+
+| Method | Approx. remote calls |
+|--------|----------------------|
+| Pre-`predictOCIDigest` (`convertDocker*`) | **41** (1 + 20×2) |
+| `predictOCIDigest` | **21** (1 + 20) |
+| `mod.Apply` `dagGet` (hypothetical remote) | **61+** (1 + 20×3, plus referrers) |
+| Full sync | `ImageCopy` of entire image + local `mod.Apply` |
+
+### Pure OCI multi-arch index with P ≈ 20
+
+| Method | Approx. remote calls |
+|--------|----------------------|
+| Pre-`predictOCIDigest` | **1** (root only; sufficient when no conversion) |
+| `predictOCIDigest` | **21** (1 + 20; all children fetched) |
+| `mod.Apply` `dagGet` (hypothetical remote) | **61+** |
+
+Extra child `ManifestGet` calls on pure OCI images are the trade-off for matching regclient when
+any child might need interior descriptor conversion.
+
+---
+
+## `isConverted` and when sync runs `mod.Apply`
+
+`predictOCIDigest` returns `(predictedDigest, originalDigest, isConverted, err)`.
+
+`isConverted` is true when regclient would change **any** manifest in the tree (not only when the
+root is Docker), e.g.:
+
+- Docker manifest list → OCI index
+- Docker platform manifest under an OCI index
+- OCI manifest envelope with docker config/layer descriptor media types inside
+- Index entries with docker referrer annotations (`WithManifestToOCIReferrers`)
+
+Sync gates `mod.Apply` on this flag so pure OCI images skip conversion.
+
+---
+
+## Why every index child is fetched
+
+`fetchManifestNode` calls `ManifestGet` on **every** child listed in an index (and recurses into
+nested indexes). Index child descriptors alone are not enough to predict conversion:
+
+| What you see in the index | What `WithManifestToOCI` may still change |
+|---------------------------|-------------------------------------------|
+| Child `mediaType` is OCI manifest | `config.mediaType` and `layers[].mediaType` inside the manifest JSON |
+| Child `mediaType` is Docker manifest | Top-level manifest `mediaType` plus interior descriptors |
+| Nested index | Recurse |
+
+Example: an OCI index whose children use `application/vnd.oci.image.manifest.v1+json` but whose
+manifest bodies still list docker config/layer media types. Regclient rewrites those interior
+descriptor strings, producing a new manifest digest and a new parent index digest. Without fetching
+the child manifest body, the predictor cannot know whether that rewrite is needed.
+
+This does **not** mean config or layer **blobs** are fetched — only manifest JSON.
+
+---
+
+## Tests
+
+`TestPredictOCIDigestMatchesRegclient` builds fixtures via `pkg/test/image-utils` + `write.go`
+(zot local store → ocidir layout) and asserts:
+
+```text
+predictOCIDigest(...) digest == mod.Apply(WithManifestToOCI, WithManifestToOCIReferrers) digest
+```
+
+Cases include OCI single/multi-arch, OCI artifacts with OCI/docker subjects, docker artifacts
+with OCI/docker subjects, docker lists, docker-from-OCI conversion, hybrid indexes
+(OCI index + docker children, docker list + OCI children, OCI index + OCI children with docker
+interior descriptors), and three-level nested indexes:
+
+| Root | Mid | Leaf platforms |
+|------|-----|----------------|
+| OCI | OCI | OCI |
+| OCI | OCI | Docker |
+| OCI | Docker | OCI |
+| Docker | OCI | OCI |
+| OCI | Docker | Docker |
+
+---
+
+## Possible follow-ups
+
+1. **`PreserveDigest: true`** — skip prediction conversion alignment; compare raw digests instead
+   (see `examples/config-docker-compat-sync.json` workaround for docker2s2).

--- a/pkg/extensions/sync/destination.go
+++ b/pkg/extensions/sync/destination.go
@@ -30,6 +30,13 @@ import (
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 )
 
+var (
+	errSyncTempImageReferenceNoPath       = errors.New("sync temp image reference has no path")
+	errSyncTempImageReferenceNoLayoutPath = errors.New("sync temp image reference has no layout path")
+	errSyncTempLayoutPathRepoMismatch     = errors.New("sync temp layout path does not end with repo")
+	errSyncTempImageStoreCreateFailed     = errors.New("failed to create temp sync image store")
+)
+
 type DestinationRegistry struct {
 	storeController storage.StoreController
 	tempStorage     OciLayoutStorage
@@ -88,7 +95,14 @@ func (registry *DestinationRegistry) GetImageReference(repo, reference string) (
 
 // CommitAll finalizes a syncing image.
 func (registry *DestinationRegistry) CommitAll(repo string, imageReference ref.Ref) error {
-	tempImageStore := getImageStoreFromImageReference(repo, imageReference, registry.log)
+	tempImageStore, err := getImageStoreFromImageReference(repo, imageReference, registry.log)
+	if err != nil {
+		registry.log.Error().Str("errorType", common.TypeOf(err)).Err(err).
+			Str("repo", repo).Str("reference", imageReference.Reference).
+			Msg("failed to open temp sync image store")
+
+		return err
+	}
 
 	defer os.RemoveAll(tempImageStore.RootDir())
 
@@ -148,11 +162,16 @@ func (registry *DestinationRegistry) CommitAll(repo string, imageReference ref.R
 }
 
 func (registry *DestinationRegistry) CleanupImage(imageReference ref.Ref, repo string) error {
-	var err error
+	sessionRoot, err := syncTempSessionRoot(repo, imageReference)
+	if err != nil {
+		registry.log.Debug().Err(err).Str("repo", repo).
+			Msg("failed to resolve temp sync session root for cleanup")
 
-	dir := strings.TrimSuffix(imageReference.Path, repo)
-	if _, err = os.Stat(dir); err == nil {
-		if err := os.RemoveAll(strings.TrimSuffix(imageReference.Path, repo)); err != nil {
+		return nil
+	}
+
+	if _, err = os.Stat(sessionRoot); err == nil {
+		if err := os.RemoveAll(sessionRoot); err != nil {
 			registry.log.Error().Err(err).Msg("failed to cleanup image from temp storage")
 
 			return err
@@ -365,11 +384,58 @@ func (registry *DestinationRegistry) copyBlob(repo string, blobDigest godigest.D
 	return err
 }
 
-// use only with local imageReferences.
-func getImageStoreFromImageReference(repo string, imageReference ref.Ref, log log.Logger) storageTypes.ImageStore {
-	sessionRootDir := strings.TrimSuffix(imageReference.Path, repo)
+// ocidirLayoutPath returns the on-disk OCI layout directory for a temp sync ref.
+// regclient may clear Path after mod.Apply while Reference still holds the ocidir URL.
+func ocidirLayoutPath(imageReference ref.Ref) (string, error) {
+	if imageReference.Path != "" {
+		return imageReference.Path, nil
+	}
 
-	return getImageStore(sessionRootDir, log)
+	if imageReference.Reference == "" {
+		return "", errSyncTempImageReferenceNoPath
+	}
+
+	parsed, err := ref.New(imageReference.Reference)
+	if err != nil {
+		return "", fmt.Errorf("parse sync temp image reference: %w", err)
+	}
+
+	if parsed.Path == "" {
+		return "", errSyncTempImageReferenceNoLayoutPath
+	}
+
+	return parsed.Path, nil
+}
+
+// syncTempSessionRoot maps a temp ocidir ref to the session directory that contains the repo layout.
+func syncTempSessionRoot(repo string, imageReference ref.Ref) (string, error) {
+	layoutPath, err := ocidirLayoutPath(imageReference)
+	if err != nil {
+		return "", err
+	}
+
+	repoSuffix := path.Join("/", repo)
+	if sessionRoot, ok := strings.CutSuffix(layoutPath, repoSuffix); ok {
+		return sessionRoot, nil
+	}
+
+	return "", fmt.Errorf("%w: layout=%q repo=%q", errSyncTempLayoutPathRepoMismatch, layoutPath, repo)
+}
+
+// use only with local imageReferences.
+func getImageStoreFromImageReference(repo string, imageReference ref.Ref, log log.Logger,
+) (storageTypes.ImageStore, error) {
+	sessionRootDir, err := syncTempSessionRoot(repo, imageReference)
+	if err != nil {
+		return nil, err
+	}
+
+	store := getImageStore(sessionRootDir, log)
+	if store == nil {
+		return nil, fmt.Errorf("%w: %q", errSyncTempImageStoreCreateFailed, sessionRootDir)
+	}
+
+	return store, nil
 }
 
 func getImageStore(rootDir string, log log.Logger) storageTypes.ImageStore {

--- a/pkg/extensions/sync/destination.go
+++ b/pkg/extensions/sync/destination.go
@@ -175,6 +175,7 @@ func (registry *DestinationRegistry) copyManifest(repo string, desc ispec.Descri
 	*seen = append(*seen, desc.Digest)
 
 	imageStore := registry.storeController.GetImageStore(repo)
+	isReferrersRef := common.IsReferrersTag(reference)
 
 	manifestContent := desc.Data
 	if manifestContent == nil {
@@ -191,6 +192,10 @@ func (registry *DestinationRegistry) copyManifest(repo string, desc ispec.Descri
 	// is image manifest
 	switch desc.MediaType {
 	case ispec.MediaTypeImageManifest, mediatype.Docker2Manifest:
+		if isReferrersRef {
+			return nil
+		}
+
 		var manifest ispec.Manifest
 
 		if err := json.Unmarshal(manifestContent, &manifest); err != nil {
@@ -297,6 +302,12 @@ func (registry *DestinationRegistry) copyManifest(repo string, desc ispec.Descri
 		// Return error if we encountered any missing manifests
 		if firstMissingErr != nil {
 			return firstMissingErr
+		}
+
+		// Referrers indexes are a transport convention in the temp ocidir layout; persist child
+		// manifests only, not the referrers index entry itself.
+		if isReferrersRef {
+			return nil
 		}
 
 		_, _, err := imageStore.PutImageManifest(context.Background(), repo, reference, desc.MediaType, manifestContent, nil)

--- a/pkg/extensions/sync/oci_digest_predict.go
+++ b/pkg/extensions/sync/oci_digest_predict.go
@@ -1,0 +1,493 @@
+//go:build sync
+
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	godigest "github.com/opencontainers/go-digest"
+	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/types/descriptor"
+	"github.com/regclient/regclient/types/manifest"
+	"github.com/regclient/regclient/types/mediatype"
+	"github.com/regclient/regclient/types/ref"
+
+	zerr "zotregistry.dev/zot/v2/errors"
+)
+
+const (
+	dockerReferenceType   = "vnd.docker.reference.type"
+	dockerReferenceDigest = "vnd.docker.reference.digest"
+
+	maxManifestTreeDepth = 32
+	maxManifestTreeNodes = 256
+)
+
+var (
+	errManifestListDescriptorNotFound = errors.New("could not find descriptor in manifest list")
+	errManifestTreeCycle              = errors.New("manifest tree cycle detected")
+	errManifestTreeLimitExceeded      = errors.New("manifest tree limit exceeded")
+	errDockerReferrerRequiresManifest = errors.New("docker referrer entry requires child manifest")
+	errDockerReferrerSubjectNotFound  = errors.New("could not find digest, convert referrers before other mod actions")
+	errDockerReferenceNoSubject       = errors.New("docker reference type does not support subject")
+	errDockerReferenceNoAnnotations   = errors.New("docker reference type does not support annotations")
+	errNotEnoughChildManifests        = errors.New("manifest does not have enough child manifests")
+)
+
+type manifestChange int
+
+const (
+	manifestUnchanged manifestChange = iota
+	manifestReplaced
+	manifestDeleted
+)
+
+// manifestNode is a minimal in-memory manifest tree used to predict the OCI digest
+// produced by regclient mod.WithManifestToOCI and mod.WithManifestToOCIReferrers.
+type manifestNode struct {
+	top         bool
+	mod         manifestChange
+	origDesc    descriptor.Descriptor
+	newDesc     descriptor.Descriptor
+	m           manifest.Manifest // nil only after manifestDeleted in referrer conversion
+	manifestRef ref.Ref           // ref from ManifestGet; close this, not node.m after in-memory replacement
+	children    []*manifestNode
+}
+
+type manifestTreeWalkState struct {
+	path      map[string]struct{}
+	nodeCount int
+	depth     int
+}
+
+func (walkState *manifestTreeWalkState) beginNode(top bool) error {
+	if walkState.nodeCount >= maxManifestTreeNodes {
+		return fmt.Errorf("%w: node count", errManifestTreeLimitExceeded)
+	}
+
+	if !top && walkState.depth >= maxManifestTreeDepth {
+		return fmt.Errorf("%w: depth", errManifestTreeLimitExceeded)
+	}
+
+	walkState.nodeCount++
+	walkState.depth++
+
+	return nil
+}
+
+func (walkState *manifestTreeWalkState) undoBegin() {
+	walkState.depth--
+}
+
+func (walkState *manifestTreeWalkState) checkChild(childDigest string) error {
+	if _, onPath := walkState.path[childDigest]; onPath {
+		return fmt.Errorf("%w: digest %s", errManifestTreeCycle, childDigest)
+	}
+
+	return nil
+}
+
+func (walkState *manifestTreeWalkState) enterPath(digest string) error {
+	if err := walkState.checkChild(digest); err != nil {
+		return err
+	}
+
+	walkState.path[digest] = struct{}{}
+
+	return nil
+}
+
+func (walkState *manifestTreeWalkState) leavePath(digest string) {
+	delete(walkState.path, digest)
+	walkState.depth--
+}
+
+// predictOCIDigest returns the digest regclient mod.WithManifestToOCI would produce,
+// the original remote digest, and whether mod.Apply would modify the image.
+func predictOCIDigest(ctx context.Context, regClient *regclient.RegClient, imageRef ref.Ref) (
+	godigest.Digest, godigest.Digest, bool, error,
+) {
+	walkState := &manifestTreeWalkState{
+		path: make(map[string]struct{}),
+	}
+
+	root, err := fetchManifestNode(ctx, regClient, imageRef, true, walkState)
+	if err != nil {
+		return "", "", false, err
+	}
+
+	defer closeManifestTree(ctx, regClient, root)
+
+	originalDigest := root.origDesc.Digest
+
+	switch root.origDesc.MediaType {
+	case mediatype.Docker2Manifest, mediatype.Docker2ManifestList,
+		mediatype.OCI1Manifest, mediatype.OCI1ManifestList:
+	default:
+		return "", "", false, zerr.ErrMediaTypeNotSupported
+	}
+
+	if err := root.applyManifestToOCI(); err != nil {
+		return "", "", false, err
+	}
+
+	if err := root.applyOCIReferrers(); err != nil {
+		return "", "", false, err
+	}
+
+	if err := root.finalize(); err != nil {
+		return "", "", false, err
+	}
+
+	predictedDigest := root.effectiveDesc().Digest
+	// Conversion is needed whenever regclient would change any manifest in the tree
+	// (e.g. docker children under an oci index), not only when the root is docker.
+	isConverted := root.mod != manifestUnchanged || predictedDigest != originalDigest
+
+	return predictedDigest, originalDigest, isConverted, nil
+}
+
+func fetchManifestNode(ctx context.Context, regClient *regclient.RegClient, imageRef ref.Ref, top bool,
+	walkState *manifestTreeWalkState,
+) (*manifestNode, error) {
+	if err := walkState.beginNode(top); err != nil {
+		return nil, err
+	}
+
+	man, err := regClient.ManifestGet(ctx, imageRef)
+	if err != nil {
+		walkState.undoBegin()
+
+		return nil, err
+	}
+
+	digest := man.GetDescriptor().Digest.String()
+	if err := walkState.enterPath(digest); err != nil {
+		regClient.Close(ctx, man.GetRef())
+		walkState.undoBegin()
+
+		return nil, err
+	}
+
+	defer walkState.leavePath(digest)
+
+	node := &manifestNode{
+		top:         top,
+		m:           man,
+		manifestRef: man.GetRef(),
+		origDesc:    man.GetDescriptor(),
+		mod:         manifestUnchanged,
+	}
+
+	if mi, ok := man.(manifest.Indexer); ok {
+		manifestList, err := mi.GetManifestList()
+		if err != nil {
+			closeManifestTree(ctx, regClient, node)
+
+			return nil, err
+		}
+
+		for _, desc := range manifestList {
+			childDigest := desc.Digest.String()
+			if err := walkState.checkChild(childDigest); err != nil {
+				closeManifestTree(ctx, regClient, node)
+
+				return nil, err
+			}
+
+			childRef := imageRef.SetDigest(childDigest)
+
+			child, err := fetchManifestNode(ctx, regClient, childRef, false, walkState)
+			if err != nil {
+				closeManifestTree(ctx, regClient, node)
+
+				return nil, err
+			}
+
+			node.children = append(node.children, child)
+		}
+	}
+
+	return node, nil
+}
+
+func closeManifestTree(ctx context.Context, regClient *regclient.RegClient, node *manifestNode) {
+	if node == nil {
+		return
+	}
+
+	for _, child := range node.children {
+		closeManifestTree(ctx, regClient, child)
+	}
+
+	if !node.manifestRef.IsZero() {
+		regClient.Close(ctx, node.manifestRef)
+	}
+}
+
+func (node *manifestNode) effectiveDesc() descriptor.Descriptor {
+	if node.newDesc.Digest != "" {
+		return node.newDesc
+	}
+
+	if node.m != nil {
+		return node.m.GetDescriptor()
+	}
+
+	return node.origDesc
+}
+
+// applyManifestToOCI mirrors regclient mod.WithManifestToOCI (children first).
+func (node *manifestNode) applyManifestToOCI() error {
+	for _, child := range node.children {
+		if err := child.applyManifestToOCI(); err != nil {
+			return err
+		}
+	}
+
+	if node.m == nil || node.mod == manifestDeleted {
+		return nil
+	}
+
+	changed := false
+
+	origManifest := node.m.GetOrig()
+
+	if node.m.IsList() {
+		ociIndex, err := manifest.OCIIndexFromAny(origManifest)
+		if err != nil {
+			return err
+		}
+
+		if node.m.GetDescriptor().MediaType != mediatype.OCI1ManifestList {
+			changed = true
+			origManifest = ociIndex
+		}
+	} else {
+		ociManifest, err := manifest.OCIManifestFromAny(origManifest)
+		if err != nil {
+			return err
+		}
+
+		if node.m.GetDescriptor().MediaType != mediatype.OCI1Manifest {
+			changed = true
+		}
+
+		if ociManifest.Config.MediaType == mediatype.Docker2ImageConfig {
+			ociManifest.Config.MediaType = mediatype.OCI1ImageConfig
+			changed = true
+		}
+
+		for i, layer := range ociManifest.Layers {
+			switch layer.MediaType {
+			case mediatype.Docker2Layer:
+				ociManifest.Layers[i].MediaType = mediatype.OCI1Layer
+			case mediatype.Docker2LayerGzip:
+				ociManifest.Layers[i].MediaType = mediatype.OCI1LayerGzip
+			case mediatype.Docker2LayerZstd:
+				ociManifest.Layers[i].MediaType = mediatype.OCI1LayerZstd
+			case mediatype.Docker2ForeignLayer:
+				ociManifest.Layers[i].MediaType = mediatype.OCI1ForeignLayerGzip
+			default:
+				continue
+			}
+
+			changed = true
+		}
+
+		if changed {
+			origManifest = ociManifest
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	newManifest, err := manifest.New(manifest.WithOrig(origManifest))
+	if err != nil {
+		return err
+	}
+
+	node.m = newManifest
+	node.newDesc = node.m.GetDescriptor()
+
+	if node.mod == manifestUnchanged {
+		node.mod = manifestReplaced
+	}
+
+	return nil
+}
+
+// applyOCIReferrers mirrors regclient mod.WithManifestToOCIReferrers (children first).
+func (node *manifestNode) applyOCIReferrers() error {
+	for _, child := range node.children {
+		if err := child.applyOCIReferrers(); err != nil {
+			return err
+		}
+	}
+
+	if node.mod == manifestDeleted {
+		return nil
+	}
+
+	indexer, ok := node.m.(manifest.Indexer)
+	if !ok {
+		return nil
+	}
+
+	changed := false
+
+	childByDigest := map[string]*manifestNode{
+		node.origDesc.Digest.String(): node,
+	}
+
+	for _, child := range node.children {
+		childByDigest[child.origDesc.Digest.String()] = child
+	}
+
+	manifestList, err := indexer.GetManifestList()
+	if err != nil {
+		return fmt.Errorf("failed to get manifest list: %w", err)
+	}
+
+	mlIndex := 0
+
+	for _, child := range node.children {
+		if child.mod == manifestDeleted {
+			mlIndex++
+
+			continue
+		}
+
+		if mlIndex >= len(manifestList) {
+			return fmt.Errorf("%w, index=%d, digest=%s",
+				errManifestListDescriptorNotFound, mlIndex, node.origDesc.Digest.String())
+		}
+
+		desc := manifestList[mlIndex]
+		mlIndex++
+
+		if len(desc.Annotations) == 0 || desc.Annotations[dockerReferenceType] == "" ||
+			desc.Annotations[dockerReferenceDigest] == "" {
+			continue
+		}
+
+		if child.m == nil {
+			return fmt.Errorf("%w, digest=%s", errDockerReferrerRequiresManifest, desc.Digest.String())
+		}
+
+		subjectNode, ok := childByDigest[desc.Annotations[dockerReferenceDigest]]
+		if !ok || subjectNode == nil {
+			return fmt.Errorf("%w, digest=%s",
+				errDockerReferrerSubjectNotFound, desc.Annotations[dockerReferenceDigest])
+		}
+
+		subjecter, ok := child.m.(manifest.Subjecter)
+		if !ok {
+			return fmt.Errorf("%w, mt=%s",
+				errDockerReferenceNoSubject, child.m.GetDescriptor().MediaType)
+		}
+
+		if subj, err := subjecter.GetSubject(); err != nil || subj == nil ||
+			subj.Digest.String() != desc.Annotations[dockerReferenceDigest] {
+			annotator, ok := child.m.(manifest.Annotator)
+			if !ok {
+				return fmt.Errorf("%w, mt=%s",
+					errDockerReferenceNoAnnotations, child.m.GetDescriptor().MediaType)
+			}
+
+			if err := annotator.SetAnnotation(dockerReferenceType, desc.Annotations[dockerReferenceType]); err != nil {
+				return fmt.Errorf("failed to set annotations: %w", err)
+			}
+		}
+
+		changed = true
+		child.mod = manifestDeleted
+		child.m = nil
+	}
+
+	if changed && node.mod == manifestUnchanged {
+		node.mod = manifestReplaced
+	}
+
+	return nil
+}
+
+// finalize rebuilds manifest lists from converted children, mirroring regclient mod dagPut.
+func (node *manifestNode) finalize() error {
+	if node.m == nil {
+		return nil
+	}
+
+	if !node.m.IsList() {
+		if node.mod == manifestReplaced {
+			node.newDesc = node.m.GetDescriptor()
+		}
+
+		return nil
+	}
+
+	changed := false
+
+	origManifest := node.m.GetOrig()
+
+	ociIndex, err := manifest.OCIIndexFromAny(origManifest)
+	if err != nil {
+		return err
+	}
+
+	for i, child := range node.children {
+		if i >= len(ociIndex.Manifests) && child.mod != manifestDeleted {
+			return errNotEnoughChildManifests
+		}
+
+		if child.mod == manifestDeleted {
+			continue
+		}
+
+		if err := child.finalize(); err != nil {
+			return err
+		}
+
+		desc := child.effectiveDesc()
+
+		if child.mod == manifestReplaced || ociIndex.Manifests[i].Digest != desc.Digest ||
+			ociIndex.Manifests[i].Size != desc.Size ||
+			ociIndex.Manifests[i].MediaType != desc.MediaType {
+			ociIndex.Manifests[i].Digest = desc.Digest
+			ociIndex.Manifests[i].Size = desc.Size
+			ociIndex.Manifests[i].MediaType = desc.MediaType
+			changed = true
+		}
+	}
+
+	for i := range slices.Backward(node.children) {
+		if node.children[i].mod != manifestDeleted {
+			continue
+		}
+
+		ociIndex.Manifests = slices.Delete(ociIndex.Manifests, i, i+1)
+		changed = true
+	}
+
+	if !changed && node.mod != manifestReplaced {
+		return nil
+	}
+
+	if err := manifest.OCIIndexToAny(ociIndex, &origManifest); err != nil {
+		return err
+	}
+
+	if err := node.m.SetOrig(origManifest); err != nil {
+		return err
+	}
+
+	node.mod = manifestReplaced
+	node.newDesc = node.m.GetDescriptor()
+
+	return nil
+}

--- a/pkg/extensions/sync/oci_digest_predict_internal_test.go
+++ b/pkg/extensions/sync/oci_digest_predict_internal_test.go
@@ -1,0 +1,969 @@
+//go:build sync
+
+package sync //nolint:testpackage // white-box tests for unexported predictOCIDigest
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	dockerList "github.com/distribution/distribution/v3/manifest/manifestlist"
+	godigest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/regclient/regclient"
+	"github.com/regclient/regclient/mod"
+	"github.com/regclient/regclient/types/ref"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"zotregistry.dev/zot/v2/pkg/compat"
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	"zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/storage"
+	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
+	"zotregistry.dev/zot/v2/pkg/storage/local"
+	stypes "zotregistry.dev/zot/v2/pkg/storage/types"
+	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+const predictTestTag = "latest"
+
+func TestPredictOCIDigestMatchesRegclient(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	regClient := regclient.New()
+
+	storeRoot, storeCtrl := newTestStore(t)
+
+	ociIndexPath := writeOCIMultiPlatformIndex(t, storeCtrl, storeRoot, "oci-index", predictTestTag)
+	ociSinglePath := writeOCISingleManifest(t, storeCtrl, storeRoot, "oci-single", predictTestTag)
+	ociArtifactPath := writeOCIArtifactManifest(t, storeCtrl, storeRoot, "oci-artifact", predictTestTag)
+
+	cases := []struct {
+		name string
+		ref  ref.Ref
+	}{
+		{
+			name: "oci multi-platform index",
+			ref:  mustOCIDirRef(t, ociIndexPath, predictTestTag),
+		},
+		{
+			name: "oci single manifest",
+			ref:  mustOCIDirRef(t, ociSinglePath, predictTestTag),
+		},
+		{
+			name: "oci artifact with oci subject",
+			ref:  mustOCIDirRef(t, ociArtifactPath, predictTestTag),
+		},
+		{
+			name: "oci artifact with docker subject",
+			ref: mustOCIDirRef(t, writeArtifactWithSubject(t, storeCtrl, storeRoot, "artifact-oci-docker-subject",
+				predictTestTag, false, true), predictTestTag),
+		},
+		{
+			name: "docker artifact with oci subject",
+			ref: mustOCIDirRef(t, writeArtifactWithSubject(t, storeCtrl, storeRoot, "artifact-docker-oci-subject",
+				predictTestTag, true, false), predictTestTag),
+		},
+		{
+			name: "docker artifact with docker subject",
+			ref: mustOCIDirRef(t, writeArtifactWithSubject(t, storeCtrl, storeRoot, "artifact-docker-docker-subject",
+				predictTestTag, true, true), predictTestTag),
+		},
+		{
+			name: "docker manifest list converted from oci index",
+			ref:  dockerConvertedFromOCI(t, regClient, ctx, ociIndexPath, predictTestTag),
+		},
+		{
+			name: "docker single manifest converted from oci",
+			ref:  dockerConvertedFromOCI(t, regClient, ctx, ociSinglePath, predictTestTag),
+		},
+		{
+			name: "docker manifest list",
+			ref: mustOCIDirRef(t,
+				writeDockerMultiPlatformIndex(t, storeCtrl, storeRoot, "docker-list", predictTestTag),
+				predictTestTag),
+		},
+		{
+			name: "oci index with docker children",
+			ref: mustOCIDirRef(t,
+				writeHybridOCIIndexDockerChildren(t, storeCtrl, storeRoot, "hybrid-oci-docker", predictTestTag),
+				predictTestTag),
+		},
+		{
+			name: "oci index with oci manifest children and docker interior",
+			ref: mustOCIDirRef(t,
+				writeHybridOCIIndexOCIChildrenDockerInterior(t, "hybrid-oci-oci-docker-interior", predictTestTag),
+				predictTestTag),
+		},
+		{
+			name: "docker manifest list with oci children",
+			ref:  mustOCIDirRef(t, writeHybridDockerIndexOCIChildren(t, "hybrid-docker-oci", predictTestTag), predictTestTag),
+		},
+		{
+			name: "oci index with docker referrer annotations",
+			ref: mustOCIDirRef(t,
+				writeOCIIndexWithDockerReferrerAnnotations(t, "docker-referrer-index", predictTestTag),
+				predictTestTag),
+		},
+		{
+			name: "oci index with docker referrer pointing to external subject",
+			ref: mustOCIDirRef(t,
+				writeOCIIndexWithDockerReferrerExternalSubject(t, "docker-referrer-external-subject", predictTestTag),
+				predictTestTag),
+		},
+		{
+			name: "three level nested OCI+OCI+OCI",
+			ref:  mustNestedIndexRef(t, "nested-oci-oci-oci", flavorOCI, flavorOCI, flavorOCI),
+		},
+		{
+			name: "three level nested OCI+OCI+Docker",
+			ref:  mustNestedIndexRef(t, "nested-oci-oci-docker", flavorOCI, flavorOCI, flavorDocker),
+		},
+		{
+			name: "three level nested OCI+Docker+OCI",
+			ref:  mustNestedIndexRef(t, "nested-oci-docker-oci", flavorOCI, flavorDocker, flavorOCI),
+		},
+		{
+			name: "three level nested Docker+OCI+OCI",
+			ref:  mustNestedIndexRef(t, "nested-docker-oci-oci", flavorDocker, flavorOCI, flavorOCI),
+		},
+		{
+			name: "three level nested OCI+Docker+Docker",
+			ref:  mustNestedIndexRef(t, "nested-oci-docker-docker", flavorOCI, flavorDocker, flavorDocker),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assertPredictMatchesRegclientApply(t, ctx, regClient, tc.ref)
+		})
+	}
+}
+
+func TestPredictOCIDigestManifestTreeLimits(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	regClient := regclient.New()
+
+	t.Run("manifest tree walk guards", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("rejects child already on path", func(t *testing.T) {
+			t.Parallel()
+
+			state := &manifestTreeWalkState{path: map[string]struct{}{"sha256:abc": {}}}
+
+			err := state.checkChild("sha256:abc")
+			require.ErrorIs(t, err, errManifestTreeCycle)
+		})
+
+		t.Run("rejects depth limit", func(t *testing.T) {
+			t.Parallel()
+
+			state := &manifestTreeWalkState{depth: maxManifestTreeDepth}
+
+			err := state.beginNode(false)
+			require.ErrorIs(t, err, errManifestTreeLimitExceeded)
+			assert.Contains(t, err.Error(), "depth")
+		})
+
+		t.Run("rejects node count limit", func(t *testing.T) {
+			t.Parallel()
+
+			state := &manifestTreeWalkState{nodeCount: maxManifestTreeNodes}
+
+			err := state.beginNode(true)
+			require.ErrorIs(t, err, errManifestTreeLimitExceeded)
+			assert.Contains(t, err.Error(), "node count")
+		})
+	})
+
+	t.Run("depth limit exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		srcRef := mustOCIDirRef(t, writeDeepIndexChain(t, "deep-index-chain", predictTestTag, maxManifestTreeDepth+1),
+			predictTestTag)
+
+		_, _, _, err := predictOCIDigest(ctx, regClient, srcRef)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errManifestTreeLimitExceeded)
+		assert.Contains(t, err.Error(), "depth")
+	})
+
+	t.Run("node count limit exceeded", func(t *testing.T) {
+		t.Parallel()
+
+		srcRef := mustOCIDirRef(t, writeWideOCIIndex(t, "wide-index", predictTestTag, maxManifestTreeNodes+1),
+			predictTestTag)
+
+		_, _, _, err := predictOCIDigest(ctx, regClient, srcRef)
+		require.Error(t, err)
+		require.ErrorIs(t, err, errManifestTreeLimitExceeded)
+		assert.Contains(t, err.Error(), "node count")
+	})
+
+	t.Run("docker referrer annotations still match regclient", func(t *testing.T) {
+		t.Parallel()
+
+		srcRef := mustOCIDirRef(t,
+			writeOCIIndexWithDockerReferrerAnnotations(t, "docker-referrer-with-limits", predictTestTag),
+			predictTestTag)
+		assertPredictMatchesRegclientApply(t, ctx, regClient, srcRef)
+	})
+
+	t.Run("docker referrer external subject still matches regclient", func(t *testing.T) {
+		t.Parallel()
+
+		srcRef := mustOCIDirRef(t,
+			writeOCIIndexWithDockerReferrerExternalSubject(t, "docker-referrer-external-with-limits", predictTestTag),
+			predictTestTag)
+		assertPredictMatchesRegclientApply(t, ctx, regClient, srcRef)
+	})
+
+	t.Run("deep valid index within limits", func(t *testing.T) {
+		t.Parallel()
+
+		srcRef := mustOCIDirRef(t, writeDeepIndexChain(t, "deep-index-valid", predictTestTag, maxManifestTreeDepth-1),
+			predictTestTag)
+		assertPredictMatchesRegclientApply(t, ctx, regClient, srcRef)
+	})
+}
+
+func mustNestedIndexRef(t *testing.T, repo string, root, mid, leaf indexFlavor) ref.Ref {
+	t.Helper()
+
+	return mustOCIDirRef(t, writeThreeLevelNestedIndex(t, repo, root, mid, leaf), predictTestTag)
+}
+
+func assertPredictMatchesRegclientApply(
+	t *testing.T, ctx context.Context, regClient *regclient.RegClient, srcRef ref.Ref,
+) {
+	t.Helper()
+
+	predicted, original, isConverted, predictErr := predictOCIDigest(ctx, regClient, srcRef)
+	applied, applyErr := regclientApplyOCIDigest(t, ctx, regClient, srcRef)
+
+	require.Equal(t, predictErr != nil, applyErr != nil,
+		"error parity: predictOCIDigest=%v regclient mod.Apply=%v", predictErr, applyErr)
+
+	if predictErr != nil {
+		return
+	}
+
+	assert.Equal(t, applied.String(), predicted.String(), "digest mismatch")
+
+	if isConverted {
+		assert.NotEqual(t, original.String(), predicted.String(), "isConverted true but digest unchanged")
+	} else {
+		assert.Equal(t, original.String(), predicted.String(), "isConverted false but digest changed")
+	}
+}
+
+// regclientApplyOCIDigest copies src to a fresh ocidir and runs the same mod.Apply options as sync.
+func regclientApplyOCIDigest(
+	t *testing.T, ctx context.Context, regClient *regclient.RegClient, srcRef ref.Ref,
+) (godigest.Digest, error) {
+	t.Helper()
+
+	workDir := t.TempDir()
+
+	repo := srcRef.Repository
+	tag := srcRef.Tag
+	if tag == "" {
+		tag = predictTestTag
+	}
+
+	tgtRef, err := ref.New("ocidir://" + filepath.Join(workDir, repo) + ":" + tag)
+	if err != nil {
+		return "", err
+	}
+
+	if err := regClient.ImageCopy(ctx, srcRef, tgtRef); err != nil {
+		return "", err
+	}
+
+	convertedRef, err := mod.Apply(ctx, regClient, tgtRef,
+		mod.WithRefTgt(tgtRef),
+		mod.WithManifestToOCI(),
+		mod.WithManifestToOCIReferrers(),
+	)
+	if err != nil {
+		return "", err
+	}
+
+	man, err := regClient.ManifestGet(ctx, convertedRef)
+	if err != nil {
+		return "", err
+	}
+	defer regClient.Close(ctx, man.GetRef())
+
+	return man.GetDescriptor().Digest, nil
+}
+
+func dockerConvertedFromOCI(
+	t *testing.T, regClient *regclient.RegClient, ctx context.Context, ociRepoPath, tag string,
+) ref.Ref {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	ociRef := mustOCIDirRef(t, ociRepoPath, tag)
+
+	dockerRepoPath := filepath.Join(tempDir, "docker")
+	dockerRef := mustOCIDirRef(t, dockerRepoPath, tag)
+
+	if !assert.NoError(t, regClient.ImageCopy(ctx, ociRef, dockerRef), "ImageCopy to docker layout") {
+		t.FailNow()
+	}
+
+	converted, err := mod.Apply(ctx, regClient, dockerRef,
+		mod.WithRefTgt(dockerRef),
+		mod.WithManifestToDocker(),
+	)
+	if !assert.NoError(t, err, "mod.WithManifestToDocker") {
+		t.FailNow()
+	}
+
+	return converted
+}
+
+func mustOCIDirRef(t *testing.T, repoPath, tag string) ref.Ref {
+	t.Helper()
+
+	imageRef, err := ref.New("ocidir://" + repoPath + ":" + tag)
+	if !assert.NoError(t, err, "ref.New") {
+		t.FailNow()
+	}
+
+	return imageRef
+}
+
+func newTestStore(t *testing.T) (string, stypes.StoreController) {
+	t.Helper()
+
+	root := t.TempDir()
+	logger := log.NewTestLogger()
+
+	store := local.NewImageStore(root, false, false, logger,
+		monitoring.NewMetricsServer(false, logger),
+		mocks.MockedLint{
+			LintFn: func(repo string, manifestDigest godigest.Digest, imageStore stypes.ImageStore) (bool, error) {
+				return true, nil
+			},
+		},
+		mocks.CacheMock{},
+		[]compat.MediaCompatibility{compat.DockerManifestV2SchemaV2},
+		nil,
+	)
+
+	return root, storage.StoreController{DefaultStore: store}
+}
+
+func repoPath(root, repo string) string {
+	return filepath.Join(root, repo)
+}
+
+func platformImages() []Image {
+	return []Image{
+		CreateImageWith().DefaultLayers().PlatformConfig("amd64", "linux").Build(),
+		CreateImageWith().DefaultLayers().PlatformConfig("arm64", "linux").Build(),
+		CreateImageWith().DefaultLayers().PlatformConfig("arm", "linux").Build(),
+	}
+}
+
+func platformImagesPair() []Image {
+	return []Image{
+		CreateImageWith().DefaultLayers().PlatformConfig("amd64", "linux").Build(),
+		CreateImageWith().DefaultLayers().PlatformConfig("arm64", "linux").Build(),
+	}
+}
+
+type indexFlavor int
+
+const (
+	flavorOCI indexFlavor = iota
+	flavorDocker
+)
+
+func (f indexFlavor) indexMediaType() string {
+	if f == flavorDocker {
+		return dockerList.MediaTypeManifestList
+	}
+
+	return ispec.MediaTypeImageIndex
+}
+
+func writeArtifactWithSubject(t *testing.T, storeCtrl stypes.StoreController, root, repo, tag string,
+	artifactDocker, subjectDocker bool,
+) string {
+	t.Helper()
+
+	subject := CreateImageWith().DefaultLayers().PlatformConfig("amd64", "linux").Build()
+	if subjectDocker {
+		subject = subject.AsDockerImage()
+	}
+
+	assert.NoError(t, WriteImageToFileSystem(subject, repo, subject.DigestStr(), storeCtrl))
+
+	artifact := CreateImageWith().EmptyLayer().EmptyConfig().
+		Subject(subject.DescriptorRef()).
+		ArtifactType("application/example.sbom").
+		Build()
+	if artifactDocker {
+		artifact = artifact.AsDockerImage()
+	}
+
+	assert.NoError(t, WriteImageToFileSystem(artifact, repo, tag, storeCtrl))
+
+	return repoPath(root, repo)
+}
+
+func writeThreeLevelNestedIndex(t *testing.T, repo string, root, mid, leaf indexFlavor) string {
+	t.Helper()
+
+	inner := buildInnerMultiarch(mid, leaf)
+	midIndex := wrapIndexDescriptor(inner.IndexDescriptor, mid)
+	rootIndex := wrapIndexDescriptor(midIndex, root)
+
+	return writeNestedIndexLayoutDirect(t, t.TempDir(), repo, predictTestTag, inner.Images,
+		inner.IndexDescriptor, midIndex, rootIndex)
+}
+
+func buildInnerMultiarch(mid, leaf indexFlavor) MultiarchImage {
+	images := platformImagesPair()
+	if leaf == flavorDocker {
+		for i := range images {
+			images[i] = images[i].AsDockerImage()
+		}
+	}
+
+	multiarch := CreateMultiarchWith().Images(images).Build()
+
+	switch {
+	case mid == flavorOCI && leaf == flavorDocker:
+		multiarch.Index.MediaType = ispec.MediaTypeImageIndex
+
+		for i := range multiarch.Index.Manifests {
+			multiarch.Index.Manifests[i].MediaType = images[i].ManifestDescriptor.MediaType
+		}
+	case mid == flavorDocker && leaf == flavorOCI:
+		multiarch.Index.MediaType = dockerList.MediaTypeManifestList
+
+		for i := range multiarch.Index.Manifests {
+			multiarch.Index.Manifests[i].MediaType = images[i].ManifestDescriptor.MediaType
+		}
+	case mid == flavorDocker && leaf == flavorDocker:
+		multiarch = multiarch.AsDockerImage()
+	}
+
+	recomputeMultiarchIndexDescriptor(&multiarch)
+
+	return multiarch
+}
+
+func recomputeMultiarchIndexDescriptor(multiarch *MultiarchImage) {
+	indexBlob, err := json.Marshal(multiarch.Index)
+	if err != nil {
+		panic("marshal inner index: " + err.Error())
+	}
+
+	multiarch.IndexDescriptor = ispec.Descriptor{
+		MediaType: multiarch.Index.MediaType,
+		Digest:    godigest.FromBytes(indexBlob),
+		Size:      int64(len(indexBlob)),
+		Data:      indexBlob,
+	}
+}
+
+func wrapIndexDescriptor(child ispec.Descriptor, flavor indexFlavor) ispec.Descriptor {
+	index := ispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: flavor.indexMediaType(),
+		Manifests: []ispec.Descriptor{
+			{
+				MediaType: child.MediaType,
+				Digest:    child.Digest,
+				Size:      child.Size,
+				Platform:  child.Platform,
+			},
+		},
+	}
+
+	indexBlob, err := json.Marshal(index)
+	if err != nil {
+		panic("marshal wrapped index: " + err.Error())
+	}
+
+	return ispec.Descriptor{
+		MediaType: index.MediaType,
+		Digest:    godigest.FromBytes(indexBlob),
+		Size:      int64(len(indexBlob)),
+		Data:      indexBlob,
+	}
+}
+
+func writeNestedIndexLayoutDirect(t *testing.T, root, repo, tag string, images []Image,
+	innerIndex, midIndex, rootIndex ispec.Descriptor,
+) string {
+	t.Helper()
+
+	repoDir := filepath.Join(root, repo)
+	blobDir := filepath.Join(repoDir, "blobs", "sha256")
+	require.NoError(t, os.MkdirAll(blobDir, storageConstants.DefaultDirPerms))
+
+	writeBlob := func(data []byte) {
+		dgst := godigest.FromBytes(data)
+		require.NoError(t, os.WriteFile(filepath.Join(blobDir, dgst.Encoded()), data, storageConstants.DefaultFilePerms))
+	}
+
+	for _, image := range images {
+		configBlob := image.ConfigDescriptor.Data
+		if len(configBlob) == 0 {
+			var err error
+
+			configBlob, err = json.Marshal(image.Config)
+			require.NoError(t, err)
+		}
+
+		writeBlob(configBlob)
+
+		for _, layer := range image.Layers {
+			writeBlob(layer)
+		}
+
+		manifestBlob := image.ManifestDescriptor.Data
+		if len(manifestBlob) == 0 {
+			var err error
+
+			manifestBlob, err = json.Marshal(image.Manifest)
+			require.NoError(t, err)
+		}
+
+		writeBlob(manifestBlob)
+	}
+
+	writeBlob(innerIndex.Data)
+	writeBlob(midIndex.Data)
+	writeBlob(rootIndex.Data)
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`),
+		storageConstants.DefaultFilePerms))
+
+	indexFile := ispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: rootIndex.MediaType,
+		Manifests: []ispec.Descriptor{
+			{
+				MediaType: rootIndex.MediaType,
+				Digest:    rootIndex.Digest,
+				Size:      rootIndex.Size,
+				Annotations: map[string]string{
+					"org.opencontainers.image.ref.name": tag,
+				},
+			},
+		},
+	}
+	indexFileData, err := json.Marshal(indexFile)
+	assert.NoError(t, err)
+
+	assert.NoError(t, os.WriteFile(filepath.Join(repoDir, "index.json"), indexFileData, storageConstants.DefaultFilePerms))
+
+	return repoDir
+}
+
+func writeOCIMultiPlatformIndex(t *testing.T, storeCtrl stypes.StoreController, root, repo, tag string) string {
+	t.Helper()
+
+	multiarch := CreateMultiarchWith().Images(platformImages()).Build()
+	assert.NoError(t, WriteMultiArchImageToFileSystem(multiarch, repo, tag, storeCtrl))
+
+	return repoPath(root, repo)
+}
+
+func writeOCISingleManifest(t *testing.T, storeCtrl stypes.StoreController, root, repo, tag string) string {
+	t.Helper()
+
+	image := CreateImageWith().DefaultLayers().PlatformConfig("amd64", "linux").Build()
+	assert.NoError(t, WriteImageToFileSystem(image, repo, tag, storeCtrl))
+
+	return repoPath(root, repo)
+}
+
+func writeOCIArtifactManifest(t *testing.T, storeCtrl stypes.StoreController, root, repo, tag string) string {
+	t.Helper()
+
+	subject := CreateImageWith().DefaultLayers().DefaultConfig().Build()
+	assert.NoError(t, WriteImageToFileSystem(subject, repo, subject.DigestStr(), storeCtrl))
+
+	artifact := CreateImageWith().EmptyLayer().EmptyConfig().
+		Subject(subject.DescriptorRef()).
+		ArtifactType("application/example.sbom").
+		Build()
+	assert.NoError(t, WriteImageToFileSystem(artifact, repo, tag, storeCtrl))
+
+	return repoPath(root, repo)
+}
+
+func writeDockerMultiPlatformIndex(t *testing.T, storeCtrl stypes.StoreController, root, repo, tag string) string {
+	t.Helper()
+
+	multiarch := CreateMultiarchWith().Images(platformImages()).Build().AsDockerImage()
+	assert.NoError(t, WriteMultiArchImageToFileSystem(multiarch, repo, tag, storeCtrl))
+
+	return repoPath(root, repo)
+}
+
+func writeHybridOCIIndexOCIChildrenDockerInterior(t *testing.T, repo, tag string) string {
+	t.Helper()
+
+	images := make([]Image, len(platformImages()))
+	for i, platformImage := range platformImages() {
+		images[i] = ociManifestDescriptorWithDockerInterior(platformImage.AsDockerImage())
+	}
+
+	multiarch := CreateMultiarchWith().Images(images).Build()
+
+	// zot manifest validation may reject oci manifest descriptors whose bodies use docker media types
+	return writeMultiarchLayoutDirect(t, t.TempDir(), repo, tag, multiarch)
+}
+
+func ociManifestDescriptorWithDockerInterior(img Image) Image {
+	img.Manifest.MediaType = ispec.MediaTypeImageManifest
+
+	manifestBlob, err := json.Marshal(img.Manifest)
+	if err != nil {
+		panic("unreachable: ispec.Manifest should always be marshable")
+	}
+
+	img.ManifestDescriptor = ispec.Descriptor{
+		MediaType: ispec.MediaTypeImageManifest,
+		Digest:    godigest.FromBytes(manifestBlob),
+		Size:      int64(len(manifestBlob)),
+		Data:      manifestBlob,
+		Platform:  img.ConfigDescriptor.Platform,
+	}
+
+	return img
+}
+
+func writeHybridOCIIndexDockerChildren(t *testing.T, storeCtrl stypes.StoreController, root, repo, tag string) string {
+	t.Helper()
+
+	dockerImages := make([]Image, len(platformImages()))
+	for i, image := range platformImages() {
+		dockerImages[i] = image.AsDockerImage()
+	}
+
+	multiarch := CreateMultiarchWith().Images(dockerImages).Build()
+	multiarch.Index.MediaType = ispec.MediaTypeImageIndex
+
+	for i := range multiarch.Index.Manifests {
+		multiarch.Index.Manifests[i].MediaType = dockerImages[i].ManifestDescriptor.MediaType
+	}
+
+	indexBlob, err := json.Marshal(multiarch.Index)
+	assert.NoError(t, err)
+
+	multiarch.IndexDescriptor = ispec.Descriptor{
+		MediaType: ispec.MediaTypeImageIndex,
+		Digest:    godigest.FromBytes(indexBlob),
+		Size:      int64(len(indexBlob)),
+		Data:      indexBlob,
+	}
+
+	assert.NoError(t, WriteMultiArchImageToFileSystem(multiarch, repo, tag, storeCtrl))
+
+	return repoPath(root, repo)
+}
+
+func writeHybridDockerIndexOCIChildren(t *testing.T, repo, tag string) string {
+	t.Helper()
+
+	ociImages := platformImages()
+
+	multiarch := CreateMultiarchWith().Images(ociImages).Build()
+	dockerIndexMT := CreateMultiarchWith().Images(platformImages()).Build().AsDockerImage().Index.MediaType
+
+	multiarch.Index.MediaType = dockerIndexMT
+
+	for i := range multiarch.Index.Manifests {
+		multiarch.Index.Manifests[i].MediaType = ociImages[i].ManifestDescriptor.MediaType
+	}
+
+	indexBlob, err := json.Marshal(multiarch.Index)
+	assert.NoError(t, err)
+
+	multiarch.IndexDescriptor = ispec.Descriptor{
+		MediaType: dockerIndexMT,
+		Digest:    godigest.FromBytes(indexBlob),
+		Size:      int64(len(indexBlob)),
+		Data:      indexBlob,
+	}
+
+	// zot manifest validation rejects a docker manifest list that references oci child manifests
+	return writeMultiarchLayoutDirect(t, t.TempDir(), repo, tag, multiarch)
+}
+
+func writeOCIIndexWithDockerReferrerAnnotations(t *testing.T, repo, tag string) string {
+	t.Helper()
+
+	platform := CreateImageWith().DefaultLayers().PlatformConfig("amd64", "linux").Build()
+	referrer := CreateImageWith().EmptyLayer().EmptyConfig().Build()
+
+	multiarch := CreateMultiarchWith().Images([]Image{platform, referrer}).Build()
+	multiarch.Index.Manifests[1].Annotations = map[string]string{
+		"vnd.docker.reference.type":   "builder",
+		"vnd.docker.reference.digest": multiarch.Index.Manifests[0].Digest.String(),
+	}
+	multiarch.Index.Manifests[1].Platform = &ispec.Platform{
+		Architecture: "unknown",
+		OS:           "unknown",
+	}
+
+	recomputeMultiarchIndexDescriptor(&multiarch)
+
+	return writeMultiarchLayoutDirect(t, t.TempDir(), repo, tag, multiarch)
+}
+
+// writeOCIIndexWithDockerReferrerExternalSubject builds a referrers-style index whose sole
+// entry annotates vnd.docker.reference.digest to a subject manifest that is stored on disk
+// but not listed in the index (external to the fetched manifest tree).
+func writeOCIIndexWithDockerReferrerExternalSubject(t *testing.T, repo, tag string) string {
+	t.Helper()
+
+	subject := CreateImageWith().DefaultLayers().PlatformConfig("amd64", "linux").Build()
+	referrer := CreateImageWith().EmptyLayer().EmptyConfig().Build()
+
+	referrerDesc := referrer.ManifestDescriptor
+	referrerDesc.Annotations = map[string]string{
+		"vnd.docker.reference.type":   "builder",
+		"vnd.docker.reference.digest": subject.ManifestDescriptor.Digest.String(),
+	}
+	referrerDesc.Platform = &ispec.Platform{
+		Architecture: "unknown",
+		OS:           "unknown",
+	}
+
+	index := ispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ispec.MediaTypeImageIndex,
+		Manifests: []ispec.Descriptor{referrerDesc},
+	}
+
+	indexBlob, err := json.Marshal(index)
+	require.NoError(t, err)
+
+	multiarch := MultiarchImage{
+		Images: []Image{subject, referrer},
+		Index:  index,
+		IndexDescriptor: ispec.Descriptor{
+			MediaType: ispec.MediaTypeImageIndex,
+			Digest:    godigest.FromBytes(indexBlob),
+			Size:      int64(len(indexBlob)),
+			Data:      indexBlob,
+		},
+	}
+
+	return writeMultiarchLayoutDirect(t, t.TempDir(), repo, tag, multiarch)
+}
+
+func writeMultiarchLayoutDirect(t *testing.T, root, repo, tag string, multiarch MultiarchImage) string {
+	t.Helper()
+
+	repoDir := filepath.Join(root, repo)
+	blobDir := filepath.Join(repoDir, "blobs", "sha256")
+	assert.NoError(t, os.MkdirAll(blobDir, storageConstants.DefaultDirPerms))
+
+	writeBlob := func(data []byte) godigest.Digest {
+		dgst := godigest.FromBytes(data)
+		assert.NoError(t, os.WriteFile(filepath.Join(blobDir, dgst.Encoded()), data, storageConstants.DefaultFilePerms))
+
+		return dgst
+	}
+
+	for _, image := range multiarch.Images {
+		configBlob := image.ConfigDescriptor.Data
+		if len(configBlob) == 0 {
+			var err error
+
+			configBlob, err = json.Marshal(image.Config)
+			assert.NoError(t, err)
+		}
+
+		writeBlob(configBlob)
+
+		for _, layer := range image.Layers {
+			writeBlob(layer)
+		}
+
+		manifestBlob := image.ManifestDescriptor.Data
+		if len(manifestBlob) == 0 {
+			var err error
+
+			manifestBlob, err = json.Marshal(image.Manifest)
+			assert.NoError(t, err)
+		}
+
+		writeBlob(manifestBlob)
+	}
+
+	indexBlob := multiarch.IndexDescriptor.Data
+	if len(indexBlob) == 0 {
+		var err error
+
+		indexBlob, err = json.Marshal(multiarch.Index)
+		assert.NoError(t, err)
+	}
+
+	indexDigest := writeBlob(indexBlob)
+
+	assert.NoError(t, os.WriteFile(filepath.Join(repoDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`),
+		storageConstants.DefaultFilePerms))
+
+	indexFile := ispec.Index{
+		Versioned: multiarch.Index.Versioned,
+		MediaType: multiarch.Index.MediaType,
+		Manifests: []ispec.Descriptor{
+			{
+				MediaType: multiarch.IndexDescriptor.MediaType,
+				Digest:    indexDigest,
+				Size:      int64(len(indexBlob)),
+				Annotations: map[string]string{
+					"org.opencontainers.image.ref.name": tag,
+				},
+			},
+		},
+	}
+	indexFileData, err := json.Marshal(indexFile)
+	assert.NoError(t, err)
+
+	assert.NoError(t, os.WriteFile(filepath.Join(repoDir, "index.json"), indexFileData, storageConstants.DefaultFilePerms))
+
+	return repoDir
+}
+
+func writeDeepIndexChain(t *testing.T, repo, tag string, depth int) string {
+	t.Helper()
+
+	platform := CreateImageWith().EmptyLayer().EmptyConfig().Build()
+	child := platform.ManifestDescriptor
+	indexBlobs := make([]ispec.Descriptor, 0, depth)
+
+	for range depth {
+		child = wrapIndexDescriptor(child, flavorOCI)
+		indexBlobs = append(indexBlobs, child)
+	}
+
+	return writeCyclicIndexLayoutDirect(t, t.TempDir(), repo, tag, []Image{platform}, child, ispec.Descriptor{}, indexBlobs...)
+}
+
+func writeWideOCIIndex(t *testing.T, repo, tag string, entries int) string {
+	t.Helper()
+
+	platform := CreateImageWith().EmptyLayer().EmptyConfig().Build()
+	manifests := make([]ispec.Descriptor, entries)
+	for i := range manifests {
+		manifests[i] = platform.ManifestDescriptor
+	}
+
+	index := ispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ispec.MediaTypeImageIndex,
+		Manifests: manifests,
+	}
+	indexBlob, err := json.Marshal(index)
+	require.NoError(t, err)
+
+	rootIndex := ispec.Descriptor{
+		MediaType: ispec.MediaTypeImageIndex,
+		Digest:    godigest.FromBytes(indexBlob),
+		Size:      int64(len(indexBlob)),
+		Data:      indexBlob,
+	}
+
+	return writeCyclicIndexLayoutDirect(t, t.TempDir(), repo, tag, []Image{platform}, rootIndex, ispec.Descriptor{})
+}
+
+func writeCyclicIndexLayoutDirect(t *testing.T, root, repo, tag string, images []Image,
+	rootIndex, secondaryIndex ispec.Descriptor, extraIndexes ...ispec.Descriptor,
+) string {
+	t.Helper()
+
+	repoDir := filepath.Join(root, repo)
+	blobDir := filepath.Join(repoDir, "blobs", "sha256")
+	require.NoError(t, os.MkdirAll(blobDir, storageConstants.DefaultDirPerms))
+
+	writeBlob := func(data []byte) {
+		dgst := godigest.FromBytes(data)
+		require.NoError(t, os.WriteFile(filepath.Join(blobDir, dgst.Encoded()), data, storageConstants.DefaultFilePerms))
+	}
+
+	for _, image := range images {
+		configBlob := image.ConfigDescriptor.Data
+		if len(configBlob) == 0 {
+			var err error
+
+			configBlob, err = json.Marshal(image.Config)
+			require.NoError(t, err)
+		}
+
+		writeBlob(configBlob)
+
+		for _, layer := range image.Layers {
+			writeBlob(layer)
+		}
+
+		manifestBlob := image.ManifestDescriptor.Data
+		if len(manifestBlob) == 0 {
+			var err error
+
+			manifestBlob, err = json.Marshal(image.Manifest)
+			require.NoError(t, err)
+		}
+
+		writeBlob(manifestBlob)
+	}
+
+	writeBlob(rootIndex.Data)
+
+	if secondaryIndex.Digest != "" {
+		writeBlob(secondaryIndex.Data)
+	}
+
+	for _, indexDesc := range extraIndexes {
+		if indexDesc.Digest != "" {
+			writeBlob(indexDesc.Data)
+		}
+	}
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "oci-layout"), []byte(`{"imageLayoutVersion":"1.0.0"}`),
+		storageConstants.DefaultFilePerms))
+
+	indexFile := ispec.Index{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: rootIndex.MediaType,
+		Manifests: []ispec.Descriptor{
+			{
+				MediaType: rootIndex.MediaType,
+				Digest:    rootIndex.Digest,
+				Size:      rootIndex.Size,
+				Annotations: map[string]string{
+					"org.opencontainers.image.ref.name": tag,
+				},
+			},
+		},
+	}
+	indexFileData, err := json.Marshal(indexFile)
+	require.NoError(t, err)
+
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "index.json"), indexFileData, storageConstants.DefaultFilePerms))
+
+	return repoDir
+}

--- a/pkg/extensions/sync/oci_digest_predict_internal_test.go
+++ b/pkg/extensions/sync/oci_digest_predict_internal_test.go
@@ -5,8 +5,10 @@ package sync //nolint:testpackage // white-box tests for unexported predictOCIDi
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	dockerList "github.com/distribution/distribution/v3/manifest/manifestlist"
@@ -15,10 +17,13 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/mod"
+	"github.com/regclient/regclient/types/descriptor"
+	"github.com/regclient/regclient/types/mediatype"
 	"github.com/regclient/regclient/types/ref"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/compat"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
 	"zotregistry.dev/zot/v2/pkg/log"
@@ -234,6 +239,71 @@ func TestPredictOCIDigestManifestTreeLimits(t *testing.T) {
 		srcRef := mustOCIDirRef(t, writeDeepIndexChain(t, "deep-index-valid", predictTestTag, maxManifestTreeDepth-1),
 			predictTestTag)
 		assertPredictMatchesRegclientApply(t, ctx, regClient, srcRef)
+	})
+}
+
+func TestPredictOCIDigestErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	regClient := regclient.New()
+
+	t.Run("unsupported root media type", func(t *testing.T) {
+		t.Parallel()
+
+		srcRef := mustOCIDirRef(t, writeUnsupportedRootMediaType(t, "unsupported-root", predictTestTag), predictTestTag)
+
+		_, _, _, err := predictOCIDigest(ctx, regClient, srcRef)
+		require.Error(t, err)
+		require.True(t, errors.Is(err, zerr.ErrMediaTypeNotSupported) || strings.Contains(err.Error(), "unsupported media type"))
+	})
+
+	t.Run("fetchManifestNode rejects digest already on path", func(t *testing.T) {
+		t.Parallel()
+
+		storeRoot, storeCtrl := newTestStore(t)
+		repoPath := writeOCISingleManifest(t, storeCtrl, storeRoot, "cycle-enter", predictTestTag)
+		srcRef := mustOCIDirRef(t, repoPath, predictTestTag)
+
+		man, err := regClient.ManifestGet(ctx, srcRef)
+		require.NoError(t, err)
+		defer regClient.Close(ctx, man.GetRef())
+
+		walkState := &manifestTreeWalkState{
+			path: map[string]struct{}{man.GetDescriptor().Digest.String(): {}},
+		}
+
+		_, err = fetchManifestNode(ctx, regClient, srcRef, true, walkState)
+		require.ErrorIs(t, err, errManifestTreeCycle)
+	})
+}
+
+func TestPredictOCIDigestDockerLayerMediaTypes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	regClient := regclient.New()
+	srcRef := mustOCIDirRef(t, writeDockerManifestVariedLayers(t, "docker-layer-types", predictTestTag), predictTestTag)
+
+	assertPredictMatchesRegclientApply(t, ctx, regClient, srcRef)
+}
+
+func TestManifestNodeHelpers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("closeManifestTree nil", func(t *testing.T) {
+		t.Parallel()
+
+		closeManifestTree(context.Background(), regclient.New(), nil)
+	})
+
+	t.Run("effectiveDesc falls back to origDesc", func(t *testing.T) {
+		t.Parallel()
+
+		orig := descriptor.Descriptor{Digest: godigest.FromString("sha256:" + strings.Repeat("a", 64))}
+		node := &manifestNode{mod: manifestDeleted, origDesc: orig}
+
+		assert.Equal(t, orig.Digest, node.effectiveDesc().Digest)
 	})
 }
 
@@ -966,4 +1036,70 @@ func writeCyclicIndexLayoutDirect(t *testing.T, root, repo, tag string, images [
 	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "index.json"), indexFileData, storageConstants.DefaultFilePerms))
 
 	return repoDir
+}
+
+func writeUnsupportedRootMediaType(t *testing.T, repo, tag string) string {
+	t.Helper()
+
+	image := CreateImageWith().EmptyLayer().EmptyConfig().Build()
+	const unsupportedMT = "application/vnd.test.unsupported+json"
+
+	manifestBlob, err := json.Marshal(image.Manifest)
+	require.NoError(t, err)
+
+	rootDesc := ispec.Descriptor{
+		MediaType: unsupportedMT,
+		Digest:    godigest.FromBytes(manifestBlob),
+		Size:      int64(len(manifestBlob)),
+		Data:      manifestBlob,
+	}
+	image.ManifestDescriptor = rootDesc
+
+	repoDir := writeCyclicIndexLayoutDirect(t, t.TempDir(), repo, tag, []Image{image}, rootDesc, ispec.Descriptor{})
+
+	// Tag descriptor media type is what regclient exposes from index.json.
+	indexPath := filepath.Join(repoDir, "index.json")
+	indexData, err := os.ReadFile(indexPath)
+	require.NoError(t, err)
+
+	var layoutIndex ispec.Index
+	require.NoError(t, json.Unmarshal(indexData, &layoutIndex))
+	layoutIndex.Manifests[0].MediaType = unsupportedMT
+
+	indexData, err = json.Marshal(layoutIndex)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(indexPath, indexData, storageConstants.DefaultFilePerms))
+
+	return repoDir
+}
+
+func writeDockerManifestVariedLayers(t *testing.T, repo, tag string) string {
+	t.Helper()
+
+	image := CreateImageWith().RandomLayers(4, 8).RandomConfig().Build().AsDockerImage()
+	require.GreaterOrEqual(t, len(image.Manifest.Layers), 4)
+
+	layerTypes := []string{
+		mediatype.Docker2Layer,
+		mediatype.Docker2LayerGzip,
+		mediatype.Docker2LayerZstd,
+		mediatype.Docker2ForeignLayer,
+	}
+
+	for i, layerType := range layerTypes {
+		image.Manifest.Layers[i].MediaType = layerType
+	}
+
+	manifestBlob, err := json.Marshal(image.Manifest)
+	require.NoError(t, err)
+
+	rootDesc := ispec.Descriptor{
+		MediaType: mediatype.Docker2Manifest,
+		Digest:    godigest.FromBytes(manifestBlob),
+		Size:      int64(len(manifestBlob)),
+		Data:      manifestBlob,
+	}
+	image.ManifestDescriptor = rootDesc
+
+	return writeCyclicIndexLayoutDirect(t, t.TempDir(), repo, tag, []Image{image}, rootDesc, ispec.Descriptor{})
 }

--- a/pkg/extensions/sync/remote.go
+++ b/pkg/extensions/sync/remote.go
@@ -4,19 +4,15 @@ package sync
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 
 	godigest "github.com/opencontainers/go-digest"
-	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/regclient/regclient"
 	"github.com/regclient/regclient/config"
 	"github.com/regclient/regclient/scheme"
-	"github.com/regclient/regclient/types/descriptor"
 	"github.com/regclient/regclient/types/errs"
 	"github.com/regclient/regclient/types/manifest"
-	"github.com/regclient/regclient/types/mediatype"
 	"github.com/regclient/regclient/types/ref"
 
 	zerr "zotregistry.dev/zot/v2/errors"
@@ -127,55 +123,38 @@ func (registry *RemoteRegistry) GetImageReference(repo, reference string) (ref.R
 	return imageRef, nil
 }
 
-func (registry *RemoteRegistry) headManifest(ctx context.Context, imageReference ref.Ref,
-) (manifest.Manifest, error) {
-	/// check what error it gives when not found
-	man, err := registry.client.ManifestHead(ctx, imageReference)
-	if err != nil {
-		/* public registries may return 401 for image not found
-		they will try to check private registries as a fallback => 401 */
-		if errors.Is(err, errs.ErrHTTPUnauthorized) {
-			registry.log.Info().Str("errorType", common.TypeOf(err)).
-				Str("repository", imageReference.Repository).Str("reference", imageReference.Reference).
-				Err(err).Msg("failed to get manifest: unauthorized")
-
-			return nil, zerr.ErrUnauthorizedAccess
-		} else if errors.Is(err, errs.ErrNotFound) {
-			registry.log.Info().Str("errorType", common.TypeOf(err)).
-				Str("repository", imageReference.Repository).Str("reference", imageReference.Reference).
-				Err(err).Msg("failed to find manifest")
-
-			return nil, zerr.ErrManifestNotFound
-		}
-
-		return nil, err
+// translateManifestErr maps regclient manifest fetch errors to zot errors for sync/on-demand callers.
+func (registry *RemoteRegistry) translateManifestErr(imageReference ref.Ref, err error) error {
+	if err == nil {
+		return nil
 	}
 
-	return man, nil
+	/* public registries may return 401 for image not found
+	they will try to check private registries as a fallback => 401 */
+	if errors.Is(err, errs.ErrHTTPUnauthorized) {
+		registry.log.Info().Str("errorType", common.TypeOf(err)).
+			Str("repository", imageReference.Repository).Str("reference", imageReference.Reference).
+			Err(err).Msg("failed to get manifest: unauthorized")
+
+		return zerr.ErrUnauthorizedAccess
+	}
+
+	if errors.Is(err, errs.ErrNotFound) {
+		registry.log.Info().Str("errorType", common.TypeOf(err)).
+			Str("repository", imageReference.Repository).Str("reference", imageReference.Reference).
+			Err(err).Msg("failed to find manifest")
+
+		return zerr.ErrManifestNotFound
+	}
+
+	return err
 }
 
-func (registry *RemoteRegistry) getManifest(ctx context.Context, imageReference ref.Ref,
+func (registry *RemoteRegistry) headManifest(ctx context.Context, imageReference ref.Ref,
 ) (manifest.Manifest, error) {
-	/// check what error it gives when not found
-	man, err := registry.client.ManifestGet(ctx, imageReference)
+	man, err := registry.client.ManifestHead(ctx, imageReference)
 	if err != nil {
-		/* public registries may return 401 for image not found
-		they will try to check private registries as a fallback => 401 */
-		if errors.Is(err, errs.ErrHTTPUnauthorized) {
-			registry.log.Info().Str("errorType", common.TypeOf(err)).
-				Str("repository", imageReference.Repository).Str("reference", imageReference.Reference).
-				Err(err).Msg("failed to get manifest: unauthorized")
-
-			return nil, zerr.ErrUnauthorizedAccess
-		} else if errors.Is(err, errs.ErrNotFound) {
-			registry.log.Info().Str("errorType", common.TypeOf(err)).
-				Str("repository", imageReference.Repository).Str("reference", imageReference.Reference).
-				Err(err).Msg("failed to find manifest")
-
-			return nil, zerr.ErrManifestNotFound
-		}
-
-		return nil, err
+		return nil, registry.translateManifestErr(imageReference, err)
 	}
 
 	return man, nil
@@ -192,41 +171,27 @@ func (registry *RemoteRegistry) GetDigest(ctx context.Context, repo, tag string,
 	if err != nil {
 		return "", err
 	}
+	defer registry.client.Close(ctx, man.GetRef())
 
-	return man.GetDescriptor().Digest, err
+	return man.GetDescriptor().Digest, nil
 }
 
-// GetOCIDigest returns OCI remote digest, original remote digest (unconverted), if it was converted.
+// GetOCIDigest returns the digest predictOCIDigest computes after regclient
+// mod.WithManifestToOCI conversion, the original remote digest, and whether
+// mod.Apply would modify the image.
 func (registry *RemoteRegistry) GetOCIDigest(ctx context.Context, repo, tag string,
 ) (godigest.Digest, godigest.Digest, bool, error) {
-	var isConverted bool
-
-	var desc ispec.Descriptor
-
 	imageReference, err := registry.GetImageReference(repo, tag)
 	if err != nil {
 		return "", "", false, err
 	}
 
-	man, err := registry.getManifest(ctx, imageReference)
+	predicted, original, isConverted, err := predictOCIDigest(ctx, registry.client, imageReference)
 	if err != nil {
-		return "", "", false, err
+		return "", "", false, registry.translateManifestErr(imageReference, err)
 	}
 
-	switch man.GetDescriptor().MediaType {
-	case mediatype.Docker2Manifest:
-		desc, err = convertDockerManifestToOCI(ctx, man, man.GetDescriptor(), imageReference, registry.client)
-		isConverted = true
-	case mediatype.Docker2ManifestList:
-		desc, err = convertDockerListToOCI(ctx, man, imageReference, registry.client)
-		isConverted = true
-	case mediatype.OCI1Manifest, mediatype.OCI1ManifestList:
-		desc = toOCIDescriptor(man.GetDescriptor())
-	default:
-		return "", "", false, zerr.ErrMediaTypeNotSupported
-	}
-
-	return desc.Digest, man.GetDescriptor().Digest, isConverted, err
+	return predicted, original, isConverted, nil
 }
 
 func (registry *RemoteRegistry) GetTags(ctx context.Context, repo string) ([]string, error) {
@@ -243,188 +208,4 @@ func (registry *RemoteRegistry) GetTags(ctx context.Context, repo string) ([]str
 	}
 
 	return tl.GetTags()
-}
-
-func convertDockerListToOCI(ctx context.Context, man manifest.Manifest, imageReference ref.Ref,
-	regclient *regclient.RegClient,
-) (
-	ispec.Descriptor, error,
-) {
-	var index ispec.Index
-
-	index.SchemaVersion = 2
-	index.Manifests = []ispec.Descriptor{}
-	index.MediaType = ispec.MediaTypeImageIndex
-
-	indexer, ok := man.(manifest.Indexer)
-	if !ok {
-		return ispec.Descriptor{}, zerr.ErrMediaTypeNotSupported
-	}
-
-	ociIndex, err := manifest.OCIIndexFromAny(man.GetOrig())
-	if err != nil {
-		return ispec.Descriptor{}, zerr.ErrMediaTypeNotSupported
-	}
-
-	manifests, err := indexer.GetManifestList()
-	if err != nil {
-		return ispec.Descriptor{}, zerr.ErrMediaTypeNotSupported
-	}
-
-	for _, manDesc := range manifests {
-		ref := imageReference
-		ref.Digest = manDesc.Digest.String()
-
-		manEntry, err := regclient.ManifestGet(ctx, ref)
-		if err != nil {
-			return ispec.Descriptor{}, err
-		}
-
-		regclient.Close(ctx, manEntry.GetRef())
-
-		var desc ispec.Descriptor
-
-		switch manEntry.GetDescriptor().MediaType {
-		case mediatype.Docker2Manifest:
-			desc, err = convertDockerManifestToOCI(ctx, manEntry, manDesc, ref, regclient)
-			if err != nil {
-				return ispec.Descriptor{}, err
-			}
-
-		case mediatype.Docker2ManifestList:
-			desc, err = convertDockerListToOCI(ctx, manEntry, ref, regclient)
-			if err != nil {
-				return ispec.Descriptor{}, err
-			}
-		default:
-			return ispec.Descriptor{}, err
-		}
-
-		index.Manifests = append(index.Manifests, desc)
-	}
-
-	index.Annotations = ociIndex.Annotations
-
-	indexBuf, err := json.Marshal(index)
-	if err != nil {
-		return ispec.Descriptor{}, err
-	}
-
-	indexDesc := toOCIDescriptor(man.GetDescriptor())
-
-	indexDesc.MediaType = ispec.MediaTypeImageIndex
-	indexDesc.Digest = godigest.FromBytes(indexBuf)
-	indexDesc.Size = int64(len(indexBuf))
-
-	return indexDesc, nil
-}
-
-func convertDockerManifestToOCI(ctx context.Context, man manifest.Manifest, desc descriptor.Descriptor,
-	imageReference ref.Ref, regclient *regclient.RegClient,
-) (
-	ispec.Descriptor, error,
-) {
-	imager, ok := man.(manifest.Imager)
-	if !ok {
-		return ispec.Descriptor{}, zerr.ErrMediaTypeNotSupported
-	}
-
-	var ociManifest ispec.Manifest
-
-	manifestBuf, err := man.RawBody()
-	if err != nil {
-		return ispec.Descriptor{}, zerr.ErrMediaTypeNotSupported
-	}
-
-	if err := json.Unmarshal(manifestBuf, &ociManifest); err != nil {
-		return ispec.Descriptor{}, err
-	}
-
-	configDesc, err := imager.GetConfig()
-	if err != nil {
-		return ispec.Descriptor{}, err
-	}
-
-	// get config blob
-	config, err := regclient.BlobGetOCIConfig(ctx, imageReference, configDesc)
-	if err != nil {
-		return ispec.Descriptor{}, err
-	}
-
-	configBuf, err := config.RawBody()
-	if err != nil {
-		return ispec.Descriptor{}, err
-	}
-
-	// convert config and manifest mediatype
-	ociManifest.Config.Size = int64(len(configBuf))
-	ociManifest.Config.Digest = godigest.FromBytes(configBuf)
-	ociManifest.Config.MediaType = ispec.MediaTypeImageConfig
-	ociManifest.MediaType = ispec.MediaTypeImageManifest
-
-	layersDesc, err := imager.GetLayers()
-	if err != nil {
-		return ispec.Descriptor{}, err
-	}
-
-	ociManifest.Layers = []ispec.Descriptor{}
-
-	for _, layerDesc := range layersDesc {
-		ociManifest.Layers = append(ociManifest.Layers, toOCIDescriptor(layerDesc))
-	}
-
-	ociManifestBuf, err := json.Marshal(ociManifest)
-	if err != nil {
-		return ispec.Descriptor{}, err
-	}
-
-	manifestDesc := toOCIDescriptor(desc)
-
-	manifestDesc.MediaType = ispec.MediaTypeImageManifest
-	manifestDesc.Digest = godigest.FromBytes(ociManifestBuf)
-	manifestDesc.Size = int64(len(ociManifestBuf))
-
-	return manifestDesc, nil
-}
-
-func toOCIDescriptor(desc descriptor.Descriptor) ispec.Descriptor {
-	ispecPlatform := &ispec.Platform{}
-
-	platform := desc.Platform
-	if platform != nil {
-		ispecPlatform.Architecture = platform.Architecture
-		ispecPlatform.OS = platform.OS
-		ispecPlatform.OSFeatures = platform.OSFeatures
-		ispecPlatform.OSVersion = platform.OSVersion
-		ispecPlatform.Variant = platform.Variant
-	} else {
-		ispecPlatform = nil
-	}
-
-	var mediaType string
-
-	switch desc.MediaType {
-	case mediatype.Docker2Manifest:
-		mediaType = ispec.MediaTypeImageManifest
-	case mediatype.Docker2ManifestList:
-		mediaType = ispec.MediaTypeImageIndex
-	case mediatype.Docker2ImageConfig:
-		mediaType = ispec.MediaTypeImageConfig
-	case mediatype.Docker2ForeignLayer:
-		mediaType = ispec.MediaTypeImageLayerNonDistributable //nolint: staticcheck
-	case mediatype.Docker2LayerGzip:
-		mediaType = ispec.MediaTypeImageLayerGzip
-	default:
-		mediaType = desc.MediaType
-	}
-
-	return ispec.Descriptor{
-		MediaType:    mediaType,
-		Digest:       desc.Digest,
-		Size:         desc.Size,
-		URLs:         desc.URLs,
-		Annotations:  desc.Annotations,
-		Platform:     ispecPlatform,
-		ArtifactType: desc.ArtifactType,
-	}
 }

--- a/pkg/extensions/sync/sync.go
+++ b/pkg/extensions/sync/sync.go
@@ -77,8 +77,8 @@ type Remote interface {
 	GetRepositories(ctx context.Context) ([]string, error)
 	// Get a list of tags given a repo
 	GetTags(ctx context.Context, repo string) ([]string, error)
-	/* Get oci digest for repo:tag, if docker image, convert it before returning:
-	oci digest,	original digest on the remote before converting, if it was converted and error	*/
+	/* Get oci digest for repo:tag as regclient mod.WithManifestToOCI would produce:
+	predicted digest, original remote digest, whether mod.Apply would modify the image, error */
 	GetOCIDigest(ctx context.Context, repo, tag string) (godigest.Digest, godigest.Digest, bool, error)
 	// Get remote digest for repo:tag
 	GetDigest(ctx context.Context, repo, tag string) (godigest.Digest, error)

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	zerr "zotregistry.dev/zot/v2/errors"
+	"zotregistry.dev/zot/v2/pkg/common"
 	"zotregistry.dev/zot/v2/pkg/extensions/config"
 	syncconf "zotregistry.dev/zot/v2/pkg/extensions/config/sync"
 	"zotregistry.dev/zot/v2/pkg/extensions/lint"
@@ -1503,6 +1504,98 @@ func TestDestinationRegistry(t *testing.T) {
 			err = registry.CommitAll("error-repo", imageReference)
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, os.ErrNotExist), ShouldBeFalse)
+		})
+	})
+}
+
+func TestCopyManifestReferrersTag(t *testing.T) {
+	Convey("referrers-shaped layout entries are not committed as tags", t, func() {
+		log := log.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		repoName := "repo"
+		subjectImage := CreateImageWith().RandomLayers(1, 10).RandomConfig().Build()
+		subjectDigest := subjectImage.Digest()
+		referrersTag := "sha256-" + subjectDigest.Encoded()
+
+		Convey("referrers-tagged manifest entry is skipped", func() {
+			tempDir := t.TempDir()
+			destDir := t.TempDir()
+			tempStore := local.NewImageStore(tempDir, true, true, log, metrics, nil, nil, nil, nil)
+			destStore := local.NewImageStore(destDir, true, true, log, metrics, nil, nil, nil, nil)
+			tempController := storage.StoreController{DefaultStore: tempStore}
+			destController := storage.StoreController{DefaultStore: destStore}
+			destReg := NewDestinationRegistry(destController, tempController, nil, log).(*DestinationRegistry)
+
+			referrerImage := CreateImageWith().RandomLayers(1, 10).RandomConfig().
+				Subject(&ispec.Descriptor{
+					Digest:    subjectDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				}).Build()
+			referrerManifest, err := json.Marshal(referrerImage.Manifest)
+			So(err, ShouldBeNil)
+			referrerDigest := godigest.FromBytes(referrerManifest)
+
+			err = WriteImageToFileSystem(referrerImage, repoName, referrersTag, tempController)
+			So(err, ShouldBeNil)
+
+			desc := ispec.Descriptor{
+				Digest:    referrerDigest,
+				MediaType: ispec.MediaTypeImageManifest,
+				Size:      int64(len(referrerManifest)),
+			}
+			seen := &[]godigest.Digest{}
+
+			err = destReg.copyManifest(repoName, desc, referrersTag, tempStore, seen)
+			So(err, ShouldBeNil)
+
+			_, _, _, err = destStore.GetImageManifest(repoName, referrerDigest.String())
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("referrers-tagged index commits child manifests only", func() {
+			tempDir := t.TempDir()
+			destDir := t.TempDir()
+			tempStore := local.NewImageStore(tempDir, true, true, log, metrics, nil, nil, nil, nil)
+			destStore := local.NewImageStore(destDir, true, true, log, metrics, nil, nil, nil, nil)
+			tempController := storage.StoreController{DefaultStore: tempStore}
+			destController := storage.StoreController{DefaultStore: destStore}
+			destReg := NewDestinationRegistry(destController, tempController, nil, log).(*DestinationRegistry)
+
+			referrerImage := CreateImageWith().RandomLayers(1, 10).RandomConfig().
+				Subject(&ispec.Descriptor{
+					Digest:    subjectDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				}).Build()
+
+			referrersIndex := CreateMultiarchWith().Images([]Image{referrerImage}).Build()
+			referrersIndex.Index.Subject = &ispec.Descriptor{
+				Digest:    subjectDigest,
+				MediaType: ispec.MediaTypeImageManifest,
+			}
+
+			err := WriteMultiArchImageToFileSystem(referrersIndex, repoName, referrersTag, tempController)
+			So(err, ShouldBeNil)
+
+			desc := referrersIndex.IndexDescriptor
+			seen := &[]godigest.Digest{}
+
+			err = destReg.copyManifest(repoName, desc, referrersTag, tempStore, seen)
+			So(err, ShouldBeNil)
+
+			tags, err := destStore.GetImageTags(repoName)
+			So(err, ShouldBeNil)
+			for _, tag := range tags {
+				So(common.IsReferrersTag(tag), ShouldBeFalse)
+			}
+
+			_, _, _, err = destStore.GetImageManifest(repoName, referrersIndex.Digest().String())
+			So(err, ShouldNotBeNil)
+
+			_, childDigest, _, err := destStore.GetImageManifest(repoName, referrerImage.Digest().String())
+			So(err, ShouldBeNil)
+			So(childDigest, ShouldEqual, referrerImage.Digest())
 		})
 	})
 }

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -1548,6 +1548,124 @@ func TestSyncTempSessionRoot(t *testing.T) {
 	})
 }
 
+func TestSyncTempLayoutPathHelpers(t *testing.T) {
+	Convey("ocidirLayoutPath and getImageStoreFromImageReference errors", t, func() {
+		log := log.NewTestLogger()
+
+		Convey("missing path and reference", func() {
+			_, err := ocidirLayoutPath(ref.Ref{})
+			So(errors.Is(err, errSyncTempImageReferenceNoPath), ShouldBeTrue)
+		})
+
+		Convey("invalid reference parse", func() {
+			_, err := ocidirLayoutPath(ref.Ref{Reference: "://bad"})
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("reparses layout path from reference", func() {
+			parsed, err := ref.New("ocidir:///tmp/layout/repo:1.0")
+			So(err, ShouldBeNil)
+
+			cleared := parsed
+			cleared.Path = ""
+
+			path, err := ocidirLayoutPath(cleared)
+			So(err, ShouldBeNil)
+			So(path, ShouldEqual, "/tmp/layout/repo")
+		})
+
+		Convey("ocidir reference without layout path fails on reparsing", func() {
+			_, err := ref.New("ocidir://")
+			So(err, ShouldNotBeNil)
+
+			_, err = ocidirLayoutPath(ref.Ref{Reference: "ocidir://"})
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, errSyncTempImageReferenceNoPath), ShouldBeFalse)
+			// regclient rejects empty ocidir paths at parse time, before no-layout-path check
+			So(errors.Is(err, errSyncTempImageReferenceNoLayoutPath), ShouldBeFalse)
+		})
+
+		Convey("session root is not a directory", func() {
+			sessionFile := path.Join(t.TempDir(), "session")
+			So(os.WriteFile(sessionFile, []byte("x"), 0o644), ShouldBeNil)
+
+			layoutPath := path.Join(sessionFile, "repo")
+			_, err := getImageStoreFromImageReference("repo", ref.Ref{Path: layoutPath}, log)
+			So(errors.Is(err, errSyncTempImageStoreCreateFailed), ShouldBeTrue)
+		})
+	})
+}
+
+func TestDestinationRegistryCommitAllErrors(t *testing.T) {
+	Convey("CommitAll and CleanupImage temp path errors", t, func() {
+		log := log.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		dir := t.TempDir()
+		store := local.NewImageStore(dir, true, true, log, metrics, nil, nil, nil, nil)
+		sc := storage.StoreController{DefaultStore: store}
+		registry := NewDestinationRegistry(sc, sc, nil, log)
+
+		Convey("CommitAll with unresolvable temp ref", func() {
+			err := registry.CommitAll("repo", ref.Ref{})
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, errSyncTempImageReferenceNoPath), ShouldBeTrue)
+		})
+
+		Convey("CleanupImage with unresolvable temp ref returns nil", func() {
+			err := registry.CleanupImage(ref.Ref{}, "repo")
+			So(err, ShouldBeNil)
+		})
+
+		Convey("CleanupImage removes existing temp session", func() {
+			repoName := "cleanup-repo"
+			imageReference, err := registry.GetImageReference(repoName, "1.0")
+			So(err, ShouldBeNil)
+
+			sessionRoot, err := syncTempSessionRoot(repoName, imageReference)
+			So(err, ShouldBeNil)
+			So(os.MkdirAll(path.Join(sessionRoot, repoName), 0o755), ShouldBeNil)
+
+			err = registry.CleanupImage(imageReference, repoName)
+			So(err, ShouldBeNil)
+			_, statErr := os.Stat(sessionRoot)
+			So(os.IsNotExist(statErr), ShouldBeTrue)
+		})
+	})
+}
+
+func TestCopyManifestInvalidJSON(t *testing.T) {
+	Convey("copyManifest rejects invalid manifest JSON", t, func() {
+		log := log.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		tempDir := t.TempDir()
+		destDir := t.TempDir()
+		tempStore := local.NewImageStore(tempDir, true, true, log, metrics, nil, nil, nil, nil)
+		destStore := local.NewImageStore(destDir, true, true, log, metrics, nil, nil, nil, nil)
+		destReg := NewDestinationRegistry(
+			storage.StoreController{DefaultStore: destStore},
+			storage.StoreController{DefaultStore: tempStore},
+			nil,
+			log,
+		).(*DestinationRegistry)
+
+		invalid := []byte("not-json")
+		desc := ispec.Descriptor{
+			MediaType: ispec.MediaTypeImageManifest,
+			Digest:    godigest.FromBytes(invalid),
+			Size:      int64(len(invalid)),
+			Data:      invalid,
+		}
+		seen := &[]godigest.Digest{}
+
+		err := destReg.copyManifest("repo", desc, "1.0", tempStore, seen)
+		So(err, ShouldNotBeNil)
+	})
+}
+
 func TestCopyManifestReferrersTag(t *testing.T) {
 	Convey("referrers-shaped layout entries are not committed as tags", t, func() {
 		log := log.NewTestLogger()

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -1028,7 +1028,8 @@ func TestDestinationRegistry(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(imageReference, ShouldNotBeNil)
 
-		imgStore := getImageStoreFromImageReference(repoName, imageReference, log)
+		imgStore, err := getImageStoreFromImageReference(repoName, imageReference, log)
+		So(err, ShouldBeNil)
 
 		// create a blob/layer
 		upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
@@ -1229,7 +1230,8 @@ func TestDestinationRegistry(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// Get the temp image store from the image reference
-			tempImgStore := getImageStoreFromImageReference(repoName, imageReference, log)
+			tempImgStore, err := getImageStoreFromImageReference(repoName, imageReference, log)
+			So(err, ShouldBeNil)
 
 			// Create an image index with multiple manifests
 			var index ispec.Index
@@ -1351,7 +1353,8 @@ func TestDestinationRegistry(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(imageReference, ShouldNotBeNil)
 
-			imgStore := getImageStoreFromImageReference(repoName, imageReference, log)
+			imgStore, err := getImageStoreFromImageReference(repoName, imageReference, log)
+			So(err, ShouldBeNil)
 
 			// upload image
 
@@ -1432,7 +1435,8 @@ func TestDestinationRegistry(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// Remove the directory to simulate it not existing
-			tempImageStore := getImageStoreFromImageReference("nonexistent-repo", imageReference, log)
+			tempImageStore, err := getImageStoreFromImageReference("nonexistent-repo", imageReference, log)
+			So(err, ShouldBeNil)
 			repoDir := path.Join(tempImageStore.RootDir(), "nonexistent-repo")
 			err = os.RemoveAll(repoDir)
 			So(err, ShouldBeNil)
@@ -1449,7 +1453,8 @@ func TestDestinationRegistry(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// Create an empty directory (no index.json, no blobs)
-			tempImageStore := getImageStoreFromImageReference("empty-repo", imageReference, log)
+			tempImageStore, err := getImageStoreFromImageReference("empty-repo", imageReference, log)
+			So(err, ShouldBeNil)
 			repoDir := path.Join(tempImageStore.RootDir(), "empty-repo")
 			err = os.MkdirAll(repoDir, 0o755)
 			So(err, ShouldBeNil)
@@ -1466,7 +1471,8 @@ func TestDestinationRegistry(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// Create a directory with some files but no index.json (inconsistent state)
-			tempImageStore := getImageStoreFromImageReference("inconsistent-repo", imageReference, log)
+			tempImageStore, err := getImageStoreFromImageReference("inconsistent-repo", imageReference, log)
+			So(err, ShouldBeNil)
 			repoDir := path.Join(tempImageStore.RootDir(), "inconsistent-repo")
 			err = os.MkdirAll(repoDir, 0o755)
 			So(err, ShouldBeNil)
@@ -1489,7 +1495,8 @@ func TestDestinationRegistry(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// Get the repo directory path
-			tempImageStore := getImageStoreFromImageReference("error-repo", imageReference, log)
+			tempImageStore, err := getImageStoreFromImageReference("error-repo", imageReference, log)
+			So(err, ShouldBeNil)
 			repoDir := path.Join(tempImageStore.RootDir(), "error-repo")
 
 			// Create a file at the repoDir path instead of a directory
@@ -1504,6 +1511,39 @@ func TestDestinationRegistry(t *testing.T) {
 			err = registry.CommitAll("error-repo", imageReference)
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, os.ErrNotExist), ShouldBeFalse)
+		})
+	})
+}
+
+func TestSyncTempSessionRoot(t *testing.T) {
+	Convey("syncTempSessionRoot resolves temp ocidir session directories", t, func() {
+		repo := "zot-test"
+		layoutPath := path.Join("/tmp", "dest", repo, ".sync", "session-id", repo)
+		imageReference, err := ref.New(fmt.Sprintf("ocidir://%s:1.0", layoutPath))
+		So(err, ShouldBeNil)
+
+		sessionRoot, err := syncTempSessionRoot(repo, imageReference)
+		So(err, ShouldBeNil)
+		So(sessionRoot, ShouldEqual, path.Join("/tmp", "dest", repo, ".sync", "session-id"))
+
+		Convey("reparses layout path from Reference when Path is empty", func() {
+			cleared := imageReference
+			cleared.Path = ""
+
+			sessionRoot, err := syncTempSessionRoot(repo, cleared)
+			So(err, ShouldBeNil)
+			So(sessionRoot, ShouldEqual, path.Join("/tmp", "dest", repo, ".sync", "session-id"))
+		})
+
+		Convey("returns error when path cannot be resolved", func() {
+			_, err := syncTempSessionRoot(repo, ref.Ref{})
+			So(err, ShouldNotBeNil)
+
+			_, err = syncTempSessionRoot("other-repo", imageReference)
+			So(err, ShouldNotBeNil)
+
+			_, err = syncTempSessionRoot(repo, ref.Ref{Path: repo})
+			So(err, ShouldNotBeNil)
 		})
 	})
 }

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -5425,12 +5425,11 @@ func TestSyncedSignaturesMetaDB(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 
-		// regclient will put all referrers under ref tag "alg-subjectDigest"
 		repoMeta, err := dctlr.MetaDB.GetRepoMeta(context.Background(), repoName)
 		So(err, ShouldBeNil)
 		So(repoMeta.Tags, ShouldContainKey, tag)
-		// one tag for refs and the tag we pushed earlier
-		So(len(repoMeta.Tags), ShouldEqual, 2)
+		// only the image tag; referrers-shaped refs are not committed as tags
+		So(len(repoMeta.Tags), ShouldEqual, 1)
 		So(repoMeta.Signatures, ShouldContainKey, signedImage.DigestStr())
 
 		imageSignatures := repoMeta.Signatures[signedImage.DigestStr()]

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -7672,7 +7672,11 @@ func TestSyncImageIndex(t *testing.T) {
 			So(resp.Body(), ShouldNotBeEmpty)
 			So(resp.Header().Get("Content-Type"), ShouldNotBeEmpty)
 
-			childMultiarchImage.IndexDescriptor.Digest = godigest.FromBytes(resp.Body())
+			childBody := resp.Body()
+			childMultiarchImage.IndexDescriptor.Digest = godigest.FromBytes(childBody)
+			childMultiarchImage.IndexDescriptor.Size = int64(len(childBody))
+			err = json.Unmarshal(childBody, &childMultiarchImage.Index)
+			So(err, ShouldBeNil)
 
 			rootMultiarchImage.Index.Manifests = append(rootMultiarchImage.Index.Manifests, childMultiarchImage.IndexDescriptor)
 			rootMultiarchImage.IndexDescriptor.Data = nil
@@ -7687,6 +7691,9 @@ func TestSyncImageIndex(t *testing.T) {
 			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 			So(resp.Body(), ShouldNotBeEmpty)
 			So(resp.Header().Get("Content-Type"), ShouldNotBeEmpty)
+
+			err = json.Unmarshal(resp.Body(), &rootMultiarchImage.Index)
+			So(err, ShouldBeNil)
 
 			Convey("sync periodically", func() {
 				// start downstream server


### PR DESCRIPTION
On-demand sync compares the locally stored digest (after regclient mod.WithManifestToOCI at commit time) with the remote digest in CanSkipImage. For Docker images such as registry.k8s.io/pause:3.10.1, the upstream manifest-list digest differs from the post-conversion OCI index digest.

The previous hand-rolled convertDockerManifestToOCI / convertDockerListToOCI logic in remote.go did not match regclient's conversion (including WithManifestToOCIReferrers and hybrid indexes), so GetOCIDigest returned the wrong value, skip never matched, and sync logged "remote image digest changed, syncing again" in a loop.

Replace that with predictOCIDigest, an in-memory mirror of regclient's manifest conversion that needs only manifest JSON (no config/layer blobs). Skip ManifestGet for unchanged OCI platform manifests listed in an index. Add tests against mod.Apply and document remote call counts.

Fixes the resync loop described in #4184; first-pull latency and full layer re-downloads are separate follow-ups.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
