### PR TITLE
fix(storage): normalize repository names to '/' separators on Windows

### DIFF
--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -310,6 +310,8 @@ func (is *ImageStore) GetNextRepositories(lastRepo string, maxEntries int, filte
 			return nil //nolint:nilerr // ignore paths that are not under root dir
 		}
 
+		rel = filepath.ToSlash(rel)
+
 		if ok, err := is.ValidateRepo(rel); !ok || err != nil {
 			return nil //nolint:nilerr // ignore invalid repos
 		}
@@ -384,6 +386,8 @@ func (is *ImageStore) GetRepositories() ([]string, error) {
 			return nil //nolint:nilerr // ignore paths that are not under root dir
 		}
 
+		rel = filepath.ToSlash(rel)
+
 		if ok, err := is.ValidateRepo(rel); !ok || err != nil {
 			return nil //nolint:nilerr // ignore invalid repos
 		}
@@ -434,6 +438,8 @@ func (is *ImageStore) GetNextRepository(processedRepos map[string]struct{}) (str
 		if err != nil {
 			return nil //nolint:nilerr // ignore paths not relative to root dir
 		}
+
+		rel = filepath.ToSlash(rel)
 
 		if _, ok := processedRepos[rel]; ok {
 			return nil // repo already processed


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

No open issue found for this; related prior Windows path-handling fixes: #3775, #3709. Repro steps below.

**What does this PR do / Why do we need it**:

On Windows, `filepath.Rel` returns backslash-separated paths, so the repository walkers in `pkg/storage/imagestore` (`GetRepositories`, `GetNextRepository`, `GetNextRepositories`) compute repo names like `openshift4\ose-cli`. `ValidateRepo` checks those names against `FullNameRegexp`, which only accepts `/` as a component separator, so every namespaced repository is silently dropped.

The visible blast radius of this one bug on Windows:
- `GET /v2/_catalog` returns `{"repositories":[]}` even though images are present on disk and pullable by exact name
- garbage collection never processes namespaced repos (`GetNextRepository` feeds the GC generator), so blobs are never reclaimed
- scrub and metadb/search/UI never see namespaced repos

This PR converts each walker's relative path with `filepath.ToSlash` before validation — a no-op on Unix, and consistent with the existing `ToSlash` usage for `blobPath` in the same file.

**If an issue # is not available please add repro steps and logs showing the issue**:

1. Run zot (v2.1.17/v2.1.18 or current main) on Windows with local filesystem storage.
2. Push any namespaced image, e.g. `docker push <host>/some/namespaced-image:tag` (push succeeds, blobs and index land on disk).
3. `GET /v2/_catalog` → `{"repositories":[]}`. Single-level repo names (no `/`) still appear; any name containing a namespace does not.
4. GC log shows no repositories being processed; storage usage only ever grows.

**Testing done on this change**:

- Verified on a production Windows Server mirror registry (originally hit on v2.1.17/v2.1.18, fix rebased onto current main): swapping only the patched binary against the unchanged production config immediately populates `/v2/_catalog` with all namespaced repositories, and garbage collection begins processing repos and reclaiming blobs.
- `go build ./pkg/storage/...` passes.
- `go test ./pkg/storage/local/ -run 'TestGetRepositories|TestGetNextRepository|TestValidateRepo' -count=1` passes (Linux; the change is a no-op there since `filepath.Rel` already returns `/`-separated paths).

**Automation added to e2e**:

No — the faulty behavior only manifests on Windows (`filepath.Rel` never emits backslashes on Unix), so a Linux-based e2e/unit test cannot reproduce it. Happy to add a Windows-gated test if CI coverage for Windows exists/is planned.

**Will this break upgrades or downgrades?**

No. Repo names computed on Unix are unchanged. On Windows, previously-invisible repositories become visible to catalog/GC/scrub/metadb, which is the intended fix.

**Does this PR introduce any user-facing change?**:

```release-note
Fixed: on Windows, namespaced repositories were missing from /v2/_catalog and were skipped by garbage collection, scrub, and metadb.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
