### PR TITLE
feat(auth): allow all authentication features to work together

### DIFF
--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -52,6 +52,7 @@ const (
 type AuthnMiddleware struct {
 	htpasswd   *HTPasswd
 	ldapClient *LDAPClient
+	bearerAuth *BearerAuth
 	log        log.Logger
 }
 
@@ -67,16 +68,19 @@ func AuthHandler(ctlr *Controller) AuthSetup {
 	}
 
 	authConfig := ctlr.Config.CopyAuthConfig()
+
+	var tokenHandler http.HandlerFunc
+
 	if authConfig.IsBearerAuthEnabled() {
 		bearerAuth := NewBearerAuth(authConfig, ctlr.Log)
-
-		return AuthSetup{
-			Middleware:   bearerAuth.Middleware(ctlr),
-			TokenHandler: bearerAuth.TokenExchangeHandler(),
-		}
+		authnMiddleware.bearerAuth = bearerAuth
+		tokenHandler = bearerAuth.TokenExchangeHandler()
 	}
 
-	return AuthSetup{Middleware: authnMiddleware.tryAuthnHandlers(ctlr)}
+	return AuthSetup{
+		Middleware:   authnMiddleware.tryAuthnHandlers(ctlr),
+		TokenHandler: tokenHandler,
+	}
 }
 
 func (amw *AuthnMiddleware) sessionAuthn(ctlr *Controller, userAc *reqCtx.UserAccessControl,
@@ -425,13 +429,6 @@ func (amw *AuthnMiddleware) tryAuthnHandlers(ctlr *Controller) mux.MiddlewareFun
 			}
 
 			isMgmtRequested := request.RequestURI == constants.FullMgmt
-			isV2Requested := strings.TrimSuffix(request.URL.Path, "/") == constants.RoutePrefix
-			// Match Docker daemon-proxied requests regardless of the upstream client tool.
-			// The Docker daemon always prefixes its UA with "docker/<version>" when proxying,
-			// while the upstream tool (docker CLI, compose, buildx, etc.) appears inside
-			// "UpstreamClient(...)". Direct Docker CLI requests use "Docker-Client/...".
-			ua := request.Header.Get("User-Agent")
-			isDockerClient := strings.Contains(ua, "Docker-Client") || strings.HasPrefix(ua, "docker/")
 
 			// Get auth config safely
 			authConfig := ctlr.Config.CopyAuthConfig()
@@ -461,8 +458,14 @@ func (amw *AuthnMiddleware) tryAuthnHandlers(ctlr *Controller) mux.MiddlewareFun
 			case hasMultipleAuthorizationHeaders(request):
 				authenticated = false
 
-			// The authorization header presence is an explicit attempt to use basic authentication
-			case !isAuthorizationHeaderEmpty(request) && authConfig.IsBasicAuthnEnabled():
+			// Bearer credentials are owned by the bearer backends.
+			case hasBearerAuthorizationHeader(request) && amw.bearerAuth != nil:
+				amw.bearerAuth.Middleware(ctlr)(next).ServeHTTP(response, request)
+
+				return
+
+			// Basic credentials are owned by htpasswd/LDAP/API key authentication.
+			case hasBasicAuthorizationHeader(request) && authConfig.CanAuthenticateWithBasicCredentials():
 				authenticated, err = amw.basicAuthn(ctlr, userAc, response, request)
 
 			// The session header is an explicit attempt to use session authentication
@@ -482,21 +485,13 @@ func (amw *AuthnMiddleware) tryAuthnHandlers(ctlr *Controller) mux.MiddlewareFun
 				authenticated, err = amw.mTLSAuthn(ctlr, userAc, request)
 
 			// If no auth methods enabled at all - then just authenticate anything
-			case !authConfig.IsBasicAuthnEnabled() && !ctlr.Config.IsMTLSAuthEnabled():
+			case !authConfig.IsBasicAuthnEnabled() && !authConfig.IsBearerAuthEnabled() && !ctlr.Config.IsMTLSAuthEnabled():
 				authenticated = true
 
-			// If no credentials provided - check for anonymous / mgmt / metrics requests
-			case allowAnonymous || isMgmtRequested || isMetricsRequestedWithAnonymousAccess:
-				// Docker workaround: force 401 on /v2/ when anonymous policies coexist with
-				// authenticated-only policies. Otherwise Docker treats 200 on /v2/ as "no auth"
-				// and will not send stored credentials for protected repositories.
-				// See: https://github.com/opencontainers/wg-auth/blob/main/docs/implementations/moby.md
-				hasMixedPolicy := accessControlConfig.HasMixedAnonymousAndAuthenticatedPolicies()
-				if isDockerClient && isV2Requested && hasMixedPolicy && authConfig.CanAuthenticateWithBasicCredentials() {
-					authenticated = false
-				} else {
-					authenticated = true
-				}
+			// If no credentials provided - check for anonymous / mgmt / metrics requests.
+			case canUseAnonymousAuthnFallback(request, authConfig, allowAnonymous, isMgmtRequested,
+				isMetricsRequestedWithAnonymousAccess):
+				authenticated = true
 			}
 
 			// If error occurred during authn process - return 500 error
@@ -506,9 +501,12 @@ func (amw *AuthnMiddleware) tryAuthnHandlers(ctlr *Controller) mux.MiddlewareFun
 				return
 			}
 
-			if authenticated {
+			switch {
+			case authenticated:
 				next.ServeHTTP(response, request)
-			} else {
+			case isAuthorizationHeaderEmpty(request) && amw.bearerAuth != nil:
+				amw.bearerAuth.Middleware(ctlr)(next).ServeHTTP(response, request)
+			default:
 				authFail(response, request, realm, delay)
 			}
 		})
@@ -850,6 +848,45 @@ func isAuthorizationHeaderEmpty(request *http.Request) bool {
 	}
 
 	return false
+}
+
+func authorizationHeaderScheme(request *http.Request) string {
+	header := strings.TrimSpace(request.Header.Get("Authorization"))
+	if header == "" {
+		return ""
+	}
+
+	scheme, _, found := strings.Cut(header, " ")
+	if !found {
+		return strings.ToLower(header)
+	}
+
+	return strings.ToLower(scheme)
+}
+
+func hasBasicAuthorizationHeader(request *http.Request) bool {
+	return !isAuthorizationHeaderEmpty(request) && authorizationHeaderScheme(request) == "basic"
+}
+
+func hasBearerAuthorizationHeader(request *http.Request) bool {
+	return !isAuthorizationHeaderEmpty(request) && authorizationHeaderScheme(request) == "bearer"
+}
+
+func canUseAnonymousAuthnFallback(request *http.Request, authConfig *config.AuthConfig,
+	allowAnonymous, isMgmtRequested, isMetricsRequestedWithAnonymousAccess bool,
+) bool {
+	if !allowAnonymous && !isMgmtRequested && !isMetricsRequestedWithAnonymousAccess {
+		return false
+	}
+
+	if isAuthorizationHeaderEmpty(request) {
+		return true
+	}
+
+	// mTLS-only configs historically ignore stray Authorization headers and can still
+	// fall back to anonymous access. Basic and bearer configs own Authorization
+	// headers, so an unsupported scheme must fail instead of becoming anonymous.
+	return !authConfig.IsBasicAuthnEnabled() && !authConfig.IsBearerAuthEnabled()
 }
 
 // hasMultipleAuthorizationHeaders checks if the request has multiple Authorization headers.

--- a/pkg/api/authn_test.go
+++ b/pkg/api/authn_test.go
@@ -1187,6 +1187,96 @@ func TestMultipleAuthorizationHeaders(t *testing.T) {
 	})
 }
 
+func TestBearerAuthDoesNotShortCircuitOtherAuthn(t *testing.T) {
+	Convey("Bearer auth does not disable OpenID, htpasswd, or API-key auth", t, func() {
+		tempDir := t.TempDir()
+
+		caCert, caKey, err := tlsutils.GenerateCACert()
+		So(err, ShouldBeNil)
+
+		serverCertPath := path.Join(tempDir, "server.cert")
+		serverKeyPath := path.Join(tempDir, "server.key")
+		opts := &tlsutils.CertificateOptions{Hostname: "localhost"}
+		err = tlsutils.GenerateServerCertToFile(caCert, caKey, serverCertPath, serverKeyPath, opts)
+		So(err, ShouldBeNil)
+
+		username, _ := test.GenerateRandomString()
+		password, _ := test.GenerateRandomString()
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
+
+		mockOIDCServer, err := authutils.MockOIDCRun()
+		So(err, ShouldBeNil)
+
+		defer func() {
+			err := mockOIDCServer.Shutdown()
+			So(err, ShouldBeNil)
+		}()
+
+		mockOIDCConfig := mockOIDCServer.Config()
+		apiKeyEnabled := true
+
+		conf := config.New()
+		port := test.GetFreePort()
+		baseURL := test.GetBaseURL(port)
+		conf.HTTP.Port = port
+		conf.HTTP.Auth = &config.AuthConfig{
+			HTPasswd: config.AuthHTPasswd{Path: htpasswdPath},
+			OpenID: &config.OpenIDConfig{
+				Providers: map[string]config.OpenIDProviderConfig{
+					"oidc": {
+						ClientID:     mockOIDCConfig.ClientID,
+						ClientSecret: mockOIDCConfig.ClientSecret,
+						Issuer:       mockOIDCConfig.Issuer,
+						Scopes:       []string{"openid", "email"},
+					},
+				},
+			},
+			APIKey: apiKeyEnabled,
+			Bearer: &config.BearerConfig{
+				Cert:    serverCertPath,
+				Realm:   "test-realm",
+				Service: "test-service",
+			},
+		}
+		conf.Storage.RootDirectory = t.TempDir()
+
+		ctlr := api.NewController(conf)
+		cm := test.NewControllerManager(ctlr)
+		cm.StartAndWait(port)
+		defer cm.StopServer()
+
+		_, ok := ctlr.RelyingParties["oidc"]
+		So(ok, ShouldBeTrue)
+
+		payload := api.APIKeyPayload{
+			Label:  "mixed-auth",
+			Scopes: []string{"test"},
+		}
+		reqBody, err := json.Marshal(payload)
+		So(err, ShouldBeNil)
+
+		resp, err := resty.R().
+			SetBody(reqBody).
+			SetBasicAuth(username, password).
+			Post(baseURL + constants.APIKeyPath)
+		So(err, ShouldBeNil)
+		So(resp, ShouldNotBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		var created apiKeyResponse
+		err = json.Unmarshal(resp.Body(), &created)
+		So(err, ShouldBeNil)
+		So(created.APIKey, ShouldNotBeEmpty)
+
+		resp, err = resty.R().
+			SetBasicAuth(username, created.APIKey).
+			Get(baseURL + "/v2/_catalog")
+		So(err, ShouldBeNil)
+		So(resp, ShouldNotBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+	})
+}
+
 func TestBearerOIDCWorkloadIdentity(t *testing.T) {
 	Convey("Test bearer auth with OIDC workload identity", t, func() {
 		// Generate test keys for mock OIDC server

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -601,6 +601,21 @@ func (config *AccessControlConfig) AnonymousPolicyExists() bool {
 	return false
 }
 
+// HasAnonymousReadPolicy reports whether at least one repository grants anonymous read access.
+func (config *AccessControlConfig) HasAnonymousReadPolicy() bool {
+	if config == nil {
+		return false
+	}
+
+	for _, repository := range config.Repositories {
+		if slices.Contains(repository.AnonymousPolicy, "read") {
+			return true
+		}
+	}
+
+	return false
+}
+
 // HasMixedAnonymousAndAuthenticatedPolicies reports whether the access control configuration contains
 // at least one anonymous repository policy AND at least one authenticated-only policy
 // (default/admin/user-specific).

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -1219,6 +1219,28 @@ func TestConfig(t *testing.T) {
 			So(accessControlConfig.AnonymousPolicyExists(), ShouldBeFalse)
 		})
 
+		Convey("Test HasAnonymousReadPolicy()", func() {
+			var accessControlConfig *config.AccessControlConfig = nil
+			So(accessControlConfig.HasAnonymousReadPolicy(), ShouldBeFalse)
+
+			accessControlConfig = &config.AccessControlConfig{}
+			So(accessControlConfig.HasAnonymousReadPolicy(), ShouldBeFalse)
+
+			accessControlConfig.Repositories = config.Repositories{
+				"repo1": config.PolicyGroup{
+					AnonymousPolicy: []string{"create"},
+				},
+			}
+			So(accessControlConfig.HasAnonymousReadPolicy(), ShouldBeFalse)
+
+			accessControlConfig.Repositories = config.Repositories{
+				"repo1": config.PolicyGroup{
+					AnonymousPolicy: []string{"read"},
+				},
+			}
+			So(accessControlConfig.HasAnonymousReadPolicy(), ShouldBeTrue)
+		})
+
 		Convey("Test GetRepositories()", func() {
 			repositories := config.Repositories{
 				"repo1": config.PolicyGroup{

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -14484,14 +14484,14 @@ func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 
 			defer cm.StopServer()
 
-			// Docker client without credentials should get 401
+			// Docker client without credentials should get 200 for anonymous read.
 			resp, err := resty.R().
 				SetHeader("User-Agent", "docker/26.1.3 go/go1.22.2 UpstreamClient(Docker-Client/26.1.3 (linux))").
 				Get(baseURL + "/v2/")
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
-			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
-			So(resp.Header().Get("WWW-Authenticate"), ShouldContainSubstring, "Basic realm=")
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			So(resp.Header().Get("WWW-Authenticate"), ShouldBeEmpty)
 
 			// Docker client with valid credentials should get 200
 			resp, err = resty.R().
@@ -14502,7 +14502,7 @@ func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 			So(resp, ShouldNotBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 
-			// Docker Compose client without credentials should get 401
+			// Docker Compose client without credentials should get 200 for anonymous read.
 			// (daemon-proxied with compose upstream client, UA starts with "docker/")
 			composeUA := "docker/29.4.0 go/go1.24.2 UpstreamClient(compose/v5.1.2)"
 			resp, err = resty.R().
@@ -14510,8 +14510,8 @@ func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 				Get(baseURL + "/v2/")
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
-			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
-			So(resp.Header().Get("WWW-Authenticate"), ShouldContainSubstring, "Basic realm=")
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			So(resp.Header().Get("WWW-Authenticate"), ShouldBeEmpty)
 
 			// Docker Compose client with valid credentials should get 200
 			resp, err = resty.R().
@@ -14522,15 +14522,15 @@ func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 			So(resp, ShouldNotBeNil)
 			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 
-			// Docker Buildx client without credentials should get 401
+			// Docker Buildx client without credentials should get 200 for anonymous read.
 			// (daemon-proxied with buildx upstream client)
 			resp, err = resty.R().
 				SetHeader("User-Agent", "docker/29.4.0 go/go1.24.2 UpstreamClient(buildx/v0.21.2)").
 				Get(baseURL + "/v2/")
 			So(err, ShouldBeNil)
 			So(resp, ShouldNotBeNil)
-			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
-			So(resp.Header().Get("WWW-Authenticate"), ShouldContainSubstring, "Basic realm=")
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			So(resp.Header().Get("WWW-Authenticate"), ShouldBeEmpty)
 
 			// Podman client without credentials should get 200 (unaffected by workaround)
 			resp, err = resty.R().

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -289,7 +289,10 @@ func (rh *RouteHandler) CheckVersionSupport(response http.ResponseWriter, reques
 	// work correctly
 	// Get auth config safely
 	authConfig := rh.c.Config.CopyAuthConfig()
-	if authConfig.IsBasicAuthnEnabled() || authConfig.IsBearerAuthEnabled() {
+	accessControlConfig := rh.c.Config.CopyAccessControlConfig()
+	anonymousRead := isAuthorizationHeaderEmpty(request) && accessControlConfig.HasAnonymousReadPolicy()
+
+	if (authConfig.IsBasicAuthnEnabled() || authConfig.IsBearerAuthEnabled()) && !anonymousRead {
 		// don't send auth headers if request is coming from UI
 		if request.Header.Get(constants.SessionClientHeaderName) != constants.SessionClientHeaderValue {
 			if authConfig.Bearer != nil {


### PR DESCRIPTION
Fixes: #4033
Fixes: #4173

Implements the plan described here: https://github.com/project-zot/zot/issues/4033#issuecomment-4883700669

> Generated with codex/gpt-5.5:
>
> - Remove the bearer-auth short-circuit (the root cause of this issue).
> - Initialize OpenID/session/API-key/basic/mTLS auth even when bearer auth is configured.
> - Route broad Zot OCI/API requests by credential shape:
>   - `Authorization: Bearer ...` -> `bearer.oidc`, then traditional bearer.
>   - `Authorization: Basic ...` -> htpasswd/LDAP/API key.
>   - UI session header + cookie -> OpenID/session.
>   - client certificate -> mTLS.
>   - no credentials -> anonymous when policy allows it.
> - Preserve anonymous as Zot's existing empty-username model, not as a configured username/group.
> - Refine Docker `/v2/` challenge behavior so anonymous pulls still work when `anonymousPolicy` grants read.