### PR TITLE
feat(retention): add untagged retention configuration

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -198,6 +198,7 @@ You can also force a full reparse with the `--force-reparse` flag to `zot serve`
 ## Retention
 
 You can define tag retention rules that govern how many tags of a given repository to retain, or for how long to retain certain tags.
+You can also define `keepUntagged` rules for untagged manifests, including manifests cached by digest-only pull-through requests.
 
 There are 4 possible rules for tags:
 
@@ -206,7 +207,12 @@ mostRecentlyPulledCount: x - top x most recently pulled tags
 pulledWithin: x hours - tags pulled in the last x hours
 pushedWithin: x hours - tags pushed in the last x hours
 
-If ANY of these rules are met by a tag, then it will be retained, in other words there is an OR logic between them
+The same 4 rules can be used under `keepUntagged`; for digest-only cached content, pushed means cached locally at the descriptor's push timestamp.
+Tagged and untagged manifests are evaluated separately, so counts in `keepTags` do not compete with counts in `keepUntagged`.
+An empty `keepUntagged: {}` does not retain all untagged manifests; it is equivalent to omitting `keepUntagged`.
+`keepUntagged` rules require the metadata database. If it is unavailable, zot ignores `keepUntagged` and uses the existing delay-based untagged cleanup.
+
+If ANY of these rules are met by a tag or untagged manifest, then it will be retained, in other words there is an OR logic between them
 
 repositories uses glob patterns
 tag patterns uses regex
@@ -236,7 +242,11 @@ tag patterns uses regex
                         "patterns": ["v1.*"],           // all the other tags will be removed
                         "pulledWithin": "168h",      
                         "pushedWithin": "168h"
-                    }]
+                    }],
+                    "keepUntagged": {                   // untagged manifests pulled or cached locally within the last 168h are retained
+                        "pulledWithin": "168h",
+                        "pushedWithin": "168h"
+                    }
                 },
                 {
                     "repositories": ["**"],
@@ -247,7 +257,13 @@ tag patterns uses regex
                         "mostRecentlyPulledCount": 10,    // top 10 recently pulled tags
                         "pulledWithin": "720h",
                         "pushedWithin": "720h"
-                    }]
+                    }],
+                    "keepUntagged": {
+                        "mostRecentlyPushedCount": 10,    // top 10 recently cached/pushed untagged manifests
+                        "mostRecentlyPulledCount": 10,    // top 10 recently pulled untagged manifests
+                        "pulledWithin": "720h",
+                        "pushedWithin": "720h"
+                    }
                 }
             ]
         }
@@ -256,6 +272,7 @@ tag patterns uses regex
 If a repo doesn't match any policy, then that repo and all its tags are retained. (default is to not delete anything)
 If keepTags is empty, then all tags are retained (default is to retain all tags)
 If we have at least one tagRetention policy in the tagRetention list then all tags that don't match at least one of them will be removed!
+`deleteUntagged` remains the master switch for untagged manifests. When `deleteUntagged` is true and `keepUntagged` is configured, untagged manifests that fail `keepUntagged` rules still honor the configured retention delay before deletion. Without `keepUntagged`, untagged manifests keep the existing delay-based cleanup behavior.
 
 For safety purpose you can have a default policy as the last policy in list, all tags that don't match the above policies will be retained by this one:
 ```

--- a/examples/config-retention.json
+++ b/examples/config-retention.json
@@ -28,7 +28,11 @@
                         "patterns": ["v1.*"],
                         "pulledWithin": "168h",
                         "pushedWithin": "168h"
-                    }]
+                    }],
+                    "keepUntagged": {
+                        "pulledWithin": "168h",
+                        "pushedWithin": "168h"
+                    }
                 },
                 {
                     "repositories": ["**"],
@@ -39,7 +43,13 @@
                         "mostRecentlyPulledCount": 10,
                         "pulledWithin": "720h",
                         "pushedWithin": "720h"
-                    }]
+                    }],
+                    "keepUntagged": {
+                        "mostRecentlyPushedCount": 10,
+                        "mostRecentlyPulledCount": 10,
+                        "pulledWithin": "720h",
+                        "pushedWithin": "720h"
+                    }
                 }
             ]
         },

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -56,10 +56,18 @@ type RetentionPolicy struct {
 	DeleteReferrers bool
 	DeleteUntagged  *bool
 	KeepTags        []KeepTagsPolicy
+	KeepUntagged    *KeepUntaggedPolicy
 }
 
 type KeepTagsPolicy struct {
 	Patterns                []string
+	PulledWithin            *time.Duration
+	PushedWithin            *time.Duration
+	MostRecentlyPushedCount int
+	MostRecentlyPulledCount int
+}
+
+type KeepUntaggedPolicy struct {
 	PulledWithin            *time.Duration
 	PushedWithin            *time.Duration
 	MostRecentlyPushedCount int
@@ -845,6 +853,10 @@ func (c *Config) isRetentionEnabledInternal() bool {
 				needsMetaDB = true
 			}
 		}
+
+		if c.isUntaggedRetentionEnabledForPolicy(retentionPolicy) {
+			needsMetaDB = true
+		}
 	}
 
 	for _, subpath := range c.Storage.SubPaths {
@@ -853,6 +865,10 @@ func (c *Config) isRetentionEnabledInternal() bool {
 				if c.isTagsRetentionEnabled(tagRetentionPolicy) {
 					needsMetaDB = true
 				}
+			}
+
+			if c.isUntaggedRetentionEnabledForPolicy(retentionPolicy) {
+				needsMetaDB = true
 			}
 		}
 	}
@@ -870,6 +886,23 @@ func (c *Config) isTagsRetentionEnabled(tagRetentionPolicy KeepTagsPolicy) bool 
 	}
 
 	return false
+}
+
+func (c *Config) isUntaggedRetentionEnabled(untaggedRetentionPolicy KeepUntaggedPolicy) bool {
+	if untaggedRetentionPolicy.MostRecentlyPulledCount != 0 ||
+		untaggedRetentionPolicy.MostRecentlyPushedCount != 0 ||
+		untaggedRetentionPolicy.PulledWithin != nil ||
+		untaggedRetentionPolicy.PushedWithin != nil {
+		return true
+	}
+
+	return false
+}
+
+func (c *Config) isUntaggedRetentionEnabledForPolicy(retentionPolicy RetentionPolicy) bool {
+	return retentionPolicy.KeepUntagged != nil &&
+		(retentionPolicy.DeleteUntagged == nil || *retentionPolicy.DeleteUntagged) &&
+		c.isUntaggedRetentionEnabled(*retentionPolicy.KeepUntagged)
 }
 
 func isSensitiveConfigMapKey(key string) bool {

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -645,6 +645,42 @@ func TestConfig(t *testing.T) {
 		}
 		So(conf.IsRetentionEnabled(), ShouldBeTrue)
 
+		// Test KeepUntagged with retention criteria
+		conf = config.New()
+		conf.Storage.Retention.Policies = []config.RetentionPolicy{
+			{
+				Repositories: []string{"repo"},
+				KeepUntagged: &config.KeepUntaggedPolicy{
+					MostRecentlyPulledCount: 2,
+				},
+			},
+		}
+		So(conf.IsRetentionEnabled(), ShouldBeTrue)
+
+		// Test KeepUntagged with retention criteria and deleteUntagged disabled
+		conf = config.New()
+		deleteUntagged := false
+		conf.Storage.Retention.Policies = []config.RetentionPolicy{
+			{
+				Repositories:   []string{"repo"},
+				DeleteUntagged: &deleteUntagged,
+				KeepUntagged: &config.KeepUntaggedPolicy{
+					MostRecentlyPulledCount: 2,
+				},
+			},
+		}
+		So(conf.IsRetentionEnabled(), ShouldBeFalse)
+
+		// Test KeepUntagged without criteria
+		conf = config.New()
+		conf.Storage.Retention.Policies = []config.RetentionPolicy{
+			{
+				Repositories: []string{"repo"},
+				KeepUntagged: &config.KeepUntaggedPolicy{},
+			},
+		}
+		So(conf.IsRetentionEnabled(), ShouldBeFalse)
+
 		// Test SubPaths with retention policies
 		conf = config.New()
 		conf.Storage.SubPaths = map[string]config.StorageConfig{
@@ -665,6 +701,25 @@ func TestConfig(t *testing.T) {
 			},
 		}
 		So(conf.IsRetentionEnabled(), ShouldBeTrue)
+
+		// Test SubPaths with KeepUntagged criteria and deleteUntagged disabled
+		conf = config.New()
+		conf.Storage.SubPaths = map[string]config.StorageConfig{
+			"subpath1": {
+				Retention: config.ImageRetention{
+					Policies: []config.RetentionPolicy{
+						{
+							Repositories:   []string{"repo1"},
+							DeleteUntagged: &deleteUntagged,
+							KeepUntagged: &config.KeepUntaggedPolicy{
+								MostRecentlyPulledCount: 5,
+							},
+						},
+					},
+				},
+			},
+		}
+		So(conf.IsRetentionEnabled(), ShouldBeFalse)
 
 		// Test empty policies with no retention criteria
 		conf = config.New()

--- a/pkg/cli/server/schema_test.go
+++ b/pkg/cli/server/schema_test.go
@@ -53,6 +53,10 @@ func TestSchemaAllowsNullForPointerFields(t *testing.T) {
 									"pushedWithin": nil,
 								},
 							},
+							"keepUntagged": map[string]any{
+								"pulledWithin": nil,
+								"pushedWithin": nil,
+							},
 						},
 					},
 				},

--- a/pkg/retention/candidate.go
+++ b/pkg/retention/candidate.go
@@ -3,6 +3,7 @@ package retention
 import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"zotregistry.dev/zot/v2/pkg/compat"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/retention/types"
 )
@@ -35,6 +36,56 @@ func GetCandidates(repoMeta mTypes.RepoMeta) []*types.Candidate {
 	}
 
 	return candidates
+}
+
+func GetUntaggedCandidates(repoMeta mTypes.RepoMeta, index ispec.Index) []*types.Candidate {
+	candidates := make([]*types.Candidate, 0)
+
+	for _, manifest := range index.Manifests {
+		if !isUntaggedRetentionDescriptor(manifest) {
+			continue
+		}
+
+		digestStr := manifest.Digest.String()
+
+		stats, hasStatistics := repoMeta.Statistics[digestStr]
+		if !hasStatistics {
+			continue
+		}
+
+		candidate := &types.Candidate{
+			MediaType:     manifest.MediaType,
+			DigestStr:     digestStr,
+			PushTimestamp: stats.PushTimestamp,
+			PullTimestamp: stats.LastPullTimestamp,
+		}
+
+		candidates = append(candidates, candidate)
+	}
+
+	return candidates
+}
+
+func getIndexUntaggedDigests(index ispec.Index) []string {
+	digests := make([]string, 0)
+
+	for _, manifest := range index.Manifests {
+		if isUntaggedRetentionDescriptor(manifest) {
+			digests = append(digests, manifest.Digest.String())
+		}
+	}
+
+	return digests
+}
+
+func isUntaggedRetentionDescriptor(manifest ispec.Descriptor) bool {
+	if _, ok := manifest.Annotations[ispec.AnnotationRefName]; ok {
+		return false
+	}
+
+	return manifest.MediaType == ispec.MediaTypeImageManifest || manifest.MediaType == ispec.MediaTypeImageIndex ||
+		compat.IsCompatibleManifestMediaType(manifest.MediaType) ||
+		compat.IsCompatibleManifestListMediaType(manifest.MediaType)
 }
 
 func GetCandidatesFromIndex(index ispec.Index) []*types.Candidate {

--- a/pkg/retention/candidate_test.go
+++ b/pkg/retention/candidate_test.go
@@ -1,11 +1,16 @@
 package retention_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
+	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	zlog "zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/retention"
 )
@@ -114,5 +119,164 @@ func TestGetCandidatesWithMissingStatistics(t *testing.T) {
 			// Should return empty list and not panic
 			So(candidates, ShouldHaveLength, 0)
 		})
+	})
+}
+
+func TestGetUntaggedCandidates(t *testing.T) {
+	Convey("GetUntaggedCandidates should use only untagged descriptors with statistics", t, func() {
+		now := time.Now()
+		untaggedDigest := godigest.FromString("untagged")
+		taggedDigest := godigest.FromString("tagged")
+		missingStatsDigest := godigest.FromString("missing-stats")
+
+		index := ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{
+					Digest:    untaggedDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				},
+				{
+					Digest:    taggedDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+					Annotations: map[string]string{
+						ispec.AnnotationRefName: "latest",
+					},
+				},
+				{
+					Digest:    missingStatsDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				},
+			},
+		}
+
+		repoMeta := mTypes.RepoMeta{
+			Name: "test-repo",
+			Statistics: map[string]mTypes.DescriptorStatistics{
+				untaggedDigest.String(): {
+					PushTimestamp:     now.Add(-2 * time.Hour),
+					LastPullTimestamp: now.Add(-time.Hour),
+					DownloadCount:     3,
+				},
+				taggedDigest.String(): {
+					PushTimestamp:     now,
+					LastPullTimestamp: now,
+				},
+			},
+		}
+
+		candidates := retention.GetUntaggedCandidates(repoMeta, index)
+
+		So(candidates, ShouldHaveLength, 1)
+		So(candidates[0].DigestStr, ShouldEqual, untaggedDigest.String())
+		So(candidates[0].Tag, ShouldBeEmpty)
+	})
+}
+
+func TestGetRetainedUntaggedFromMetaDB(t *testing.T) {
+	Convey("GetRetainedUntaggedFromMetaDB applies untagged retention rules separately", t, func() {
+		now := time.Now()
+		recentDigest := godigest.FromString("recent")
+		oldDigest := godigest.FromString("old")
+		pulledWithin := 24 * time.Hour
+
+		index := ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{
+					Digest:    recentDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				},
+				{
+					Digest:    oldDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				},
+			},
+		}
+
+		repoMeta := mTypes.RepoMeta{
+			Name: "test-repo",
+			Statistics: map[string]mTypes.DescriptorStatistics{
+				recentDigest.String(): {
+					PushTimestamp:     now.Add(-time.Hour),
+					LastPullTimestamp: now.Add(-time.Hour),
+				},
+				oldDigest.String(): {
+					PushTimestamp:     now.Add(-48 * time.Hour),
+					LastPullTimestamp: now.Add(-36 * time.Hour),
+				},
+			},
+		}
+
+		policyMgr := retention.NewPolicyManager(config.ImageRetention{
+			Policies: []config.RetentionPolicy{
+				{
+					Repositories: []string{"test-repo"},
+					KeepUntagged: &config.KeepUntaggedPolicy{
+						PulledWithin:            &pulledWithin,
+						MostRecentlyPushedCount: 1,
+					},
+				},
+			},
+		}, zlog.NewTestLogger(), nil)
+
+		retained := policyMgr.GetRetainedUntaggedFromMetaDB(context.Background(), repoMeta, index)
+
+		So(retained, ShouldHaveLength, 1)
+		So(retained[0], ShouldEqual, recentDigest.String())
+	})
+
+	Convey("GetRetainedUntaggedFromMetaDB keeps untagged manifests missing statistics", t, func() {
+		now := time.Now()
+		recentDigest := godigest.FromString("recent")
+		missingStatsDigest := godigest.FromString("missing-stats")
+		oldDigest := godigest.FromString("old")
+		pulledWithin := 24 * time.Hour
+
+		index := ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{
+					Digest:    recentDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				},
+				{
+					Digest:    missingStatsDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				},
+				{
+					Digest:    oldDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				},
+			},
+		}
+
+		repoMeta := mTypes.RepoMeta{
+			Name: "test-repo",
+			Statistics: map[string]mTypes.DescriptorStatistics{
+				recentDigest.String(): {
+					PushTimestamp:     now.Add(-time.Hour),
+					LastPullTimestamp: now.Add(-time.Hour),
+				},
+				oldDigest.String(): {
+					PushTimestamp:     now.Add(-48 * time.Hour),
+					LastPullTimestamp: now.Add(-36 * time.Hour),
+				},
+			},
+		}
+
+		policyMgr := retention.NewPolicyManager(config.ImageRetention{
+			Policies: []config.RetentionPolicy{
+				{
+					Repositories: []string{"test-repo"},
+					KeepUntagged: &config.KeepUntaggedPolicy{
+						PulledWithin: &pulledWithin,
+					},
+				},
+			},
+		}, zlog.NewTestLogger(), nil)
+
+		retained := policyMgr.GetRetainedUntaggedFromMetaDB(context.Background(), repoMeta, index)
+
+		So(retained, ShouldContain, recentDigest.String())
+		So(retained, ShouldContain, missingStatsDigest.String())
+		So(retained, ShouldNotContain, oldDigest.String())
 	})
 }

--- a/pkg/retention/retention.go
+++ b/pkg/retention/retention.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"time"
 
 	glob "github.com/bmatcuk/doublestar/v4"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -18,8 +19,9 @@ import (
 
 const (
 	// reasons for gc.
-	filteredByTagRules = "didn't meet any tag retention rule"
-	filteredByTagNames = "didn't meet any tag 'patterns' rules"
+	filteredByTagRules      = "didn't meet any tag retention rule"
+	filteredByTagNames      = "didn't meet any tag 'patterns' rules"
+	filteredByUntaggedRules = "didn't meet any untagged retention rule"
 	// reasons for retention.
 	retainedStrFormat = "retained by %s policy"
 )
@@ -77,23 +79,43 @@ func (p policyManager) HasTagRetention(repo string) bool {
 	return false
 }
 
+func (p policyManager) HasUntaggedRetention(repo string) bool {
+	if policy, err := p.getRepoPolicy(repo); err == nil {
+		return policy.KeepUntagged != nil && len(p.getUntaggedRules(*policy.KeepUntagged)) > 0
+	}
+
+	return false
+}
+
 func (p policyManager) getRules(tagPolicy config.KeepTagsPolicy) []types.Rule {
+	return getRules(tagPolicy.MostRecentlyPulledCount, tagPolicy.MostRecentlyPushedCount,
+		tagPolicy.PulledWithin, tagPolicy.PushedWithin)
+}
+
+func (p policyManager) getUntaggedRules(untaggedPolicy config.KeepUntaggedPolicy) []types.Rule {
+	return getRules(untaggedPolicy.MostRecentlyPulledCount, untaggedPolicy.MostRecentlyPushedCount,
+		untaggedPolicy.PulledWithin, untaggedPolicy.PushedWithin)
+}
+
+func getRules(mostRecentlyPulledCount, mostRecentlyPushedCount int,
+	pulledWithin, pushedWithin *time.Duration,
+) []types.Rule {
 	rules := make([]types.Rule, 0)
 
-	if tagPolicy.MostRecentlyPulledCount != 0 {
-		rules = append(rules, NewLatestPull(tagPolicy.MostRecentlyPulledCount))
+	if mostRecentlyPulledCount != 0 {
+		rules = append(rules, NewLatestPull(mostRecentlyPulledCount))
 	}
 
-	if tagPolicy.MostRecentlyPushedCount != 0 {
-		rules = append(rules, NewLatestPush(tagPolicy.MostRecentlyPushedCount))
+	if mostRecentlyPushedCount != 0 {
+		rules = append(rules, NewLatestPush(mostRecentlyPushedCount))
 	}
 
-	if tagPolicy.PulledWithin != nil {
-		rules = append(rules, NewDaysPull(*tagPolicy.PulledWithin))
+	if pulledWithin != nil {
+		rules = append(rules, NewDaysPull(*pulledWithin))
 	}
 
-	if tagPolicy.PushedWithin != nil {
-		rules = append(rules, NewDaysPush(*tagPolicy.PushedWithin))
+	if pushedWithin != nil {
+		rules = append(rules, NewDaysPush(*pushedWithin))
 	}
 
 	return rules
@@ -240,6 +262,89 @@ func (p policyManager) GetRetainedTagsFromMetaDB(ctx context.Context, repoMeta m
 	return retainTags
 }
 
+func (p policyManager) GetRetainedUntaggedFromMetaDB(ctx context.Context, repoMeta mTypes.RepoMeta,
+	index ispec.Index,
+) []string {
+	repo := repoMeta.Name
+	policy, err := p.getRepoPolicy(repo)
+	if err != nil || policy.KeepUntagged == nil {
+		return nil
+	}
+
+	candidates := GetUntaggedCandidates(repoMeta, index)
+	retainDigests := make([]string, 0)
+	retainDigestsSet := make(map[string]struct{})
+	candidateDigestsSet := make(map[string]struct{}, len(candidates))
+
+	for _, candidate := range candidates {
+		candidateDigestsSet[candidate.DigestStr] = struct{}{}
+	}
+
+	for _, digestStr := range getIndexUntaggedDigests(index) {
+		if _, found := candidateDigestsSet[digestStr]; found {
+			continue
+		}
+
+		if _, retained := retainDigestsSet[digestStr]; retained {
+			continue
+		}
+
+		p.log.Info().Str("module", "retention").
+			Bool("dry-run", p.config.DryRun).
+			Str("repository", repo).
+			Str("digest", digestStr).
+			Str("reference", digestStr).
+			Str("decision", "keep").
+			Str("reason", "untagged manifest statistics not found").Msg("will keep untagged manifest")
+
+		retainDigestsSet[digestStr] = struct{}{}
+		retainDigests = append(retainDigests, digestStr)
+	}
+
+	retainCandidates := candidates
+	rules := p.getUntaggedRules(*policy.KeepUntagged)
+	if len(rules) == 0 {
+		return nil
+	}
+
+	rulesCandidates := make([]*types.Candidate, 0)
+
+	for _, rule := range rules {
+		if zcommon.IsContextDone(ctx) {
+			return nil
+		}
+
+		ruleCandidates := rule.Perform(retainCandidates)
+
+		rulesCandidates = append(rulesCandidates, ruleCandidates...)
+	}
+
+	retainCandidates = rulesCandidates
+
+	for _, retainCandidate := range retainCandidates {
+		if _, ok := retainDigestsSet[retainCandidate.DigestStr]; !ok {
+			reason := fmt.Sprintf(retainedStrFormat, retainCandidate.RetainedBy)
+
+			logDigestAction(repo, "keep", reason, retainCandidate, p.config.DryRun, &p.log)
+
+			retainDigestsSet[retainCandidate.DigestStr] = struct{}{}
+			retainDigests = append(retainDigests, retainCandidate.DigestStr)
+		}
+	}
+
+	for _, candidateInfo := range candidates {
+		if _, ok := retainDigestsSet[candidateInfo.DigestStr]; !ok {
+			logDigestAction(repo, "delete", filteredByUntaggedRules, candidateInfo, p.config.DryRun, &p.log)
+
+			if p.auditLog != nil {
+				logDigestAction(repo, "delete", filteredByUntaggedRules, candidateInfo, p.config.DryRun, p.auditLog)
+			}
+		}
+	}
+
+	return retainDigests
+}
+
 func (p policyManager) getRepoPolicy(repo string) (config.RetentionPolicy, error) {
 	for _, policy := range p.config.Policies {
 		for _, pattern := range policy.Repositories {
@@ -306,6 +411,19 @@ func logAction(repo, decision, reason string, candidate *types.Candidate, dryRun
 		Str("pushTimestamp", candidate.PushTimestamp.String()).
 		Str("decision", decision).
 		Str("reason", reason).Msg("applied policy")
+}
+
+func logDigestAction(repo, decision, reason string, candidate *types.Candidate, dryRun bool, log *zlog.Logger) {
+	log.Info().Str("module", "retention").
+		Bool("dry-run", dryRun).
+		Str("repository", repo).
+		Str("mediaType", candidate.MediaType).
+		Str("digest", candidate.DigestStr).
+		Str("reference", candidate.DigestStr).
+		Str("lastPullTimestamp", candidate.PullTimestamp.String()).
+		Str("pushTimestamp", candidate.PushTimestamp.String()).
+		Str("decision", decision).
+		Str("reason", reason).Msg("applied untagged policy")
 }
 
 func getIndexTags(index ispec.Index) []string {

--- a/pkg/retention/types/types.go
+++ b/pkg/retention/types/types.go
@@ -21,9 +21,11 @@ type Candidate struct {
 type PolicyManager interface {
 	HasDeleteReferrer(repo string) bool
 	HasDeleteUntagged(repo string) bool
+	HasUntaggedRetention(repo string) bool
 	HasTagRetention(repo string) bool
 	GetRetainedTagsFromIndex(ctx context.Context, repo string, index ispec.Index) []string
 	GetRetainedTagsFromMetaDB(ctx context.Context, repoMeta mTypes.RepoMeta, index ispec.Index) []string
+	GetRetainedUntaggedFromMetaDB(ctx context.Context, repoMeta mTypes.RepoMeta, index ispec.Index) []string
 }
 
 type Rule interface {

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -408,7 +408,7 @@ func (gc GarbageCollect) removeManifestsPerRepoPolicy(ctx context.Context, repo 
 			}
 
 			// apply image retention policy
-			gcedUntagged, err = gc.removeUntaggedManifests(repo, index, referenced)
+			gcedUntagged, err = gc.removeUntaggedManifests(ctx, repo, index, referenced)
 			if err != nil {
 				return err
 			}
@@ -699,7 +699,7 @@ func (gc GarbageCollect) removeManifest(repo string, index *ispec.Index,
 	return true, nil
 }
 
-func (gc GarbageCollect) removeUntaggedManifests(repo string, index *ispec.Index,
+func (gc GarbageCollect) removeUntaggedManifests(ctx context.Context, repo string, index *ispec.Index,
 	referenced map[godigest.Digest]bool,
 ) (bool, error) {
 	var gced bool
@@ -707,6 +707,27 @@ func (gc GarbageCollect) removeUntaggedManifests(repo string, index *ispec.Index
 	var err error
 
 	gc.log.Debug().Str("module", "gc").Str("repository", repo).Msg("manifests without tags")
+
+	retainUntagged := make(map[string]bool)
+	if gc.policyMgr.HasUntaggedRetention(repo) {
+		if gc.metaDB != nil {
+			repoMeta, err := gc.metaDB.GetRepoMeta(ctx, repo)
+			if err != nil {
+				gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).
+					Msg("failed to get repoMeta for untagged retention")
+
+				return false, err
+			}
+
+			for _, digestStr := range gc.policyMgr.GetRetainedUntaggedFromMetaDB(ctx, repoMeta, *index) {
+				retainUntagged[digestStr] = true
+			}
+		} else {
+			gc.log.Warn().Str("module", "gc").Str("repository", repo).
+				Msg("keepUntagged policy requires metadata database;" +
+					" ignoring keepUntagged rules and using delay-based untagged cleanup")
+		}
+	}
 
 	for _, desc := range index.Manifests {
 		// skip manifests referenced in image indexes
@@ -719,6 +740,10 @@ func (gc GarbageCollect) removeUntaggedManifests(repo string, index *ispec.Index
 			desc.MediaType == ispec.MediaTypeImageIndex || compat.IsCompatibleManifestListMediaType(desc.MediaType) {
 			_, ok := getDescriptorTag(desc)
 			if !ok {
+				if retainUntagged[desc.Digest.String()] {
+					continue
+				}
+
 				gced, err = gc.gcManifest(repo, index, desc, "", "", gc.opts.ImageRetention.Delay)
 				if err != nil {
 					return false, err

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -35,6 +35,42 @@ var (
 	repoName = "test" //nolint: gochecknoglobals
 )
 
+type retentionPolicyMock struct {
+	retainedUntagged []string
+}
+
+func (rpm retentionPolicyMock) HasDeleteReferrer(repo string) bool {
+	return false
+}
+
+func (rpm retentionPolicyMock) HasDeleteUntagged(repo string) bool {
+	return true
+}
+
+func (rpm retentionPolicyMock) HasUntaggedRetention(repo string) bool {
+	return true
+}
+
+func (rpm retentionPolicyMock) HasTagRetention(repo string) bool {
+	return false
+}
+
+func (rpm retentionPolicyMock) GetRetainedTagsFromIndex(ctx context.Context, repo string, index ispec.Index) []string {
+	return nil
+}
+
+func (rpm retentionPolicyMock) GetRetainedTagsFromMetaDB(ctx context.Context, repoMeta types.RepoMeta,
+	index ispec.Index,
+) []string {
+	return nil
+}
+
+func (rpm retentionPolicyMock) GetRetainedUntaggedFromMetaDB(ctx context.Context, repoMeta types.RepoMeta,
+	index ispec.Index,
+) []string {
+	return rpm.retainedUntagged
+}
+
 func TestGarbageCollectManifestErrors(t *testing.T) {
 	Convey("Make imagestore and upload manifest", t, func(c C) {
 		dir := t.TempDir()
@@ -164,6 +200,39 @@ func TestGarbageCollectManifestErrors(t *testing.T) {
 			err = gc.addIndexBlobsToReferences(repoName, index, map[string]bool{})
 			So(err, ShouldNotBeNil)
 		})
+	})
+}
+
+func TestRemoveUntaggedManifestsWithRetention(t *testing.T) {
+	Convey("removeUntaggedManifests keeps untagged manifests retained by policy", t, func() {
+		digest := godigest.FromString("retained")
+		index := ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{
+					Digest:    digest,
+					MediaType: ispec.MediaTypeImageManifest,
+				},
+			},
+		}
+
+		gc := GarbageCollect{
+			metaDB: mocks.MetaDBMock{
+				GetRepoMetaFn: func(ctx context.Context, repo string) (types.RepoMeta, error) {
+					return types.RepoMeta{Name: repo}, nil
+				},
+			},
+			policyMgr: retentionPolicyMock{
+				retainedUntagged: []string{digest.String()},
+			},
+			log: zlog.NewTestLogger(),
+		}
+
+		gced, err := gc.removeUntaggedManifests(context.Background(), repoName, &index, map[godigest.Digest]bool{})
+
+		So(err, ShouldBeNil)
+		So(gced, ShouldBeFalse)
+		So(index.Manifests, ShouldHaveLength, 1)
+		So(index.Manifests[0].Digest, ShouldEqual, digest)
 	})
 }
 


### PR DESCRIPTION
Fixes https://github.com/project-zot/zot/issues/4148

Digest-only pull-through cache entries are stored as untagged manifests, so existing tag-based retention rules do not protect actively pulled content. This adds explicit untagged retention rules that use the same pull/push activity signals as tag retention.

Configuration
Added keepUntagged under retention policies.
Reuses mostRecentlyPushedCount, mostRecentlyPulledCount, pulledWithin, and pushedWithin. Keeps deleteUntagged as the master switch.
{
  "repositories": ["infra/*", "tmp/**"],
  "deleteUntagged": true,
  "keepTags": [{
    "patterns": ["v2.*", ".*-prod"],
    "mostRecentlyPulledCount": 10,
    "pulledWithin": "720h"
  }],
  "keepUntagged": {
    "mostRecentlyPulledCount": 10,
    "pulledWithin": "720h"
  }
}
Retention evaluation

Builds untagged candidates from index descriptors without tag annotations. Joins candidates with MetaDB digest statistics.
Evaluates tag and untagged pools independently.
Garbage collection

Skips untagged manifests retained by keepUntagged. Falls back to existing delay-based cleanup when untagged retention cannot use MetaDB statistics. Docs and schema

Updated retention examples and README guidance.
Extended generated schema coverage for keepUntagged.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
