### PR TITLE
fix(storage): defer blob deletes for cache-unknown blobs until dedupe rebuild completes

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -130,6 +130,7 @@ var (
 	ErrTimeout                          = errors.New("operation timeout")
 	ErrNotImplemented                   = errors.New("not implemented")
 	ErrDedupeRebuild                    = errors.New("couldn't rebuild dedupe index")
+	ErrDedupeRebuildInProgress          = errors.New("dedupe cache rebuild in progress, blob delete deferred")
 	ErrMissingAuthHeader                = errors.New("required authorization header is missing")
 	ErrUserAPIKeyNotFound               = errors.New("user info for given API key hash not found")
 	ErrUserSessionNotFound              = errors.New("user session for given ID not found")

--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -918,9 +918,9 @@ type restoreRunState struct {
 	// completed successfully. It is incremented when a task is generated and decremented
 	// only by onDone, which a task calls on success (see dedupeTask.DoWork). A failed task
 	// is therefore never decremented, so the count intentionally never reaches zero again
-	// for this run, preventing checkCompletion from firing OnRestoreComplete after a failure.
+	// for this run, preventing checkCompletion from firing OnRunComplete after a failure.
 	pendingTaskCount atomic.Int64
-	// completeOnce ensures OnRestoreComplete is called at most once for this run.
+	// completeOnce ensures OnRunComplete is called at most once for this run.
 	completeOnce sync.Once
 	// done is set to true once all tasks for this run have been generated. It is read
 	// both by IsDone() on the scheduler goroutine and by checkCompletion() from onDone
@@ -943,10 +943,12 @@ type DedupeTaskGenerator struct {
 	lastDigests []godigest.Digest
 	repos       []string // list of repos on which we run dedupe
 	Log         zlog.Logger
-	// OnRestoreComplete is called exactly once after ALL restore tasks have executed
-	// successfully. Used to write the restore-complete marker so the next startup with
-	// dedupe=false can skip the expensive per-digest scan.
-	OnRestoreComplete func()
+	// OnRunComplete is called exactly once after all tasks of a run have
+	// succeeded, whether the run dedupes blobs (Dedupe=true) or restores them
+	// (Dedupe=false). Restore runs use it to write the restore-complete marker;
+	// both kinds use it to signal the image store that blob deletes may proceed
+	// (see ImageStore.deleteBlob).
+	OnRunComplete func()
 	// run holds the completion-tracking state for the current run. onDone closures
 	// capture the *restoreRunState pointer directly and operate on it independently
 	// of any later Reset(). It is an atomic.Pointer because checkCompletion() compares
@@ -975,7 +977,7 @@ func (gen *DedupeTaskGenerator) getRun() *restoreRunState {
 
 // All restore tasks for this run have been generated AND all of them have completed successfully.
 func (gen *DedupeTaskGenerator) checkCompletion(run *restoreRunState) {
-	if gen.OnRestoreComplete != nil &&
+	if gen.OnRunComplete != nil &&
 		run.done.Load() &&
 		run.pendingTaskCount.Load() == 0 {
 		// Dispatch asynchronously so the executor goroutine that triggered completion
@@ -985,11 +987,11 @@ func (gen *DedupeTaskGenerator) checkCompletion(run *restoreRunState) {
 				defer func() {
 					if r := recover(); r != nil {
 						gen.Log.Error().Interface("panic", r).Str("component", "dedupe").
-							Msg("panic in OnRestoreComplete")
+							Msg("panic in OnRunComplete")
 					}
 				}()
 
-				gen.OnRestoreComplete()
+				gen.OnRunComplete()
 			}()
 		})
 	}
@@ -1044,10 +1046,10 @@ func (gen *DedupeTaskGenerator) Next() (scheduler.Task, error) {
 	// mark digest as processed before running its task
 	gen.lastDigests = append(gen.lastDigests, gen.digest)
 
-	// For restore passes, track each task so the marker is only written after all succeed.
+	// Track each task so completion fires only after all of them succeed.
 	var onDone func()
 
-	if !gen.Dedupe && gen.OnRestoreComplete != nil {
+	if gen.OnRunComplete != nil {
 		run.pendingTaskCount.Add(1)
 
 		onDone = func() {
@@ -1074,10 +1076,10 @@ func (gen *DedupeTaskGenerator) Reset() {
 
 	// Only start a fresh run if the current one has no in-flight tasks (or completion
 	// isn't tracked at all). If tasks are still executing, keep the same run state so
-	// their onDone callbacks can still drive checkCompletion to fire OnRestoreComplete
+	// their onDone callbacks can still drive checkCompletion to fire OnRunComplete
 	// once they finish; replacing gen.run here would otherwise make that run's
 	// completion unobservable forever.
-	if gen.OnRestoreComplete == nil || (run.done.Load() && run.pendingTaskCount.Load() == 0) {
+	if gen.OnRunComplete == nil || (run.done.Load() && run.pendingTaskCount.Load() == 0) {
 		gen.run.Store(&restoreRunState{})
 	}
 
@@ -1095,7 +1097,7 @@ type dedupeTask struct {
 	duplicateBlobs []string
 	dedupe         bool
 	log            zlog.Logger
-	// onDone is called when this restore task succeeds. nil for dedupe (non-restore) tasks.
+	// onDone is called when this task succeeds; nil when completion isn't tracked.
 	onDone func()
 }
 

--- a/pkg/storage/common/common_test.go
+++ b/pkg/storage/common/common_test.go
@@ -624,7 +624,7 @@ func TestDedupeGeneratorErrors(t *testing.T) {
 func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 	testLog := log.NewTestLogger()
 
-	Convey("OnRestoreComplete fires once after all restore tasks finish successfully", t, func(c C) {
+	Convey("OnRunComplete fires once after all restore tasks finish successfully", t, func(c C) {
 		digest := godigest.FromString("blob1")
 		duplicateBlobs := []string{"/repo/blob1-a", "/repo/blob1-b"}
 
@@ -662,7 +662,7 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 			ImgStore: imgStore,
 			Dedupe:   false,
 			Log:      testLog,
-			OnRestoreComplete: func() {
+			OnRunComplete: func() {
 				callCountMutex.Lock()
 				callCount++
 				callCountMutex.Unlock()
@@ -687,11 +687,11 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 		So(task, ShouldBeNil)
 		So(generator.IsDone(), ShouldBeTrue)
 
-		// OnRestoreComplete is dispatched asynchronously
+		// OnRunComplete is dispatched asynchronously
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			t.Fatal("timed out waiting for OnRestoreComplete")
+			t.Fatal("timed out waiting for OnRunComplete")
 		}
 
 		callCountMutex.Lock()
@@ -701,6 +701,76 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 		// Reset() starts a fresh run since this one completed with no pending tasks
 		generator.Reset()
 		So(generator.IsDone(), ShouldBeFalse)
+	})
+
+	Convey("OnRunComplete fires once after all dedupe tasks finish successfully", t, func(c C) {
+		digest := godigest.FromString("blob-dedupe")
+		duplicateBlobs := []string{"/repo/blob-dedupe-a", "/repo/blob-dedupe-b"}
+
+		getNextCalls := 0
+
+		imgStore := &mocks.MockedImageStore{
+			GetRepositoriesFn: func() ([]string, error) {
+				return []string{"repo1"}, nil
+			},
+			GetNextDigestWithBlobPathsFn: func(repos []string, lastDigests []godigest.Digest) (
+				godigest.Digest, []string, error,
+			) {
+				getNextCalls++
+				if getNextCalls == 1 {
+					return digest, duplicateBlobs, nil
+				}
+
+				return "", nil, nil
+			},
+			RunDedupeForDigestFn: func(ctx context.Context, digest godigest.Digest, dedupe bool,
+				duplicateBlobs []string,
+			) error {
+				return nil
+			},
+		}
+
+		var (
+			callCountMutex sync.Mutex
+			callCount      int
+		)
+
+		done := make(chan struct{})
+
+		generator := &common.DedupeTaskGenerator{
+			ImgStore: imgStore,
+			Dedupe:   true,
+			Log:      testLog,
+			OnRunComplete: func() {
+				callCountMutex.Lock()
+				callCount++
+				callCountMutex.Unlock()
+				close(done)
+			},
+		}
+
+		task, err := generator.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldNotBeNil)
+		So(generator.IsDone(), ShouldBeFalse)
+
+		err = task.DoWork(context.Background())
+		So(err, ShouldBeNil)
+
+		task, err = generator.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldBeNil)
+		So(generator.IsDone(), ShouldBeTrue)
+
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for OnRunComplete")
+		}
+
+		callCountMutex.Lock()
+		So(callCount, ShouldEqual, 1)
+		callCountMutex.Unlock()
 	})
 
 	Convey("Reset keeps the same run while a restore task is in-flight", t, func(c C) {
@@ -741,7 +811,7 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 			ImgStore: imgStore,
 			Dedupe:   false,
 			Log:      testLog,
-			OnRestoreComplete: func() {
+			OnRunComplete: func() {
 				callCountMutex.Lock()
 				callCount++
 				callCountMutex.Unlock()
@@ -760,18 +830,18 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(generator.IsDone(), ShouldBeTrue)
 
-		// Reset() must keep the same run state, since OnRestoreComplete hasn't fired yet
+		// Reset() must keep the same run state, since OnRunComplete hasn't fired yet
 		generator.Reset()
 		So(generator.IsDone(), ShouldBeTrue)
 
-		// finishing the in-flight task now drives checkCompletion to fire OnRestoreComplete
+		// finishing the in-flight task now drives checkCompletion to fire OnRunComplete
 		err = task.DoWork(context.Background())
 		So(err, ShouldBeNil)
 
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			t.Fatal("timed out waiting for OnRestoreComplete")
+			t.Fatal("timed out waiting for OnRunComplete")
 		}
 
 		callCountMutex.Lock()
@@ -779,7 +849,7 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 		callCountMutex.Unlock()
 	})
 
-	Convey("checkCompletion recovers if OnRestoreComplete panics", t, func(c C) {
+	Convey("checkCompletion recovers if OnRunComplete panics", t, func(c C) {
 		digest := godigest.FromString("blob3")
 		duplicateBlobs := []string{"/repo/blob3-a"}
 
@@ -816,7 +886,7 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 			ImgStore: imgStore,
 			Dedupe:   false,
 			Log:      panicLog,
-			OnRestoreComplete: func() {
+			OnRunComplete: func() {
 				defer close(done)
 				panic("boom")
 			},
@@ -836,18 +906,18 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 		select {
 		case <-done:
 		case <-time.After(5 * time.Second):
-			t.Fatal("timed out waiting for OnRestoreComplete")
+			t.Fatal("timed out waiting for OnRunComplete")
 		}
 
 		for range 100 {
-			if strings.Contains(logBuf.String(), "panic in OnRestoreComplete") {
+			if strings.Contains(logBuf.String(), "panic in OnRunComplete") {
 				break
 			}
 
 			time.Sleep(10 * time.Millisecond)
 		}
 
-		So(logBuf.String(), ShouldContainSubstring, "panic in OnRestoreComplete")
+		So(logBuf.String(), ShouldContainSubstring, "panic in OnRunComplete")
 	})
 
 	Convey("getRun is safe when the first call races across goroutines", t, func(c C) {

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -54,6 +55,9 @@ type ImageStore struct {
 	linter      common.Lint
 	commit      bool
 	compat      []compat.MediaCompatibility
+	// dedupeRebuildDone is set once RunDedupeBlobs has walked all blobs, i.e. the
+	// cache accounts for every pre-existing blob; see deleteBlob.
+	dedupeRebuildDone atomic.Bool
 }
 
 func (is *ImageStore) Name() string {
@@ -94,6 +98,9 @@ func NewImageStore(rootDir string, cacheDir string, dedupe, commit bool, log zlo
 		compat:      compat,
 		events:      recorder,
 	}
+
+	// Deletes are only gated while a dedupe/restore walk is pending; see RunDedupeBlobs.
+	imgStore.dedupeRebuildDone.Store(true)
 
 	return imgStore
 }
@@ -1983,7 +1990,7 @@ func (is *ImageStore) CleanupRepo(repo string, blobs []godigest.Digest, removeRe
 func (is *ImageStore) deleteBlob(repo string, digest godigest.Digest) error {
 	blobPath := is.BlobPath(repo, digest)
 
-	_, err := is.storeDriver.Stat(blobPath)
+	binfo, err := is.storeDriver.Stat(blobPath)
 	if err != nil {
 		var pathNotFoundErr driver.PathNotFoundError
 		if errors.As(err, &pathNotFoundErr) {
@@ -2007,6 +2014,16 @@ func (is *ImageStore) deleteBlob(repo string, digest godigest.Digest) error {
 				Msg("failed to lookup blob record")
 
 			return err
+		}
+
+		// Cache miss: with dedupe on remote storage this blob may be the only
+		// content copy backing zero-size duplicates elsewhere.
+		// Defer until the startup walk has rebuilt the cache; GC retries later.
+		if dstRecord == "" && binfo.Size() > 0 && !is.dedupeRebuildDone.Load() {
+			is.log.Warn().Str("digest", digest.String()).Str("blobPath", blobPath).Str("component", "dedupe").
+				Msg("no cache record for content blob while dedupe rebuild is still running, deferring delete")
+
+			return zerr.ErrDedupeRebuildInProgress
 		}
 
 		// remove cache entry and move blob contents to the next candidate if there is any
@@ -2054,6 +2071,15 @@ func (is *ImageStore) deleteBlob(repo string, digest godigest.Digest) error {
 				return nil
 			}
 		}
+	}
+
+	// No cache (dedupe off): leftover placeholders are refilled by the restore
+	// walk; until it completes this blob may be their only content copy.
+	if fmt.Sprintf("%v", is.cache) == fmt.Sprintf("%v", nil) && binfo.Size() > 0 && !is.dedupeRebuildDone.Load() {
+		is.log.Warn().Str("digest", digest.String()).Str("blobPath", blobPath).Str("component", "dedupe").
+			Msg("content blob delete requested before dedupe restore walk finished, deferring delete")
+
+		return zerr.ErrDedupeRebuildInProgress
 	}
 
 	if err := is.storeDriver.Delete(blobPath); err != nil {
@@ -2442,6 +2468,12 @@ func (is *ImageStore) RunDedupeForDigest(ctx context.Context, digest godigest.Di
 func (is *ImageStore) RunDedupeBlobs(interval time.Duration, sch *scheduler.Scheduler) {
 	markerPath := path.Join(is.rootDir, storageConstants.DedupeRestoreCompleteMarker)
 
+	// Gate deletes of cache-unknown blobs until the walk completes (see deleteBlob).
+	// Local storage dedupes via hardlinks, so deletes there never destroy shared content.
+	if is.storeDriver.Name() != storageConstants.LocalStorageDriverName {
+		is.dedupeRebuildDone.Store(false)
+	}
+
 	if is.dedupe {
 		// Dedupe is active: remove the restore-complete marker so that a future dedupe→false
 		// transition knows it must run restore again.
@@ -2470,6 +2502,9 @@ func (is *ImageStore) RunDedupeBlobs(interval time.Duration, sch *scheduler.Sche
 				is.log.Info().Str("component", "dedupe").
 					Msg("restore-complete marker present, skipping dedupe restore scan")
 
+				// storage holds no deduped blobs, so deletes are safe without a walk
+				is.dedupeRebuildDone.Store(true)
+
 				return
 			}
 
@@ -2490,16 +2525,21 @@ func (is *ImageStore) RunDedupeBlobs(interval time.Duration, sch *scheduler.Sche
 		Log:      is.log,
 	}
 
-	if !is.dedupe {
-		generator.OnRestoreComplete = func() {
-			if _, err := is.storeDriver.WriteFile(markerPath,
-				[]byte(storageConstants.DedupeRestoreMarkerComplete)); err != nil {
-				is.log.Error().Err(err).Str("component", "dedupe").
-					Msg("failed to write restore-complete marker")
-			} else {
-				is.log.Info().Str("component", "dedupe").
-					Msg("restore-complete marker written; future startups will skip the restore scan")
-			}
+	generator.OnRunComplete = func() {
+		// walk finished: deferred blob deletes may proceed (see deleteBlob)
+		is.dedupeRebuildDone.Store(true)
+
+		if is.dedupe {
+			return
+		}
+
+		if _, err := is.storeDriver.WriteFile(markerPath,
+			[]byte(storageConstants.DedupeRestoreMarkerComplete)); err != nil {
+			is.log.Error().Err(err).Str("component", "dedupe").
+				Msg("failed to write restore-complete marker")
+		} else {
+			is.log.Info().Str("component", "dedupe").
+				Msg("restore-complete marker written; future startups will skip the restore scan")
 		}
 	}
 

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -4017,5 +4018,372 @@ func TestInjectDedupe(t *testing.T) {
 		} else {
 			So(err, ShouldBeNil)
 		}
+	})
+}
+
+// Deleting a blob the dedupe cache cannot account for must be
+// deferred until the startup dedupe walk completes.
+func TestDeleteBlobDeferredDuringDedupeRebuild(t *testing.T) {
+	testDir := "/oci-repo-test/dedupe-rebuild-delete"
+	repoName := "repo"
+
+	content := []byte("content-bearing-blob")
+	contentDigest := godigest.FromBytes(content)
+	contentBlobPath := path.Join(testDir, repoName, "blobs",
+		contentDigest.Algorithm().String(), contentDigest.Encoded())
+
+	newStoppedScheduler := func() *scheduler.Scheduler {
+		log := log.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		taskScheduler := scheduler.NewScheduler(config.New(), metrics, log)
+		taskScheduler.RateLimit = 50 * time.Millisecond
+
+		return taskScheduler
+	}
+
+	Convey("content blob with no cache record: delete deferred, then allowed after rebuild", t, func() {
+		var deletedContentBlob atomic.Bool
+
+		imgStore := createMockStorageWithMockCache(testDir, &mocks.StorageDriverMock{
+			StatFn: func(ctx context.Context, statPath string) (driver.FileInfo, error) {
+				if statPath == contentBlobPath {
+					return &mocks.FileInfoMock{SizeFn: func() int64 { return int64(len(content)) }}, nil
+				}
+
+				return nil, driver.PathNotFoundError{Path: statPath}
+			},
+			DeleteFn: func(ctx context.Context, deletePath string) error {
+				if deletePath == contentBlobPath {
+					deletedContentBlob.Store(true)
+				}
+
+				return nil
+			},
+		}, &mocks.CacheMock{
+			GetBlobFn: func(digest godigest.Digest) (string, error) {
+				return "", zerr.ErrCacheMiss
+			},
+			HasBlobFn: func(digest godigest.Digest, blob string) bool {
+				return false
+			},
+		})
+
+		// walk submitted but not yet run: delete deferred, content preserved
+		taskScheduler := newStoppedScheduler()
+		imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
+
+		err := imgStore.DeleteBlob(repoName, contentDigest)
+		So(err, ShouldNotBeNil)
+		So(errors.Is(err, zerr.ErrDedupeRebuildInProgress), ShouldBeTrue)
+		So(deletedContentBlob.Load(), ShouldBeFalse)
+
+		// empty storage: the walk completes immediately once the scheduler runs
+		taskScheduler.RunScheduler()
+		defer taskScheduler.Shutdown()
+
+		for range 100 {
+			err = imgStore.DeleteBlob(repoName, contentDigest)
+			if err == nil {
+				break
+			}
+
+			So(errors.Is(err, zerr.ErrDedupeRebuildInProgress), ShouldBeTrue)
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		So(err, ShouldBeNil)
+		So(deletedContentBlob.Load(), ShouldBeTrue)
+	})
+
+	Convey("zero-size placeholder can still be deleted while the rebuild is running", t, func() {
+		var deletedPlaceholder atomic.Bool
+
+		imgStore := createMockStorageWithMockCache(testDir, &mocks.StorageDriverMock{
+			StatFn: func(ctx context.Context, statPath string) (driver.FileInfo, error) {
+				if statPath == contentBlobPath {
+					return &mocks.FileInfoMock{SizeFn: func() int64 { return 0 }}, nil
+				}
+
+				return nil, driver.PathNotFoundError{Path: statPath}
+			},
+			DeleteFn: func(ctx context.Context, deletePath string) error {
+				if deletePath == contentBlobPath {
+					deletedPlaceholder.Store(true)
+				}
+
+				return nil
+			},
+		}, &mocks.CacheMock{
+			GetBlobFn: func(digest godigest.Digest) (string, error) {
+				return "", zerr.ErrCacheMiss
+			},
+			HasBlobFn: func(digest godigest.Digest, blob string) bool {
+				return false
+			},
+		})
+
+		// zero-size placeholders are deletable while the walk is pending
+		imgStore.RunDedupeBlobs(time.Duration(0), newStoppedScheduler())
+
+		err := imgStore.DeleteBlob(repoName, contentDigest)
+		So(err, ShouldBeNil)
+		So(deletedPlaceholder.Load(), ShouldBeTrue)
+	})
+
+	Convey("content blob known to the cache is deleted normally during the rebuild", t, func() {
+		var deletedContentBlob atomic.Bool
+
+		removedFromCache := false
+
+		imgStore := createMockStorageWithMockCache(testDir, &mocks.StorageDriverMock{
+			StatFn: func(ctx context.Context, statPath string) (driver.FileInfo, error) {
+				if statPath == contentBlobPath {
+					return &mocks.FileInfoMock{SizeFn: func() int64 { return int64(len(content)) }}, nil
+				}
+
+				return nil, driver.PathNotFoundError{Path: statPath}
+			},
+			DeleteFn: func(ctx context.Context, deletePath string) error {
+				if deletePath == contentBlobPath {
+					deletedContentBlob.Store(true)
+				}
+
+				return nil
+			},
+		}, &mocks.CacheMock{
+			GetBlobFn: func(digest godigest.Digest) (string, error) {
+				if removedFromCache {
+					return "", zerr.ErrCacheMiss
+				}
+
+				return contentBlobPath, nil
+			},
+			HasBlobFn: func(digest godigest.Digest, blob string) bool {
+				return !removedFromCache
+			},
+			DeleteBlobFn: func(digest godigest.Digest, blob string) error {
+				removedFromCache = true
+
+				return nil
+			},
+		})
+
+		// cache-known blob: delete proceeds while the walk is pending
+		imgStore.RunDedupeBlobs(time.Duration(0), newStoppedScheduler())
+
+		err := imgStore.DeleteBlob(repoName, contentDigest)
+		So(err, ShouldBeNil)
+		So(deletedContentBlob.Load(), ShouldBeTrue)
+	})
+}
+
+// Restore-direction gating (dedupe=false, no cache): leftover zero-size
+// duplicates are refilled by the restore walk, so content deletes are deferred
+// until it completes; the restore-complete marker skips both the walk and the
+// deferral on later startups.
+func TestDeleteBlobDeferredDuringRestoreWalk(t *testing.T) {
+	testDir := "/oci-repo-test/restore-walk-delete"
+	repoName := "repo"
+
+	content := []byte("restore-content-blob")
+	contentDigest := godigest.FromBytes(content)
+	contentBlobPath := path.Join(testDir, repoName, "blobs",
+		contentDigest.Algorithm().String(), contentDigest.Encoded())
+
+	newStoppedScheduler := func() *scheduler.Scheduler {
+		log := log.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		taskScheduler := scheduler.NewScheduler(config.New(), metrics, log)
+		taskScheduler.RateLimit = 50 * time.Millisecond
+
+		return taskScheduler
+	}
+
+	newMockDriver := func(markerContent string, deleted *atomic.Bool, markerWritten *atomic.Bool, writeErr error,
+	) *mocks.StorageDriverMock {
+		return &mocks.StorageDriverMock{
+			StatFn: func(ctx context.Context, statPath string) (driver.FileInfo, error) {
+				if statPath == contentBlobPath {
+					return &mocks.FileInfoMock{SizeFn: func() int64 { return int64(len(content)) }}, nil
+				}
+
+				return nil, driver.PathNotFoundError{Path: statPath}
+			},
+			GetContentFn: func(ctx context.Context, readPath string) ([]byte, error) {
+				if markerContent != "" && strings.HasSuffix(readPath, storageConstants.DedupeRestoreCompleteMarker) {
+					return []byte(markerContent), nil
+				}
+
+				return nil, driver.PathNotFoundError{Path: readPath}
+			},
+			// zot's s3 Driver.WriteFile goes through store.Writer, not PutContent.
+			WriterFn: func(ctx context.Context, writePath string, isAppend bool) (driver.FileWriter, error) {
+				if strings.HasSuffix(writePath, storageConstants.DedupeRestoreCompleteMarker) {
+					if writeErr != nil {
+						return nil, writeErr
+					}
+
+					return &mocks.FileWriterMock{CommitFn: func() error {
+						markerWritten.Store(true)
+
+						return nil
+					}}, nil
+				}
+
+				return &mocks.FileWriterMock{}, nil
+			},
+			DeleteFn: func(ctx context.Context, deletePath string) error {
+				if deletePath == contentBlobPath {
+					deleted.Store(true)
+				}
+
+				return nil
+			},
+		}
+	}
+
+	Convey("no marker: content delete deferred until the restore walk completes, then marker written", t, func() {
+		var deleted, markerWritten atomic.Bool
+
+		imgStore := createMockStorage(testDir, t.TempDir(), false,
+			newMockDriver("", &deleted, &markerWritten, nil))
+
+		taskScheduler := newStoppedScheduler()
+		imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
+
+		err := imgStore.DeleteBlob(repoName, contentDigest)
+		So(err, ShouldNotBeNil)
+		So(errors.Is(err, zerr.ErrDedupeRebuildInProgress), ShouldBeTrue)
+		So(deleted.Load(), ShouldBeFalse)
+
+		taskScheduler.RunScheduler()
+		defer taskScheduler.Shutdown()
+
+		for range 100 {
+			err = imgStore.DeleteBlob(repoName, contentDigest)
+			if err == nil {
+				break
+			}
+
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		So(err, ShouldBeNil)
+		So(deleted.Load(), ShouldBeTrue)
+		So(markerWritten.Load(), ShouldBeTrue)
+	})
+
+	Convey("restore-complete marker present: walk skipped, deletes proceed immediately", t, func() {
+		var deleted, markerWritten atomic.Bool
+
+		imgStore := createMockStorage(testDir, t.TempDir(), false,
+			newMockDriver(storageConstants.DedupeRestoreMarkerComplete, &deleted, &markerWritten, nil))
+
+		imgStore.RunDedupeBlobs(time.Duration(0), newStoppedScheduler())
+
+		err := imgStore.DeleteBlob(repoName, contentDigest)
+		So(err, ShouldBeNil)
+		So(deleted.Load(), ShouldBeTrue)
+	})
+
+	Convey("marker write failure: deletes still proceed once the walk completed", t, func() {
+		var deleted, markerWritten atomic.Bool
+
+		imgStore := createMockStorage(testDir, t.TempDir(), false,
+			newMockDriver("", &deleted, &markerWritten, errS3))
+
+		taskScheduler := newStoppedScheduler()
+		imgStore.RunDedupeBlobs(time.Duration(0), taskScheduler)
+
+		taskScheduler.RunScheduler()
+		defer taskScheduler.Shutdown()
+
+		var err error
+		for range 100 {
+			err = imgStore.DeleteBlob(repoName, contentDigest)
+			if err == nil {
+				break
+			}
+
+			time.Sleep(100 * time.Millisecond)
+		}
+
+		So(err, ShouldBeNil)
+		So(deleted.Load(), ShouldBeTrue)
+		So(markerWritten.Load(), ShouldBeFalse)
+	})
+}
+
+// One repo holds the only content-bearing copy, another holds a
+// zero-size deduped placeholder. With an empty cache and the rebuild gate armed,
+// GC must not delete the original or every duplicate becomes permanently unreadable.
+func TestDeleteBlobDeferredIssue2625CrossRepoOriginal(t *testing.T) {
+	testDir := "/oci-repo-test/dedupe-2625-cross-repo"
+	repoA := "repo-a"
+	repoB := "repo-b"
+
+	content := []byte("shared-layer-content")
+	digest := godigest.FromBytes(content)
+
+	originalPath := path.Join(testDir, repoA, ispec.ImageBlobsDir,
+		digest.Algorithm().String(), digest.Encoded())
+	placeholderPath := path.Join(testDir, repoB, ispec.ImageBlobsDir,
+		digest.Algorithm().String(), digest.Encoded())
+
+	newStoppedScheduler := func() *scheduler.Scheduler {
+		log := log.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		taskScheduler := scheduler.NewScheduler(config.New(), metrics, log)
+		taskScheduler.RateLimit = 50 * time.Millisecond
+
+		return taskScheduler
+	}
+
+	statFn := func(_ context.Context, statPath string) (driver.FileInfo, error) {
+		switch statPath {
+		case originalPath:
+			return &mocks.FileInfoMock{SizeFn: func() int64 { return int64(len(content)) }}, nil
+		case placeholderPath:
+			return &mocks.FileInfoMock{SizeFn: func() int64 { return 0 }}, nil
+		default:
+			return nil, driver.PathNotFoundError{Path: statPath}
+		}
+	}
+
+	Convey("content original is preserved while rebuild is armed; placeholder still deletable", t, func() {
+		var deletedOriginal, deletedPlaceholder atomic.Bool
+
+		imgStore := createMockStorageWithMockCache(testDir, &mocks.StorageDriverMock{
+			StatFn: statFn,
+			DeleteFn: func(ctx context.Context, deletePath string) error {
+				switch deletePath {
+				case originalPath:
+					deletedOriginal.Store(true)
+				case placeholderPath:
+					deletedPlaceholder.Store(true)
+				}
+
+				return nil
+			},
+		}, &mocks.CacheMock{
+			GetBlobFn: func(digest godigest.Digest) (string, error) {
+				return "", zerr.ErrCacheMiss
+			},
+			HasBlobFn: func(digest godigest.Digest, blob string) bool {
+				return false
+			},
+		})
+
+		imgStore.RunDedupeBlobs(time.Duration(0), newStoppedScheduler())
+
+		err := imgStore.DeleteBlob(repoA, digest)
+		So(err, ShouldNotBeNil)
+		So(errors.Is(err, zerr.ErrDedupeRebuildInProgress), ShouldBeTrue)
+		So(deletedOriginal.Load(), ShouldBeFalse)
+
+		err = imgStore.DeleteBlob(repoB, digest)
+		So(err, ShouldBeNil)
+		So(deletedPlaceholder.Load(), ShouldBeTrue)
+		So(deletedOriginal.Load(), ShouldBeFalse)
 	})
 }


### PR DESCRIPTION
## Problem

Fixes #2625 (data loss: zero-size deduped blobs left permanently unreadable, `416 RequestedRangeNotSatisfiable` on pull).

With `dedupe: true` on cloud storage, duplicates are zero-size placeholder files whose content lives in one original blob, resolvable only through the dedupe cache. `deleteBlob` handles the "deleting the original" case by moving content to the next duplicate — **but only when the cache has a record for the digest**:

- `is.cache.GetBlob(digest)` misses → `dstRecord == ""`
- `dstRecord == blobPath` is false → the move-to-next-candidate logic is skipped entirely
- `is.storeDriver.Delete(blobPath)` destroys the only content-bearing copy

The cache misses exactly when it has been lost or is incomplete — e.g. an ephemeral local BoltDB cache with S3 storage (the configuration in #2625). The startup dedupe/restore walk (`RunDedupeBlobs`) does rebuild the cache from storage, but GC/retention can and does run before/while the walk completes. Every retention pass during that window can delete originals out from under placeholders in other repositories, which matches the reporter's observation that things "work for a while from scratch, and then break".

## Fix

Track completion of the startup dedupe/restore walk on `ImageStore` and defer deletes that cannot be proven safe until it finishes:

- `DedupeTaskGenerator`'s existing completion tracking (`OnRunComplete`, `pendingTaskCount`) now fires for **both** directions, not just restore.
- `ImageStore` gains a `dedupeWalkPending` flag: `RunDedupeBlobs` sets it (for remote storage) strictly before submitting the walk's task generator, and clears it when the walk completes (or never sets it when the restore-complete marker allows skipping the scan). The zero value means no walk is pending, so zero-value `ImageStore` literals behave as before.
- `deleteBlob` returns the new `ErrDedupeRebuildInProgress` instead of deleting, **only** when all of the following hold:
  - the blob has content (zero-size placeholders remain deletable), and
  - the dedupe cache has no record for the digest (or there is no cache at all, i.e. `dedupe:false` with leftover placeholders pending restore), and
  - a walk has been scheduled and has not completed yet.

GC/retention already tolerates per-repo errors and retries on the next interval, so deferred deletes are picked up once the cache is rebuilt. Blobs known to the cache keep the existing move-to-candidate behavior, and blobs pushed after startup are in the cache by construction, so the hot path is unaffected.

Local storage never arms the gate: it dedupes via hardlinks, so deleting one path never destroys shared content.

## Notes for reviewers

- Conservative by design: if the walk fails permanently (e.g. persistent storage errors), unknown-blob deletes stay deferred until the next successful walk — loud in logs, and strictly better than deleting possibly-shared content.
- The gate deliberately starts **open** (the flag's zero value) and is only armed inside `RunDedupeBlobs` before the walk's task generator is submitted. This is sufficient: the gate exists to protect deletes while rebuild work is in flight, and no rebuild work can exist before the generator is submitted — a delete in the interval between GC scheduling and `RunDedupeBlobs` in `StartBackgroundTasks` is plain pre-walk behavior, identical to today. Arming earlier was tried and reverted twice: initializing the flag at construction defers all cache-unknown remote deletes for consumers that never schedule a walk (the standalone retention-verify CLI path, and the existing remote-storage GC suites), and reordering `StartBackgroundTasks` shifts GC's first scan into windows existing behavior depends on.
- No API/config changes; one new error value.

## Testing

- New mock-driver tests (no cloud infra needed): `TestDeleteBlobDeferredDuringDedupeRebuild` (deferral before the walk completes → success after; zero-size placeholder deletable during the walk; cache-known content blob deletable during the walk), `TestDeleteBlobDeferredDuringRestoreWalk` (`dedupe:false` restore path incl. restore-complete marker handling), and `TestDeleteBlobDeferredIssue2625CrossRepoOriginal` (the exact #2625 shape: cross-repo original + placeholder with an empty cache). Retry loops fail fast on any error other than `ErrDedupeRebuildInProgress`.
- Verified against real backends locally (minio, azurite, localstack DynamoDB): `pkg/storage`, `pkg/storage/s3`, `pkg/storage/gc`, `pkg/storage/common`, `pkg/storage/imagestore`, `pkg/storage/azure` suites pass; `make check` clean.

