### PR TITLE
fix(storage): only promote dedupe origin when the deleted blob is the origin (boltdb)

### DIFF
--- a/pkg/storage/cache/boltdb.go
+++ b/pkg/storage/cache/boltdb.go
@@ -345,7 +345,7 @@ func (d *BoltDBDriver) DeleteBlob(digest godigest.Digest, path string) error {
 		origin := bucket.Bucket([]byte(constants.OriginalBucket))
 		if origin != nil {
 			originBlob := d.getOne(origin)
-			if originBlob != nil {
+			if originBlob != nil && string(originBlob) == path {
 				if err := origin.Delete([]byte(path)); err != nil {
 					d.log.Error().Err(err).Str("digest", digest.String()).Str("bucket", constants.OriginalBucket).
 						Str("path", path).Msg("failed to delete")

--- a/pkg/storage/cache/boltdb_test.go
+++ b/pkg/storage/cache/boltdb_test.go
@@ -166,3 +166,35 @@ func TestBoltDBCache(t *testing.T) {
 		So(blobs, ShouldResemble, []string{"second"})
 	})
 }
+
+func TestBoltDBDeleteNonOriginDuplicate(t *testing.T) {
+	Convey("Deleting a non-origin duplicate must not promote another path to origin", t, func() {
+		dir := t.TempDir()
+
+		log := log.NewTestLogger()
+		So(log, ShouldNotBeNil)
+
+		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{dir, "cache_test", false}, log)
+		So(cacheDriver, ShouldNotBeNil)
+
+		err := cacheDriver.PutBlob("digest", "zebra")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.PutBlob("digest", "alpha")
+		So(err, ShouldBeNil)
+
+		err = cacheDriver.PutBlob("digest", "mango")
+		So(err, ShouldBeNil)
+
+		val, err := cacheDriver.GetBlob("digest")
+		So(err, ShouldBeNil)
+		So(val, ShouldEqual, "zebra")
+
+		err = cacheDriver.DeleteBlob("digest", "mango")
+		So(err, ShouldBeNil)
+
+		val, err = cacheDriver.GetBlob("digest")
+		So(err, ShouldBeNil)
+		So(val, ShouldEqual, "zebra")
+	})
+}


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR do / Why do we need it**:
The BoltDB cache driver promoted a duplicate blob into the origin bucket even when the deleted path was not the current origin. On S3 dedupe, where duplicates are zero-size stubs, this points the content holder at a stub and the blob can be lost on a later delete. The DynamoDB and Redis drivers already guard this with an origin == path check; this makes BoltDB match them.

**Testing done on this change**:
Added TestBoltDBDeleteNonOriginDuplicate. It fails without the fix and passes with it.

**Will this break upgrades or downgrades?**
No.

**Does this PR introduce any user-facing change?**:
No.