### PR TITLE
fix(imagetrust): bind cosign signature verification to the manifest digest

### DIFF
--- a/pkg/extensions/imagetrust/cosign.go
+++ b/pkg/extensions/imagetrust/cosign.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -20,6 +21,7 @@ import (
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigstoreSigs "github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
+	sigPayload "github.com/sigstore/sigstore/pkg/signature/payload"
 
 	zerr "zotregistry.dev/zot/v2/errors"
 )
@@ -117,6 +119,16 @@ func VerifyCosignSignature(
 		err = verifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(payload),
 			options.WithContext(context.Background()))
 		if err == nil {
+			var signedPayload sigPayload.SimpleContainerImage
+
+			if err := json.Unmarshal(payload, &signedPayload); err != nil {
+				continue
+			}
+
+			if signedPayload.Critical.Image.DockerManifestDigest != digest.String() {
+				continue
+			}
+
 			return string(pubKeyContent), true, nil
 		}
 	}

--- a/pkg/extensions/imagetrust/image_trust_test.go
+++ b/pkg/extensions/imagetrust/image_trust_test.go
@@ -548,6 +548,114 @@ func TestVerifySignatures(t *testing.T) {
 	})
 }
 
+func TestCosignSignatureDigestBinding(t *testing.T) {
+	Convey("transplanted cosign signature is bound to the signed manifest digest", t, func() {
+		repo := "repo"
+		tag := "test"
+
+		image := CreateRandomImage()
+
+		rootDir := t.TempDir()
+
+		port := test.GetFreePort()
+		baseURL := test.GetBaseURL(port)
+		conf := config.New()
+		conf.HTTP.Port = port
+		conf.Storage.GC = false
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = rootDir
+
+		cm := test.NewControllerManager(ctlr)
+		cm.StartAndWait(conf.HTTP.Port)
+		defer cm.StopServer()
+
+		err := UploadImage(image, baseURL, repo, tag)
+		So(err, ShouldBeNil)
+
+		pubKeyStorage, err := imagetrust.NewPublicKeyLocalStorage(rootDir)
+		So(err, ShouldBeNil)
+
+		cosignDir, err := pubKeyStorage.GetCosignDirPath()
+		So(err, ShouldBeNil)
+
+		cwd, err := os.Getwd()
+		So(err, ShouldBeNil)
+
+		So(os.Chdir(cosignDir), ShouldBeNil)
+
+		t.Setenv("COSIGN_PASSWORD", "")
+		err = generate.GenerateKeyPairCmd(context.TODO(), "", "cosign", nil)
+		So(err, ShouldBeNil)
+
+		So(os.Chdir(cwd), ShouldBeNil)
+
+		err = sign.SignCmd(context.TODO(),
+			&options.RootOptions{Verbose: true, Timeout: 1 * time.Minute},
+			options.KeyOpts{KeyRef: path.Join(cosignDir, "cosign.key"), PassFunc: generate.GetPass},
+			options.SignOptions{
+				Registry:          options.RegistryOptions{AllowInsecure: true},
+				AnnotationOptions: options.AnnotationOptions{Annotations: []string{"tag=" + tag}},
+				Upload:            true,
+			},
+			[]string{fmt.Sprintf("localhost:%s/%s@%s", port, repo, image.DigestStr())})
+		So(err, ShouldBeNil)
+
+		err = os.Remove(path.Join(cosignDir, "cosign.key"))
+		So(err, ShouldBeNil)
+
+		indexContent, err := ctlr.StoreController.DefaultStore.GetIndexContent(repo)
+		So(err, ShouldBeNil)
+
+		var index ispec.Index
+
+		err = json.Unmarshal(indexContent, &index)
+		So(err, ShouldBeNil)
+
+		var (
+			rawSignature []byte
+			sigKey       string
+		)
+
+		for _, manifest := range index.Manifests {
+			if manifest.Digest != image.Digest() {
+				blobContent, err := ctlr.StoreController.DefaultStore.GetBlobContent(repo, manifest.Digest)
+				So(err, ShouldBeNil)
+
+				var cosignSig ispec.Manifest
+
+				err = json.Unmarshal(blobContent, &cosignSig)
+				So(err, ShouldBeNil)
+
+				sigKey = cosignSig.Layers[0].Annotations[zcommon.CosignSigKey]
+				So(sigKey, ShouldNotBeEmpty)
+
+				rawSignature, err = ctlr.StoreController.DefaultStore.GetBlobContent(repo, cosignSig.Layers[0].Digest)
+				So(err, ShouldBeNil)
+				So(rawSignature, ShouldNotBeEmpty)
+			}
+		}
+
+		Convey("genuine signature verifies against the manifest it signed", func() {
+			author, isTrusted, err := imagetrust.VerifyCosignSignature(pubKeyStorage, repo, image.Digest(), sigKey,
+				rawSignature)
+			So(err, ShouldBeNil)
+			So(isTrusted, ShouldBeTrue)
+			So(author, ShouldNotBeEmpty)
+		})
+
+		Convey("same genuine signature transplanted onto a different manifest is not trusted", func() {
+			otherImage := CreateRandomImage()
+			So(otherImage.Digest(), ShouldNotEqual, image.Digest())
+
+			author, isTrusted, err := imagetrust.VerifyCosignSignature(pubKeyStorage, repo, otherImage.Digest(), sigKey,
+				rawSignature)
+			So(err, ShouldBeNil)
+			So(isTrusted, ShouldBeFalse)
+			So(author, ShouldBeEmpty)
+		})
+	})
+}
+
 func TestCheckExpiryErr(t *testing.T) {
 	Convey("no expiry err", t, func() {
 		isExpiryErr := imagetrust.CheckExpiryErr([]*notation.ValidationResult{{Error: nil, Type: "wrongtype"}}, time.Now(),


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR do / Why do we need it**:
VerifyCosignSignature checked the signature over the payload but never checked that the payload's docker-manifest-digest matches the manifest being verified, which is the claim check cosign performs in CheckClaims. A signature valid for one image could be attached to another image signed by the same key and reported as trusted. This verifies the claimed digest before returning trusted.

**Testing done on this change**:
Added TestCosignSignatureDigestBinding. It signs a real image, then verifies that signature against a different manifest digest: trusted without the fix, rejected with it.

**Will this break upgrades or downgrades?**
No.

**Does this PR introduce any user-facing change?**:
An image whose recorded cosign signature does not reference its own manifest digest is no longer reported as trusted.