### PR TITLE
fix(gc): resolve subject digest for cosign .sbom tags, not only .sig

### DIFF
--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -1079,7 +1079,9 @@ func isBlobOlderThan(imgStore types.ImageStore, repo string,
 
 func getSubjectFromCosignTag(tag string) godigest.Digest {
 	alg := strings.Split(tag, "-")[0]
-	encoded := strings.Split(strings.Split(tag, "-")[1], ".sig")[0]
+	encoded := strings.Split(tag, "-")[1]
+	encoded = strings.TrimSuffix(encoded, "."+cosignSignatureTagSuffix)
+	encoded = strings.TrimSuffix(encoded, "."+SBOMTagSuffix)
 
 	return godigest.NewDigestFromEncoded(godigest.Algorithm(alg), encoded)
 }

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -1698,6 +1698,37 @@ func TestCleanRepoWithStaleManifestEntries(t *testing.T) {
 	})
 }
 
+func TestGetSubjectFromCosignTag(t *testing.T) {
+	Convey("cosign tag subject digests are parsed for both .sig and .sbom", t, func() {
+		subjectDigest := godigest.FromString("app:v1")
+
+		index := &ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{
+					Digest:    subjectDigest,
+					MediaType: ispec.MediaTypeImageManifest,
+				},
+			},
+		}
+
+		Convey("signature tag resolves to the subject and stays referenced", func() {
+			sigTag := "sha256-" + subjectDigest.Encoded() + ".sig"
+
+			So(zcommon.IsCosignTag(sigTag), ShouldBeTrue)
+			So(getSubjectFromCosignTag(sigTag), ShouldEqual, subjectDigest)
+			So(isManifestReferencedInIndex(index, getSubjectFromCosignTag(sigTag)), ShouldBeTrue)
+		})
+
+		Convey("SBOM tag resolves to the subject and stays referenced", func() {
+			sbomTag := "sha256-" + subjectDigest.Encoded() + ".sbom"
+
+			So(zcommon.IsCosignTag(sbomTag), ShouldBeTrue)
+			So(getSubjectFromCosignTag(sbomTag), ShouldEqual, subjectDigest)
+			So(isManifestReferencedInIndex(index, getSubjectFromCosignTag(sbomTag)), ShouldBeTrue)
+		})
+	})
+}
+
 func TestCleanupRepoMissingBlob(t *testing.T) {
 	Convey("CleanupRepo skips blobs that are already absent", t, func() {
 		dir := t.TempDir()


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR do / Why do we need it**:
getSubjectFromCosignTag split the tag only on ".sig", but IsCosignTag also matches ".sbom" tags. This handles both suffixes.

**Testing done on this change**:
Added TestGetSubjectFromCosignTag covering .sig and .sbom. The .sbom case fails without the fix.

**Will this break upgrades or downgrades?**
No.

**Does this PR introduce any user-facing change?**:
No.