### PR TITLE
fix(meta): avoid panic on malformed cosign signature tag

### DIFF
--- a/pkg/meta/parse.go
+++ b/pkg/meta/parse.go
@@ -561,10 +561,19 @@ func isSignature(reference string, manifestContent ispec.Manifest) (bool, string
 	if tag := reference; zcommon.IsCosignSignature(reference) {
 		prefixLen := len("sha256-")
 		digestLen := 64
+
+		if len(tag) != prefixLen+digestLen+len(".sig") {
+			return false, "", ""
+		}
+
 		signedImageManifestDigestEncoded := tag[prefixLen : prefixLen+digestLen]
 
 		signedImageManifestDigest := godigest.NewDigestFromEncoded(godigest.SHA256,
 			signedImageManifestDigestEncoded)
+
+		if err := signedImageManifestDigest.Validate(); err != nil {
+			return false, "", ""
+		}
 
 		return true, CosignType, signedImageManifestDigest
 	}

--- a/pkg/meta/parse_internal_test.go
+++ b/pkg/meta/parse_internal_test.go
@@ -60,6 +60,37 @@ func TestFastRestartStamp(t *testing.T) {
 	})
 }
 
+func TestIsSignatureCosignTag(t *testing.T) {
+	Convey("isSignature handles cosign-style tags safely", t, func() {
+		manifest := ispec.Manifest{}
+
+		Convey("a short tag matching the cosign regex does not panic and is not a signature", func() {
+			ok, sigType, digest := isSignature("sha256-abc.sig", manifest)
+			So(ok, ShouldBeFalse)
+			So(sigType, ShouldBeEmpty)
+			So(digest, ShouldBeEmpty)
+		})
+
+		Convey("a tag with a non-hex digest of the right length is not a signature", func() {
+			nonHex := ""
+			for range 64 {
+				nonHex += "z"
+			}
+			ok, _, _ := isSignature("sha256-"+nonHex+".sig", manifest)
+			So(ok, ShouldBeFalse)
+		})
+
+		Convey("a well-formed cosign tag is recognized as a signature", func() {
+			signed := godigest.FromString("signed-image")
+			tag := "sha256-" + signed.Encoded() + ".sig"
+			ok, sigType, digest := isSignature(tag, manifest)
+			So(ok, ShouldBeTrue)
+			So(sigType, ShouldEqual, CosignType)
+			So(digest, ShouldEqual, signed)
+		})
+	})
+}
+
 func TestParseStorageStats(t *testing.T) {
 	logger := log.NewTestLogger()
 


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR do / Why do we need it**:
isSignature sliced a cosign tag at a fixed offset without checking its length, so a short tag that still matches the cosign regex (for example sha256-abc.sig) panicked with slice out of range. This adds a length check and validates the digest.

**Testing done on this change**:
Added TestIsSignatureCosignTag. The short-tag case panics without the fix.

**Will this break upgrades or downgrades?**
No.

**Does this PR introduce any user-facing change?**:
No.