### PR TITLE
fix(zb): record benchmark errors in stats instead of aborting with log.Fatal

### DIFF
--- a/cmd/zb/helper.go
+++ b/cmd/zb/helper.go
@@ -233,14 +233,20 @@ func pullAndCollect(url string, repos []string, manifestItem manifestStruct,
 			latency = time.Since(start)
 
 			if err != nil {
-				log.Fatal(err)
+				log.Println(err)
+				isConnFail = true
+
+				return
 			}
 
 			var pulledManifest ispec.Manifest
 
 			err = json.Unmarshal(manifestBody, &pulledManifest)
 			if err != nil {
-				log.Fatal(err)
+				log.Println(err)
+				isErr = true
+
+				return
 			}
 
 			// check config
@@ -305,7 +311,10 @@ func pullAndCollect(url string, repos []string, manifestItem manifestStruct,
 			latency = time.Since(start)
 
 			if err != nil {
-				log.Fatal(err)
+				log.Println(err)
+				isConnFail = true
+
+				return
 			}
 
 			// download blobs
@@ -357,9 +366,11 @@ func pullAndCollect(url string, repos []string, manifestItem manifestStruct,
 
 				// request specific check
 				statusCode = resp.StatusCode()
+				body := resp.RawBody()
+
 				if statusCode != http.StatusOK {
 					isErr = true
-					resp.RawBody().Close()
+					_ = body.Close()
 
 					return
 				}
@@ -369,11 +380,17 @@ func pullAndCollect(url string, repos []string, manifestItem manifestStruct,
 				}
 
 				// drain response body without buffering in memory
-				if _, err = io.Copy(io.Discard, resp.RawBody()); err != nil {
-					log.Fatal(err)
+				if _, err = io.Copy(io.Discard, body); err != nil {
+					_ = body.Close()
+					latency = time.Since(start)
+					log.Println(err)
+					isConnFail = true
+
+					return
 				}
 
-				resp.RawBody().Close()
+				_ = body.Close()
+				latency = time.Since(start)
 			}
 
 			timings = append(timings, tagTiming)
@@ -567,7 +584,11 @@ func pushMonolithAndCollect(workdir, url, trepo string, count int,
 
 		ruid, err := uuid.NewUUID()
 		if err != nil {
-			log.Fatal(err)
+			latency = time.Since(start)
+			log.Println(err)
+			isErr = true
+
+			return
 		}
 
 		var repo string
@@ -715,7 +736,11 @@ func pushMonolithAndCollect(workdir, url, trepo string, count int,
 
 		content, err := json.MarshalIndent(&manifest, "", "\t")
 		if err != nil {
-			log.Fatal(err)
+			latency = time.Since(start)
+			log.Println(err)
+			isErr = true
+
+			return
 		}
 
 		manifestTag := fmt.Sprintf("tag%d", count)
@@ -773,7 +798,11 @@ func pushChunkAndCollect(workdir, url, trepo string, count int,
 
 		ruid, err := uuid.NewUUID()
 		if err != nil {
-			log.Fatal(err)
+			latency = time.Since(start)
+			log.Println(err)
+			isErr = true
+
+			return
 		}
 
 		var repo string
@@ -990,7 +1019,11 @@ func pushChunkAndCollect(workdir, url, trepo string, count int,
 
 		content, err := json.Marshal(manifest)
 		if err != nil {
-			log.Fatal(err)
+			latency = time.Since(start)
+			log.Println(err)
+			isErr = true
+
+			return
 		}
 
 		manifestTag := fmt.Sprintf("tag%d", count)

--- a/cmd/zb/perf.go
+++ b/cmd/zb/perf.go
@@ -247,7 +247,7 @@ func printStats(requests int, summary *statsSummary) {
 	log.Printf("Failed requests:\t%v", summary.errorCount)
 
 	for errStr, count := range summary.errors {
-		log.Printf("Error %s count:\t%d", errStr, count)
+		log.Printf("Error\t%s count:\t%d", errStr, count)
 	}
 
 	log.Printf("\n")
@@ -608,7 +608,7 @@ func MixedPullAndPush(
 			repos = pushMonolithAndCollect(
 				suiteCfg.workDir, suiteCfg.targetServerURL, suiteCfg.repo, count, repos, config, client, statsCh)
 			current := loadOrStore(&statusRequests, "Push", 0)
-			statusRequests.Store("Pull", current+1)
+			statusRequests.Store("Push", current+1)
 		}
 	}
 


### PR DESCRIPTION
Streamed blob pulls (#3929) could fail mid-body with unexpected EOF and
exit immediately, leaving no test name or failure summary in CI output.
Treat io.Copy, JSON parse, UUID, and marshal errors in collect helpers
as failed requests so printStats reports them like other request errors.

Update latency after io.Copy on blob pulls so percentiles reflect the
full layer transfer, not just time-to-first-byte. Set latency before
early returns on UUID generation failures so failed requests cannot
report zero and skew min.

fix a visual issue with long error messages pushing the counters to the far right
See failure in https://github.com/project-zot/zot/actions/runs/29029424913/job/86157873790

fix incorrect labeling in mixed push/pull stats
See failure:

```
2026-07-09T12:17:02.2722053Z ============
2026-07-09T12:17:02.2722385Z Test name:            Pull 10MB
2026-07-09T12:17:02.2722689Z Time taken for tests: 332.37565ms
2026-07-09T12:17:02.2723041Z Requests per second:  300.8644
2026-07-09T12:17:02.2723354Z Complete requests:    100
2026-07-09T12:17:02.2723568Z Failed requests:      0
2026-07-09T12:17:02.2723687Z
2026-07-09T12:17:02.2723765Z 2xx responses: 100
2026-07-09T12:17:02.2723870Z
2026-07-09T12:17:02.2723942Z min: 1.85381ms
2026-07-09T12:17:02.2724485Z max: 29.216462ms
2026-07-09T12:17:02.2724741Z p50: 3.239915ms
2026-07-09T12:17:02.2724989Z p75: 4.274378ms
2026-07-09T12:17:02.2725240Z p90: 5.764932ms
2026-07-09T12:17:02.2725484Z p99: 29.216462ms
2026-07-09T12:17:02.2725643Z
2026-07-09T12:17:02.2726047Z Manifest HEAD TTFB p50: 374.824µs
2026-07-09T12:17:02.2726346Z Manifest HEAD TTFB p75: 542.572µs
2026-07-09T12:17:02.2726584Z Manifest HEAD TTFB p90: 958.277µs
2026-07-09T12:17:02.2726804Z Manifest HEAD TTFB p99: 3.949471ms
2026-07-09T12:17:02.2726944Z
2026-07-09T12:17:02.2727052Z Manifest GET TTFB p50: 379.341µs
2026-07-09T12:17:02.2727285Z Manifest GET TTFB p75: 546.487µs
2026-07-09T12:17:02.2727488Z Manifest GET TTFB p90: 1.025201ms
2026-07-09T12:17:02.2727697Z Manifest GET TTFB p99: 3.88971ms
2026-07-09T12:17:02.2727990Z
2026-07-09T12:17:02.2728098Z Config TTFB p50: 406.562µs
2026-07-09T12:17:02.2728316Z Config TTFB p75: 655.865µs
2026-07-09T12:17:02.2728530Z Config TTFB p90: 982.166µs
2026-07-09T12:17:02.2728716Z Config TTFB p99: 2.901075ms
2026-07-09T12:17:02.2728850Z
2026-07-09T12:17:02.2728947Z Layer TTFB p50: 371.899µs
2026-07-09T12:17:02.2729223Z Layer TTFB p75: 572.948µs
2026-07-09T12:17:02.2729413Z Layer TTFB p90: 1.1617ms
2026-07-09T12:17:02.2729601Z Layer TTFB p99: 2.856896ms
2026-07-09T12:17:02.2729714Z
2026-07-09T12:18:41.5300841Z unexpected EOF
2026-07-09T12:18:41.7311849Z make: *** [Makefile:270: run-bench] Error 1
2026-07-09T12:18:46.7344944Z ##[error]Process completed with exit code 2.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
