### PR TITLE
ci: use more powerful runner to run unit tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ permissions: read-all
 jobs:
   test-run-minimal:
     name: Running zot without extensions tests
-    runs-on: ubuntu-latest
+    runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:


### PR DESCRIPTION
Change from ubuntu-latest to cncf-ubuntu-8-32-x86.

ubuntu-latest - has 4 CPUs and 16 GB memory
cncf-ubuntu-8-32-x86 - has 8 CPUs and 32 GB memory

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
