### PR TITLE
fix(sync): guard registry credentials map against concurrent refresh

### DIFF
--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -146,6 +146,10 @@ func (service *BaseService) init() error {
 	service.clientLock.Lock()
 	defer service.clientLock.Unlock()
 
+	return service.initLocked()
+}
+
+func (service *BaseService) initLocked() error {
 	client, hosts, err := newClient(service.config, service.credentials, service.log)
 	if err != nil {
 		service.log.Err(err).Msg("failed to create registry client")
@@ -174,6 +178,9 @@ func (service *BaseService) refreshRegistryTemporaryCredentials() error {
 		return nil
 	}
 
+	service.clientLock.Lock()
+	defer service.clientLock.Unlock()
+
 	for _, host := range service.hosts {
 		// Exit early if the credentials are valid.
 		if service.credentialHelper.AreCredentialsValid(host.Hostname) {
@@ -200,7 +207,7 @@ func (service *BaseService) refreshRegistryTemporaryCredentials() error {
 	}
 
 	// Reinitialize regclient with new credentials
-	return service.init()
+	return service.initLocked()
 }
 
 func (service *BaseService) CanRetryOnError() bool {

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1416,5 +1417,46 @@ func TestHTTPRetryDelayBounds(t *testing.T) {
 			So(delayInit, ShouldEqual, retryDelay)
 			So(delayMax, ShouldEqual, maxRetryDelay)
 		})
+	})
+}
+
+func TestRefreshRegistryTemporaryCredentialsConcurrent(t *testing.T) {
+	Convey("Concurrent on-demand credential refresh must not race on the credentials map", t, func() {
+		logger := log.NewTestLogger()
+
+		service := &BaseService{
+			config: syncconf.RegistryConfig{
+				URLs: []string{
+					"https://111111111111.dkr.ecr.us-east-1.amazonaws.com",
+					"https://222222222222.dkr.ecr.us-east-1.amazonaws.com",
+					"https://333333333333.dkr.ecr.us-east-1.amazonaws.com",
+					"https://444444444444.dkr.ecr.us-east-1.amazonaws.com",
+				},
+				CredentialHelper: "ecr",
+			},
+			credentials:      syncconf.CredentialsFile{},
+			credentialHelper: NewECRCredentialHelper(logger, GetMockECRCredentials),
+			log:              logger,
+		}
+
+		So(service.init(), ShouldBeNil)
+		So(len(service.hosts), ShouldEqual, len(service.config.URLs))
+
+		var wg sync.WaitGroup
+		for range 10 {
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				for range 3 {
+					_ = service.refreshRegistryTemporaryCredentials()
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		So(len(service.credentials), ShouldEqual, len(service.hosts))
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR do / Why do we need it**:
refreshRegistryTemporaryCredentials wrote service.credentials and reinitialized the client without holding clientLock, racing with concurrent on-demand syncs and risking a fatal concurrent map write. This holds clientLock during refresh.

**Testing done on this change**:
Added TestRefreshRegistryTemporaryCredentialsConcurrent. Run with -race it reports a data race without the fix.

**Will this break upgrades or downgrades?**
No.

**Does this PR introduce any user-facing change?**:
No.