### PR TITLE
fix(events): apply default HTTP sink timeout when unset

### DIFF
--- a/pkg/extensions/events/http_sink.go
+++ b/pkg/extensions/events/http_sink.go
@@ -30,6 +30,10 @@ func NewHTTPSink(config eventsconf.SinkConfig) (*HTTPSink, error) {
 		return nil, zerr.ErrEventSinkAddressEmpty
 	}
 
+	if config.Timeout <= 0 {
+		config.Timeout = DefaultHTTPTimeout
+	}
+
 	// Create the basic http client
 	httpClient, err := GetHTTPClientForConfig(config)
 	if err != nil {

--- a/pkg/extensions/events/http_sink_test.go
+++ b/pkg/extensions/events/http_sink_test.go
@@ -3,6 +3,9 @@
 package events_test
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -150,6 +153,33 @@ func TestHTTPSink(t *testing.T) {
 
 		err = sink.Emit(&event)
 		So(err, ShouldNotBeNil)
+	})
+
+	Convey("HTTPSink.Emit delivers when timeout is unset", t, func() {
+		var hits int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			atomic.AddInt32(&hits, 1)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		event := cloudevents.NewEvent()
+		event.SetID("1234")
+		event.SetType("test.event")
+		event.SetSource("unit.test")
+
+		cfg := eventsconf.SinkConfig{
+			Type:    eventsconf.HTTP,
+			Address: server.URL,
+		}
+
+		sink, err := events.NewHTTPSink(cfg)
+		So(err, ShouldBeNil)
+
+		result := sink.Emit(&event)
+		So(cloudevents.IsACK(result), ShouldBeTrue)
+		So(atomic.LoadInt32(&hits), ShouldEqual, 1)
 	})
 
 	Convey("HTTPSink.Close completes successfully", t, func() {


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR do / Why do we need it**:
NewHTTPSink built the request context deadline from config.Timeout without a default, so an unset timeout produced an already-expired deadline and every event failed to deliver. This applies the default timeout when none is configured.

**Testing done on this change**:
Added a TestHTTPSink case that emits an event through a sink with no timeout set and expects it to be delivered. It fails without the fix.

**Will this break upgrades or downgrades?**
No.

**Does this PR introduce any user-facing change?**:
No.