### PR TITLE
fix(api): reject backslash in OIDC callback redirect to prevent open redirect

### DIFF
--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -593,6 +593,10 @@ func ValidateCallbackUI(callbackUI string, allowOrigins []string) string {
 		return "/"
 	}
 
+	if strings.Contains(callbackUI, "\\") {
+		return "/"
+	}
+
 	parsed, err := url.Parse(callbackUI)
 	if err != nil {
 		return "/"

--- a/pkg/api/authn_test.go
+++ b/pkg/api/authn_test.go
@@ -140,6 +140,9 @@ func TestValidateCallbackUI(t *testing.T) {
 		},
 		{name: "header injection rejected (newline)", input: "/v2/\nSet-Cookie: x=y", expected: "/"},
 		{name: "header injection rejected (carriage return)", input: "/v2/\rSet-Cookie: x=y", expected: "/"},
+		{name: "backslash open redirect rejected", input: "/\\evil.com", expected: "/"},
+		{name: "leading backslash open redirect rejected", input: "\\\\evil.com", expected: "/"},
+		{name: "backslash in path rejected", input: "/v2\\evil.com", expected: "/"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR do / Why do we need it**:
ValidateCallbackUI accepted callbacks such as /\example.com. This rejects callbacks containing a backslash.

**Testing done on this change**:
Added backslash cases to TestValidateCallbackUI. They redirect to the safe default only with the fix.

**Will this break upgrades or downgrades?**
No.

**Does this PR introduce any user-facing change?**:
No.