### PR TITLE
fix(storage): verify manifest and config blob digests during scrub

### DIFF
--- a/pkg/storage/scrub.go
+++ b/pkg/storage/scrub.go
@@ -360,6 +360,10 @@ func CheckManifestAndConfig(
 		return manifestDesc.Digest, ispec.Manifest{}, zerr.ErrBadManifest
 	}
 
+	if err := imgStore.VerifyBlobDigestValue(imageName, manifestDesc.Digest); err != nil {
+		return manifestDesc.Digest, ispec.Manifest{}, err
+	}
+
 	configContent, err := imgStore.GetBlobContent(imageName, manifest.Config.Digest)
 	if err != nil {
 		return manifest.Config.Digest, ispec.Manifest{}, err
@@ -370,6 +374,10 @@ func CheckManifestAndConfig(
 	err = json.Unmarshal(configContent, &config)
 	if err != nil {
 		return manifest.Config.Digest, ispec.Manifest{}, zerr.ErrBadConfig
+	}
+
+	if err := imgStore.VerifyBlobDigestValue(imageName, manifest.Config.Digest); err != nil {
+		return manifest.Config.Digest, ispec.Manifest{}, err
 	}
 
 	return "", manifest, nil

--- a/pkg/storage/scrub_test.go
+++ b/pkg/storage/scrub_test.go
@@ -136,6 +136,61 @@ func TestAzureCheckAllBlobsIntegrity(t *testing.T) {
 	})
 }
 
+func TestScrubDetectsCorruptedConfigContent(t *testing.T) {
+	Convey("scrub detects config corruption that stays valid JSON", t, func() {
+		tdir := t.TempDir()
+		log := log.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+
+		defer metrics.Stop()
+
+		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
+			RootDir:     tdir,
+			Name:        "cache",
+			UseRelPaths: true,
+		}, log)
+		driver := local.New(true)
+		imgStore := local.NewImageStore(tdir, true, true, log, metrics, nil, cacheDriver, nil, nil)
+
+		err := imgStore.InitRepo(context.Background(), repoName)
+		So(err, ShouldBeNil)
+
+		storeCtlr := storage.StoreController{}
+		storeCtlr.DefaultStore = imgStore
+
+		image := CreateRandomImage()
+
+		err = WriteImageToFileSystem(image, repoName, tag, storeCtlr)
+		So(err, ShouldBeNil)
+
+		// corrupt the config blob on disk while keeping it valid JSON so its
+		// stored bytes no longer hash to the config digest
+		corruptedConfig := image.Config
+		corruptedConfig.Architecture += "-corrupted"
+
+		corruptedContent, err := json.Marshal(corruptedConfig)
+		So(err, ShouldBeNil)
+
+		var stillValidJSON ispec.Image
+		So(json.Unmarshal(corruptedContent, &stillValidJSON), ShouldBeNil)
+
+		configDig := image.ConfigDescriptor.Digest.Encoded()
+		configFile := path.Join(imgStore.RootDir(), repoName, "/blobs/sha256", configDig)
+		_, err = driver.WriteFile(configFile, corruptedContent)
+		So(err, ShouldBeNil)
+
+		buff := bytes.NewBufferString("")
+
+		res, err := storeCtlr.CheckAllBlobsIntegrity(context.Background())
+		res.PrintScrubResults(buff)
+		So(err, ShouldBeNil)
+
+		space := regexp.MustCompile(`\s+`)
+		actual := strings.TrimSpace(space.ReplaceAllString(buff.String(), " "))
+		So(actual, ShouldContainSubstring, fmt.Sprintf("test 1.0 affected %s bad blob digest", configDig))
+	})
+}
+
 func RunCheckAllBlobsIntegrityTests( //nolint: thelper
 	t *testing.T, imgStore storageTypes.ImageStore, driver storageTypes.Driver, log log.Logger,
 ) {


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR do / Why do we need it**:
Scrub checked that manifest and config blobs parse but never verified that their bytes hash to their digest, so bitrot that keeps the content valid JSON was reported ok. This verifies the manifest and config blob digests.

**Testing done on this change**:
Added TestScrubDetectsCorruptedConfigContent. It corrupts a config blob while keeping it valid JSON and expects scrub to report a bad blob digest, which it does not without the fix.

**Will this break upgrades or downgrades?**
No.

**Does this PR introduce any user-facing change?**:
Scrub now reports manifest and config blobs whose stored bytes do not match their digest.