### PR TITLE
fix(meta): guard GetReferrersInfo against a missing referrer entry

### DIFF
--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -1250,7 +1250,7 @@ func (bdw *BoltDB) GetReferrersInfo(repo string, referredDigest godigest.Digest,
 			return err
 		}
 
-		referrersInfo := protoRepoMeta.Referrers[referredDigest.String()].List
+		referrersInfo := protoRepoMeta.Referrers[referredDigest.String()].GetList()
 		seenDigests := make(map[string]struct{})
 
 		for i := range referrersInfo {

--- a/pkg/meta/boltdb/boltdb_test.go
+++ b/pkg/meta/boltdb/boltdb_test.go
@@ -306,6 +306,15 @@ func TestWrapperErrors(t *testing.T) {
 				_, err = boltdbWrapper.GetReferrersInfo("repo", "refDig", []string{})
 				So(err, ShouldNotBeNil)
 			})
+
+			Convey("digest with no referrers entry returns empty list without panic", func() {
+				err := boltdbWrapper.SetRepoReference(ctx, "repo", "tag", imageMeta)
+				So(err, ShouldBeNil)
+
+				referrers, err := boltdbWrapper.GetReferrersInfo("repo", godigest.FromString("no-referrers"), []string{})
+				So(err, ShouldBeNil)
+				So(referrers, ShouldBeEmpty)
+			})
 		})
 
 		Convey("ResetRepoReferences", func() {

--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -1732,7 +1732,7 @@ func (rc *RedisDB) GetReferrersInfo(repo string, referredDigest godigest.Digest,
 		return referrersInfoResult, err
 	}
 
-	referrersInfo := protoRepoMeta.Referrers[referredDigest.String()].List
+	referrersInfo := protoRepoMeta.Referrers[referredDigest.String()].GetList()
 	seenDigests := make(map[string]struct{})
 
 	for i := range referrersInfo {

--- a/pkg/meta/redis/redis_test.go
+++ b/pkg/meta/redis/redis_test.go
@@ -822,6 +822,15 @@ func TestWrapperErrors(t *testing.T) {
 				_, err = metaDB.GetReferrersInfo("repo", "refDig", []string{})
 				So(err, ShouldNotBeNil)
 			})
+
+			Convey("digest with no referrers entry returns empty list without panic", func() {
+				err := metaDB.SetRepoReference(ctx, "repo", "tag", imageMeta)
+				So(err, ShouldBeNil)
+
+				referrers, err := metaDB.GetReferrersInfo("repo", godigest.FromString("no-referrers"), []string{})
+				So(err, ShouldBeNil)
+				So(referrers, ShouldBeEmpty)
+			})
 		})
 
 		Convey("ResetRepoReferences", func() {


### PR DESCRIPTION
**What type of PR is this?**
bug

**What does this PR do / Why do we need it**:
GetReferrersInfo dereferenced Referrers[referredDigest].List for a digest with no referrers entry (a nil map value) and panicked. This uses the generated nil-safe GetList() accessor, in both the BoltDB and Redis drivers.

**Testing done on this change**:
Added a no-referrers case to TestWrapperErrors in both the boltdb and redis drivers. It panics without the fix and returns an empty list with it.

**Will this break upgrades or downgrades?**
No.

**Does this PR introduce any user-facing change?**:
No.