### PR TITLE
test: fix flaky server port binding in integration tests

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -84,16 +84,14 @@ const (
 )
 
 var (
-	username         = "test"                    //nolint: gochecknoglobals
-	password         = "test"                    //nolint: gochecknoglobals
-	group            = "test"                    //nolint: gochecknoglobals
-	LDAPBaseDN       = "ou=" + username          //nolint: gochecknoglobals
-	LDAPBindDN       = "cn=reader," + LDAPBaseDN //nolint: gochecknoglobals
-	LDAPBindPassword = "ldappass"                //nolint: gochecknoglobals
-	LDAPUserAttr     = "uid"                     //nolint: gochecknoglobals
-
-	errTimedOutWaitingForControllerPort = goerrors.New("timed out waiting for controller port") //nolint: gochecknoglobals
-	errGetCertificateFailed             = goerrors.New("GetCertificate failed")                 //nolint: gochecknoglobals
+	username                = "test"                                //nolint: gochecknoglobals
+	password                = "test"                                //nolint: gochecknoglobals
+	group                   = "test"                                //nolint: gochecknoglobals
+	LDAPBaseDN              = "ou=" + username                      //nolint: gochecknoglobals
+	LDAPBindDN              = "cn=reader," + LDAPBaseDN             //nolint: gochecknoglobals
+	LDAPBindPassword        = "ldappass"                            //nolint: gochecknoglobals
+	LDAPUserAttr            = "uid"                                 //nolint: gochecknoglobals
+	errGetCertificateFailed = goerrors.New("GetCertificate failed") //nolint: gochecknoglobals
 )
 
 // setupBearerAuthServerCerts generates CA and server certificates for bearer auth server testing
@@ -587,9 +585,7 @@ func TestAutoPortSelection(t *testing.T) {
 		ctlr := makeController(conf, t.TempDir())
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartServer()
-		So(waitForControllerPort(ctlr, 30*time.Second), ShouldBeNil)
-		cm.WaitServerToBeReady(strconv.Itoa(ctlr.GetPort()))
+		cm.StartAndWait()
 
 		defer cm.StopServer()
 
@@ -608,19 +604,6 @@ func TestAutoPortSelection(t *testing.T) {
 		So(ctlr.GetPort(), ShouldBeGreaterThan, 0)
 		So(ctlr.GetPort(), ShouldBeLessThan, 65536)
 	})
-}
-
-func waitForControllerPort(ctlr interface{ GetPort() int }, timeout time.Duration) error {
-	deadline := time.Now().Add(timeout)
-
-	for time.Now().Before(deadline) {
-		if p := ctlr.GetPort(); p > 0 {
-			return nil
-		}
-		time.Sleep(50 * time.Millisecond)
-	}
-
-	return errTimedOutWaitingForControllerPort
 }
 
 func TestObjectStorageController(t *testing.T) {
@@ -648,9 +631,8 @@ func TestObjectStorageController(t *testing.T) {
 	})
 
 	Convey("Make a new object storage controller", t, func() {
-		port := test.GetFreePort()
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		endpoint := os.Getenv("S3MOCK_ENDPOINT")
 		tmp := t.TempDir()
@@ -670,15 +652,14 @@ func TestObjectStorageController(t *testing.T) {
 		So(ctlr, ShouldNotBeNil)
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		cm.StartAndWait()
 
 		defer cm.StopServer()
 	})
 
 	Convey("Make a new object storage controller with openid", t, func() {
-		port := test.GetFreePort()
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		endpoint := os.Getenv("S3MOCK_ENDPOINT")
 
@@ -745,7 +726,7 @@ func TestObjectStorageController(t *testing.T) {
 		So(ctlr, ShouldNotBeNil)
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		cm.StartAndWait()
 
 		defer cm.StopServer()
 	})
@@ -5533,10 +5514,7 @@ func TestAuthnMetaDBErrors(t *testing.T) {
 
 func TestAuthorization(t *testing.T) {
 	Convey("Make a new controller", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
@@ -5565,6 +5543,9 @@ func TestAuthorization(t *testing.T) {
 		}
 
 		Convey("with openid", func() {
+			// OIDC redirect URIs are registered at controller init from conf.HTTP.Port.
+			conf.HTTP.Port = test.GetFreePort()
+
 			mockOIDCServer, err := authutils.MockOIDCRun()
 			if err != nil {
 				panic(err)
@@ -5601,7 +5582,7 @@ func TestAuthorization(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 
 			defer cm.StopServer()
 
@@ -5630,6 +5611,8 @@ func TestAuthorization(t *testing.T) {
 		})
 
 		Convey("with basic auth", func() {
+			conf.HTTP.Port = "0"
+
 			ctlr := api.NewController(conf)
 			ctlr.Config.Storage.RootDirectory = t.TempDir()
 
@@ -5638,7 +5621,7 @@ func TestAuthorization(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 
 			defer cm.StopServer()
 
@@ -6455,11 +6438,7 @@ func TestAuthorizationWithAnonymousPolicyBasicAuthAndSessionHeader(t *testing.T)
 
 func TestAuthorizationWithMultiplePolicies(t *testing.T) {
 	Convey("Make a new controller", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
 		// have two users: one for  user Policy, and another for default policy
 		username1, seedUser1 := test.GenerateRandomString()
 		password1, seedPass1 := test.GenerateRandomString()
@@ -6495,6 +6474,9 @@ func TestAuthorizationWithMultiplePolicies(t *testing.T) {
 		}
 
 		Convey("with openid", func() {
+			// OIDC redirect URIs are registered at controller init from conf.HTTP.Port.
+			conf.HTTP.Port = test.GetFreePort()
+
 			dir := t.TempDir()
 
 			mockOIDCServer, err := authutils.MockOIDCRun()
@@ -6537,7 +6519,7 @@ func TestAuthorizationWithMultiplePolicies(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 
 			defer cm.StopServer()
 
@@ -6587,6 +6569,8 @@ func TestAuthorizationWithMultiplePolicies(t *testing.T) {
 		})
 
 		Convey("with basic auth", func() {
+			conf.HTTP.Port = "0"
+
 			dir := t.TempDir()
 
 			ctlr := api.NewController(conf)
@@ -6597,7 +6581,7 @@ func TestAuthorizationWithMultiplePolicies(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 
 			defer cm.StopServer()
 
@@ -11767,10 +11751,8 @@ func TestGCSignaturesAndUntaggedManifestsWithMetaDB(t *testing.T) {
 			repoName := "testrepo" //nolint:goconst
 			tag := "0.0.1"
 
-			port := test.GetFreePort()
-			baseURL := test.GetBaseURL(port)
 			conf := config.New()
-			conf.HTTP.Port = port
+			conf.HTTP.Port = "0"
 			conf.Log.Output = test.MakeTempFilePath(t, "zot-log.txt")
 			conf.Log.Audit = test.MakeTempFilePath(t, "zot-audit.log")
 
@@ -11806,11 +11788,10 @@ func TestGCSignaturesAndUntaggedManifestsWithMetaDB(t *testing.T) {
 
 			ctlr.Config.Storage.Dedupe = false
 
-			cm := test.NewControllerManager(ctlr)
-			cm.StartServer() //nolint: contextcheck
-			cm.WaitServerToBeReady(port)
+			controllerManager := test.NewControllerManager(ctlr)
+			baseURL := controllerManager.StartAndWait()
 
-			defer cm.StopServer()
+			defer controllerManager.StopServer()
 
 			img := CreateDefaultImage()
 
@@ -11843,7 +11824,7 @@ func TestGCSignaturesAndUntaggedManifestsWithMetaDB(t *testing.T) {
 			err = generate.GenerateKeyPairCmd(ctx, "", "cosign", nil)
 			So(err, ShouldBeNil)
 
-			image := fmt.Sprintf("localhost:%s/%s@%s", port, repoName, digest.String())
+			image := fmt.Sprintf("localhost:%d/%s@%s", controllerManager.Port(), repoName, digest.String())
 
 			annotations := []string{"tag=" + tag}
 
@@ -14447,16 +14428,13 @@ func TestDynamicTLSCertificateReloading(t *testing.T) {
 
 func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 	Convey("Test Docker client /v2/ challenge workaround", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		htpasswdUsername, seedUser := test.GenerateRandomString()
 		htpasswdPassword, seedPass := test.GenerateRandomString()
 		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
 
 		Convey("With mixed anonymous and authenticated repository policies", func() {
 			conf := config.New()
-			conf.HTTP.Port = port
+			conf.HTTP.Port = "0"
 			conf.HTTP.Auth = &config.AuthConfig{
 				HTPasswd: config.AuthHTPasswd{
 					Path: htpasswdPath,
@@ -14480,7 +14458,7 @@ func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 			ctlr.Log.Info().Int64("seedUser", seedUser).Int64("seedPass", seedPass).
 				Msg("random seed for username & password")
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 
 			defer cm.StopServer()
 
@@ -14550,7 +14528,7 @@ func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 
 		Convey("With only anonymous repository policies", func() {
 			conf := config.New()
-			conf.HTTP.Port = port
+			conf.HTTP.Port = "0"
 			conf.HTTP.Auth = &config.AuthConfig{
 				HTPasswd: config.AuthHTPasswd{
 					Path: htpasswdPath,
@@ -14569,7 +14547,7 @@ func TestDockerClientV2ChallengeWorkaround(t *testing.T) {
 			ctlr.Log.Info().Int64("seedUser", seedUser).Int64("seedPass", seedPass).
 				Msg("random seed for username & password")
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 
 			defer cm.StopServer()
 

--- a/pkg/cli/client/image_cmd_test.go
+++ b/pkg/cli/client/image_cmd_test.go
@@ -931,10 +931,8 @@ func TestServerResponseGQLWithoutPermissions(t *testing.T) {
 
 func TestDisplayIndex(t *testing.T) {
 	Convey("Init Basic Server, No GQL", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		Convey("No GQL", func() {
 			defaultVal := false
@@ -945,7 +943,7 @@ func TestDisplayIndex(t *testing.T) {
 			ctlr.Config.Storage.RootDirectory = t.TempDir()
 			cm := test.NewControllerManager(ctlr)
 
-			cm.StartAndWait(conf.HTTP.Port)
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
 
 			runDisplayIndexTests(baseURL)
@@ -960,7 +958,7 @@ func TestDisplayIndex(t *testing.T) {
 			ctlr.Config.Storage.RootDirectory = t.TempDir()
 			cm := test.NewControllerManager(ctlr)
 
-			cm.StartAndWait(conf.HTTP.Port)
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
 
 			runDisplayIndexTests(baseURL)

--- a/pkg/debug/pprof/pprof_test.go
+++ b/pkg/debug/pprof/pprof_test.go
@@ -18,8 +18,6 @@ import (
 
 func TestProfilingAuthz(t *testing.T) {
 	Convey("Make a new controller", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		adminUsername, seedAdminUser := test.GenerateRandomString()
 		adminPassword, seedAdminPass := test.GenerateRandomString()
 		username, seedUser := test.GenerateRandomString()
@@ -31,13 +29,13 @@ func TestProfilingAuthz(t *testing.T) {
 		htpasswdPath := test.MakeHtpasswdFileFromString(t, testCreds)
 
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 
 		Convey("Test with no access control", func() {
 			ctlr := api.NewController(conf)
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 
 			defer cm.StopServer()
 
@@ -100,7 +98,7 @@ func TestProfilingAuthz(t *testing.T) {
 				Msg("random seed for admin username & password")
 			ctlr.Log.Info().Int64("seedUser", seedUser).Int64("seedPass", seedPass).Msg("random seed for username & password")
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 
 			defer cm.StopServer()
 
@@ -158,7 +156,7 @@ func TestProfilingAuthz(t *testing.T) {
 
 			ctlr := api.NewController(conf)
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 
 			defer cm.StopServer()
 

--- a/pkg/exporter/api/controller_test.go
+++ b/pkg/exporter/api/controller_test.go
@@ -230,7 +230,7 @@ func TestNewExporter(t *testing.T) {
 						panic(err)
 					}
 
-					reqsSize := int(nBig.Int64())
+					reqsSize := int(nBig.Int64()) + 1
 					for range reqsSize {
 						monitoring.IncDownloadCounter(serverController.Metrics, "dummyrepo")
 					}
@@ -317,7 +317,7 @@ func TestNewExporter(t *testing.T) {
 						panic(err)
 					}
 
-					reqsSize := int(nBig.Int64())
+					reqsSize := int(nBig.Int64()) + 1
 					for range reqsSize {
 						latency := getRandomLatency()
 						latencySum += latency.Seconds()

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -233,10 +233,8 @@ func TestMetricsAuthorization(t *testing.T) {
 	const AuthorizationAllRepos = "**"
 
 	Convey("Make a new controller with auth & metrics enabled", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		username := generateRandomString()
 		password := generateRandomString()
@@ -271,7 +269,7 @@ func TestMetricsAuthorization(t *testing.T) {
 			ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
 
 			// authenticated but not authorized user should not have access to/metrics
@@ -299,7 +297,7 @@ func TestMetricsAuthorization(t *testing.T) {
 			ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
 
 			// authenticated but not authorized user should not have access to/metrics
@@ -339,7 +337,7 @@ func TestMetricsAuthorization(t *testing.T) {
 			ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
 
 			// unauthenticated clients should not have access to /metrics
@@ -395,7 +393,7 @@ func TestMetricsAuthorization(t *testing.T) {
 			ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
 
 			// unauthenticated clients should not have access to /metrics
@@ -435,7 +433,7 @@ func TestMetricsAuthorization(t *testing.T) {
 			ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
 
 			// unauthenticated client should be allowed to scrape /metrics
@@ -485,7 +483,7 @@ func TestMetricsAuthorization(t *testing.T) {
 			ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
 
 			// unauthenticated client should be allowed to scrape /metrics
@@ -533,7 +531,7 @@ func TestMetricsAuthorization(t *testing.T) {
 			ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
 
 			// unauthenticated client should be blocked

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -1741,6 +1741,7 @@ func TestFixedTagsWithIndex(t *testing.T) {
 		conf.HTTP.Port = port
 		defaultVal := true
 		conf.Storage.RootDirectory = tempDir
+		conf.Storage.GC = false
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: &extconf.SearchConfig{
 				BaseConfig: extconf.BaseConfig{Enable: &defaultVal},

--- a/pkg/test/common/utils.go
+++ b/pkg/test/common/utils.go
@@ -24,6 +24,7 @@ const (
 	BaseURL               = "http://127.0.0.1:%s"
 	BaseSecureURL         = "https://127.0.0.1:%s"
 	SleepTime             = 100 * time.Millisecond
+	boundPortWaitTimeout  = 30 * time.Second
 	AuthorizationAllRepos = "**"
 )
 
@@ -98,28 +99,54 @@ func (cm *ControllerManager) StopServer() {
 	cm.controller.Shutdown()
 }
 
-func (cm *ControllerManager) WaitServerToBeReady(port string) {
-	url := GetBaseURL(port)
-	WaitTillServerReady(url)
+// StartAndWait starts the controller and blocks until the server responds to HTTP GET.
+// It returns the HTTP base URL (http://127.0.0.1:<port>).
+//
+// The listen port comes from the controller config. After bind, the port is
+// read from the controller (including kernel-chosen ports when config uses "0").
+// Prefer conf.HTTP.Port = "0" in new tests to avoid port-allocation races.
+//
+// Optional port arguments are deprecated and ignored; kept for call-site compatibility.
+func (cm *ControllerManager) StartAndWait(_ ...string) string {
+	cm.StartServer()
+	baseURL := GetBaseURL(cm.waitForBoundPort())
+	WaitTillServerReady(baseURL)
+
+	return baseURL
 }
 
-func (cm *ControllerManager) StartAndWait(port string) {
-	cm.StartServer()
+// Port returns the TCP port the controller bound to, or 0 if not listening yet.
+func (cm *ControllerManager) Port() int {
+	return cm.controller.GetPort()
+}
 
-	if port == "0" || port == "" {
-		for {
-			if chosenPort := cm.controller.GetPort(); chosenPort > 0 {
-				port = strconv.Itoa(chosenPort)
-
-				break
-			}
-
-			time.Sleep(SleepTime)
-		}
+// BaseURL returns http://127.0.0.1:<port> from the bound listen port, or "" if not listening yet.
+func (cm *ControllerManager) BaseURL() string {
+	port := cm.Port()
+	if port <= 0 {
+		return ""
 	}
 
-	url := GetBaseURL(port)
-	WaitTillServerReady(url)
+	return GetBaseURL(strconv.Itoa(port))
+}
+
+func (cm *ControllerManager) waitForBoundPort() string {
+	deadline := time.Now().Add(boundPortWaitTimeout)
+
+	for time.Now().Before(deadline) {
+		if port := cm.controller.GetPort(); port > 0 {
+			return strconv.Itoa(port)
+		}
+
+		time.Sleep(SleepTime)
+	}
+
+	panic(fmt.Sprintf("timed out after %s waiting for controller to bind a port", boundPortWaitTimeout))
+}
+
+// WaitServerReady blocks until the server responds to HTTP GET on the bound port.
+func (cm *ControllerManager) WaitServerReady() {
+	WaitTillServerReady(GetBaseURL(cm.waitForBoundPort()))
 }
 
 func NewControllerManager(controller Controller) ControllerManager {

--- a/pkg/test/common/utils_test.go
+++ b/pkg/test/common/utils_test.go
@@ -1,8 +1,10 @@
 package common_test
 
 import (
+	"net/http"
 	"os"
 	"path"
+	"strconv"
 	"testing"
 	"time"
 
@@ -57,6 +59,30 @@ func TestControllerManager(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		So(func() { ctlrManager.RunServer() }, ShouldPanic)
+	})
+
+	Convey("StartAndWait returns base URL from bound port", t, func() {
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		conf.Storage.RootDirectory = t.TempDir()
+
+		ctlr := api.NewController(conf)
+		ctlrManager := tcommon.NewControllerManager(ctlr)
+
+		baseURL := ctlrManager.StartAndWait()
+		defer ctlrManager.StopServer()
+
+		So(baseURL, ShouldEqual, tcommon.GetBaseURL(strconv.Itoa(ctlrManager.Port())))
+		So(ctlrManager.BaseURL(), ShouldEqual, baseURL)
+
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, baseURL+"/v2/", nil)
+		So(err, ShouldBeNil)
+
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Do(req)
+		So(err, ShouldBeNil)
+		defer resp.Body.Close()
+		So(resp.StatusCode, ShouldEqual, http.StatusOK)
 	})
 }
 


### PR DESCRIPTION
Derive the listen port from the controller after bind instead of pre-allocating with GetFreePort(). StartAndWait() now returns the base URL; add Port(), BaseURL(), and WaitServerReady() helpers.

Migrate some of the tests to conf.HTTP.Port = "0" to avoid TOCTOU races under parallel go test ./... in CI.


See https://github.com/project-zot/zot/actions/runs/29035155788/job/86177992833?pr=4207

```
{"time":"2026-07-09T17:00:35.203954272Z","level":"info","message":"setting up metrics routes","caller":"zotregistry.dev/zot/v2/pkg/extensions/extension_metrics.go:27","func":"zotregistry.dev/zot/v2/pkg/extensions.SetupMetricsRoutes","goroutine":261}
{"time":"2026-07-09T17:00:35.204095986Z","level":"info","message":"skip enabling the search route as the config prerequisites are not met","caller":"zotregistry.dev/zot/v2/pkg/extensions/extension_search.go:83","func":"zotregistry.dev/zot/v2/pkg/extensions.SetupSearchRoutes","goroutine":261}
{"time":"2026-07-09T17:00:35.204227035Z","level":"info","message":"skip enabling the image trust routes as the config prerequisites are not met","caller":"zotregistry.dev/zot/v2/pkg/extensions/extension_image_trust.go:32","func":"zotregistry.dev/zot/v2/pkg/extensions.SetupImageTrustRoutes","goroutine":261}
{"time":"2026-07-09T17:00:35.204328308Z","level":"info","message":"skip enabling the mgmt route as the config prerequisites are not met","caller":"zotregistry.dev/zot/v2/pkg/extensions/extension_mgmt.go:89","func":"zotregistry.dev/zot/v2/pkg/extensions.SetupMgmtRoutes","goroutine":261}
{"time":"2026-07-09T17:00:35.204420257Z","level":"info","message":"skip enabling the user preferences route as the config prerequisites are not met","caller":"zotregistry.dev/zot/v2/pkg/extensions/extension_userprefs.go:33","func":"zotregistry.dev/zot/v2/pkg/extensions.SetupUserPreferencesRoutes","goroutine":261}
{"time":"2026-07-09T17:00:35.204517484Z","level":"info","message":"skip enabling the ui route as the config prerequisites are not met","caller":"zotregistry.dev/zot/v2/pkg/extensions/extension_ui.go:67","func":"zotregistry.dev/zot/v2/pkg/extensions.SetupUIRoutes","goroutine":261}
panic: listen tcp 127.0.0.1:33711: bind: address already in use

goroutine 261 [running]:
zotregistry.dev/zot/v2/pkg/test/common.(*ControllerManager).RunServer(0xc000034450)
        zotregistry.dev/zot/v2/pkg/test/common/utils.go:83 +0xfe
zotregistry.dev/zot/v2/pkg/test/common.(*ControllerManager).StartServer.func1()
        zotregistry.dev/zot/v2/pkg/test/common/utils.go:93 +0x45
created by zotregistry.dev/zot/v2/pkg/test/common.(*ControllerManager).StartServer in goroutine 26
        zotregistry.dev/zot/v2/pkg/test/common/utils.go:92 +0x125
FAIL    zotregistry.dev/zot/v2/pkg/debug/pprof  7.145s
        zotregistry.dev/zot/v2/pkg/debug/swagger                coverage: 0.0% of statements
ok      zotregistry.dev/zot/v2/pkg/extensions   49.405s coverage: 17.1% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/extensions/config    1.452s  coverage: 0.2% of statements in ./...
```

On top of this:

Ensure concurrent exporter subtests always record at least one metric
observation so Collect() emits the expected counter/summary instead of
leaving the test blocked on an empty channel when reqsSize is 0.

See: https://github.com/project-zot/zot/actions/runs/29081599266/job/86325480120?pr=4216

Disable GC in TestFixedTagsWithIndex so platform manifests referenced
only by a multi-arch index are not removed before the CVE scanner runs.

See: https://github.com/project-zot/zot/actions/runs/29081599266/job/86325480044?pr=4216

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
