### PR TITLE
test: fix flaky test

### DIFF
--- a/pkg/api/htpasswd_test.go
+++ b/pkg/api/htpasswd_test.go
@@ -323,10 +323,12 @@ func TestHTPasswdWatcher(t *testing.T) {
 			time.Sleep(50 * time.Millisecond)
 			So(func() { htw.Close() }, ShouldNotPanic)
 			So(test.WaitForLogMessages(logBuffer, "htpasswd watcher terminating...", 1, 5*time.Second), ShouldBeTrue)
+			time.Sleep(100 * time.Millisecond) // let watcher goroutine finish cleanup before restart
 
 			// Test concurrent ChangeFile() operations
 			htw.Run()
 			defer htw.Close()
+			time.Sleep(10 * time.Millisecond)
 
 			go func() {
 				for range 3 {
@@ -344,11 +346,22 @@ func TestHTPasswdWatcher(t *testing.T) {
 				}
 			}()
 
-			time.Sleep(50 * time.Millisecond)
+			// Poll until at least one concurrent ChangeFile() reload authenticates.
+			deadline := time.Now().Add(5 * time.Second)
+
+			var ok1, present1, ok2, present2 bool
+
+			for time.Now().Before(deadline) {
+				ok1, present1 = htp.Authenticate(username1, password1)
+				ok2, present2 = htp.Authenticate(username2, password2)
+				if ok1 || ok2 {
+					break
+				}
+
+				time.Sleep(10 * time.Millisecond)
+			}
 
 			// At least one user should be present
-			ok1, present1 := htp.Authenticate(username1, password1)
-			ok2, present2 := htp.Authenticate(username2, password2)
 			So(present1 || present2, ShouldBeTrue)
 			So(ok1 || ok2, ShouldBeTrue)
 


### PR DESCRIPTION
See: https://github.com/project-zot/zot/actions/runs/29072040791/job/86295357131?pr=4216

```
......{"time":"2026-07-10T05:55:15.087452573Z","level":"info","message":"loaded htpasswd file","htpasswd-file":"/tmp/TestHTPasswdWatcher3310482795/011/htpasswd","users":1,"caller":"zotregistry.dev/zot/v2/pkg/api/htpasswd.go:60","func":"zotregistry.dev/zot/v2/pkg/api.(*HTPasswd).Reload","goroutine":269}
...{"time":"2026-07-10T05:55:15.806575031Z","level":"warn","message":"loaded htpasswd file appears to have zero users","htpasswd-file":"/tmp/TestHTPasswdWatcher3310482795/012/htpasswd","caller":"zotregistry.dev/zot/v2/pkg/api/htpasswd.go:58","func":"zotregistry.dev/zot/v2/pkg/api.(*HTPasswd).Reload","goroutine":269}
...{"time":"2026-07-10T05:55:16.526216362Z","level":"info","message":"loaded htpasswd file","htpasswd-file":"/tmp/TestHTPasswdWatcher3310482795/013/htpasswd","users":1,"caller":"zotregistry.dev/zot/v2/pkg/api/htpasswd.go:60","func":"zotregistry.dev/zot/v2/pkg/api.(*HTPasswd).Reload","goroutine":269}
....
Failures:

  * zotregistry.dev/zot/v2/pkg/api/htpasswd_test.go
  Line 352:
  Expected: true
  Actual:   false

444 total assertions

--- FAIL: TestHTPasswdWatcher (22.64s)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
