### PR TITLE
ci: raise zb bench HTTP timeouts and wait for zot shutdown

### DIFF
--- a/.github/workflows/gc-stress-test.yaml
+++ b/.github/workflows/gc-stress-test.yaml
@@ -34,7 +34,7 @@ jobs:
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
 
-            killall -r zot-*
+            killall --wait -r zot-*
 
             # clean zot storage
             sudo rm -rf /tmp/zot
@@ -76,7 +76,7 @@ jobs:
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
 
-            killall -r zot-*
+            killall --wait -r zot-*
 
             # clean zot storage
             sudo rm -rf /tmp/zot
@@ -158,7 +158,7 @@ jobs:
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
 
-            killall -r zot-*
+            killall --wait -r zot-*
 
             # clean zot storage
             sudo rm -rf /tmp/zot
@@ -245,7 +245,7 @@ jobs:
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
 
-            killall -r zot-*
+            killall --wait -r zot-*
 
             # clean zot storage
             sudo rm -rf /tmp/zot

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -100,7 +100,7 @@ jobs:
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080 --skip-cleanup
 
-            killall -r zot-*
+            killall --wait -r zot-*
 
             # clean zot storage
             sudo rm -rf /tmp/zot
@@ -146,7 +146,7 @@ jobs:
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080 --skip-cleanup
 
-            killall -r zot-*
+            killall --wait -r zot-*
 
             # clean zot storage
             sudo rm -rf /tmp/zot

--- a/examples/config-bench.json
+++ b/examples/config-bench.json
@@ -5,7 +5,9 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080"
+        "port": "8080",
+        "readTimeout": "2m",
+        "writeTimeout": "2m"
     },
     "log": {
         "level": "debug",

--- a/test/cluster/config-minio-redis.json
+++ b/test/cluster/config-minio-redis.json
@@ -20,7 +20,9 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8081"
+        "port": "8081",
+        "readTimeout": "2m",
+        "writeTimeout": "2m"
     },
     "log": {
         "level": "debug",

--- a/test/cluster/config-minio.json
+++ b/test/cluster/config-minio.json
@@ -16,7 +16,9 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8081"
+        "port": "8081",
+        "readTimeout": "2m",
+        "writeTimeout": "2m"
     },
     "log": {
         "level": "debug",

--- a/test/gc-stress/config-gc-bench-local.json
+++ b/test/gc-stress/config-gc-bench-local.json
@@ -8,7 +8,9 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080"
+        "port": "8080",
+        "readTimeout": "2m",
+        "writeTimeout": "2m"
     },
     "log": {
         "level": "debug",

--- a/test/gc-stress/config-gc-bench-s3-localstack.json
+++ b/test/gc-stress/config-gc-bench-s3-localstack.json
@@ -29,7 +29,9 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080"
+        "port": "8080",
+        "readTimeout": "2m",
+        "writeTimeout": "2m"
     },
     "log": {
         "level": "debug",

--- a/test/gc-stress/config-gc-bench-s3-minio.json
+++ b/test/gc-stress/config-gc-bench-s3-minio.json
@@ -31,7 +31,9 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080"
+        "port": "8080",
+        "readTimeout": "2m",
+        "writeTimeout": "2m"
     },
     "log": {
         "level": "debug",

--- a/test/gc-stress/config-gc-referrers-bench-local.json
+++ b/test/gc-stress/config-gc-referrers-bench-local.json
@@ -17,7 +17,9 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080"
+        "port": "8080",
+        "readTimeout": "2m",
+        "writeTimeout": "2m"
     },
     "log": {
         "level": "debug",

--- a/test/gc-stress/config-gc-referrers-bench-s3-localstack.json
+++ b/test/gc-stress/config-gc-referrers-bench-s3-localstack.json
@@ -38,7 +38,9 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080"
+        "port": "8080",
+        "readTimeout": "2m",
+        "writeTimeout": "2m"
     },
     "log": {
         "level": "debug",

--- a/test/gc-stress/config-gc-referrers-bench-s3-minio.json
+++ b/test/gc-stress/config-gc-referrers-bench-s3-minio.json
@@ -40,7 +40,9 @@
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "8080"
+        "port": "8080",
+        "readTimeout": "2m",
+        "writeTimeout": "2m"
     },
     "log": {
         "level": "debug",


### PR DESCRIPTION
zb GC stress and benchmark jobs were flaking when slow chunked pushes or large pulls approached zot's 60s default read/write timeout. Set 2m timeouts on all zb bench configs and use killall --wait so zot can shut down cleanly before CI collects logs.

See: https://github.com/project-zot/zot/actions/runs/29038448071/job/86317480369?pr=4210

```
Test name:            Push Chunk Mixed 33% 1MB, 33% 10MB, 33% 100MB
Time taken for tests: 1m0.281970856s
Requests per second:  1.6588708
Complete requests:    99
Failed requests:      1
Error                 Patch "http://localhost:8080/v2/a960d36a-7c37-11f1-92d0-02001713c410/blobs/uploads/a6772496-8c5e-46d2-b1d6-01fb47440b66": readfrom tcp 127.0.0.1:53292->127.0.0.1:8080: write tcp 127.0.0.1:53292->127.0.0.1:8080: use of closed network connection count: 1

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
