### PR TITLE
test: migrate extensions and pkg/test from GetFreePort to port "0"

### DIFF
--- a/pkg/extensions/extension_events_disabled_test.go
+++ b/pkg/extensions/extension_events_disabled_test.go
@@ -18,14 +18,13 @@ import (
 func TestEventsExtension(t *testing.T) {
 	Convey("event generation is skipped when extension is disabled", t, func() {
 		conf := config.New()
-		port := test.GetFreePort()
 
 		globalDir := t.TempDir()
 		defaultValue := true
 
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = globalDir
 		conf.Storage.Commit = true
 		conf.Extensions = &extconf.ExtensionConfig{}
@@ -38,7 +37,7 @@ func TestEventsExtension(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlrManager := test.NewControllerManager(ctlr)
 
-		ctlrManager.StartAndWait(port)
+		ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		data, err := os.ReadFile(logPath)

--- a/pkg/extensions/extension_image_trust_disabled_test.go
+++ b/pkg/extensions/extension_image_trust_disabled_test.go
@@ -17,14 +17,13 @@ import (
 func TestImageTrustExtension(t *testing.T) {
 	Convey("periodic signature verification is skipped when binary doesn't include imagetrust", t, func() {
 		conf := config.New()
-		port := test.GetFreePort()
 
 		globalDir := t.TempDir()
 		defaultValue := true
 
 		logFile := test.MakeTempFile(t, "zot-log.txt")
 
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = globalDir
 		conf.Storage.Commit = true
 		conf.Extensions = &extconf.ExtensionConfig{}
@@ -38,7 +37,7 @@ func TestImageTrustExtension(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlrManager := test.NewControllerManager(ctlr)
 
-		ctlrManager.StartAndWait(port)
+		ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		data, err := os.ReadFile(logFile.Name())

--- a/pkg/extensions/extension_image_trust_test.go
+++ b/pkg/extensions/extension_image_trust_test.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"strconv"
 	"testing"
 	"time"
 
@@ -116,22 +117,19 @@ func TestSignaturesAllowedMethodsHeader(t *testing.T) {
 
 	Convey("Test http options response", t, func() {
 		conf := config.New()
-		port := test.GetFreePort()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Extensions = &extconf.ExtensionConfig{}
 		conf.Extensions.Trust = &extconf.ImageTrustConfig{}
 		conf.Extensions.Trust.Enable = &defaultVal
 		conf.Extensions.Trust.Cosign = defaultVal
 		conf.Extensions.Trust.Notation = defaultVal
 
-		baseURL := test.GetBaseURL(port)
-
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		ctrlManager := test.NewControllerManager(ctlr)
 
-		ctrlManager.StartAndWait(port)
+		baseURL := ctrlManager.StartAndWait()
 		defer ctrlManager.StopServer()
 
 		resp, _ := resty.R().Options(baseURL + constants.FullCosign)
@@ -220,10 +218,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 
 	Convey("Verify cosign public key upload without search or notation being enabled", func() {
 		globalDir := t.TempDir()
-		port := test.GetFreePort()
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		if cacheDriverParams != nil {
 			conf.Storage.CacheDriver = cacheDriverParams
@@ -232,8 +228,6 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		conf.Extensions.Trust = &extconf.ImageTrustConfig{}
 		conf.Extensions.Trust.Enable = &defaultValue
 		conf.Extensions.Trust.Cosign = defaultValue
-
-		baseURL := test.GetBaseURL(port)
 
 		logFile := test.MakeTempFile(t, "zot-log.txt")
 		defer logFile.Close()
@@ -258,7 +252,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		ctlr.Config.Storage.RootDirectory = globalDir
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logFile.Name(), "setting up image trust routes", time.Second)
@@ -340,10 +335,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 
 	Convey("Verify notation certificate upload without search or cosign being enabled", func() {
 		globalDir := t.TempDir()
-		port := test.GetFreePort()
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		if cacheDriverParams != nil {
 			conf.Storage.CacheDriver = cacheDriverParams
@@ -352,8 +345,6 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		conf.Extensions.Trust = &extconf.ImageTrustConfig{}
 		conf.Extensions.Trust.Enable = &defaultValue
 		conf.Extensions.Trust.Notation = defaultValue
-
-		baseURL := test.GetBaseURL(port)
 
 		logFile := test.MakeTempFile(t, "zot-log.txt")
 		defer logFile.Close()
@@ -378,7 +369,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		ctlr.Config.Storage.RootDirectory = globalDir
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logFile.Name(), "setting up image trust routes", time.Second)
@@ -442,10 +434,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 
 	Convey("Verify uploading notation certificates", func() {
 		globalDir := t.TempDir()
-		port := test.GetFreePort()
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		if cacheDriverParams != nil {
 			conf.Storage.CacheDriver = cacheDriverParams
@@ -457,9 +447,6 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		conf.Extensions.Trust = &extconf.ImageTrustConfig{}
 		conf.Extensions.Trust.Enable = &defaultValue
 		conf.Extensions.Trust.Notation = defaultValue
-
-		baseURL := test.GetBaseURL(port)
-		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, constants.FullSearchPrefix)
 
 		logFile := test.MakeTempFile(t, "zot-log.txt")
 		defer logFile.Close()
@@ -484,8 +471,11 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		ctlr.Config.Storage.RootDirectory = globalDir
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
 		defer ctlrManager.StopServer()
+
+		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, constants.FullSearchPrefix)
 
 		found, err := test.ReadLogFileAndSearchString(logFile.Name(), "setting up image trust routes", time.Second)
 		So(err, ShouldBeNil)
@@ -603,10 +593,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 
 	Convey("Verify uploading cosign public keys", func() {
 		globalDir := t.TempDir()
-		port := test.GetFreePort()
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		if cacheDriverParams != nil {
 			conf.Storage.CacheDriver = cacheDriverParams
@@ -618,9 +606,6 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		conf.Extensions.Trust = &extconf.ImageTrustConfig{}
 		conf.Extensions.Trust.Enable = &defaultValue
 		conf.Extensions.Trust.Cosign = defaultValue
-
-		baseURL := test.GetBaseURL(port)
-		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, constants.FullSearchPrefix)
 
 		logFile := test.MakeTempFile(t, "zot-log.txt")
 		defer logFile.Close()
@@ -645,8 +630,11 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		ctlr.Config.Storage.RootDirectory = globalDir
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
 		defer ctlrManager.StopServer()
+
+		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, constants.FullSearchPrefix)
 
 		found, err := test.ReadLogFileAndSearchString(logFile.Name(), "setting up image trust routes", time.Second)
 		So(err, ShouldBeNil)
@@ -770,13 +758,12 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 
 	Convey("Verify uploading cosign public keys with auth configured", func() {
 		globalDir := t.TempDir()
-		port := test.GetFreePort()
 		testCreds := test.GetBcryptCredString("admin", "admin") + "\n" + test.GetBcryptCredString("test", "test")
 
 		htpasswdPath := test.MakeHtpasswdFileFromString(t, testCreds)
 
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.HTTP.Auth.HTPasswd.Path = htpasswdPath
 		conf.HTTP.AccessControl = &config.AccessControlConfig{
 			AdminPolicy: config.Policy{
@@ -796,8 +783,6 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		conf.Extensions.Trust.Enable = &defaultValue
 		conf.Extensions.Trust.Cosign = defaultValue
 
-		baseURL := test.GetBaseURL(port)
-
 		logFile := test.MakeTempFile(t, "zot-log.txt")
 		defer logFile.Close()
 
@@ -809,7 +794,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		ctlr.Config.Storage.RootDirectory = globalDir
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logFile.Name(), "setting up image trust routes", time.Second)
@@ -862,10 +847,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 
 	Convey("Verify signatures are read from the disk and updated in the DB when zot starts", func() {
 		globalDir := t.TempDir()
-		port := test.GetFreePort()
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		if cacheDriverParams != nil {
 			conf.Storage.CacheDriver = cacheDriverParams
@@ -877,9 +860,6 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		conf.Extensions.Trust = &extconf.ImageTrustConfig{}
 		conf.Extensions.Trust.Enable = &defaultValue
 		conf.Extensions.Trust.Cosign = defaultValue
-
-		baseURL := test.GetBaseURL(port)
-		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, constants.FullSearchPrefix)
 
 		logFile := test.MakeTempFile(t, "zot-log.txt")
 		defer logFile.Close()
@@ -915,9 +895,11 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		ctlr.Config.Storage.RootDirectory = globalDir
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 
 		defer ctlrManager.StopServer()
+
+		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, constants.FullSearchPrefix)
 
 		strQuery := fmt.Sprintf(imageQuery, repo, tag)
 		gqlTargetURL := fmt.Sprintf("%s%s", gqlEndpoint, url.QueryEscape(strQuery))
@@ -968,10 +950,8 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 
 	Convey("Verify failures when saving uploaded certificates and public keys", func() {
 		globalDir := t.TempDir()
-		port := test.GetFreePort()
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		if cacheDriverParams != nil {
 			conf.Storage.CacheDriver = cacheDriverParams
@@ -985,13 +965,11 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		conf.Extensions.Trust.Notation = defaultValue
 		conf.Extensions.Trust.Cosign = defaultValue
 
-		baseURL := test.GetBaseURL(port)
-
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = globalDir
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		rootDir := t.TempDir()

--- a/pkg/extensions/extension_ui_test.go
+++ b/pkg/extensions/extension_ui_test.go
@@ -23,9 +23,7 @@ import (
 func TestUIExtension(t *testing.T) {
 	Convey("Verify zot with UI extension starts successfully", t, func() {
 		conf := config.New()
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		// we won't use the logging config feature as we want logs in both
 		// stdout and a file
@@ -48,7 +46,8 @@ func TestUIExtension(t *testing.T) {
 		ctlr.Log = log.NewLoggerWithWriter("debug", writers)
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath, "\"UI\":{\"Enable\":true}", 2*time.Minute)
 		So(found, ShouldBeTrue)

--- a/pkg/extensions/extension_userprefs_test.go
+++ b/pkg/extensions/extension_userprefs_test.go
@@ -33,8 +33,7 @@ func TestAllowedMethodsHeaderUserPrefs(t *testing.T) {
 
 	Convey("Test http options response", t, func() {
 		conf := config.New()
-		port := test.GetFreePort()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Extensions = &extconf.ExtensionConfig{}
 		conf.Extensions.Search = &extconf.SearchConfig{}
 		conf.Extensions.Search.Enable = &defaultVal
@@ -42,14 +41,12 @@ func TestAllowedMethodsHeaderUserPrefs(t *testing.T) {
 		conf.Extensions.UI = &extconf.UIConfig{}
 		conf.Extensions.UI.Enable = &defaultVal
 
-		baseURL := test.GetBaseURL(port)
-
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		ctrlManager := test.NewControllerManager(ctlr)
 
-		ctrlManager.StartAndWait(port)
+		baseURL := ctrlManager.StartAndWait()
 		defer ctrlManager.StopServer()
 
 		resp, _ := resty.R().Options(baseURL + constants.FullUserPrefs)

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -61,7 +61,6 @@ func setupTestServerCerts(t *testing.T) (string, string) {
 func TestEnableExtension(t *testing.T) {
 	Convey("Verify log if sync disabled in config", t, func() {
 		globalDir := t.TempDir()
-		port := test.GetFreePort()
 		conf := config.New()
 		falseValue := false
 
@@ -73,7 +72,7 @@ func TestEnableExtension(t *testing.T) {
 		// conf.Extensions.Sync.Enable = &falseValue
 		conf.Extensions = &extconf.ExtensionConfig{}
 		conf.Extensions.Sync = syncConfig
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 		conf.Log.Level = "info"
@@ -86,7 +85,7 @@ func TestEnableExtension(t *testing.T) {
 
 		ctlr.Config.Storage.RootDirectory = globalDir
 
-		ctlrManager.StartAndWait(port)
+		ctlrManager.StartAndWait()
 
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
@@ -99,8 +98,7 @@ func TestMetricsExtension(t *testing.T) {
 	Convey("Verify Metrics enabled for storage subpaths", t, func() {
 		globalDir := t.TempDir()
 		conf := config.New()
-		port := test.GetFreePort()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 		defaultValue := true
@@ -125,7 +123,8 @@ func TestMetricsExtension(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = globalDir
 		ctlr.Config.Storage.SubPaths = subPaths
 
-		ctlrManager.StartAndWait(port)
+		ctlrManager.StartAndWait()
+		defer ctlrManager.StopServer()
 
 		data, _ := os.ReadFile(logPath)
 
@@ -136,9 +135,7 @@ func TestMetricsExtension(t *testing.T) {
 func TestMgmtExtension(t *testing.T) {
 	globalDir := t.TempDir()
 	conf := config.New()
-	port := test.GetFreePort()
-	conf.HTTP.Port = port
-	baseURL := test.GetBaseURL(port)
+	conf.HTTP.Port = "0"
 	mgmtReadyTimeout := 5 * time.Second
 
 	defaultValue := true
@@ -188,7 +185,7 @@ func TestMgmtExtension(t *testing.T) {
 		ctlr.Config.Storage.SubPaths = subPaths
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath,
@@ -274,7 +271,7 @@ func TestMgmtExtension(t *testing.T) {
 		ctlr.Config.Storage.SubPaths = subPaths
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath,
@@ -339,7 +336,7 @@ func TestMgmtExtension(t *testing.T) {
 		ctlr.Config.Storage.SubPaths = subPaths
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath,
@@ -409,7 +406,7 @@ func TestMgmtExtension(t *testing.T) {
 		ctlr.Config.Storage.SubPaths = subPaths
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath,
@@ -494,7 +491,7 @@ func TestMgmtExtension(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath,
@@ -578,7 +575,7 @@ func TestMgmtExtension(t *testing.T) {
 		ctlr.Config.Storage.SubPaths = subPaths
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath,
@@ -638,7 +635,7 @@ func TestMgmtExtension(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath,
@@ -705,7 +702,7 @@ func TestMgmtExtension(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath,
@@ -777,7 +774,7 @@ func TestMgmtExtension(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath,
@@ -815,9 +812,7 @@ func TestMgmtExtension(t *testing.T) {
 
 	Convey("Verify mgmt auth info route enabled without any auth", t, func() {
 		conf := config.New()
-		port := test.GetFreePort()
-		conf.HTTP.Port = port
-		baseURL := test.GetBaseURL(port)
+		conf.HTTP.Port = "0"
 
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 		defaultValue := true
@@ -838,7 +833,7 @@ func TestMgmtExtension(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		resp, err := resty.R().Get(baseURL + constants.FullMgmt)
@@ -884,11 +879,8 @@ func TestMgmtWithBearer(t *testing.T) {
 		authTestServer := authutils.MakeAuthTestServer(serverKeyPath, "RS256", unauthorizedNamespace)
 		defer authTestServer.Close()
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		aurl, err := url.Parse(authTestServer.URL)
 		So(err, ShouldBeNil)
@@ -915,7 +907,7 @@ func TestMgmtWithBearer(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		resp, err := resty.R().Get(baseURL + "/v2/")
@@ -1038,8 +1030,7 @@ func TestAllowedMethodsHeaderMgmt(t *testing.T) {
 
 	Convey("Test http options response", t, func() {
 		conf := config.New()
-		port := test.GetFreePort()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Extensions = &extconf.ExtensionConfig{}
 		conf.Extensions.Search = &extconf.SearchConfig{}
 		conf.Extensions.Search.Enable = &defaultVal
@@ -1047,14 +1038,12 @@ func TestAllowedMethodsHeaderMgmt(t *testing.T) {
 		conf.Extensions.UI = &extconf.UIConfig{}
 		conf.Extensions.UI.Enable = &defaultVal
 
-		baseURL := test.GetBaseURL(port)
-
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		ctrlManager := test.NewControllerManager(ctlr)
 
-		ctrlManager.StartAndWait(port)
+		baseURL := ctrlManager.StartAndWait()
 		defer ctrlManager.StopServer()
 
 		resp, _ := resty.R().Options(baseURL + constants.FullMgmt)

--- a/pkg/extensions/get_extensions_disabled_test.go
+++ b/pkg/extensions/get_extensions_disabled_test.go
@@ -20,10 +20,8 @@ import (
 func TestGetExensionsDisabled(t *testing.T) {
 	Convey("start zot server with extensions but no extensions built", t, func(c C) {
 		conf := config.New()
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		defaultVal := true
 
@@ -41,7 +39,7 @@ func TestGetExensionsDisabled(t *testing.T) {
 		ctlr := makeController(conf, t.TempDir())
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		var extensionList distext.ExtensionList

--- a/pkg/extensions/imagetrust/image_trust_test.go
+++ b/pkg/extensions/imagetrust/image_trust_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strconv"
 	"testing"
 	"time"
 
@@ -263,16 +264,15 @@ func TestVerifySignatures(t *testing.T) {
 		Convey("signature is trusted", func() {
 			rootDir := t.TempDir()
 
-			port := test.GetFreePort()
-			baseURL := test.GetBaseURL(port)
 			conf := config.New()
-			conf.HTTP.Port = port
+			conf.HTTP.Port = "0"
 			conf.Storage.GC = false
 			ctlr := api.NewController(conf)
 			ctlr.Config.Storage.RootDirectory = rootDir
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(conf.HTTP.Port)
+			baseURL := cm.StartAndWait()
+			port := strconv.Itoa(cm.Port())
 			defer cm.StopServer()
 
 			err := UploadImage(image, baseURL, repo, tag)
@@ -431,16 +431,15 @@ func TestVerifySignatures(t *testing.T) {
 		Convey("signature is trusted", func() {
 			rootDir := t.TempDir()
 
-			port := test.GetFreePort()
-			baseURL := test.GetBaseURL(port)
 			conf := config.New()
-			conf.HTTP.Port = port
+			conf.HTTP.Port = "0"
 			conf.Storage.GC = false
 			ctlr := api.NewController(conf)
 			ctlr.Config.Storage.RootDirectory = rootDir
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(conf.HTTP.Port)
+			baseURL := cm.StartAndWait()
+			port := strconv.Itoa(cm.Port())
 			defer cm.StopServer()
 
 			err := UploadImage(image, baseURL, repo, tag)
@@ -557,16 +556,15 @@ func TestCosignSignatureDigestBinding(t *testing.T) {
 
 		rootDir := t.TempDir()
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.GC = false
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = rootDir
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
+		port := strconv.Itoa(cm.Port())
 		defer cm.StopServer()
 
 		err := UploadImage(image, baseURL, repo, tag)
@@ -1355,10 +1353,8 @@ func RunVerificationTests(t *testing.T, dbDriverParams map[string]any) { //nolin
 
 		writers := io.MultiWriter(os.Stdout, logFile)
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.GC = false
 
 		if dbDriverParams != nil {
@@ -1377,7 +1373,8 @@ func RunVerificationTests(t *testing.T, dbDriverParams map[string]any) { //nolin
 		ctlr.Config.Storage.RootDirectory = rootDir
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
+		port := strconv.Itoa(cm.Port())
 		defer cm.StopServer()
 
 		repo := "repo" //nolint:goconst

--- a/pkg/extensions/lint/lint_test.go
+++ b/pkg/extensions/lint/lint_test.go
@@ -31,11 +31,8 @@ import (
 func TestVerifyMandatoryAnnotations(t *testing.T) {
 	//nolint: dupl
 	Convey("Mandatory annotations disabled", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		enable := false
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
@@ -51,7 +48,7 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = dir
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		resp, err := resty.R().Get(baseURL + "/v2/zot-test/manifests/0.0.1")
@@ -78,11 +75,8 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 
 	//nolint: dupl
 	Convey("Mandatory annotations enabled, but no list in config", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
@@ -99,7 +93,7 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = dir
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		resp, err := resty.R().Get(baseURL + "/v2/zot-test/manifests/0.0.1")
@@ -125,11 +119,8 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 	})
 
 	Convey("Mandatory annotations verification passing", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
@@ -147,7 +138,7 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = dir
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		resp, err := resty.R().Get(baseURL + "/v2/zot-test/manifests/0.0.1")
@@ -179,11 +170,8 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 	})
 
 	Convey("Mandatory annotations verification in manifest and config passing", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
@@ -201,7 +189,7 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = dir
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		resp, err := resty.R().Get(baseURL + "/v2/zot-test/manifests/0.0.1")
@@ -269,11 +257,8 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 	})
 
 	Convey("Mandatory annotations verification in manifest and config failing", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
@@ -291,7 +276,7 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = dir
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		resp, err := resty.R().Get(baseURL + "/v2/zot-test/manifests/0.0.1")
@@ -357,11 +342,8 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 	})
 
 	Convey("Mandatory annotations incomplete in manifest", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
@@ -379,7 +361,7 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = dir
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		resp, err := resty.R().Get(baseURL + "/v2/zot-test/manifests/0.0.1")
@@ -410,11 +392,8 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 	})
 
 	Convey("Mandatory annotations verification passing - more annotations than the mandatory list", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		enable := true
 		conf.Extensions = &extconf.ExtensionConfig{Lint: &extconf.LintConfig{}}
 		conf.Extensions.Lint.MandatoryAnnotations = []string{}
@@ -436,7 +415,7 @@ func TestVerifyMandatoryAnnotations(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = dir
 		cm := test.NewControllerManager(ctlr)
 
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		resp, err := resty.R().Get(baseURL + "/v2/zot-test/manifests/0.0.1")

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -37,10 +37,8 @@ import (
 
 func TestExtensionMetrics(t *testing.T) {
 	Convey("Make a new controller with explicitly enabled metrics", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		rootDir := t.TempDir()
 
@@ -61,7 +59,7 @@ func TestExtensionMetrics(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		// improve code coverage
@@ -94,10 +92,8 @@ func TestExtensionMetrics(t *testing.T) {
 		So(respStr, ShouldContainSubstring, "zot_storage_lock_latency_seconds_bucket")
 	})
 	Convey("Make a new controller with disabled metrics extension", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		var disabled bool
 
@@ -109,7 +105,7 @@ func TestExtensionMetrics(t *testing.T) {
 		So(ctlr, ShouldNotBeNil)
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		So(ctlr.Metrics.IsEnabled(), ShouldBeFalse)
@@ -123,16 +119,14 @@ func TestExtensionMetrics(t *testing.T) {
 
 func TestMetricsAuthentication(t *testing.T) {
 	Convey("test metrics without authentication and metrics enabled", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		// metrics endpoint not available
@@ -142,10 +136,8 @@ func TestMetricsAuthentication(t *testing.T) {
 		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
 	})
 	Convey("test metrics without authentication and with metrics enabled", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		enabled := true
 		metricsConfig := &extconf.MetricsConfig{
 			BaseConfig: extconf.BaseConfig{Enable: &enabled},
@@ -159,7 +151,7 @@ func TestMetricsAuthentication(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		// without auth set metrics endpoint is available
@@ -169,10 +161,8 @@ func TestMetricsAuthentication(t *testing.T) {
 		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 	})
 	Convey("test metrics with authentication and metrics enabled", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		username := generateRandomString()
 		password := generateRandomString()
@@ -201,7 +191,7 @@ func TestMetricsAuthentication(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		// without credentials
@@ -555,10 +545,8 @@ func TestMetricsAuthorization(t *testing.T) {
 		authTestServer := authutils.MakeAuthTestServer(serverKeyPath, "RS256", "unauthorized-repo")
 		defer authTestServer.Close()
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		authURL, err := url.Parse(authTestServer.URL)
 		So(err, ShouldBeNil)
@@ -588,7 +576,7 @@ func TestMetricsAuthorization(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		Convey("with bearer auth: metrics.anonymousPolicy=[read] allows unauthenticated scraping", func() {
@@ -615,10 +603,8 @@ func TestMetricsAuthorization(t *testing.T) {
 
 func TestMetricsAnonymousAccessNoAuth(t *testing.T) {
 	Convey("Make a new controller with no auth and metrics.anonymousPolicy=[read]", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		enabled := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -638,7 +624,7 @@ func TestMetricsAnonymousAccessNoAuth(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		// unauthenticated client should be allowed to scrape /metrics
@@ -659,10 +645,8 @@ func TestMetricsAnonymousPolicyNilAccessControl(t *testing.T) {
 
 func TestPopulateStorageMetrics(t *testing.T) {
 	Convey("Start a scheduler when metrics enabled", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		rootDir := t.TempDir()
 
@@ -693,7 +677,7 @@ func TestPopulateStorageMetrics(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		metrics := monitoring.NewMetricsServer(true, ctlr.Log)
@@ -741,10 +725,8 @@ func TestPopulateStorageMetrics(t *testing.T) {
 
 func TestGCMetrics(t *testing.T) {
 	Convey("GC metrics should be emitted after garbage collection", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		rootDir := t.TempDir()
 		conf.Storage.RootDirectory = rootDir
 		conf.Storage.GC = false
@@ -762,7 +744,7 @@ func TestGCMetrics(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		imgStore := ctlr.StoreController.DefaultStore

--- a/pkg/extensions/scrub/scrub_test.go
+++ b/pkg/extensions/scrub/scrub_test.go
@@ -31,12 +31,10 @@ const (
 
 func TestScrubExtension(t *testing.T) {
 	Convey("Blobs integrity not affected", t, func(c C) {
-		port := test.GetFreePort()
-
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		dir := t.TempDir()
 		subdir := t.TempDir()
@@ -64,7 +62,7 @@ func TestScrubExtension(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		cm.StartAndWait()
 		defer cm.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath, "blobs/manifest ok", 60*time.Second)
@@ -73,12 +71,10 @@ func TestScrubExtension(t *testing.T) {
 	})
 
 	Convey("Blobs integrity affected", t, func(c C) {
-		port := test.GetFreePort()
-
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		dir := t.TempDir()
 
@@ -111,7 +107,7 @@ func TestScrubExtension(t *testing.T) {
 		}
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		cm.StartAndWait()
 		defer cm.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath, "blobs/manifest affected", 60*time.Second)
@@ -120,12 +116,10 @@ func TestScrubExtension(t *testing.T) {
 	})
 
 	Convey("Generator error - not enough permissions to access root directory", t, func(c C) {
-		port := test.GetFreePort()
-
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		dir := t.TempDir()
 
@@ -154,7 +148,7 @@ func TestScrubExtension(t *testing.T) {
 		So(os.Chmod(path.Join(dir, repoName), 0o000), ShouldBeNil)
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		cm.StartAndWait()
 		defer cm.StopServer()
 
 		found, err := test.ReadLogFileAndSearchString(logPath, "failed to execute generator", 60*time.Second)

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -425,10 +425,8 @@ func TestImageFormat(t *testing.T) {
 
 func TestCVESearchDisabled(t *testing.T) {
 	Convey("Test with CVE search disabled", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
@@ -463,7 +461,7 @@ func TestCVESearchDisabled(t *testing.T) {
 		ctlr.Log = log.NewLoggerWithWriter("debug", writers)
 		ctrlManager := test.NewControllerManager(ctlr)
 
-		ctrlManager.StartAndWait(port)
+		baseURL := ctrlManager.StartAndWait()
 
 		// Wait for trivy db to download
 		found, err := test.ReadLogFileAndSearchString(logPath, "cve config not provided, skipping cve-db update", 90*time.Second)
@@ -490,10 +488,8 @@ func TestCVESearchDisabled(t *testing.T) {
 func TestCVESearch(t *testing.T) {
 	Convey("Test image vulnerability scanning", t, func() {
 		updateDuration, _ := time.ParseDuration("1h")
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
@@ -538,7 +534,7 @@ func TestCVESearch(t *testing.T) {
 		ctlr.Log.Info().Int64("seedUser", seedUser).Int64("seedPass", seedPass).Msg("random seed for username & password")
 		ctrlManager := test.NewControllerManager(ctlr)
 
-		ctrlManager.StartAndWait(port)
+		baseURL := ctrlManager.StartAndWait()
 
 		// trivy db download fail
 		err = os.Mkdir(dbDir+"/_trivy", 0o000)
@@ -1735,10 +1731,8 @@ func TestFixedTags(t *testing.T) {
 func TestFixedTagsWithIndex(t *testing.T) {
 	Convey("Test fixed tags", t, func() {
 		tempDir := t.TempDir()
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		defaultVal := true
 		conf.Storage.RootDirectory = tempDir
 		conf.Storage.GC = false
@@ -1765,7 +1759,7 @@ func TestFixedTagsWithIndex(t *testing.T) {
 		ctlr.Log = log.NewLoggerWithWriter("debug", writers)
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 		// push index with 2 manifests: one with vulns and one without
 		vulnManifestCreated := time.Date(2010, 1, 1, 1, 1, 1, 1, time.UTC)

--- a/pkg/extensions/search/cve/trivy/scanner_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_test.go
@@ -41,9 +41,8 @@ func TestScanBigTestFile(t *testing.T) {
 		testImage := filepath.Join(projRootDir, "test/data/zot-test")
 
 		tempDir := t.TempDir()
-		port := GetFreePort()
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		defaultVal := true
 		conf.Storage.RootDirectory = tempDir
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -58,7 +57,7 @@ func TestScanBigTestFile(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		cm := NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		cm.StartAndWait()
 		defer cm.StopServer()
 		// scan
 		scanner := trivy.NewScanner(ctlr.StoreController, ctlr.MetaDB, &extconf.CVEConfig{
@@ -80,10 +79,8 @@ func TestScanningByDigest(t *testing.T) {
 	Convey("Scan the individual manifests inside an index", t, func() {
 		// start server
 		tempDir := t.TempDir()
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		defaultVal := true
 		conf.Storage.RootDirectory = tempDir
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -95,7 +92,7 @@ func TestScanningByDigest(t *testing.T) {
 		So(ctlr, ShouldNotBeNil)
 
 		cm := NewControllerManager(ctlr)
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 		// push index with 2 manifests: one with vulns and one without
 		vulnImage := CreateDefaultVulnerableImage()

--- a/pkg/extensions/search/digest_test.go
+++ b/pkg/extensions/search/digest_test.go
@@ -51,10 +51,8 @@ func TestDigestSearchHTTP(t *testing.T) {
 	Convey("Test image search by digest scanning", t, func() {
 		rootDir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = rootDir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -64,7 +62,7 @@ func TestDigestSearchHTTP(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctrlManager := NewControllerManager(ctlr)
 
-		ctrlManager.StartAndWait(port)
+		baseURL := ctrlManager.StartAndWait()
 
 		// shut down server
 		defer ctrlManager.StopServer()
@@ -260,10 +258,8 @@ func TestDigestSearchHTTPSubPaths(t *testing.T) {
 	Convey("Test image search by digest scanning using storage subpaths", t, func() {
 		subRootDir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
@@ -283,7 +279,7 @@ func TestDigestSearchHTTPSubPaths(t *testing.T) {
 		ctlr.Config.Storage.SubPaths = subPathMap
 		ctrlManager := NewControllerManager(ctlr)
 
-		ctrlManager.StartAndWait(port)
+		baseURL := ctrlManager.StartAndWait()
 
 		// shut down server
 		defer ctrlManager.StopServer()
@@ -335,10 +331,8 @@ func TestDigestSearchHTTPSubPaths(t *testing.T) {
 func TestDigestSearchDisabled(t *testing.T) {
 	Convey("Test disabling image search", t, func() {
 		var disabled bool
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &disabled}},
@@ -347,7 +341,7 @@ func TestDigestSearchDisabled(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctrlManager := NewControllerManager(ctlr)
 
-		ctrlManager.StartAndWait(port)
+		baseURL := ctrlManager.StartAndWait()
 
 		// shut down server
 		defer ctrlManager.StopServer()

--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -355,10 +355,8 @@ func getMockCveScanner(metaDB mTypes.MetaDB) cveinfo.Scanner {
 func TestRepoListWithNewestImage(t *testing.T) {
 	Convey("Test repoListWithNewestImage by tag with HTTP", t, func() {
 		subpath := "/a"
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		rootDir := t.TempDir()
 		subRootDir := t.TempDir()
 		conf.Storage.RootDirectory = rootDir
@@ -374,7 +372,7 @@ func TestRepoListWithNewestImage(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		uploadedImage := CreateImageWith().RandomLayers(1, 100).DefaultConfig().Build()
@@ -649,10 +647,8 @@ func TestRepoListWithNewestImage(t *testing.T) {
 
 	Convey("Test repoListWithNewestImage with vulnerability scan enabled", t, func() {
 		subpath := "/a"
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		rootDir := t.TempDir()
 		subRootDir := t.TempDir()
 		conf.Storage.RootDirectory = rootDir
@@ -718,7 +714,9 @@ func TestRepoListWithNewestImage(t *testing.T) {
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
 
-		WaitTillServerReady(baseURL)
+		cm := NewControllerManager(ctlr)
+		cm.WaitServerReady()
+		baseURL := cm.BaseURL()
 
 		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix)
 		So(resp, ShouldNotBeNil)
@@ -790,10 +788,8 @@ func TestRepoListWithNewestImage(t *testing.T) {
 
 func TestGetReferrersGQL(t *testing.T) {
 	Convey("get referrers", t, func() {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 
 		defaultVal := true
@@ -806,13 +802,12 @@ func TestGetReferrersGQL(t *testing.T) {
 			},
 		}
 
-		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, graphqlQueryPrefix)
-
 		conf.Extensions.Search.CVE = nil
 
 		ctlr := api.NewController(conf)
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, graphqlQueryPrefix)
 
 		defer ctlrManager.StopServer()
 
@@ -914,10 +909,8 @@ func TestGetReferrersGQL(t *testing.T) {
 	})
 
 	Convey("referrers for image index", t, func() {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 		conf.Storage.GC = false
 
@@ -931,13 +924,12 @@ func TestGetReferrersGQL(t *testing.T) {
 			},
 		}
 
-		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, graphqlQueryPrefix)
-
 		conf.Extensions.Search.CVE = nil
 
 		ctlr := api.NewController(conf)
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, graphqlQueryPrefix)
 
 		defer ctlrManager.StopServer()
 
@@ -1043,10 +1035,8 @@ func TestGetReferrersGQL(t *testing.T) {
 	})
 
 	Convey("Get referrers with index as referrer", t, func() {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 		conf.Storage.GC = false
 
@@ -1065,7 +1055,7 @@ func TestGetReferrersGQL(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		// Upload the index referrer
@@ -1141,11 +1131,9 @@ func TestExpandedRepoInfo(t *testing.T) {
 		tagToBeRemoved := "3.0"
 		repo1 := "test1"
 		tempDir := t.TempDir()
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = tempDir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -1195,7 +1183,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		query := `{
@@ -1238,10 +1226,8 @@ func TestExpandedRepoInfo(t *testing.T) {
 		subpath := "/a"
 		rootDir := t.TempDir()
 		subRootDir := t.TempDir()
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = rootDir
 		conf.Storage.GC = false
 		conf.Storage.SubPaths = make(map[string]config.StorageConfig)
@@ -1255,7 +1241,8 @@ func TestExpandedRepoInfo(t *testing.T) {
 
 		ctlr := api.NewController(conf)
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
 
 		defer ctlrManager.StopServer()
 
@@ -1472,10 +1459,8 @@ func TestExpandedRepoInfo(t *testing.T) {
 	Convey("Test expanded repo info with tagged referrers", t, func() {
 		const testTag = "test"
 		rootDir := t.TempDir()
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = rootDir
 		conf.Storage.GC = false
 		defaultVal := true
@@ -1487,7 +1472,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 
 		ctlr := api.NewController(conf)
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 
 		defer ctlrManager.StopServer()
 
@@ -1547,10 +1532,8 @@ func TestExpandedRepoInfo(t *testing.T) {
 	})
 
 	Convey("Test image tags order", t, func() {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 
 		defaultVal := true
@@ -1563,7 +1546,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		resp, err := resty.R().Get(baseURL + "/v2/")
@@ -1622,8 +1605,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 
 	Convey("With Multiarch Images", t, func() {
 		conf := config.New()
-		conf.HTTP.Port = GetFreePort()
-		baseURL := GetBaseURL(conf.HTTP.Port)
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 
 		defaultVal := true
@@ -1694,7 +1676,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		// ------- Start Server /tmp/TestExpandedRepoInfo4021254039/005
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(conf.HTTP.Port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		// ------- Test ExpandedRepoInfo
@@ -1752,10 +1734,8 @@ func TestExpandedRepoInfo(t *testing.T) {
 		subpath := "/a"
 		rootDir := t.TempDir()
 		subRootDir := t.TempDir()
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = rootDir
 		conf.Storage.GC = false
 		conf.Storage.SubPaths = make(map[string]config.StorageConfig)
@@ -1769,7 +1749,8 @@ func TestExpandedRepoInfo(t *testing.T) {
 
 		ctlr := api.NewController(conf)
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
 
 		defer ctlrManager.StopServer()
 
@@ -2003,10 +1984,8 @@ func TestExpandedRepoInfo(t *testing.T) {
 func TestDerivedImageList(t *testing.T) {
 	rootDir := t.TempDir()
 
-	port := GetFreePort()
-	baseURL := GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	conf.Storage.RootDirectory = rootDir
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
@@ -2018,7 +1997,7 @@ func TestDerivedImageList(t *testing.T) {
 	ctlr := api.NewController(conf)
 	ctlrManager := NewControllerManager(ctlr)
 
-	ctlrManager.StartAndWait(port)
+	baseURL := ctlrManager.StartAndWait()
 	defer ctlrManager.StopServer()
 
 	Convey("Test dependency list for image working", t, func() {
@@ -2398,11 +2377,8 @@ func TestDerivedImageList(t *testing.T) {
 //nolint:dupl
 func TestDerivedImageListNoRepos(t *testing.T) {
 	Convey("No repositories found", t, func() {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -2414,7 +2390,7 @@ func TestDerivedImageListNoRepos(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		query := `
@@ -2477,10 +2453,8 @@ func TestGetImageManifest(t *testing.T) {
 func TestBaseImageList(t *testing.T) {
 	rootDir := t.TempDir()
 
-	port := GetFreePort()
-	baseURL := GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	conf.Storage.RootDirectory = rootDir
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
@@ -2492,7 +2466,7 @@ func TestBaseImageList(t *testing.T) {
 	ctlr := api.NewController(conf)
 	ctlrManager := NewControllerManager(ctlr)
 
-	ctlrManager.StartAndWait(port)
+	baseURL := ctlrManager.StartAndWait()
 	defer ctlrManager.StopServer()
 
 	Convey("Test base image list for image working", t, func() {
@@ -3046,11 +3020,8 @@ func TestBaseImageList(t *testing.T) {
 //nolint:dupl
 func TestBaseImageListNoRepos(t *testing.T) {
 	Convey("No repositories found", t, func() {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -3062,7 +3033,7 @@ func TestBaseImageListNoRepos(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		query := `
@@ -3120,10 +3091,8 @@ func TestGetRepositories(t *testing.T) {
 }
 
 func TestGlobalSearchImageAuthor(t *testing.T) {
-	port := GetFreePort()
-	baseURL := GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	tempDir := t.TempDir()
 	conf.Storage.RootDirectory = tempDir
 
@@ -3137,7 +3106,7 @@ func TestGlobalSearchImageAuthor(t *testing.T) {
 	ctlr := api.NewController(conf)
 	ctlrManager := NewControllerManager(ctlr)
 
-	ctlrManager.StartAndWait(port)
+	baseURL := ctlrManager.StartAndWait()
 	defer ctlrManager.StopServer()
 
 	Convey("Test global search with author in manifest's annotations", t, func() {
@@ -3262,10 +3231,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		dir := t.TempDir()
 		subRootDir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		conf.Storage.SubPaths = make(map[string]config.StorageConfig)
 		conf.Storage.SubPaths[subpath] = config.StorageConfig{RootDirectory: subRootDir}
@@ -3279,7 +3246,7 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		// push test images to repo 1 image 1
@@ -3616,10 +3583,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		dir := t.TempDir()
 		subRootDir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		conf.Storage.SubPaths = make(map[string]config.StorageConfig)
 		conf.Storage.SubPaths[subpath] = config.StorageConfig{RootDirectory: subRootDir}
@@ -3684,7 +3649,9 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		So(found, ShouldBeTrue)
 		So(err, ShouldBeNil)
 
-		WaitTillServerReady(baseURL)
+		cm := NewControllerManager(ctlr)
+		cm.WaitServerReady()
+		baseURL := cm.BaseURL()
 
 		// push test images to repo 1 image 1
 		createdTime := time.Date(2010, 1, 1, 12, 0, 0, 0, time.UTC)
@@ -3990,10 +3957,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 	Convey("global searching by digest", t, func() {
 		log := log.NewTestLogger()
 		rootDir := t.TempDir()
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = rootDir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -4020,7 +3985,7 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		err = WriteImageToFileSystem(image2, "repo2", "tag2", storeCtlr)
 		So(err, ShouldBeNil)
 
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		// simple image
@@ -4055,10 +4020,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 	Convey("global searching by tag cross repo", t, func() {
 		log := log.NewTestLogger()
 		rootDir := t.TempDir()
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = rootDir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -4113,7 +4076,7 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 		err = WriteMultiArchImageToFileSystem(multiArch62, "repo6", "tag2", storeCtlr)
 		So(err, ShouldBeNil)
 
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		// Search for a specific tag cross-repo and return single arch images
@@ -4198,10 +4161,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 	Convey("test nested indexes CVE scanning disabled", t, func() {
 		log := log.NewTestLogger()
 		rootDir := t.TempDir()
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = rootDir
 
 		Convey("test with boltdb", func() {
@@ -4336,7 +4297,7 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 			context.Background(), repoName, "multiArchTop", ispec.MediaTypeImageIndex, indexMultiArchTopBlob, nil)
 		So(err, ShouldBeNil)
 
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		// Search for a specific tag cross-repo and return single arch images
@@ -4361,10 +4322,8 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 	Convey("test nested indexes CVE scanning enabled", t, func() {
 		log := log.NewTestLogger()
 		rootDir := t.TempDir()
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = rootDir
 
 		Convey("test with boltdb", func() {
@@ -4524,7 +4483,9 @@ func TestGlobalSearch(t *testing.T) { //nolint: gocyclo
 
 		defer ctlr.Shutdown()
 
-		WaitTillServerReady(baseURL)
+		cm := NewControllerManager(ctlr)
+		cm.WaitServerReady()
+		baseURL := cm.BaseURL()
 
 		// Search for a specific tag cross-repo and return single arch images
 		results := GlobalSearchGQL(":multiArch", baseURL).GlobalSearch
@@ -4550,10 +4511,8 @@ func TestCleaningFilteringParamsGlobalSearch(t *testing.T) {
 	Convey("Test cleaning filtering parameters for global search", t, func() {
 		dir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -4563,7 +4522,7 @@ func TestCleaningFilteringParamsGlobalSearch(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		image := CreateImageWith().RandomLayers(1, 100).
@@ -4609,10 +4568,8 @@ func TestCleaningFilteringParamsGlobalSearch(t *testing.T) {
 func TestGlobalSearchFiltering(t *testing.T) {
 	Convey("Global search HasToBeSigned filtering", t, func() {
 		dir := t.TempDir()
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 
 		defaultVal := true
@@ -4623,7 +4580,8 @@ func TestGlobalSearchFiltering(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
 		defer ctlrManager.StopServer()
 
 		image := CreateRandomImage()
@@ -4667,10 +4625,8 @@ func TestGlobalSearchWithInvalidInput(t *testing.T) {
 	Convey("Global search with invalid input", t, func() {
 		dir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -4680,7 +4636,7 @@ func TestGlobalSearchWithInvalidInput(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		longString := RandomString(1000)
@@ -4757,11 +4713,8 @@ func TestImageList(t *testing.T) {
 	Convey("Test ImageList", t, func() {
 		rootDir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = rootDir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -4773,7 +4726,7 @@ func TestImageList(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		createdTime := time.Date(2010, 1, 1, 12, 0, 0, 0, time.UTC)
@@ -4921,10 +4874,8 @@ func TestGlobalSearchPagination(t *testing.T) {
 	Convey("Test global search pagination", t, func() {
 		dir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -4934,7 +4885,7 @@ func TestGlobalSearchPagination(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		for i := range 3 {
@@ -5106,10 +5057,8 @@ func TestMetaDBWhenSigningImages(t *testing.T) {
 		dir := t.TempDir()
 		subRootDir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		conf.Storage.SubPaths = make(map[string]config.StorageConfig)
 		conf.Storage.SubPaths[subpath] = config.StorageConfig{RootDirectory: subRootDir}
@@ -5123,7 +5072,8 @@ func TestMetaDBWhenSigningImages(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
 		defer ctlrManager.StopServer()
 
 		// push test images to repo 1 image 1
@@ -5322,10 +5272,8 @@ func TestMetaDBWhenPushingImages(t *testing.T) {
 	Convey("Cover errors when pushing", t, func() {
 		dir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -5335,7 +5283,7 @@ func TestMetaDBWhenPushingImages(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		Convey("SetManifestMeta succeeds but SetRepoReference fails", func() {
@@ -5365,10 +5313,8 @@ func TestMetaDBIndexOperations(t *testing.T) {
 	Convey("Idex Operations BoltDB", t, func() {
 		dir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.HTTP.Compat = []compat.MediaCompatibility{compat.DockerManifestV2SchemaV2}
 		conf.Storage.RootDirectory = dir
 		conf.Storage.GC = false
@@ -5380,7 +5326,8 @@ func TestMetaDBIndexOperations(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
 		defer ctlrManager.StopServer()
 
 		RunMetaDBIndexTests(baseURL, port)
@@ -6111,10 +6058,8 @@ func TestMetaDBWhenReadingImages(t *testing.T) {
 	Convey("Push test image", t, func() {
 		dir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -6124,7 +6069,7 @@ func TestMetaDBWhenReadingImages(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		image := CreateImageWith().RandomLayers(1, 100).DefaultConfig().Build()
@@ -6203,10 +6148,8 @@ func TestMetaDBWhenReadingImages(t *testing.T) {
 	Convey("Push test image with Docker media types", t, func() {
 		dir := t.TempDir()
 
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.HTTP.Compat = []compat.MediaCompatibility{compat.DockerManifestV2SchemaV2}
 		conf.Storage.RootDirectory = dir
 		defaultVal := true
@@ -6217,7 +6160,7 @@ func TestMetaDBWhenReadingImages(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		image := CreateImageWith().RandomLayers(1, 100).DefaultConfig().Build().AsDockerImage()
@@ -6285,11 +6228,9 @@ func TestMetaDBWhenReadingImages(t *testing.T) {
 func TestMetaDBWhenDeletingImages(t *testing.T) {
 	Convey("Setting up zot repo with test images", t, func() {
 		dir := t.TempDir()
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		conf.Storage.GC = false
 
@@ -6303,7 +6244,8 @@ func TestMetaDBWhenDeletingImages(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
 		defer ctlrManager.StopServer()
 
 		// push test images to repo 1 image 1
@@ -6718,11 +6660,8 @@ func TestMetaDBWhenDeletingImages(t *testing.T) {
 
 func TestSearchSize(t *testing.T) {
 	Convey("Repo sizes", t, func() {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		tr := true
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &tr}},
@@ -6733,7 +6672,7 @@ func TestSearchSize(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = dir
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		repoName := "testrepo"
@@ -6903,10 +6842,8 @@ func TestSearchSize(t *testing.T) {
 
 func TestImageSummary(t *testing.T) {
 	Convey("GraphQL query ImageSummary", t, func() {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 		conf.Storage.GC = false
 
@@ -6970,10 +6907,9 @@ func TestImageSummary(t *testing.T) {
 				}
 			}`
 
-		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, graphqlQueryPrefix)
-
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
+		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, graphqlQueryPrefix)
 		defer ctlrManager.StopServer()
 
 		repoName := "test-repo" //nolint:goconst
@@ -7132,10 +7068,8 @@ func TestImageSummary(t *testing.T) {
 	})
 
 	Convey("GraphQL query ImageSummary with Vulnerability scan enabled", t, func() {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 
 		defaultVal := true
@@ -7181,8 +7115,6 @@ func TestImageSummary(t *testing.T) {
 				}
 			}`
 
-		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, graphqlQueryPrefix)
-
 		createdTime := time.Date(2010, 1, 1, 12, 0, 0, 0, time.UTC)
 
 		image := CreateImageWith().DefaultLayers().ImageConfig(ispec.Image{
@@ -7210,7 +7142,10 @@ func TestImageSummary(t *testing.T) {
 
 		defer ctlr.Shutdown()
 
-		WaitTillServerReady(baseURL)
+		cm := NewControllerManager(ctlr)
+		cm.WaitServerReady()
+		baseURL := cm.BaseURL()
+		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, graphqlQueryPrefix)
 
 		repoName := "test-repo" //nolint:goconst
 		tagTarget := "latest"
@@ -7266,10 +7201,8 @@ func TestImageSummary(t *testing.T) {
 	})
 
 	Convey("GraphQL query for Artifact Type", t, func() {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 		conf.Storage.GC = false
 
@@ -7303,7 +7236,7 @@ func TestImageSummary(t *testing.T) {
 		var imgSummaryResponse zcommon.ImageSummaryResult
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		// upload the images
@@ -7410,10 +7343,8 @@ func TestImageSummary(t *testing.T) {
 
 func TestUploadingArtifactsWithDifferentMediaType(t *testing.T) {
 	Convey("", t, func() {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 		conf.Storage.GC = false
 
@@ -7426,7 +7357,7 @@ func TestUploadingArtifactsWithDifferentMediaType(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		const customMediaType = "application/custom.media.type+json"
@@ -7505,10 +7436,8 @@ func TestReadUploadDeleteDynamoDB(t *testing.T) {
 		"versiontablename":       versionTablename,
 	}
 
-	port := GetFreePort()
-	baseURL := GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	conf.Storage.RootDirectory = t.TempDir()
 	conf.Storage.GC = false
 	conf.Storage.CacheDriver = cacheDriverParams
@@ -7523,17 +7452,15 @@ func TestReadUploadDeleteDynamoDB(t *testing.T) {
 	ctlr := api.NewController(conf)
 	ctlrManager := NewControllerManager(ctlr)
 
-	ctlrManager.StartAndWait(port)
+	baseURL := ctlrManager.StartAndWait()
 	defer ctlrManager.StopServer()
 
 	RunReadUploadDeleteTests(t, baseURL)
 }
 
 func TestReadUploadDeleteBoltDB(t *testing.T) {
-	port := GetFreePort()
-	baseURL := GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	conf.Storage.RootDirectory = t.TempDir()
 	conf.Storage.GC = false
 	conf.Log = &config.LogConfig{Level: "debug", Output: "/dev/null"}
@@ -7546,7 +7473,7 @@ func TestReadUploadDeleteBoltDB(t *testing.T) {
 	ctlr := api.NewController(conf)
 	ctlrManager := NewControllerManager(ctlr)
 
-	ctlrManager.StartAndWait(port)
+	baseURL := ctlrManager.StartAndWait()
 	defer ctlrManager.StopServer()
 
 	RunReadUploadDeleteTests(t, baseURL)
@@ -7821,10 +7748,8 @@ func TestSearchWithMissingManifest(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// 3. Start the controller (MetaDB parsing would be done in the background)
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -7836,7 +7761,7 @@ func TestSearchWithMissingManifest(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		// Search for the repository

--- a/pkg/extensions/search/userprefs_test.go
+++ b/pkg/extensions/search/userprefs_test.go
@@ -26,8 +26,6 @@ import (
 //nolint:dupl
 func TestUserData(t *testing.T) {
 	Convey("Test user stars and bookmarks", t, func(c C) {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		defaultVal := true
 
 		accessibleRepo := "accessible-repo"
@@ -47,7 +45,7 @@ func TestUserData(t *testing.T) {
 
 		conf := config.New()
 		conf.Storage.RootDirectory = tempDir
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
 				Path: htpasswdPath,
@@ -90,7 +88,7 @@ func TestUserData(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		image := CreateDefaultImage()
@@ -444,8 +442,6 @@ func TestUserData(t *testing.T) {
 }
 
 func TestChangingRepoState(t *testing.T) {
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	defaultVal := true
 
 	simpleUser := "test"
@@ -459,7 +455,7 @@ func TestChangingRepoState(t *testing.T) {
 
 	conf := config.New()
 	conf.Storage.RootDirectory = tempDir
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	conf.HTTP.Auth = &config.AuthConfig{
 		HTPasswd: config.AuthHTPasswd{
 			Path: htpasswdPath,
@@ -538,7 +534,7 @@ func TestChangingRepoState(t *testing.T) {
 
 	ctlrManager := test.NewControllerManager(ctlr)
 
-	ctlrManager.StartAndWait(port)
+	baseURL := ctlrManager.StartAndWait()
 
 	defer ctlrManager.StopServer()
 
@@ -596,10 +592,8 @@ func TestChangingRepoState(t *testing.T) {
 func TestGlobalSearchWithUserPrefFiltering(t *testing.T) {
 	Convey("Bookmarks and Stars filtering", t, func() {
 		dir := t.TempDir()
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 
 		simpleUser := "simpleUser"
@@ -637,7 +631,7 @@ func TestGlobalSearchWithUserPrefFiltering(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		preferencesBaseURL := baseURL + constants.FullUserPrefs
@@ -790,10 +784,8 @@ func TestGlobalSearchWithUserPrefFiltering(t *testing.T) {
 func TestExpandedRepoInfoWithUserPrefs(t *testing.T) {
 	Convey("ExpandedRepoInfo with User Prefs", t, func() {
 		dir := t.TempDir()
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 
 		simpleUser := "simpleUser"
@@ -831,7 +823,7 @@ func TestExpandedRepoInfoWithUserPrefs(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		preferencesBaseURL := baseURL + constants.FullUserPrefs

--- a/pkg/test/common/utils_test.go
+++ b/pkg/test/common/utils_test.go
@@ -32,10 +32,8 @@ func TestWaitTillTrivyDBDownloadStarted(t *testing.T) {
 
 func TestControllerManager(t *testing.T) {
 	Convey("Test StartServer Init() panic", t, func() {
-		port := tcommon.GetFreePort()
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		ctlr := api.NewController(conf)
 		ctlrManager := tcommon.NewControllerManager(ctlr)

--- a/pkg/test/image-utils/upload_test.go
+++ b/pkg/test/image-utils/upload_test.go
@@ -20,17 +20,14 @@ import (
 
 func TestUploadImage(t *testing.T) {
 	Convey("Manifest without schemaVersion should fail validation", t, func() {
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		layerBlob := []byte("test")
@@ -57,12 +54,9 @@ func TestUploadImage(t *testing.T) {
 	})
 
 	Convey("Post request results in an error", t, func() {
+		// No server started: need a reachable-looking URL with nothing listening.
 		port := tcommon.GetFreePort()
 		baseURL := tcommon.GetBaseURL(port)
-
-		conf := config.New()
-		conf.HTTP.Port = port
-		conf.Storage.RootDirectory = t.TempDir()
 
 		img := Image{
 			Layers: make([][]byte, 10),
@@ -73,18 +67,15 @@ func TestUploadImage(t *testing.T) {
 	})
 
 	Convey("Post request status differs from accepted", t, func() {
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
-
 		tempDir := t.TempDir()
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = tempDir
 
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		err := os.Chmod(tempDir, 0o400)
@@ -108,17 +99,14 @@ func TestUploadImage(t *testing.T) {
 	})
 
 	Convey("Put request results in an error", t, func() {
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		img := Image{
@@ -131,17 +119,14 @@ func TestUploadImage(t *testing.T) {
 	})
 
 	Convey("Image uploaded successfully", t, func() {
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		layerBlob := []byte("test")
@@ -173,8 +158,7 @@ func TestUploadImage(t *testing.T) {
 	Convey("Upload image with authentification", t, func() {
 		tempDir := t.TempDir()
 		conf := config.New()
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
+		conf.HTTP.Port = "0"
 
 		user1 := "test"
 		password1 := "test"
@@ -186,8 +170,6 @@ func TestUploadImage(t *testing.T) {
 				Path: htpasswdPath,
 			},
 		}
-
-		conf.HTTP.Port = port
 
 		conf.HTTP.AccessControl = &config.AccessControlConfig{
 			Repositories: config.Repositories{
@@ -221,7 +203,7 @@ func TestUploadImage(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = tempDir
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		Convey("Request fail while pushing layer", func() {
@@ -243,18 +225,15 @@ func TestUploadImage(t *testing.T) {
 	})
 
 	Convey("Blob upload wrong response status code", t, func() {
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
-
 		tempDir := t.TempDir()
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = tempDir
 
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		layerBlob := []byte("test")
@@ -299,18 +278,15 @@ func TestUploadImage(t *testing.T) {
 	})
 
 	Convey("CreateBlobUpload wrong response status code", t, func() {
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
-
 		tempDir := t.TempDir()
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = tempDir
 
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		layerBlob := []byte("test")
@@ -341,18 +317,15 @@ func TestUploadImage(t *testing.T) {
 
 func TestInjectUploadImage(t *testing.T) {
 	Convey("Inject failures for unreachable lines", t, func() {
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
-
 		tempDir := t.TempDir()
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = tempDir
 
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		layerBlob := []byte("test")
@@ -405,17 +378,14 @@ func TestInjectUploadImage(t *testing.T) {
 
 func TestUploadMultiarchImage(t *testing.T) {
 	Convey("make controller", t, func() {
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		layerBlob := []byte("test")
@@ -484,9 +454,6 @@ func TestUploadMultiarchImage(t *testing.T) {
 
 func TestUploadImageWithOpts(t *testing.T) {
 	Convey("WithBasicAuth uploads image successfully with valid credentials", t, func() {
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
-
 		user := "user"
 		password := "password"
 		testString := tcommon.GetBcryptCredString(user, password)
@@ -494,7 +461,7 @@ func TestUploadImageWithOpts(t *testing.T) {
 		htpasswdPath := tcommon.MakeHtpasswdFileFromString(t, testString)
 
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -505,7 +472,7 @@ func TestUploadImageWithOpts(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		layerBlob := []byte("test")
@@ -533,17 +500,14 @@ func TestUploadImageWithOpts(t *testing.T) {
 	})
 
 	Convey("WithExtraTags exercises tag params path", t, func() {
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = t.TempDir()
 
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		layerBlob := []byte("test")
@@ -595,12 +559,9 @@ func TestUploadImageWithOpts(t *testing.T) {
 
 func TestInjectUploadImageWithBasicAuth(t *testing.T) {
 	Convey("Inject failures for unreachable lines", t, func() {
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
-
 		tempDir := t.TempDir()
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = tempDir
 
 		user := "user"
@@ -617,7 +578,7 @@ func TestInjectUploadImageWithBasicAuth(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		layerBlob := []byte("test")

--- a/pkg/test/oci-utils/oci_layout_test.go
+++ b/pkg/test/oci-utils/oci_layout_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"testing"
 	"time"
 
@@ -291,10 +292,8 @@ func TestBaseOciLayoutUtils(t *testing.T) {
 		// checkNotarySignature -> true
 		dir := t.TempDir()
 
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -306,8 +305,9 @@ func TestBaseOciLayoutUtils(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
+		port := strconv.Itoa(ctlrManager.Port())
 
 		// push test image to repo
 		image := CreateRandomImage()
@@ -337,10 +337,8 @@ func TestBaseOciLayoutUtils(t *testing.T) {
 		// checkCosignSignature -> true (tag)
 		dir := t.TempDir()
 
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -352,8 +350,9 @@ func TestBaseOciLayoutUtils(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
+		port := strconv.Itoa(ctlrManager.Port())
 
 		// push test image to repo
 		image := CreateRandomImage()
@@ -384,10 +383,8 @@ func TestBaseOciLayoutUtils(t *testing.T) {
 		// checkCosignSignature -> true (referrers)
 		dir := t.TempDir()
 
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -399,8 +396,9 @@ func TestBaseOciLayoutUtils(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		ctlrManager := tcommon.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
+		port := strconv.Itoa(ctlrManager.Port())
 
 		// push test image to repo
 		image := CreateRandomImage()

--- a/pkg/test/signature/notation_test.go
+++ b/pkg/test/signature/notation_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"testing"
 
 	notconfig "github.com/notaryproject/notation-go/config"
@@ -251,19 +252,18 @@ func TestVerifyWithNotation(t *testing.T) {
 
 	Convey("invalid content of trustpolicy.json", t, func() {
 		// start a new server
-		port := tcommon.GetFreePort()
-		baseURL := tcommon.GetBaseURL(port)
 		dir := t.TempDir()
 
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = dir
 
 		ctlr := api.NewController(conf)
 		cm := tcommon.NewControllerManager(ctlr)
 		// this blocks
-		cm.StartAndWait(port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
+		port := strconv.Itoa(cm.Port())
 
 		repoName := "signed-repo"
 		tag := "1.0"


### PR DESCRIPTION
Replace pre-allocated ports with kernel-assigned binding across pkg/extensions (except sync) and pkg/test integration helpers to avoid TOCTOU bind races under parallel CI.

Extensions: imagetrust, lint, monitoring, scrub, search, and parent extension tests use conf.HTTP.Port = "0" with baseURL := cm.StartAndWait(). Cosign and notation tests resolve localhost:port refs from cm.Port() after bind. Search CVE subtests that inject a mock scanner after Init() poll ctlr.GetPort() before WaitTillServerReady().

pkg/test: migrate upload, oci-utils, notation, and utils_test helpers the same way. One no-server upload subtest keeps GetFreePort() to hit a port with nothing listening (no bind, so no TOCTOU risk).

This is a pattern added in https://github.com/project-zot/zot/pull/4216

And one of the extension failures we fis is highlighted at: https://github.com/project-zot/zot/actions/runs/28934135670/job/85843668079

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
