### PR TITLE
fix(search): use index descriptor platform when config platform is empty

### DIFF
--- a/pkg/extensions/search/convert/convert_internal_test.go
+++ b/pkg/extensions/search/convert/convert_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/99designs/gqlgen/graphql"
+	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -328,6 +329,60 @@ func TestCVEConvert(t *testing.T) {
 			So(*manifestSummary.Vulnerabilities.Count, ShouldEqual, 0)
 			So(*manifestSummary.Vulnerabilities.MaxSeverity, ShouldEqual, "")
 			So(graphql.GetErrors(ctx).Error(), ShouldContainSubstring, "unable to run vulnerability scan in repo")
+		})
+	})
+}
+
+func TestManifestPlatformHelpers(t *testing.T) {
+	Convey("manifest platform helpers", t, func() {
+		Convey("IspecPlatformEmpty", func() {
+			So(IspecPlatformEmpty(ispec.Platform{}), ShouldBeTrue)
+			So(IspecPlatformEmpty(ispec.Platform{OS: "linux"}), ShouldBeFalse)
+			So(IspecPlatformEmpty(ispec.Platform{Architecture: "amd64"}), ShouldBeFalse)
+			So(IspecPlatformEmpty(ispec.Platform{OS: "linux", Architecture: "amd64"}), ShouldBeFalse)
+			So(IspecPlatformEmpty(ispec.Platform{Variant: "v8"}), ShouldBeTrue)
+		})
+
+		Convey("IndexPlatformByDigest", func() {
+			amd64Digest := godigest.FromString("sha256:amd64manifest")
+			arm64Digest := godigest.FromString("sha256:arm64manifest")
+
+			So(IndexPlatformByDigest(nil), ShouldResemble, map[string]ispec.Platform{})
+			So(IndexPlatformByDigest(&ispec.Index{}), ShouldResemble, map[string]ispec.Platform{})
+
+			index := &ispec.Index{
+				Manifests: []ispec.Descriptor{
+					{Digest: amd64Digest, Platform: &ispec.Platform{OS: "linux", Architecture: "amd64"}},
+					{Digest: arm64Digest},
+					{Digest: godigest.FromString("sha256:noplatform")},
+				},
+			}
+
+			platforms := IndexPlatformByDigest(index)
+			So(platforms, ShouldHaveLength, 1)
+			So(platforms[amd64Digest.String()], ShouldResemble, ispec.Platform{OS: "linux", Architecture: "amd64"})
+		})
+
+		Convey("ResolveManifestPlatform", func() {
+			configPlatform := ispec.Platform{OS: "windows", Architecture: "amd64"}
+			indexPlatform := ispec.Platform{OS: "linux", Architecture: "arm64"}
+			indexPlatforms := map[string]ispec.Platform{
+				"sha256:manifest": indexPlatform,
+			}
+
+			So(ResolveManifestPlatform(configPlatform, "sha256:manifest", indexPlatforms), ShouldResemble, configPlatform)
+			So(ResolveManifestPlatform(ispec.Platform{}, "sha256:manifest", indexPlatforms), ShouldResemble, indexPlatform)
+			So(ResolveManifestPlatform(ispec.Platform{}, "sha256:missing", indexPlatforms), ShouldResemble, ispec.Platform{})
+			So(ResolveManifestPlatform(ispec.Platform{}, "sha256:missing", nil), ShouldResemble, ispec.Platform{})
+		})
+
+		Convey("platformSummaryIsEmpty", func() {
+			So(platformSummaryIsEmpty(nil), ShouldBeTrue)
+			So(platformSummaryIsEmpty(&gql_generated.Platform{}), ShouldBeTrue)
+			So(platformSummaryIsEmpty(&gql_generated.Platform{Os: ref(""), Arch: ref("")}), ShouldBeTrue)
+			So(platformSummaryIsEmpty(&gql_generated.Platform{Os: ref("linux")}), ShouldBeFalse)
+			So(platformSummaryIsEmpty(&gql_generated.Platform{Arch: ref("amd64")}), ShouldBeFalse)
+			So(platformSummaryIsEmpty(&gql_generated.Platform{Os: ref("linux"), Arch: ref("amd64")}), ShouldBeFalse)
 		})
 	})
 }

--- a/pkg/extensions/search/convert/convert_test.go
+++ b/pkg/extensions/search/convert/convert_test.go
@@ -462,6 +462,143 @@ func TestTaggedTimestamp(t *testing.T) {
 			So(imageSummary.TaggedTimestamp, ShouldNotBeNil)
 			So(*imageSummary.TaggedTimestamp, ShouldEqual, pushTime)
 		})
+
+		Convey("ImageIndex uses index descriptor platform when config platform is empty", func() {
+			amd64Digest := godigest.FromString("sha256:amd64manifest")
+			arm64Digest := godigest.FromString("sha256:arm64manifest")
+			indexDigest := godigest.FromString("sha256:indexdigest")
+
+			imageMeta := mTypes.ImageMeta{
+				MediaType: ispec.MediaTypeImageIndex,
+				Digest:    indexDigest,
+				Index: &ispec.Index{
+					MediaType: ispec.MediaTypeImageIndex,
+					Manifests: []ispec.Descriptor{
+						{
+							MediaType: ispec.MediaTypeImageManifest,
+							Digest:    amd64Digest,
+							Size:      572,
+							Platform:  &ispec.Platform{OS: "linux", Architecture: "amd64"},
+						},
+						{
+							MediaType: ispec.MediaTypeImageManifest,
+							Digest:    arm64Digest,
+							Size:      572,
+							Platform:  &ispec.Platform{OS: "linux", Architecture: "arm64"},
+						},
+					},
+				},
+				Manifests: []mTypes.ManifestMeta{
+					{
+						Digest:   amd64Digest,
+						Size:     572,
+						Config:   ispec.Image{},
+						Manifest: ispec.Manifest{MediaType: ispec.MediaTypeImageManifest},
+					},
+					{
+						Digest:   arm64Digest,
+						Size:     572,
+						Config:   ispec.Image{},
+						Manifest: ispec.Manifest{MediaType: ispec.MediaTypeImageManifest},
+					},
+				},
+			}
+
+			repoMeta := mTypes.RepoMeta{
+				Name: "hello-artifact",
+				Tags: map[string]mTypes.Descriptor{
+					"v2": {
+						Digest:    indexDigest.String(),
+						MediaType: ispec.MediaTypeImageIndex,
+					},
+				},
+			}
+
+			fullImageMeta := convert.GetFullImageMeta("v2", repoMeta, imageMeta)
+
+			imageSummary, _, err := convert.ImageIndex2ImageSummary(ctx, fullImageMeta)
+			So(err, ShouldBeNil)
+			So(len(imageSummary.Manifests), ShouldEqual, 2)
+			So(*imageSummary.Manifests[0].Platform.Os, ShouldEqual, "linux")
+			So(*imageSummary.Manifests[0].Platform.Arch, ShouldEqual, "amd64")
+			So(*imageSummary.Manifests[1].Platform.Os, ShouldEqual, "linux")
+			So(*imageSummary.Manifests[1].Platform.Arch, ShouldEqual, "arm64")
+		})
+
+		Convey("ImageIndex prefers config platform over index descriptor", func() {
+			manifestDigest := godigest.FromString("sha256:manifest")
+
+			imageMeta := mTypes.ImageMeta{
+				MediaType: ispec.MediaTypeImageIndex,
+				Digest:    godigest.FromString("sha256:indexdigest"),
+				Index: &ispec.Index{
+					MediaType: ispec.MediaTypeImageIndex,
+					Manifests: []ispec.Descriptor{
+						{
+							MediaType: ispec.MediaTypeImageManifest,
+							Digest:    manifestDigest,
+							Platform:  &ispec.Platform{OS: "linux", Architecture: "arm64"},
+						},
+					},
+				},
+				Manifests: []mTypes.ManifestMeta{
+					{
+						Digest: manifestDigest,
+						Config: ispec.Image{Platform: ispec.Platform{OS: "linux", Architecture: "amd64"}},
+						Manifest: ispec.Manifest{
+							MediaType: ispec.MediaTypeImageManifest,
+							Config:    ispec.Descriptor{Digest: godigest.FromString("sha256:config"), Size: 1},
+						},
+					},
+				},
+			}
+
+			repoMeta := mTypes.RepoMeta{
+				Name: "repo",
+				Tags: map[string]mTypes.Descriptor{
+					"v2": {Digest: imageMeta.Digest.String(), MediaType: ispec.MediaTypeImageIndex},
+				},
+			}
+
+			imageSummary, _, err := convert.ImageIndex2ImageSummary(ctx, convert.GetFullImageMeta("v2", repoMeta, imageMeta))
+			So(err, ShouldBeNil)
+			So(*imageSummary.Manifests[0].Platform.Os, ShouldEqual, "linux")
+			So(*imageSummary.Manifests[0].Platform.Arch, ShouldEqual, "amd64")
+		})
+
+		Convey("ImageIndex leaves platform empty without index descriptor platform", func() {
+			manifestDigest := godigest.FromString("sha256:manifest")
+
+			imageMeta := mTypes.ImageMeta{
+				MediaType: ispec.MediaTypeImageIndex,
+				Digest:    godigest.FromString("sha256:indexdigest"),
+				Index: &ispec.Index{
+					MediaType: ispec.MediaTypeImageIndex,
+					Manifests: []ispec.Descriptor{
+						{MediaType: ispec.MediaTypeImageManifest, Digest: manifestDigest},
+					},
+				},
+				Manifests: []mTypes.ManifestMeta{
+					{
+						Digest:   manifestDigest,
+						Config:   ispec.Image{},
+						Manifest: ispec.Manifest{MediaType: ispec.MediaTypeImageManifest},
+					},
+				},
+			}
+
+			repoMeta := mTypes.RepoMeta{
+				Name: "repo",
+				Tags: map[string]mTypes.Descriptor{
+					"v2": {Digest: imageMeta.Digest.String(), MediaType: ispec.MediaTypeImageIndex},
+				},
+			}
+
+			imageSummary, _, err := convert.ImageIndex2ImageSummary(ctx, convert.GetFullImageMeta("v2", repoMeta, imageMeta))
+			So(err, ShouldBeNil)
+			So(*imageSummary.Manifests[0].Platform.Os, ShouldEqual, "")
+			So(*imageSummary.Manifests[0].Platform.Arch, ShouldEqual, "")
+		})
 	})
 }
 

--- a/pkg/extensions/search/convert/metadb.go
+++ b/pkg/extensions/search/convert/metadb.go
@@ -424,6 +424,8 @@ func ImageIndex2ImageSummary(ctx context.Context, fullImageMeta mTypes.FullImage
 		taggedTimestamp = pushTimestamp
 	}
 
+	indexPlatforms := IndexPlatformByDigest(fullImageMeta.Index)
+
 	for _, imageManifest := range fullImageMeta.Manifests {
 		imageManifestSummary, manifestBlobs, err := ImageManifest2ImageSummary(ctx, mTypes.FullImageMeta{
 			Repo:            fullImageMeta.Repo,
@@ -459,7 +461,16 @@ func ImageIndex2ImageSummary(ctx context.Context, fullImageMeta mTypes.FullImage
 
 		indexSize += manifestSize
 
-		manifestSummaries = append(manifestSummaries, imageManifestSummary.Manifests[0])
+		manifestSummary := imageManifestSummary.Manifests[0]
+		if platformSummaryIsEmpty(manifestSummary.Platform) {
+			resolved := ResolveManifestPlatform(imageManifest.Config.Platform, imageManifest.Digest.String(), indexPlatforms)
+			if !IspecPlatformEmpty(resolved) {
+				gqlPlatform := getPlatform(resolved)
+				manifestSummary.Platform = &gqlPlatform
+			}
+		}
+
+		manifestSummaries = append(manifestSummaries, manifestSummary)
 	}
 
 	signaturesInfo := GetSignaturesInfo(isSigned, fullImageMeta.Signatures)
@@ -618,6 +629,49 @@ func getPlatform(platform ispec.Platform) gql_generated.Platform {
 		Os:   ref(platform.OS),
 		Arch: ref(getArch(platform.Architecture, platform.Variant)),
 	}
+}
+
+func IspecPlatformEmpty(platform ispec.Platform) bool {
+	return platform.OS == "" && platform.Architecture == ""
+}
+
+func IndexPlatformByDigest(index *ispec.Index) map[string]ispec.Platform {
+	result := make(map[string]ispec.Platform)
+	if index == nil {
+		return result
+	}
+
+	for i := range index.Manifests {
+		desc := index.Manifests[i]
+		if desc.Platform == nil {
+			continue
+		}
+
+		result[desc.Digest.String()] = *desc.Platform
+	}
+
+	return result
+}
+
+func ResolveManifestPlatform(configPlatform ispec.Platform, digest string, indexPlatforms map[string]ispec.Platform,
+) ispec.Platform {
+	if !IspecPlatformEmpty(configPlatform) {
+		return configPlatform
+	}
+
+	if platform, ok := indexPlatforms[digest]; ok {
+		return platform
+	}
+
+	return configPlatform
+}
+
+func platformSummaryIsEmpty(platform *gql_generated.Platform) bool {
+	if platform == nil {
+		return true
+	}
+
+	return deref(platform.Os, "") == "" && deref(platform.Arch, "") == ""
 }
 
 func getArch(arch string, variant string) string {

--- a/pkg/extensions/search/resolver.go
+++ b/pkg/extensions/search/resolver.go
@@ -479,13 +479,21 @@ func resolveImageData(ctx context.Context, imageInput gql_generated.ImageInput, 
 			return gql_generated.ImageInput{}, err
 		}
 
+		indexPlatforms := convert.IndexPlatformByDigest(imageMeta.Index)
+
 		for _, manifest := range imageMeta.Manifests {
+			platform := convert.ResolveManifestPlatform(
+				manifest.Config.Platform,
+				manifest.Digest.String(),
+				indexPlatforms,
+			)
+
 			if manifest.Digest.String() == dderef(imageInput.Digest) ||
-				isMatchingPlatform(manifest.Config.Platform, dderef(imageInput.Platform)) {
+				isMatchingPlatform(platform, dderef(imageInput.Platform)) {
 				imageInput.Digest = ref(manifest.Digest.String())
 				imageInput.Platform = &gql_generated.PlatformInput{
-					Os:   ref(manifest.Config.OS),
-					Arch: ref(getArch(manifest.Config.Platform)),
+					Os:   ref(platform.OS),
+					Arch: ref(getArch(platform)),
 				}
 
 				return imageInput, nil

--- a/pkg/extensions/search/resolver_test.go
+++ b/pkg/extensions/search/resolver_test.go
@@ -3053,6 +3053,161 @@ func TestUtils(t *testing.T) {
 				})
 			So(err, ShouldBeNil)
 		})
+
+		Convey("checkImageInput resolves index manifest platform from index descriptor", func() {
+			amd64Digest := godigest.FromString("sha256:amd64manifest")
+
+			imageInput, err := resolveImageData(context.Background(), gql_generated.ImageInput{
+				Repo: "hello-artifact",
+				Tag:  "v2",
+				Platform: &gql_generated.PlatformInput{
+					Os:   ref("linux"),
+					Arch: ref("amd64"),
+				},
+			}, mocks.MetaDBMock{
+				GetRepoMetaFn: func(ctx context.Context, repo string) (mTypes.RepoMeta, error) {
+					return mTypes.RepoMeta{Tags: map[string]mTypes.Descriptor{
+						"v2": {
+							Digest:    "sha256:indexdigest",
+							MediaType: ispec.MediaTypeImageIndex,
+						},
+					}}, nil
+				},
+				GetImageMetaFn: func(digest godigest.Digest) (mTypes.ImageMeta, error) {
+					return mTypes.ImageMeta{
+						MediaType: ispec.MediaTypeImageIndex,
+						Index: &ispec.Index{
+							Manifests: []ispec.Descriptor{
+								{
+									Digest:   amd64Digest,
+									Platform: &ispec.Platform{OS: "linux", Architecture: "amd64"},
+								},
+							},
+						},
+						Manifests: []mTypes.ManifestMeta{
+							{
+								Digest: amd64Digest,
+								Config: ispec.Image{},
+							},
+						},
+					}, nil
+				},
+			})
+			So(err, ShouldBeNil)
+			So(dderef(imageInput.Digest), ShouldEqual, amd64Digest.String())
+			So(dderef(imageInput.Platform.Os), ShouldEqual, "linux")
+			So(dderef(imageInput.Platform.Arch), ShouldEqual, "amd64")
+		})
+
+		Convey("checkImageInput resolves index manifest by digest and fills platform from index descriptor", func() {
+			amd64Digest := godigest.FromString("sha256:amd64manifest")
+
+			imageInput, err := resolveImageData(context.Background(), gql_generated.ImageInput{
+				Repo:   "hello-artifact",
+				Tag:    "v2",
+				Digest: ref(amd64Digest.String()),
+			}, mocks.MetaDBMock{
+				GetRepoMetaFn: func(ctx context.Context, repo string) (mTypes.RepoMeta, error) {
+					return mTypes.RepoMeta{Tags: map[string]mTypes.Descriptor{
+						"v2": {Digest: "sha256:indexdigest", MediaType: ispec.MediaTypeImageIndex},
+					}}, nil
+				},
+				GetImageMetaFn: func(digest godigest.Digest) (mTypes.ImageMeta, error) {
+					return mTypes.ImageMeta{
+						MediaType: ispec.MediaTypeImageIndex,
+						Index: &ispec.Index{
+							Manifests: []ispec.Descriptor{
+								{
+									Digest:   amd64Digest,
+									Platform: &ispec.Platform{OS: "linux", Architecture: "amd64"},
+								},
+							},
+						},
+						Manifests: []mTypes.ManifestMeta{{Digest: amd64Digest, Config: ispec.Image{}}},
+					}, nil
+				},
+			})
+			So(err, ShouldBeNil)
+			So(dderef(imageInput.Digest), ShouldEqual, amd64Digest.String())
+			So(dderef(imageInput.Platform.Os), ShouldEqual, "linux")
+			So(dderef(imageInput.Platform.Arch), ShouldEqual, "amd64")
+		})
+
+		Convey("checkImageInput prefers config platform over index descriptor", func() {
+			manifestDigest := godigest.FromString("sha256:manifest")
+
+			imageInput, err := resolveImageData(context.Background(), gql_generated.ImageInput{
+				Repo: "hello-artifact",
+				Tag:  "v2",
+				Platform: &gql_generated.PlatformInput{
+					Os:   ref("linux"),
+					Arch: ref("amd64"),
+				},
+			}, mocks.MetaDBMock{
+				GetRepoMetaFn: func(ctx context.Context, repo string) (mTypes.RepoMeta, error) {
+					return mTypes.RepoMeta{Tags: map[string]mTypes.Descriptor{
+						"v2": {Digest: "sha256:indexdigest", MediaType: ispec.MediaTypeImageIndex},
+					}}, nil
+				},
+				GetImageMetaFn: func(digest godigest.Digest) (mTypes.ImageMeta, error) {
+					return mTypes.ImageMeta{
+						MediaType: ispec.MediaTypeImageIndex,
+						Index: &ispec.Index{
+							Manifests: []ispec.Descriptor{
+								{
+									Digest:   manifestDigest,
+									Platform: &ispec.Platform{OS: "linux", Architecture: "arm64"},
+								},
+							},
+						},
+						Manifests: []mTypes.ManifestMeta{
+							{
+								Digest: manifestDigest,
+								Config: ispec.Image{Platform: ispec.Platform{OS: "linux", Architecture: "amd64"}},
+							},
+						},
+					}, nil
+				},
+			})
+			So(err, ShouldBeNil)
+			So(dderef(imageInput.Digest), ShouldEqual, manifestDigest.String())
+			So(dderef(imageInput.Platform.Os), ShouldEqual, "linux")
+			So(dderef(imageInput.Platform.Arch), ShouldEqual, "amd64")
+		})
+
+		Convey("checkImageInput returns not found when index platform does not match", func() {
+			manifestDigest := godigest.FromString("sha256:manifest")
+
+			_, err := resolveImageData(context.Background(), gql_generated.ImageInput{
+				Repo: "hello-artifact",
+				Tag:  "v2",
+				Platform: &gql_generated.PlatformInput{
+					Os:   ref("linux"),
+					Arch: ref("amd64"),
+				},
+			}, mocks.MetaDBMock{
+				GetRepoMetaFn: func(ctx context.Context, repo string) (mTypes.RepoMeta, error) {
+					return mTypes.RepoMeta{Tags: map[string]mTypes.Descriptor{
+						"v2": {Digest: "sha256:indexdigest", MediaType: ispec.MediaTypeImageIndex},
+					}}, nil
+				},
+				GetImageMetaFn: func(digest godigest.Digest) (mTypes.ImageMeta, error) {
+					return mTypes.ImageMeta{
+						MediaType: ispec.MediaTypeImageIndex,
+						Index: &ispec.Index{
+							Manifests: []ispec.Descriptor{
+								{
+									Digest:   manifestDigest,
+									Platform: &ispec.Platform{OS: "linux", Architecture: "arm64"},
+								},
+							},
+						},
+						Manifests: []mTypes.ManifestMeta{{Digest: manifestDigest, Config: ispec.Image{}}},
+					}, nil
+				},
+			})
+			So(err, ShouldEqual, zerr.ErrImageNotFound)
+		})
 	})
 }
 


### PR DESCRIPTION
Multi-arch image indexes (including ORAS artifact indexes) could carry OS/arch on index manifest descriptors rather than in the config blob. GraphQL search omitted platform for those manifests, leaving the UI OS/Arch dropdown empty.

Fall back to the index descriptor when config platform is unset, while still preferring config when both are present. Apply the same resolution when resolving index tags by platform or digest in resolveImageData.

See symptoms below.

Before:
<img width="1291" height="1041" alt="image" src="https://github.com/user-attachments/assets/55167477-ca55-4d9e-8cc8-f3b3f4377b7c" />

After:
<img width="1279" height="968" alt="image" src="https://github.com/user-attachments/assets/9379e29b-89ae-4c76-9094-bd6ba6b88e72" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
