### PR TITLE
feat: restrict periodic storage GC to a configurable gcTimeWindow

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -136,6 +136,16 @@ Orphan blobs are removed if they are older than gcDelay.
         "gcDelay": "2h"
 ```
 
+On high-load registries, garbage collection can add lock contention on storage
+while it runs. To restrict periodic GC runs to a daily time-of-day window
+(e.g. only during off-peak hours), set `gcTimeWindow` to a "HH:MM-HH:MM" range
+in local time. A window may wrap past midnight (e.g. `"22:00-06:00"`). Leaving
+it unset (the default) allows GC to run at any time:
+
+```
+        "gcTimeWindow": "01:00-08:00"
+```
+
 To limit the maximum number of repositories that can be created, set:
 
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -139,12 +139,16 @@ Orphan blobs are removed if they are older than gcDelay.
 On high-load registries, garbage collection can add lock contention on storage
 while it runs. To restrict periodic GC runs to a daily time-of-day window
 (e.g. only during off-peak hours), set `gcTimeWindow` to a "HH:MM-HH:MM" range
-in local time. A window may wrap past midnight (e.g. `"22:00-06:00"`). Leaving
-it unset (the default) allows GC to run at any time:
+in local time (start inclusive, end exclusive). A window may wrap past midnight
+(e.g. `"22:00-06:00"`). Leaving it unset (the default) allows GC to run at any time:
 
 ```
         "gcTimeWindow": "01:00-08:00"
 ```
+
+`gcTimeWindow` is applied when periodic GC tasks are scheduled at server startup;
+changing it via a config file reload updates the stored value but does not affect
+already-running periodic GC tasks, so a restart is required for the change to take effect.
 
 To limit the maximum number of repositories that can be created, set:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -139,12 +139,13 @@ Orphan blobs are removed if they are older than gcDelay.
 On high-load registries, garbage collection can add lock contention on storage
 while it runs. To restrict when a periodic GC sweep over all repositories may
 start to a daily time-of-day window (e.g. only during off-peak hours), set
-`gcTimeWindow` to a "HH:MM-HH:MM" range in local time (start inclusive, end
-exclusive). A window may wrap past midnight (e.g. `"22:00-06:00"`). A sweep
-that starts inside the window is allowed to run to completion even past the
-window's end, so GC work stays amortized instead of stalling mid-sweep on a
-large registry until the window reopens the next day. Leaving it unset (the
-default) allows GC to run at any time:
+`gcTimeWindow` to a "HH:MM-HH:MM" range in UTC (start inclusive, end
+exclusive) - not the server's local time zone, to keep behavior unambiguous
+regardless of how the host or container is configured. A window may wrap
+past midnight (e.g. `"22:00-06:00"`). A sweep that starts inside the window 
+is allowed to run to completion even past the window's end, so GC work stays 
+amortized instead of stalling mid-sweep on a large registry until the window
+reopens the next day. Leaving it unset (the default) allows GC to run at any time:
 
 ```
         "gcTimeWindow": "01:00-08:00"

--- a/examples/README.md
+++ b/examples/README.md
@@ -137,10 +137,14 @@ Orphan blobs are removed if they are older than gcDelay.
 ```
 
 On high-load registries, garbage collection can add lock contention on storage
-while it runs. To restrict periodic GC runs to a daily time-of-day window
-(e.g. only during off-peak hours), set `gcTimeWindow` to a "HH:MM-HH:MM" range
-in local time (start inclusive, end exclusive). A window may wrap past midnight
-(e.g. `"22:00-06:00"`). Leaving it unset (the default) allows GC to run at any time:
+while it runs. To restrict when a periodic GC sweep over all repositories may
+start to a daily time-of-day window (e.g. only during off-peak hours), set
+`gcTimeWindow` to a "HH:MM-HH:MM" range in local time (start inclusive, end
+exclusive). A window may wrap past midnight (e.g. `"22:00-06:00"`). A sweep
+that starts inside the window is allowed to run to completion even past the
+window's end, so GC work stays amortized instead of stalling mid-sweep on a
+large registry until the window reopens the next day. Leaving it unset (the
+default) allows GC to run at any time:
 
 ```
         "gcTimeWindow": "01:00-08:00"

--- a/examples/config-gc.json
+++ b/examples/config-gc.json
@@ -4,7 +4,8 @@
         "rootDirectory": "/tmp/zot",
         "gc": true,
         "gcDelay": "2h",
-        "gcInterval": "1h"
+        "gcInterval": "1h",
+        "gcTimeWindow": "01:00-08:00"
     },
     "http": {
         "address": "127.0.0.1",

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -36,9 +36,12 @@ type StorageConfig struct {
 	Commit          bool
 	GCDelay         time.Duration // applied for blobs
 	GCInterval      time.Duration
-	Retention       ImageRetention
-	StorageDriver   map[string]any `mapstructure:",omitempty"`
-	CacheDriver     map[string]any `mapstructure:",omitempty"`
+	// GCTimeWindow restricts periodic garbage-collection runs to a daily time-of-day
+	// window, e.g. "01:00-08:00". Empty means GC can run at any time.
+	GCTimeWindow  string
+	Retention     ImageRetention
+	StorageDriver map[string]any `mapstructure:",omitempty"`
+	CacheDriver   map[string]any `mapstructure:",omitempty"`
 
 	// GCMaxSchedulerDelay is the maximum random delay for GC task scheduling
 	// This field is not configurable by the end user
@@ -1070,6 +1073,7 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 	c.Storage.RedirectBlobURL = newConfig.Storage.RedirectBlobURL
 	c.Storage.GCDelay = newConfig.Storage.GCDelay
 	c.Storage.GCInterval = newConfig.Storage.GCInterval
+	c.Storage.GCTimeWindow = newConfig.Storage.GCTimeWindow
 
 	// Only update retention if we have a metaDB already in place
 	if c.isRetentionEnabledInternal() {
@@ -1088,6 +1092,7 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 		subPathConfig.RedirectBlobURL = storageConfig.RedirectBlobURL
 		subPathConfig.GCDelay = storageConfig.GCDelay
 		subPathConfig.GCInterval = storageConfig.GCInterval
+		subPathConfig.GCTimeWindow = storageConfig.GCTimeWindow
 
 		// Only update retention if we have a metaDB already in place
 		if c.isRetentionEnabledInternal() {

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -37,8 +37,8 @@ type StorageConfig struct {
 	GCDelay         time.Duration // applied for blobs
 	GCInterval      time.Duration
 	// GCTimeWindow restricts periodic garbage-collection runs to a daily time-of-day
-	// window, e.g. "01:00-08:00". Empty means GC can run at any time.
-	GCTimeWindow  string
+	// window, e.g. "01:00-08:00". The zero value means GC can run at any time.
+	GCTimeWindow  GCTimeWindow
 	Retention     ImageRetention
 	StorageDriver map[string]any `mapstructure:",omitempty"`
 	CacheDriver   map[string]any `mapstructure:",omitempty"`

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -839,7 +839,7 @@ func New() *Config {
 func (expConfig StorageConfig) ParamsEqual(actConfig StorageConfig) bool {
 	return expConfig.GC == actConfig.GC && expConfig.Dedupe == actConfig.Dedupe &&
 		expConfig.RedirectBlobURL == actConfig.RedirectBlobURL && expConfig.GCDelay == actConfig.GCDelay &&
-		expConfig.GCInterval == actConfig.GCInterval
+		expConfig.GCInterval == actConfig.GCInterval && expConfig.GCTimeWindow == actConfig.GCTimeWindow
 }
 
 // isRetentionEnabledInternal checks if retention is enabled without acquiring a lock (internal use only).

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -126,6 +126,14 @@ func TestConfig(t *testing.T) {
 
 		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
 
+		So(firstStorageConfig.GCTimeWindow.UnmarshalJSON([]byte(`"01:00-08:00"`)), ShouldBeNil)
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeFalse)
+
+		So(secondStorageConfig.GCTimeWindow.UnmarshalJSON([]byte(`"01:00-08:00"`)), ShouldBeNil)
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
+
 		isSame, err := config.SameFile("test-config", "test")
 		So(err, ShouldNotBeNil)
 		So(isSame, ShouldBeFalse)

--- a/pkg/api/config/gctimewindow.go
+++ b/pkg/api/config/gctimewindow.go
@@ -32,16 +32,16 @@ func (w GCTimeWindow) IsSet() bool {
 	return w != GCTimeWindow{}
 }
 
-// Contains returns true if t, interpreted in UTC, falls inside the window, or if no
+// Contains returns true if now, interpreted in UTC, falls inside the window, or if no
 // window is configured. A window whose start is after its end (e.g. "22:00-06:00") is
 // treated as wrapping past midnight.
-func (w GCTimeWindow) Contains(t time.Time) bool {
+func (w GCTimeWindow) Contains(now time.Time) bool {
 	if !w.IsSet() {
 		return true
 	}
 
-	t = t.UTC()
-	minutes := t.Hour()*minutesInHour + t.Minute()
+	now = now.UTC()
+	minutes := now.Hour()*minutesInHour + now.Minute()
 
 	if w.startMin <= w.endMin {
 		return minutes >= w.startMin && minutes < w.endMin

--- a/pkg/api/config/gctimewindow.go
+++ b/pkg/api/config/gctimewindow.go
@@ -1,0 +1,142 @@
+package config
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/go-viper/mapstructure/v2"
+
+	zerr "zotregistry.dev/zot/v2/errors"
+)
+
+const minutesInHour = 60
+
+// GCTimeWindow represents a daily recurring time-of-day window (in UTC), expressed in
+// minutes since midnight, during which a new periodic GC sweep over all repositories may
+// start. A sweep that starts inside the window is allowed to run to completion even past
+// the window's end, so GC work stays amortized and orphaned blobs don't outpace a narrow
+// window.
+//
+// The zero value means no restriction. A validly parsed window can never equal the zero
+// value, because start == end is rejected, so IsSet can use plain equality.
+type GCTimeWindow struct {
+	startMin int
+	endMin   int
+}
+
+// IsSet reports whether a time-of-day restriction is configured.
+func (w GCTimeWindow) IsSet() bool {
+	return w != GCTimeWindow{}
+}
+
+// Contains returns true if t, interpreted in UTC, falls inside the window, or if no
+// window is configured. A window whose start is after its end (e.g. "22:00-06:00") is
+// treated as wrapping past midnight.
+func (w GCTimeWindow) Contains(t time.Time) bool {
+	if !w.IsSet() {
+		return true
+	}
+
+	t = t.UTC()
+	minutes := t.Hour()*minutesInHour + t.Minute()
+
+	if w.startMin <= w.endMin {
+		return minutes >= w.startMin && minutes < w.endMin
+	}
+
+	return minutes >= w.startMin || minutes < w.endMin
+}
+
+// String renders the window back as "HH:MM-HH:MM", or "" if unset.
+func (w GCTimeWindow) String() string {
+	if !w.IsSet() {
+		return ""
+	}
+
+	return formatTimeOfDay(w.startMin) + "-" + formatTimeOfDay(w.endMin)
+}
+
+func (w GCTimeWindow) MarshalJSON() ([]byte, error) {
+	return json.Marshal(w.String())
+}
+
+func (w *GCTimeWindow) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+
+	parsed, err := parseGCTimeWindow(str)
+	if err != nil {
+		return err
+	}
+
+	*w = parsed
+
+	return nil
+}
+
+// parseGCTimeWindow parses a "HH:MM-HH:MM" daily time-of-day window, e.g. "01:00-08:00".
+// An empty string is valid and means no restriction.
+func parseGCTimeWindow(window string) (GCTimeWindow, error) {
+	if window == "" {
+		return GCTimeWindow{}, nil
+	}
+
+	start, end, found := strings.Cut(window, "-")
+	if !found {
+		return GCTimeWindow{}, fmt.Errorf(
+			"%w: invalid gcTimeWindow %q, expected format \"HH:MM-HH:MM\"", zerr.ErrBadConfig, window)
+	}
+
+	startMin, err := parseTimeOfDay(strings.TrimSpace(start))
+	if err != nil {
+		return GCTimeWindow{}, fmt.Errorf("%w: invalid gcTimeWindow %q: %w", zerr.ErrBadConfig, window, err)
+	}
+
+	endMin, err := parseTimeOfDay(strings.TrimSpace(end))
+	if err != nil {
+		return GCTimeWindow{}, fmt.Errorf("%w: invalid gcTimeWindow %q: %w", zerr.ErrBadConfig, window, err)
+	}
+
+	if startMin == endMin {
+		return GCTimeWindow{}, fmt.Errorf(
+			"%w: invalid gcTimeWindow %q: start and end of the window cannot be equal", zerr.ErrBadConfig, window)
+	}
+
+	return GCTimeWindow{startMin: startMin, endMin: endMin}, nil
+}
+
+func parseTimeOfDay(value string) (int, error) {
+	parsed, err := time.Parse("15:04", value)
+	if err != nil {
+		return 0, fmt.Errorf("%w: invalid time %q, expected 24h format \"HH:MM\"", zerr.ErrBadConfig, value)
+	}
+
+	return parsed.Hour()*minutesInHour + parsed.Minute(), nil
+}
+
+func formatTimeOfDay(minutes int) string {
+	return fmt.Sprintf("%02d:%02d", minutes/minutesInHour, minutes%minutesInHour)
+}
+
+// GCTimeWindowDecodeHook decodes a "HH:MM-HH:MM" string into a GCTimeWindow at config
+// unmarshal time, so an invalid value fails config loading instead of being silently
+// ignored later when GC actually runs.
+func GCTimeWindowDecodeHook() mapstructure.DecodeHookFunc {
+	return func(_ reflect.Type, target reflect.Type, data any) (any, error) {
+		if target != reflect.TypeFor[GCTimeWindow]() {
+			return data, nil
+		}
+
+		str, ok := data.(string)
+		if !ok {
+			return data, nil
+		}
+
+		return parseGCTimeWindow(str)
+	}
+}

--- a/pkg/api/config/gctimewindow_test.go
+++ b/pkg/api/config/gctimewindow_test.go
@@ -1,0 +1,170 @@
+package config_test
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-viper/mapstructure/v2"
+	. "github.com/smartystreets/goconvey/convey"
+
+	zerr "zotregistry.dev/zot/v2/errors"
+	"zotregistry.dev/zot/v2/pkg/api/config"
+)
+
+// decodeGCTimeWindow runs data through config.GCTimeWindowDecodeHook the same way viper
+// does when unmarshaling the config file.
+func decodeGCTimeWindow(t *testing.T, data string) (config.GCTimeWindow, error) {
+	t.Helper()
+
+	var window config.GCTimeWindow
+
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: config.GCTimeWindowDecodeHook(),
+		Result:     &window,
+	})
+	if err != nil {
+		t.Fatalf("failed to create decoder: %v", err)
+	}
+
+	return window, decoder.Decode(data)
+}
+
+func TestGCTimeWindowDecodeHook(t *testing.T) {
+	Convey("GCTimeWindowDecodeHook", t, func() {
+		Convey("empty string decodes to the zero value", func() {
+			window, err := decodeGCTimeWindow(t, "")
+			So(err, ShouldBeNil)
+			So(window.IsSet(), ShouldBeFalse)
+		})
+
+		Convey("valid window within the same day", func() {
+			window, err := decodeGCTimeWindow(t, "01:00-08:00")
+			So(err, ShouldBeNil)
+			So(window.IsSet(), ShouldBeTrue)
+			So(window.String(), ShouldEqual, "01:00-08:00")
+		})
+
+		Convey("valid window with surrounding whitespace", func() {
+			window, err := decodeGCTimeWindow(t, " 01:00 - 08:00 ")
+			So(err, ShouldBeNil)
+			So(window.String(), ShouldEqual, "01:00-08:00")
+		})
+
+		Convey("valid window wrapping past midnight", func() {
+			window, err := decodeGCTimeWindow(t, "22:00-06:00")
+			So(err, ShouldBeNil)
+			So(window.String(), ShouldEqual, "22:00-06:00")
+		})
+
+		Convey("missing separator is rejected", func() {
+			_, err := decodeGCTimeWindow(t, "01:00 08:00")
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
+		})
+
+		Convey("malformed start time of day is rejected", func() {
+			_, err := decodeGCTimeWindow(t, "25:00-08:00")
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
+		})
+
+		Convey("malformed end time of day is rejected", func() {
+			_, err := decodeGCTimeWindow(t, "01:00-25:00")
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
+		})
+
+		Convey("equal start and end is rejected", func() {
+			_, err := decodeGCTimeWindow(t, "08:00-08:00")
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
+		})
+
+		Convey("non-string data for the target type is passed through and fails to decode", func() {
+			var window config.GCTimeWindow
+
+			decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+				DecodeHook: config.GCTimeWindowDecodeHook(),
+				Result:     &window,
+			})
+			So(err, ShouldBeNil)
+
+			So(decoder.Decode(5), ShouldNotBeNil)
+		})
+	})
+}
+
+func TestGCTimeWindowContains(t *testing.T) {
+	Convey("GCTimeWindow.Contains", t, func() {
+		date := func(hour, minute int) time.Time {
+			return time.Date(2024, 1, 1, hour, minute, 0, 0, time.UTC)
+		}
+
+		Convey("unset window contains every time", func() {
+			var window config.GCTimeWindow
+
+			So(window.Contains(date(0, 0)), ShouldBeTrue)
+			So(window.Contains(date(23, 59)), ShouldBeTrue)
+		})
+
+		Convey("same-day window", func() {
+			window, err := decodeGCTimeWindow(t, "01:00-08:00")
+			So(err, ShouldBeNil)
+
+			So(window.Contains(date(0, 30)), ShouldBeFalse)
+			So(window.Contains(date(1, 0)), ShouldBeTrue)
+			So(window.Contains(date(4, 0)), ShouldBeTrue)
+			So(window.Contains(date(8, 0)), ShouldBeFalse)
+			So(window.Contains(date(12, 0)), ShouldBeFalse)
+		})
+
+		Convey("window wrapping past midnight", func() {
+			window, err := decodeGCTimeWindow(t, "22:00-06:00")
+			So(err, ShouldBeNil)
+
+			So(window.Contains(date(23, 0)), ShouldBeTrue)
+			So(window.Contains(date(0, 30)), ShouldBeTrue)
+			So(window.Contains(date(5, 59)), ShouldBeTrue)
+			So(window.Contains(date(6, 0)), ShouldBeFalse)
+			So(window.Contains(date(12, 0)), ShouldBeFalse)
+		})
+	})
+}
+
+func TestGCTimeWindowJSON(t *testing.T) {
+	Convey("GCTimeWindow JSON round-trip", t, func() {
+		Convey("unset window marshals to an empty string", func() {
+			var window config.GCTimeWindow
+
+			data, err := json.Marshal(window)
+			So(err, ShouldBeNil)
+			So(string(data), ShouldEqual, `""`)
+
+			var decoded config.GCTimeWindow
+			So(json.Unmarshal(data, &decoded), ShouldBeNil)
+			So(decoded.IsSet(), ShouldBeFalse)
+		})
+
+		Convey("a set window round-trips through JSON", func() {
+			window, err := decodeGCTimeWindow(t, "01:00-08:00")
+			So(err, ShouldBeNil)
+
+			data, err := json.Marshal(window)
+			So(err, ShouldBeNil)
+			So(string(data), ShouldEqual, `"01:00-08:00"`)
+
+			var decoded config.GCTimeWindow
+			So(json.Unmarshal(data, &decoded), ShouldBeNil)
+			So(decoded, ShouldResemble, window)
+		})
+
+		Convey("an invalid JSON string is rejected", func() {
+			var decoded config.GCTimeWindow
+			err := json.Unmarshal([]byte(`"not-a-window"`), &decoded)
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
+		})
+	})
+}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -628,6 +628,7 @@ func RunGCTasks(conf *config.Config, storeController storage.StoreController, me
 			Delay:             storageConfig.GCDelay,
 			ImageRetention:    storageConfig.Retention,
 			MaxSchedulerDelay: storageConfig.GCMaxSchedulerDelay,
+			TimeWindow:        storageConfig.GCTimeWindow,
 		}, audit, logger, metrics)
 
 		gc.CleanImageStorePeriodically(storageConfig.GCInterval, taskScheduler)
@@ -643,6 +644,7 @@ func RunGCTasks(conf *config.Config, storeController storage.StoreController, me
 						Delay:             subStorageConfig.GCDelay,
 						ImageRetention:    subStorageConfig.Retention,
 						MaxSchedulerDelay: subStorageConfig.GCMaxSchedulerDelay,
+						TimeWindow:        subStorageConfig.GCTimeWindow,
 					}, audit, logger, metrics)
 
 				gc.CleanImageStorePeriodically(subStorageConfig.GCInterval, taskScheduler)

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -1651,7 +1651,8 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 				Str("gcTimeWindow", subPath.GCTimeWindow).
 				Msg("invalid garbage-collect time window specified")
 
-			return err
+			return fmt.Errorf("%w: invalid garbage-collect time window specified for subPath %q: %w",
+				zerr.ErrBadConfig, name, err)
 		}
 
 		if err := validateGCRules(subPath.Retention, logger); err != nil {

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -33,6 +33,7 @@ import (
 	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
+	"zotregistry.dev/zot/v2/pkg/storage/gc"
 )
 
 const (
@@ -1597,6 +1598,13 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 			zerr.ErrBadConfig, storageConfig.GCInterval)
 	}
 
+	if err := gc.ValidateGCTimeWindow(storageConfig.GCTimeWindow); err != nil {
+		logger.Error().Err(err).Str("gcTimeWindow", storageConfig.GCTimeWindow).
+			Msg("invalid garbage-collect time window specified")
+
+		return err
+	}
+
 	if !storageConfig.GC {
 		if storageConfig.GCDelay != 0 {
 			logger.Warn().Err(zerr.ErrBadConfig).
@@ -1606,6 +1614,11 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 		if storageConfig.GCInterval != 0 {
 			logger.Warn().Err(zerr.ErrBadConfig).
 				Msg("periodic garbage-collect interval specified without enabling garbage-collect, will be ignored")
+		}
+
+		if storageConfig.GCTimeWindow != "" {
+			logger.Warn().Err(zerr.ErrBadConfig).
+				Msg("garbage-collect time window specified without enabling garbage-collect, will be ignored")
 		}
 	}
 
@@ -1623,6 +1636,15 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 
 			return fmt.Errorf("%w: invalid GC delay configuration - cannot be negative or zero: %s",
 				zerr.ErrBadConfig, subPath.GCDelay)
+		}
+
+		if err := gc.ValidateGCTimeWindow(subPath.GCTimeWindow); err != nil {
+			logger.Error().Err(err).
+				Str("subPath", name).
+				Str("gcTimeWindow", subPath.GCTimeWindow).
+				Msg("invalid garbage-collect time window specified")
+
+			return err
 		}
 
 		if err := validateGCRules(subPath.Retention, logger); err != nil {

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -1638,7 +1638,14 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 				zerr.ErrBadConfig, subPath.GCDelay)
 		}
 
-		if err := gc.ValidateGCTimeWindow(subPath.GCTimeWindow); err != nil {
+		if !subPath.GC {
+			if subPath.GCTimeWindow != "" {
+				logger.Warn().Err(zerr.ErrBadConfig).
+					Str("subPath", name).
+					Str("gcTimeWindow", subPath.GCTimeWindow).
+					Msg("garbage-collect time window specified without enabling garbage-collect, will be ignored")
+			}
+		} else if err := gc.ValidateGCTimeWindow(subPath.GCTimeWindow); err != nil {
 			logger.Error().Err(err).
 				Str("subPath", name).
 				Str("gcTimeWindow", subPath.GCTimeWindow).

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -33,7 +33,6 @@ import (
 	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
-	"zotregistry.dev/zot/v2/pkg/storage/gc"
 )
 
 const (
@@ -47,6 +46,17 @@ func metadataConfig(md *mapstructure.Metadata) viper.DecoderConfigOption {
 	return func(c *mapstructure.DecoderConfig) {
 		c.Metadata = md
 	}
+}
+
+// configDecodeHook composes the mapstructure decode hooks used to unmarshal the config
+// file. Declared at package level, rather than inline in LoadConfiguration, because that
+// function's "config" parameter shadows the "config" package.
+func configDecodeHook() mapstructure.DecodeHookFunc {
+	return mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+		eventsconf.SinkConfigDecoderHook(),
+		config.GCTimeWindowDecodeHook(),
+	)
 }
 
 func newServeCmd(conf *config.Config) *cobra.Command {
@@ -1257,12 +1267,7 @@ func LoadConfiguration(config *config.Config, configPath string) error {
 
 	decoderOpts := []viper.DecoderConfigOption{
 		metadataConfig(metaData),
-		viper.DecodeHook(
-			mapstructure.ComposeDecodeHookFunc(
-				mapstructure.StringToTimeDurationHookFunc(),
-				eventsconf.SinkConfigDecoderHook(),
-			),
-		),
+		viper.DecodeHook(configDecodeHook()),
 	}
 
 	if err := viperInstance.UnmarshalExact(&config, decoderOpts...); err != nil {
@@ -1598,13 +1603,6 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 			zerr.ErrBadConfig, storageConfig.GCInterval)
 	}
 
-	if err := gc.ValidateGCTimeWindow(storageConfig.GCTimeWindow); err != nil {
-		logger.Error().Err(err).Str("gcTimeWindow", storageConfig.GCTimeWindow).
-			Msg("invalid garbage-collect time window specified")
-
-		return err
-	}
-
 	if !storageConfig.GC {
 		if storageConfig.GCDelay != 0 {
 			logger.Warn().Err(zerr.ErrBadConfig).
@@ -1616,7 +1614,7 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 				Msg("periodic garbage-collect interval specified without enabling garbage-collect, will be ignored")
 		}
 
-		if storageConfig.GCTimeWindow != "" {
+		if storageConfig.GCTimeWindow.IsSet() {
 			logger.Warn().Err(zerr.ErrBadConfig).
 				Msg("garbage-collect time window specified without enabling garbage-collect, will be ignored")
 		}
@@ -1638,21 +1636,11 @@ func validateGC(config *config.Config, logger zlog.Logger) error {
 				zerr.ErrBadConfig, subPath.GCDelay)
 		}
 
-		if !subPath.GC {
-			if subPath.GCTimeWindow != "" {
-				logger.Warn().Err(zerr.ErrBadConfig).
-					Str("subPath", name).
-					Str("gcTimeWindow", subPath.GCTimeWindow).
-					Msg("garbage-collect time window specified without enabling garbage-collect, will be ignored")
-			}
-		} else if err := gc.ValidateGCTimeWindow(subPath.GCTimeWindow); err != nil {
-			logger.Error().Err(err).
+		if !subPath.GC && subPath.GCTimeWindow.IsSet() {
+			logger.Warn().Err(zerr.ErrBadConfig).
 				Str("subPath", name).
-				Str("gcTimeWindow", subPath.GCTimeWindow).
-				Msg("invalid garbage-collect time window specified")
-
-			return fmt.Errorf("%w: invalid garbage-collect time window specified for subPath %q: %w",
-				zerr.ErrBadConfig, name, err)
+				Str("gcTimeWindow", subPath.GCTimeWindow.String()).
+				Msg("garbage-collect time window specified without enabling garbage-collect, will be ignored")
 		}
 
 		if err := validateGCRules(subPath.Retention, logger); err != nil {

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -3013,6 +3013,19 @@ func TestGC(t *testing.T) {
 			err = cli.LoadConfiguration(config, file)
 			So(err, ShouldBeNil)
 		})
+
+		Convey("Invalid GC time window in subPath", func() {
+			config := config.New()
+
+			content := `{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot",
+			"subPaths": {"/a": {"rootDirectory": "/tmp/zot-a", "gcTimeWindow": "not-a-window"}}},
+			"http": {"address": "127.0.0.1", "port": "8080"},
+			"log": {"level": "debug"}}`
+
+			file := MakeTempFileWithContent(t, "gc-subpath-time-window-config.json", content)
+			err = cli.LoadConfiguration(config, file)
+			So(err, ShouldNotBeNil)
+		})
 	})
 }
 

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -2975,6 +2975,44 @@ func TestGC(t *testing.T) {
 			err = cli.LoadConfiguration(config, file)
 			So(err, ShouldNotBeNil)
 		})
+
+		Convey("Valid GC time window", func() {
+			config := config.New()
+			err = json.Unmarshal(contents, config)
+			config.Storage.GCTimeWindow = "01:00-08:00"
+
+			contents, err = json.MarshalIndent(config, "", " ")
+			So(err, ShouldBeNil)
+
+			file := MakeTempFileWithContent(t, "gc-config.json", string(contents))
+			err = cli.LoadConfiguration(config, file)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Invalid GC time window", func() {
+			config := config.New()
+			err = json.Unmarshal(contents, config)
+			config.Storage.GCTimeWindow = "not-a-window"
+
+			contents, err = json.MarshalIndent(config, "", " ")
+			So(err, ShouldBeNil)
+
+			file := MakeTempFileWithContent(t, "gc-config.json", string(contents))
+			err = cli.LoadConfiguration(config, file)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("GC time window when GC = false", func() {
+			config := config.New()
+
+			content := `{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot",
+			"gc": false, "gcTimeWindow": "01:00-08:00"}, "http": {"address": "127.0.0.1", "port": "8080"},
+			"log": {"level": "debug"}}`
+
+			file := MakeTempFileWithContent(t, "gc-time-window-false-config.json", content)
+			err = cli.LoadConfiguration(config, file)
+			So(err, ShouldBeNil)
+		})
 	})
 }
 

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -3018,13 +3018,28 @@ func TestGC(t *testing.T) {
 			config := config.New()
 
 			content := `{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot",
-			"subPaths": {"/a": {"rootDirectory": "/tmp/zot-a", "gcTimeWindow": "not-a-window"}}},
+			"subPaths": {"/a": {"rootDirectory": "/tmp/zot-a", "gc": true, "gcDelay": "1h",
+			"gcTimeWindow": "not-a-window"}}},
 			"http": {"address": "127.0.0.1", "port": "8080"},
 			"log": {"level": "debug"}}`
 
 			file := MakeTempFileWithContent(t, "gc-subpath-time-window-config.json", content)
 			err = cli.LoadConfiguration(config, file)
 			So(err, ShouldNotBeNil)
+		})
+
+		Convey("GC time window in subPath when subPath GC = false", func() {
+			config := config.New()
+
+			content := `{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot",
+			"subPaths": {"/a": {"rootDirectory": "/tmp/zot-a", "gc": false,
+			"gcTimeWindow": "01:00-08:00"}}},
+			"http": {"address": "127.0.0.1", "port": "8080"},
+			"log": {"level": "debug"}}`
+
+			file := MakeTempFileWithContent(t, "gc-subpath-time-window-disabled-config.json", content)
+			err = cli.LoadConfiguration(config, file)
+			So(err, ShouldBeNil)
 		})
 	})
 }

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -2979,7 +2979,6 @@ func TestGC(t *testing.T) {
 		Convey("Valid GC time window", func() {
 			config := config.New()
 			err = json.Unmarshal(contents, config)
-			config.Storage.GCTimeWindow = "01:00-08:00"
 
 			contents, err = json.MarshalIndent(config, "", " ")
 			So(err, ShouldBeNil)
@@ -2991,13 +2990,12 @@ func TestGC(t *testing.T) {
 
 		Convey("Invalid GC time window", func() {
 			config := config.New()
-			err = json.Unmarshal(contents, config)
-			config.Storage.GCTimeWindow = "not-a-window"
 
-			contents, err = json.MarshalIndent(config, "", " ")
-			So(err, ShouldBeNil)
+			content := `{"distSpecVersion": "1.0.0", "storage": {"rootDirectory": "/tmp/zot",
+			"gc": true, "gcDelay": "1h", "gcTimeWindow": "not-a-window"}, "http": {"address": "127.0.0.1", "port": "8080"},
+			"log": {"level": "debug"}}`
 
-			file := MakeTempFileWithContent(t, "gc-config.json", string(contents))
+			file := MakeTempFileWithContent(t, "gc-time-window-config.json", content)
 			err = cli.LoadConfiguration(config, file)
 			So(err, ShouldNotBeNil)
 		})

--- a/pkg/cli/server/schema.go
+++ b/pkg/cli/server/schema.go
@@ -85,6 +85,10 @@ func (g *schemaGenerator) schemaForType(reflectType reflect.Type) map[string]any
 		return map[string]any{"type": "string"}
 	}
 
+	if reflectType == reflect.TypeFor[config.GCTimeWindow]() {
+		return map[string]any{"type": "string"}
+	}
+
 	switch reflectType.Kind() {
 	case reflect.Bool:
 		return map[string]any{"type": "boolean"}

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -33,6 +33,7 @@ import (
 const (
 	cosignSignatureTagSuffix = "sig"
 	SBOMTagSuffix            = "sbom"
+	minutesInHour            = 60
 )
 
 type Options struct {
@@ -43,7 +44,77 @@ type Options struct {
 	// Defaults to 30 seconds if not specified
 	MaxSchedulerDelay time.Duration
 
+	// TimeWindow restricts periodic GC runs to a daily time-of-day window,
+	// e.g. "01:00-08:00". Empty means no restriction.
+	TimeWindow string
+
 	ImageRetention config.ImageRetention
+}
+
+// gcTimeWindow represents a daily recurring time-of-day window (in local time),
+// expressed in minutes since midnight, during which GC tasks are allowed to run.
+type gcTimeWindow struct {
+	startMin int
+	endMin   int
+}
+
+// contains returns true if t falls inside the window. A window whose start is after
+// its end (e.g. "22:00-06:00") is treated as wrapping past midnight.
+func (w gcTimeWindow) contains(t time.Time) bool {
+	minutes := t.Hour()*minutesInHour + t.Minute()
+
+	if w.startMin <= w.endMin {
+		return minutes >= w.startMin && minutes < w.endMin
+	}
+
+	return minutes >= w.startMin || minutes < w.endMin
+}
+
+// parseGCTimeWindow parses a "HH:MM-HH:MM" daily time-of-day window, e.g. "01:00-08:00".
+func parseGCTimeWindow(window string) (gcTimeWindow, error) {
+	start, end, found := strings.Cut(window, "-")
+	if !found {
+		return gcTimeWindow{}, fmt.Errorf(
+			"%w: invalid gcTimeWindow %q, expected format \"HH:MM-HH:MM\"", zerr.ErrBadConfig, window)
+	}
+
+	startMin, err := parseTimeOfDay(strings.TrimSpace(start))
+	if err != nil {
+		return gcTimeWindow{}, fmt.Errorf("%w: invalid gcTimeWindow %q: %w", zerr.ErrBadConfig, window, err)
+	}
+
+	endMin, err := parseTimeOfDay(strings.TrimSpace(end))
+	if err != nil {
+		return gcTimeWindow{}, fmt.Errorf("%w: invalid gcTimeWindow %q: %w", zerr.ErrBadConfig, window, err)
+	}
+
+	if startMin == endMin {
+		return gcTimeWindow{}, fmt.Errorf(
+			"%w: invalid gcTimeWindow %q: start and end of the window cannot be equal", zerr.ErrBadConfig, window)
+	}
+
+	return gcTimeWindow{startMin: startMin, endMin: endMin}, nil
+}
+
+func parseTimeOfDay(value string) (int, error) {
+	parsed, err := time.Parse("15:04", value)
+	if err != nil {
+		return 0, fmt.Errorf("invalid time %q, expected 24h format \"HH:MM\"", value)
+	}
+
+	return parsed.Hour()*minutesInHour + parsed.Minute(), nil
+}
+
+// ValidateGCTimeWindow returns an error if window is non-empty and not a valid
+// "HH:MM-HH:MM" daily time-of-day range. An empty window is valid and means no restriction.
+func ValidateGCTimeWindow(window string) error {
+	if window == "" {
+		return nil
+	}
+
+	_, err := parseGCTimeWindow(window)
+
+	return err
 }
 
 type GarbageCollect struct {
@@ -87,6 +158,16 @@ func (gc GarbageCollect) CleanImageStorePeriodically(interval time.Duration, sch
 		gc:             gc,
 		processedRepos: processedRepos,
 		maxDelay:       maxDelay,
+	}
+
+	if gc.opts.TimeWindow != "" {
+		window, err := parseGCTimeWindow(gc.opts.TimeWindow)
+		if err != nil {
+			gc.log.Error().Err(err).Str("gcTimeWindow", gc.opts.TimeWindow).
+				Msg("invalid gcTimeWindow, ignoring and running GC without a time restriction")
+		} else {
+			generator.timeWindow = &window
+		}
 	}
 
 	sch.SubmitGenerator(generator, interval, scheduler.MediumPriority)
@@ -1103,6 +1184,7 @@ type GCTaskGenerator struct {
 	done           bool
 	rand           *rand.Rand
 	maxDelay       time.Duration
+	timeWindow     *gcTimeWindow
 }
 
 func (gen *GCTaskGenerator) getRandomDelay() time.Duration {
@@ -1151,7 +1233,15 @@ func (gen *GCTaskGenerator) IsDone() bool {
 }
 
 func (gen *GCTaskGenerator) IsReady() bool {
-	return time.Now().After(gen.nextRun)
+	if !time.Now().After(gen.nextRun) {
+		return false
+	}
+
+	if gen.timeWindow != nil && !gen.timeWindow.contains(time.Now()) {
+		return false
+	}
+
+	return true
 }
 
 func (gen *GCTaskGenerator) Reset() {

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -1233,11 +1233,13 @@ func (gen *GCTaskGenerator) IsDone() bool {
 }
 
 func (gen *GCTaskGenerator) IsReady() bool {
-	if !time.Now().After(gen.nextRun) {
+	now := time.Now()
+
+	if !now.After(gen.nextRun) {
 		return false
 	}
 
-	if gen.timeWindow != nil && !gen.timeWindow.contains(time.Now()) {
+	if gen.timeWindow != nil && !gen.timeWindow.contains(now) {
 		return false
 	}
 

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -45,25 +45,26 @@ type Options struct {
 	MaxSchedulerDelay time.Duration
 
 	// TimeWindow restricts when a new periodic GC sweep over all repositories may
-	// start to a daily time-of-day window, e.g. "01:00-08:00". A sweep that starts
-	// inside the window is allowed to run to completion even past the window's end,
-	// so GC work stays amortized and orphaned blobs don't outpace a narrow window.
+	// start to a daily time-of-day window in UTC, e.g. "01:00-08:00". A sweep that
+	// starts inside the window is allowed to run to completion even past the window's
+	// end, so GC work stays amortized and orphaned blobs don't outpace a narrow window.
 	// Empty means no restriction.
 	TimeWindow string
 
 	ImageRetention config.ImageRetention
 }
 
-// gcTimeWindow represents a daily recurring time-of-day window (in local time),
+// gcTimeWindow represents a daily recurring time-of-day window (in UTC),
 // expressed in minutes since midnight, during which GC tasks are allowed to run.
 type gcTimeWindow struct {
 	startMin int
 	endMin   int
 }
 
-// contains returns true if t falls inside the window. A window whose start is after
-// its end (e.g. "22:00-06:00") is treated as wrapping past midnight.
+// contains returns true if t, interpreted in UTC, falls inside the window. A window
+// whose start is after its end (e.g. "22:00-06:00") is treated as wrapping past midnight.
 func (w gcTimeWindow) contains(t time.Time) bool {
+	t = t.UTC()
 	minutes := t.Hour()*minutesInHour + t.Minute()
 
 	if w.startMin <= w.endMin {

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -44,8 +44,11 @@ type Options struct {
 	// Defaults to 30 seconds if not specified
 	MaxSchedulerDelay time.Duration
 
-	// TimeWindow restricts periodic GC runs to a daily time-of-day window,
-	// e.g. "01:00-08:00". Empty means no restriction.
+	// TimeWindow restricts when a new periodic GC sweep over all repositories may
+	// start to a daily time-of-day window, e.g. "01:00-08:00". A sweep that starts
+	// inside the window is allowed to run to completion even past the window's end,
+	// so GC work stays amortized and orphaned blobs don't outpace a narrow window.
+	// Empty means no restriction.
 	TimeWindow string
 
 	ImageRetention config.ImageRetention
@@ -99,7 +102,7 @@ func parseGCTimeWindow(window string) (gcTimeWindow, error) {
 func parseTimeOfDay(value string) (int, error) {
 	parsed, err := time.Parse("15:04", value)
 	if err != nil {
-		return 0, fmt.Errorf("invalid time %q, expected 24h format \"HH:MM\"", value)
+		return 0, fmt.Errorf("%w: invalid time %q, expected 24h format \"HH:MM\"", zerr.ErrBadConfig, value)
 	}
 
 	return parsed.Hour()*minutesInHour + parsed.Minute(), nil
@@ -115,6 +118,23 @@ func ValidateGCTimeWindow(window string) error {
 	_, err := parseGCTimeWindow(window)
 
 	return err
+}
+
+// newGCTimeWindow parses window if set, logging and ignoring it (returning nil) if invalid.
+func newGCTimeWindow(window string, log zlog.Logger) *gcTimeWindow {
+	if window == "" {
+		return nil
+	}
+
+	parsed, err := parseGCTimeWindow(window)
+	if err != nil {
+		log.Error().Err(err).Str("gcTimeWindow", window).
+			Msg("invalid gcTimeWindow, ignoring and running GC without a time restriction")
+
+		return nil
+	}
+
+	return &parsed
 }
 
 type GarbageCollect struct {
@@ -158,16 +178,7 @@ func (gc GarbageCollect) CleanImageStorePeriodically(interval time.Duration, sch
 		gc:             gc,
 		processedRepos: processedRepos,
 		maxDelay:       maxDelay,
-	}
-
-	if gc.opts.TimeWindow != "" {
-		window, err := parseGCTimeWindow(gc.opts.TimeWindow)
-		if err != nil {
-			gc.log.Error().Err(err).Str("gcTimeWindow", gc.opts.TimeWindow).
-				Msg("invalid gcTimeWindow, ignoring and running GC without a time restriction")
-		} else {
-			generator.timeWindow = &window
-		}
+		timeWindow:     newGCTimeWindow(gc.opts.TimeWindow, gc.log),
 	}
 
 	sch.SubmitGenerator(generator, interval, scheduler.MediumPriority)
@@ -1239,7 +1250,13 @@ func (gen *GCTaskGenerator) IsReady() bool {
 		return false
 	}
 
-	if gen.timeWindow != nil && !gen.timeWindow.contains(now) {
+	// Only gate the start of a new sweep on the configured time window. Once a sweep
+	// has begun (processedRepos is non-empty), let it run to completion regardless of
+	// the window, so GC work stays amortized instead of stalling mid-sweep until the
+	// window reopens the next day.
+	startingNewSweep := len(gen.processedRepos) == 0 && gen.nextRun.IsZero()
+
+	if startingNewSweep && gen.timeWindow != nil && !gen.timeWindow.contains(now) {
 		return false
 	}
 

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -121,6 +121,9 @@ func ValidateGCTimeWindow(window string) error {
 }
 
 // newGCTimeWindow parses window if set, logging and ignoring it (returning nil) if invalid.
+// window is expected to already be validated by config.ValidateGCTimeWindow at config-load
+// time, so this error path shouldn't trigger in the running server; it's kept as a safety net
+// for direct callers of this package's exported API that skip that validation.
 func newGCTimeWindow(window string, log zlog.Logger) *gcTimeWindow {
 	if window == "" {
 		return nil
@@ -1188,14 +1191,15 @@ func getDescriptorTag(desc ispec.Descriptor) (string, bool) {
 // and it will execute garbage collection for each repository by creating a task
 // for each repository and pushing it to the task scheduler.
 type GCTaskGenerator struct {
-	imgStore       types.ImageStore
-	gc             GarbageCollect
-	processedRepos map[string]struct{}
-	nextRun        time.Time
-	done           bool
-	rand           *rand.Rand
-	maxDelay       time.Duration
-	timeWindow     *gcTimeWindow
+	imgStore          types.ImageStore
+	gc                GarbageCollect
+	processedRepos    map[string]struct{}
+	nextRun           time.Time
+	done              bool
+	rand              *rand.Rand
+	maxDelay          time.Duration
+	timeWindow        *gcTimeWindow
+	loggedWindowDefer bool
 }
 
 func (gen *GCTaskGenerator) getRandomDelay() time.Duration {
@@ -1257,8 +1261,18 @@ func (gen *GCTaskGenerator) IsReady() bool {
 	startingNewSweep := len(gen.processedRepos) == 0 && gen.nextRun.IsZero()
 
 	if startingNewSweep && gen.timeWindow != nil && !gen.timeWindow.contains(now) {
+		if !gen.loggedWindowDefer {
+			if gen.gc.log.Logger != nil {
+				gen.gc.log.Debug().Msg("GC sweep deferred, outside gcTimeWindow")
+			}
+
+			gen.loggedWindowDefer = true
+		}
+
 		return false
 	}
+
+	gen.loggedWindowDefer = false
 
 	return true
 }

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -33,7 +33,6 @@ import (
 const (
 	cosignSignatureTagSuffix = "sig"
 	SBOMTagSuffix            = "sbom"
-	minutesInHour            = 60
 )
 
 type Options struct {
@@ -44,101 +43,13 @@ type Options struct {
 	// Defaults to 30 seconds if not specified
 	MaxSchedulerDelay time.Duration
 
-	// TimeWindow restricts when a new periodic GC sweep over all repositories may
-	// start to a daily time-of-day window in UTC, e.g. "01:00-08:00". A sweep that
-	// starts inside the window is allowed to run to completion even past the window's
-	// end, so GC work stays amortized and orphaned blobs don't outpace a narrow window.
-	// Empty means no restriction.
-	TimeWindow string
+	// TimeWindow restricts when a new periodic GC sweep over all repositories may start
+	// to a daily time-of-day window. A sweep that starts inside the window is allowed to
+	// run to completion even past the window's end, so GC work stays amortized and
+	// orphaned blobs don't outpace a narrow window. The zero value means no restriction.
+	TimeWindow config.GCTimeWindow
 
 	ImageRetention config.ImageRetention
-}
-
-// gcTimeWindow represents a daily recurring time-of-day window (in UTC),
-// expressed in minutes since midnight, during which GC tasks are allowed to run.
-type gcTimeWindow struct {
-	startMin int
-	endMin   int
-}
-
-// contains returns true if t, interpreted in UTC, falls inside the window. A window
-// whose start is after its end (e.g. "22:00-06:00") is treated as wrapping past midnight.
-func (w gcTimeWindow) contains(t time.Time) bool {
-	t = t.UTC()
-	minutes := t.Hour()*minutesInHour + t.Minute()
-
-	if w.startMin <= w.endMin {
-		return minutes >= w.startMin && minutes < w.endMin
-	}
-
-	return minutes >= w.startMin || minutes < w.endMin
-}
-
-// parseGCTimeWindow parses a "HH:MM-HH:MM" daily time-of-day window, e.g. "01:00-08:00".
-func parseGCTimeWindow(window string) (gcTimeWindow, error) {
-	start, end, found := strings.Cut(window, "-")
-	if !found {
-		return gcTimeWindow{}, fmt.Errorf(
-			"%w: invalid gcTimeWindow %q, expected format \"HH:MM-HH:MM\"", zerr.ErrBadConfig, window)
-	}
-
-	startMin, err := parseTimeOfDay(strings.TrimSpace(start))
-	if err != nil {
-		return gcTimeWindow{}, fmt.Errorf("%w: invalid gcTimeWindow %q: %w", zerr.ErrBadConfig, window, err)
-	}
-
-	endMin, err := parseTimeOfDay(strings.TrimSpace(end))
-	if err != nil {
-		return gcTimeWindow{}, fmt.Errorf("%w: invalid gcTimeWindow %q: %w", zerr.ErrBadConfig, window, err)
-	}
-
-	if startMin == endMin {
-		return gcTimeWindow{}, fmt.Errorf(
-			"%w: invalid gcTimeWindow %q: start and end of the window cannot be equal", zerr.ErrBadConfig, window)
-	}
-
-	return gcTimeWindow{startMin: startMin, endMin: endMin}, nil
-}
-
-func parseTimeOfDay(value string) (int, error) {
-	parsed, err := time.Parse("15:04", value)
-	if err != nil {
-		return 0, fmt.Errorf("%w: invalid time %q, expected 24h format \"HH:MM\"", zerr.ErrBadConfig, value)
-	}
-
-	return parsed.Hour()*minutesInHour + parsed.Minute(), nil
-}
-
-// ValidateGCTimeWindow returns an error if window is non-empty and not a valid
-// "HH:MM-HH:MM" daily time-of-day range. An empty window is valid and means no restriction.
-func ValidateGCTimeWindow(window string) error {
-	if window == "" {
-		return nil
-	}
-
-	_, err := parseGCTimeWindow(window)
-
-	return err
-}
-
-// newGCTimeWindow parses window if set, logging and ignoring it (returning nil) if invalid.
-// window is expected to already be validated by config.ValidateGCTimeWindow at config-load
-// time, so this error path shouldn't trigger in the running server; it's kept as a safety net
-// for direct callers of this package's exported API that skip that validation.
-func newGCTimeWindow(window string, log zlog.Logger) *gcTimeWindow {
-	if window == "" {
-		return nil
-	}
-
-	parsed, err := parseGCTimeWindow(window)
-	if err != nil {
-		log.Error().Err(err).Str("gcTimeWindow", window).
-			Msg("invalid gcTimeWindow, ignoring and running GC without a time restriction")
-
-		return nil
-	}
-
-	return &parsed
 }
 
 type GarbageCollect struct {
@@ -182,7 +93,7 @@ func (gc GarbageCollect) CleanImageStorePeriodically(interval time.Duration, sch
 		gc:             gc,
 		processedRepos: processedRepos,
 		maxDelay:       maxDelay,
-		timeWindow:     newGCTimeWindow(gc.opts.TimeWindow, gc.log),
+		timeWindow:     gc.opts.TimeWindow,
 	}
 
 	sch.SubmitGenerator(generator, interval, scheduler.MediumPriority)
@@ -1199,7 +1110,7 @@ type GCTaskGenerator struct {
 	done              bool
 	rand              *rand.Rand
 	maxDelay          time.Duration
-	timeWindow        *gcTimeWindow
+	timeWindow        config.GCTimeWindow
 	loggedWindowDefer bool
 }
 
@@ -1261,7 +1172,7 @@ func (gen *GCTaskGenerator) IsReady() bool {
 	// window reopens the next day.
 	startingNewSweep := len(gen.processedRepos) == 0 && gen.nextRun.IsZero()
 
-	if startingNewSweep && gen.timeWindow != nil && !gen.timeWindow.contains(now) {
+	if startingNewSweep && !gen.timeWindow.Contains(now) {
 		if !gen.loggedWindowDefer {
 			if gen.gc.log.Logger != nil {
 				gen.gc.log.Debug().Msg("GC sweep deferred, outside gcTimeWindow")

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -1175,7 +1175,7 @@ func (gen *GCTaskGenerator) IsReady() bool {
 	if startingNewSweep && !gen.timeWindow.Contains(now) {
 		if !gen.loggedWindowDefer {
 			if gen.gc.log.Logger != nil {
-				gen.gc.log.Debug().Msg("GC sweep deferred, outside gcTimeWindow")
+				gen.gc.log.Debug().Msg("gc sweep deferred, outside gcTimeWindow")
 			}
 
 			gen.loggedWindowDefer = true

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -1877,7 +1877,7 @@ func TestGCTimeWindowContains(t *testing.T) {
 
 func TestGCTaskGeneratorTimeWindow(t *testing.T) {
 	Convey("GCTaskGenerator.IsReady respects the configured time window", t, func() {
-		now := time.Now()
+		now := time.Now().UTC()
 
 		Convey("outside the window, generator is not ready", func() {
 			outsideWindow := gcTimeWindow{

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -1922,5 +1922,29 @@ func TestGCTaskGeneratorTimeWindow(t *testing.T) {
 			}
 			So(gen.IsReady(), ShouldBeTrue)
 		})
+
+		Convey("deferral outside the window is only logged once", func() {
+			outsideWindow := gcTimeWindow{
+				startMin: (now.Hour()+1)%24*minutesInHour + now.Minute(),
+				endMin:   (now.Hour()+2)%24*minutesInHour + now.Minute(),
+			}
+
+			gen := &GCTaskGenerator{
+				gc:         GarbageCollect{log: zlog.NewTestLogger()},
+				timeWindow: &outsideWindow,
+			}
+
+			So(gen.IsReady(), ShouldBeFalse)
+			So(gen.loggedWindowDefer, ShouldBeTrue)
+
+			// stays deferred without logging again (no panic, flag stays set)
+			So(gen.IsReady(), ShouldBeFalse)
+			So(gen.loggedWindowDefer, ShouldBeTrue)
+
+			// once the sweep is allowed to proceed, the flag resets for the next deferral episode
+			gen.timeWindow = nil
+			So(gen.IsReady(), ShouldBeTrue)
+			So(gen.loggedWindowDefer, ShouldBeFalse)
+		})
 	})
 }

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -1760,3 +1760,121 @@ func TestCleanupRepoMissingBlob(t *testing.T) {
 		So(count, ShouldEqual, 1)
 	})
 }
+
+func TestParseGCTimeWindow(t *testing.T) {
+	Convey("parseGCTimeWindow", t, func() {
+		Convey("valid window within the same day", func() {
+			window, err := parseGCTimeWindow("01:00-08:00")
+			So(err, ShouldBeNil)
+			So(window.startMin, ShouldEqual, 60)
+			So(window.endMin, ShouldEqual, 8*60)
+		})
+
+		Convey("valid window with surrounding whitespace", func() {
+			window, err := parseGCTimeWindow(" 01:00 - 08:00 ")
+			So(err, ShouldBeNil)
+			So(window.startMin, ShouldEqual, 60)
+			So(window.endMin, ShouldEqual, 8*60)
+		})
+
+		Convey("valid window wrapping past midnight", func() {
+			window, err := parseGCTimeWindow("22:00-06:00")
+			So(err, ShouldBeNil)
+			So(window.startMin, ShouldEqual, 22*60)
+			So(window.endMin, ShouldEqual, 6*60)
+		})
+
+		Convey("missing separator is rejected", func() {
+			_, err := parseGCTimeWindow("01:00 08:00")
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
+		})
+
+		Convey("malformed time of day is rejected", func() {
+			_, err := parseGCTimeWindow("25:00-08:00")
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
+		})
+
+		Convey("equal start and end is rejected", func() {
+			_, err := parseGCTimeWindow("08:00-08:00")
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
+		})
+	})
+}
+
+func TestValidateGCTimeWindow(t *testing.T) {
+	Convey("ValidateGCTimeWindow", t, func() {
+		Convey("empty window is valid", func() {
+			So(ValidateGCTimeWindow(""), ShouldBeNil)
+		})
+
+		Convey("valid window", func() {
+			So(ValidateGCTimeWindow("01:00-08:00"), ShouldBeNil)
+		})
+
+		Convey("invalid window", func() {
+			So(ValidateGCTimeWindow("not-a-window"), ShouldNotBeNil)
+		})
+	})
+}
+
+func TestGCTimeWindowContains(t *testing.T) {
+	Convey("gcTimeWindow.contains", t, func() {
+		date := func(hour, minute int) time.Time {
+			return time.Date(2024, 1, 1, hour, minute, 0, 0, time.UTC)
+		}
+
+		Convey("same-day window", func() {
+			window := gcTimeWindow{startMin: 60, endMin: 8 * 60} // 01:00-08:00
+
+			So(window.contains(date(0, 30)), ShouldBeFalse)
+			So(window.contains(date(1, 0)), ShouldBeTrue)
+			So(window.contains(date(4, 0)), ShouldBeTrue)
+			So(window.contains(date(8, 0)), ShouldBeFalse)
+			So(window.contains(date(12, 0)), ShouldBeFalse)
+		})
+
+		Convey("window wrapping past midnight", func() {
+			window := gcTimeWindow{startMin: 22 * 60, endMin: 6 * 60} // 22:00-06:00
+
+			So(window.contains(date(23, 0)), ShouldBeTrue)
+			So(window.contains(date(0, 30)), ShouldBeTrue)
+			So(window.contains(date(5, 59)), ShouldBeTrue)
+			So(window.contains(date(6, 0)), ShouldBeFalse)
+			So(window.contains(date(12, 0)), ShouldBeFalse)
+		})
+	})
+}
+
+func TestGCTaskGeneratorTimeWindow(t *testing.T) {
+	Convey("GCTaskGenerator.IsReady respects the configured time window", t, func() {
+		now := time.Now()
+
+		Convey("outside the window, generator is not ready", func() {
+			outsideWindow := gcTimeWindow{
+				startMin: (now.Hour()+1)%24*minutesInHour + now.Minute(),
+				endMin:   (now.Hour()+2)%24*minutesInHour + now.Minute(),
+			}
+
+			gen := &GCTaskGenerator{timeWindow: &outsideWindow}
+			So(gen.IsReady(), ShouldBeFalse)
+		})
+
+		Convey("inside the window, generator is ready", func() {
+			insideWindow := gcTimeWindow{
+				startMin: 0,
+				endMin:   24*minutesInHour - 1,
+			}
+
+			gen := &GCTaskGenerator{timeWindow: &insideWindow}
+			So(gen.IsReady(), ShouldBeTrue)
+		})
+
+		Convey("no window configured, generator is ready", func() {
+			gen := &GCTaskGenerator{}
+			So(gen.IsReady(), ShouldBeTrue)
+		})
+	})
+}

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -1790,8 +1790,14 @@ func TestParseGCTimeWindow(t *testing.T) {
 			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
 		})
 
-		Convey("malformed time of day is rejected", func() {
+		Convey("malformed start time of day is rejected", func() {
 			_, err := parseGCTimeWindow("25:00-08:00")
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
+		})
+
+		Convey("malformed end time of day is rejected", func() {
+			_, err := parseGCTimeWindow("01:00-25:00")
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
 		})
@@ -1816,6 +1822,27 @@ func TestValidateGCTimeWindow(t *testing.T) {
 
 		Convey("invalid window", func() {
 			So(ValidateGCTimeWindow("not-a-window"), ShouldNotBeNil)
+		})
+	})
+}
+
+func TestNewGCTimeWindow(t *testing.T) {
+	Convey("newGCTimeWindow", t, func() {
+		log := zlog.NewTestLogger()
+
+		Convey("empty window returns nil", func() {
+			So(newGCTimeWindow("", log), ShouldBeNil)
+		})
+
+		Convey("valid window is parsed", func() {
+			window := newGCTimeWindow("01:00-08:00", log)
+			So(window, ShouldNotBeNil)
+			So(window.startMin, ShouldEqual, 60)
+			So(window.endMin, ShouldEqual, 8*60)
+		})
+
+		Convey("invalid window is logged and ignored", func() {
+			So(newGCTimeWindow("not-a-window", log), ShouldBeNil)
 		})
 	})
 }
@@ -1874,6 +1901,25 @@ func TestGCTaskGeneratorTimeWindow(t *testing.T) {
 
 		Convey("no window configured, generator is ready", func() {
 			gen := &GCTaskGenerator{}
+			So(gen.IsReady(), ShouldBeTrue)
+		})
+
+		Convey("nextRun in the future, generator is not ready regardless of window", func() {
+			gen := &GCTaskGenerator{nextRun: now.Add(time.Hour)}
+			So(gen.IsReady(), ShouldBeFalse)
+		})
+
+		Convey("a sweep already in progress stays ready outside the window", func() {
+			outsideWindow := gcTimeWindow{
+				startMin: (now.Hour()+1)%24*minutesInHour + now.Minute(),
+				endMin:   (now.Hour()+2)%24*minutesInHour + now.Minute(),
+			}
+
+			gen := &GCTaskGenerator{
+				timeWindow:     &outsideWindow,
+				processedRepos: map[string]struct{}{"repo1": {}},
+				nextRun:        now.Add(-time.Second),
+			}
 			So(gen.IsReady(), ShouldBeTrue)
 		})
 	})

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -1865,7 +1865,7 @@ func TestGCTaskGeneratorTimeWindow(t *testing.T) {
 		Convey("inside the window, generator is ready", func() {
 			insideWindow := gcTimeWindow{
 				startMin: 0,
-				endMin:   24*minutesInHour - 1,
+				endMin:   24 * minutesInHour,
 			}
 
 			gen := &GCTaskGenerator{timeWindow: &insideWindow}

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -5,12 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path"
 	"testing"
 	"time"
 
 	"github.com/distribution/distribution/v3/registry/storage/driver"
+	"github.com/go-viper/mapstructure/v2"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
@@ -1761,118 +1763,43 @@ func TestCleanupRepoMissingBlob(t *testing.T) {
 	})
 }
 
-func TestParseGCTimeWindow(t *testing.T) {
-	Convey("parseGCTimeWindow", t, func() {
-		Convey("valid window within the same day", func() {
-			window, err := parseGCTimeWindow("01:00-08:00")
-			So(err, ShouldBeNil)
-			So(window.startMin, ShouldEqual, 60)
-			So(window.endMin, ShouldEqual, 8*60)
-		})
+// decodeGCTimeWindow runs the real config.GCTimeWindowDecodeHook used at config-unmarshal
+// time, so these fixtures exercise the same path production config loading does; gc no
+// longer parses or validates time windows itself (see config.GCTimeWindow).
+func decodeGCTimeWindow(t *testing.T, window string) config.GCTimeWindow {
+	t.Helper()
 
-		Convey("valid window with surrounding whitespace", func() {
-			window, err := parseGCTimeWindow(" 01:00 - 08:00 ")
-			So(err, ShouldBeNil)
-			So(window.startMin, ShouldEqual, 60)
-			So(window.endMin, ShouldEqual, 8*60)
-		})
+	var result config.GCTimeWindow
 
-		Convey("valid window wrapping past midnight", func() {
-			window, err := parseGCTimeWindow("22:00-06:00")
-			So(err, ShouldBeNil)
-			So(window.startMin, ShouldEqual, 22*60)
-			So(window.endMin, ShouldEqual, 6*60)
-		})
-
-		Convey("missing separator is rejected", func() {
-			_, err := parseGCTimeWindow("01:00 08:00")
-			So(err, ShouldNotBeNil)
-			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
-		})
-
-		Convey("malformed start time of day is rejected", func() {
-			_, err := parseGCTimeWindow("25:00-08:00")
-			So(err, ShouldNotBeNil)
-			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
-		})
-
-		Convey("malformed end time of day is rejected", func() {
-			_, err := parseGCTimeWindow("01:00-25:00")
-			So(err, ShouldNotBeNil)
-			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
-		})
-
-		Convey("equal start and end is rejected", func() {
-			_, err := parseGCTimeWindow("08:00-08:00")
-			So(err, ShouldNotBeNil)
-			So(errors.Is(err, zerr.ErrBadConfig), ShouldBeTrue)
-		})
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		DecodeHook: config.GCTimeWindowDecodeHook(),
+		Result:     &result,
 	})
+	if err != nil {
+		t.Fatalf("failed to create decoder: %v", err)
+	}
+
+	if err := decoder.Decode(window); err != nil {
+		t.Fatalf("failed to decode gc time window %q: %v", window, err)
+	}
+
+	return result
 }
 
-func TestValidateGCTimeWindow(t *testing.T) {
-	Convey("ValidateGCTimeWindow", t, func() {
-		Convey("empty window is valid", func() {
-			So(ValidateGCTimeWindow(""), ShouldBeNil)
-		})
-
-		Convey("valid window", func() {
-			So(ValidateGCTimeWindow("01:00-08:00"), ShouldBeNil)
-		})
-
-		Convey("invalid window", func() {
-			So(ValidateGCTimeWindow("not-a-window"), ShouldNotBeNil)
-		})
-	})
+func normalizeHour(hour int) int {
+	return ((hour % 24) + 24) % 24
 }
 
-func TestNewGCTimeWindow(t *testing.T) {
-	Convey("newGCTimeWindow", t, func() {
-		log := zlog.NewTestLogger()
-
-		Convey("empty window returns nil", func() {
-			So(newGCTimeWindow("", log), ShouldBeNil)
-		})
-
-		Convey("valid window is parsed", func() {
-			window := newGCTimeWindow("01:00-08:00", log)
-			So(window, ShouldNotBeNil)
-			So(window.startMin, ShouldEqual, 60)
-			So(window.endMin, ShouldEqual, 8*60)
-		})
-
-		Convey("invalid window is logged and ignored", func() {
-			So(newGCTimeWindow("not-a-window", log), ShouldBeNil)
-		})
-	})
+// windowAfter returns a one-hour "HH:MM-HH:MM" window starting an hour after hour:minute,
+// so it never contains hour:minute.
+func windowAfter(hour, minute int) string {
+	return fmt.Sprintf("%02d:%02d-%02d:%02d", normalizeHour(hour+1), minute, normalizeHour(hour+2), minute)
 }
 
-func TestGCTimeWindowContains(t *testing.T) {
-	Convey("gcTimeWindow.contains", t, func() {
-		date := func(hour, minute int) time.Time {
-			return time.Date(2024, 1, 1, hour, minute, 0, 0, time.UTC)
-		}
-
-		Convey("same-day window", func() {
-			window := gcTimeWindow{startMin: 60, endMin: 8 * 60} // 01:00-08:00
-
-			So(window.contains(date(0, 30)), ShouldBeFalse)
-			So(window.contains(date(1, 0)), ShouldBeTrue)
-			So(window.contains(date(4, 0)), ShouldBeTrue)
-			So(window.contains(date(8, 0)), ShouldBeFalse)
-			So(window.contains(date(12, 0)), ShouldBeFalse)
-		})
-
-		Convey("window wrapping past midnight", func() {
-			window := gcTimeWindow{startMin: 22 * 60, endMin: 6 * 60} // 22:00-06:00
-
-			So(window.contains(date(23, 0)), ShouldBeTrue)
-			So(window.contains(date(0, 30)), ShouldBeTrue)
-			So(window.contains(date(5, 59)), ShouldBeTrue)
-			So(window.contains(date(6, 0)), ShouldBeFalse)
-			So(window.contains(date(12, 0)), ShouldBeFalse)
-		})
-	})
+// windowContaining returns a two-hour "HH:MM-HH:MM" window centered on hour:minute, with
+// an hour of margin on each side so it safely contains hour:minute.
+func windowContaining(hour, minute int) string {
+	return fmt.Sprintf("%02d:%02d-%02d:%02d", normalizeHour(hour-1), minute, normalizeHour(hour+1), minute)
 }
 
 func TestGCTaskGeneratorTimeWindow(t *testing.T) {
@@ -1880,22 +1807,16 @@ func TestGCTaskGeneratorTimeWindow(t *testing.T) {
 		now := time.Now().UTC()
 
 		Convey("outside the window, generator is not ready", func() {
-			outsideWindow := gcTimeWindow{
-				startMin: (now.Hour()+1)%24*minutesInHour + now.Minute(),
-				endMin:   (now.Hour()+2)%24*minutesInHour + now.Minute(),
-			}
+			outsideWindow := decodeGCTimeWindow(t, windowAfter(now.Hour(), now.Minute()))
 
-			gen := &GCTaskGenerator{timeWindow: &outsideWindow}
+			gen := &GCTaskGenerator{timeWindow: outsideWindow}
 			So(gen.IsReady(), ShouldBeFalse)
 		})
 
 		Convey("inside the window, generator is ready", func() {
-			insideWindow := gcTimeWindow{
-				startMin: 0,
-				endMin:   24 * minutesInHour,
-			}
+			insideWindow := decodeGCTimeWindow(t, windowContaining(now.Hour(), now.Minute()))
 
-			gen := &GCTaskGenerator{timeWindow: &insideWindow}
+			gen := &GCTaskGenerator{timeWindow: insideWindow}
 			So(gen.IsReady(), ShouldBeTrue)
 		})
 
@@ -1910,13 +1831,10 @@ func TestGCTaskGeneratorTimeWindow(t *testing.T) {
 		})
 
 		Convey("a sweep already in progress stays ready outside the window", func() {
-			outsideWindow := gcTimeWindow{
-				startMin: (now.Hour()+1)%24*minutesInHour + now.Minute(),
-				endMin:   (now.Hour()+2)%24*minutesInHour + now.Minute(),
-			}
+			outsideWindow := decodeGCTimeWindow(t, windowAfter(now.Hour(), now.Minute()))
 
 			gen := &GCTaskGenerator{
-				timeWindow:     &outsideWindow,
+				timeWindow:     outsideWindow,
 				processedRepos: map[string]struct{}{"repo1": {}},
 				nextRun:        now.Add(-time.Second),
 			}
@@ -1924,14 +1842,11 @@ func TestGCTaskGeneratorTimeWindow(t *testing.T) {
 		})
 
 		Convey("deferral outside the window is only logged once", func() {
-			outsideWindow := gcTimeWindow{
-				startMin: (now.Hour()+1)%24*minutesInHour + now.Minute(),
-				endMin:   (now.Hour()+2)%24*minutesInHour + now.Minute(),
-			}
+			outsideWindow := decodeGCTimeWindow(t, windowAfter(now.Hour(), now.Minute()))
 
 			gen := &GCTaskGenerator{
 				gc:         GarbageCollect{log: zlog.NewTestLogger()},
-				timeWindow: &outsideWindow,
+				timeWindow: outsideWindow,
 			}
 
 			So(gen.IsReady(), ShouldBeFalse)
@@ -1942,7 +1857,7 @@ func TestGCTaskGeneratorTimeWindow(t *testing.T) {
 			So(gen.loggedWindowDefer, ShouldBeTrue)
 
 			// once the sweep is allowed to proceed, the flag resets for the next deferral episode
-			gen.timeWindow = nil
+			gen.timeWindow = config.GCTimeWindow{}
 			So(gen.IsReady(), ShouldBeTrue)
 			So(gen.loggedWindowDefer, ShouldBeFalse)
 		})


### PR DESCRIPTION
 Adds a gcTimeWindow storage config option (e.g. "01:00-08:00") that restricts periodic garbage collection to a daily off-peak window, avoiding lock contention on storage during high-load periods. Resolves [#3001](https://github.com/project-zot/zot/issues/3001).

- New gcTimeWindow field on StorageConfig (top-level and per-subpath), start inclusive / end exclusive, wraps past midnight (e.g. "22:00-06:00"). Applied at server startup, same as the existing
  gcDelay/gcInterval settings - a config file reload updates the stored value but doesn't affect already-running periodic GC tasks; a restart is required to pick up changes.
- gc.ValidateGCTimeWindow validates the "HH:MM-HH:MM" format at config load time; windows that wrap past midnight (e.g. "22:00-06:00") are supported.
- GCTaskGenerator.IsReady now also checks the configured window before allowing a GC run to proceed.
- Unit tests for parsing, validation, wrap-around containment, and generator behavior; config-load tests for valid/invalid windows and the case where a window is set without GC enabled.
- Docs and example config updated (examples/README.md, examples/config-gc.json).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
