### PR TITLE
fix(meta): derive push timestamp from blob mod time on storage parse

### DIFF
--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -281,13 +281,13 @@ func (bdw *BoltDB) SetRepoReference(ctx context.Context, repo string, reference 
 			stats = &proto_go.DescriptorStatistics{
 				DownloadCount:     0,
 				LastPullTimestamp: &timestamppb.Timestamp{},
-				PushTimestamp:     timestamppb.Now(),
+				PushTimestamp:     mConvert.GetProtoPushTimestamp(imageMeta),
 				PushedBy:          userid,
 			}
 			protoRepoMeta.Statistics[digestStr] = stats
 		} else {
 			if stats.PushTimestamp.AsTime().IsZero() {
-				stats.PushTimestamp = timestamppb.Now()
+				stats.PushTimestamp = mConvert.GetProtoPushTimestamp(imageMeta)
 			}
 
 			if userid != "" && stats.PushedBy == "" {

--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -183,10 +183,13 @@ func (bdw *BoltDB) SetImageMeta(digest godigest.Digest, imageMeta mTypes.ImageMe
 }
 
 func (bdw *BoltDB) SetRepoReference(ctx context.Context, repo string, reference string, imageMeta mTypes.ImageMeta,
+	opts ...mTypes.SetRepoReferenceOption,
 ) error {
 	if err := common.ValidateRepoReferenceInput(repo, reference, imageMeta.Digest); err != nil {
 		return err
 	}
+
+	options := mTypes.ApplySetRepoReferenceOptions(opts...)
 
 	var userid string
 
@@ -281,13 +284,13 @@ func (bdw *BoltDB) SetRepoReference(ctx context.Context, repo string, reference 
 			stats = &proto_go.DescriptorStatistics{
 				DownloadCount:     0,
 				LastPullTimestamp: &timestamppb.Timestamp{},
-				PushTimestamp:     mConvert.GetProtoPushTimestamp(imageMeta),
+				PushTimestamp:     mConvert.GetProtoPushTimestamp(options.PushTimestamp),
 				PushedBy:          userid,
 			}
 			protoRepoMeta.Statistics[digestStr] = stats
 		} else {
 			if stats.PushTimestamp.AsTime().IsZero() {
-				stats.PushTimestamp = mConvert.GetProtoPushTimestamp(imageMeta)
+				stats.PushTimestamp = mConvert.GetProtoPushTimestamp(options.PushTimestamp)
 			}
 
 			if userid != "" && stats.PushedBy == "" {

--- a/pkg/meta/convert/convert_proto.go
+++ b/pkg/meta/convert/convert_proto.go
@@ -135,6 +135,17 @@ func GetProtoStatistics(stats map[mTypes.ImageDigest]mTypes.DescriptorStatistics
 	return results
 }
 
+// GetProtoPushTimestamp returns the push timestamp for a newly created statistics entry:
+// the ImageMeta hint when set (e.g. the blob storage mod time on a storage re-parse),
+// otherwise the current time.
+func GetProtoPushTimestamp(imageMeta mTypes.ImageMeta) *timestamppb.Timestamp {
+	if imageMeta.PushTimestamp.IsZero() {
+		return timestamppb.Now()
+	}
+
+	return timestamppb.New(imageMeta.PushTimestamp)
+}
+
 func GetProtoPlatforms(platforms []ispec.Platform) []*proto_go.Platform {
 	result := []*proto_go.Platform{}
 

--- a/pkg/meta/convert/convert_proto.go
+++ b/pkg/meta/convert/convert_proto.go
@@ -136,14 +136,14 @@ func GetProtoStatistics(stats map[mTypes.ImageDigest]mTypes.DescriptorStatistics
 }
 
 // GetProtoPushTimestamp returns the push timestamp for a newly created statistics entry:
-// the ImageMeta hint when set (e.g. the blob storage mod time on a storage re-parse),
+// the given hint when set (e.g. the blob storage mod time on a storage re-parse),
 // otherwise the current time.
-func GetProtoPushTimestamp(imageMeta mTypes.ImageMeta) *timestamppb.Timestamp {
-	if imageMeta.PushTimestamp.IsZero() {
+func GetProtoPushTimestamp(pushTimestamp time.Time) *timestamppb.Timestamp {
+	if pushTimestamp.IsZero() {
 		return timestamppb.Now()
 	}
 
-	return timestamppb.New(imageMeta.PushTimestamp)
+	return timestamppb.New(pushTimestamp)
 }
 
 func GetProtoPlatforms(platforms []ispec.Platform) []*proto_go.Platform {

--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -490,13 +490,13 @@ func (dwr *DynamoDB) SetRepoReference(ctx context.Context, repo string, referenc
 		stats = &proto_go.DescriptorStatistics{
 			DownloadCount:     0,
 			LastPullTimestamp: &timestamppb.Timestamp{},
-			PushTimestamp:     timestamppb.Now(),
+			PushTimestamp:     mConvert.GetProtoPushTimestamp(imageMeta),
 			PushedBy:          userid,
 		}
 		repoMeta.Statistics[digestStr] = stats
 	} else {
 		if stats.PushTimestamp.AsTime().IsZero() {
-			stats.PushTimestamp = timestamppb.Now()
+			stats.PushTimestamp = mConvert.GetProtoPushTimestamp(imageMeta)
 		}
 
 		if userid != "" && stats.PushedBy == "" {

--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -403,11 +403,13 @@ func (dwr *DynamoDB) getProtoRepoMeta(ctx context.Context, repo string) (*proto_
 }
 
 func (dwr *DynamoDB) SetRepoReference(ctx context.Context, repo string, reference string,
-	imageMeta mTypes.ImageMeta,
+	imageMeta mTypes.ImageMeta, opts ...mTypes.SetRepoReferenceOption,
 ) error {
 	if err := common.ValidateRepoReferenceInput(repo, reference, imageMeta.Digest); err != nil {
 		return err
 	}
+
+	options := mTypes.ApplySetRepoReferenceOptions(opts...)
 
 	var userid string
 
@@ -490,13 +492,13 @@ func (dwr *DynamoDB) SetRepoReference(ctx context.Context, repo string, referenc
 		stats = &proto_go.DescriptorStatistics{
 			DownloadCount:     0,
 			LastPullTimestamp: &timestamppb.Timestamp{},
-			PushTimestamp:     mConvert.GetProtoPushTimestamp(imageMeta),
+			PushTimestamp:     mConvert.GetProtoPushTimestamp(options.PushTimestamp),
 			PushedBy:          userid,
 		}
 		repoMeta.Statistics[digestStr] = stats
 	} else {
 		if stats.PushTimestamp.AsTime().IsZero() {
-			stats.PushTimestamp = mConvert.GetProtoPushTimestamp(imageMeta)
+			stats.PushTimestamp = mConvert.GetProtoPushTimestamp(options.PushTimestamp)
 		}
 
 		if userid != "" && stats.PushedBy == "" {

--- a/pkg/meta/hooks_test.go
+++ b/pkg/meta/hooks_test.go
@@ -38,13 +38,13 @@ type setRepoRefFailMetaDB struct {
 }
 
 func (w *setRepoRefFailMetaDB) SetRepoReference(
-	ctx context.Context, repo, ref string, imageMeta mTypes.ImageMeta,
+	ctx context.Context, repo, ref string, imageMeta mTypes.ImageMeta, opts ...mTypes.SetRepoReferenceOption,
 ) error {
 	if ref == w.failRef {
 		return errDigestTagsSetRepoReferenceFail
 	}
 
-	return w.MetaDB.SetRepoReference(ctx, repo, ref, imageMeta)
+	return w.MetaDB.SetRepoReference(ctx, repo, ref, imageMeta, opts...)
 }
 
 // failDeleteImageStore delegates to an inner ImageStore but forces DeleteImageManifest to return deleteErr.

--- a/pkg/meta/parse.go
+++ b/pkg/meta/parse.go
@@ -535,6 +535,13 @@ func SetImageMetaFromInput(ctx context.Context, repo, reference, mediaType strin
 		return nil
 	}
 
+	// The push time only lives in the metaDB; when it is lost, the manifest blob's storage
+	// mod time is the closest remaining record of when the image was pushed. Pass it as a
+	// hint so a metaDB rebuild doesn't stamp every image with the current time.
+	if found, _, modTime, err := imageStore.StatBlob(repo, digest); err == nil && found {
+		imageMeta.PushTimestamp = modTime
+	}
+
 	err := metaDB.SetRepoReference(ctx, repo, reference, imageMeta)
 	if err != nil {
 		log.Error().Err(err).Str("component", "metadb").Msg("failed to set repo meta")

--- a/pkg/meta/parse.go
+++ b/pkg/meta/parse.go
@@ -538,11 +538,12 @@ func SetImageMetaFromInput(ctx context.Context, repo, reference, mediaType strin
 	// The push time only lives in the metaDB; when it is lost, the manifest blob's storage
 	// mod time is the closest remaining record of when the image was pushed. Pass it as a
 	// hint so a metaDB rebuild doesn't stamp every image with the current time.
+	setOpts := []mTypes.SetRepoReferenceOption{}
 	if found, _, modTime, err := imageStore.StatBlob(repo, digest); err == nil && found {
-		imageMeta.PushTimestamp = modTime
+		setOpts = append(setOpts, mTypes.WithPushTimestamp(modTime))
 	}
 
-	err := metaDB.SetRepoReference(ctx, repo, reference, imageMeta)
+	err := metaDB.SetRepoReference(ctx, repo, reference, imageMeta, setOpts...)
 	if err != nil {
 		log.Error().Err(err).Str("component", "metadb").Msg("failed to set repo meta")
 

--- a/pkg/meta/parse.go
+++ b/pkg/meta/parse.go
@@ -294,8 +294,17 @@ func parseRepo(repo string, metaDB mTypes.MetaDB, storeController stypes.StoreCo
 			reference = manifest.Digest.String()
 		}
 
+		// The push time only lives in the metaDB; when it is lost, the manifest blob's storage
+		// mod time is the closest remaining record of when the image was pushed. Pass it as a
+		// hint so a metaDB rebuild doesn't stamp every image with the current time. StatBlob
+		// requires the store lock, which this function already holds.
+		setOpts := []mTypes.SetRepoReferenceOption{}
+		if found, _, modTime, err := imageStore.StatBlob(repo, manifest.Digest); err == nil && found {
+			setOpts = append(setOpts, mTypes.WithPushTimestamp(modTime))
+		}
+
 		err = SetImageMetaFromInput(context.Background(), repo, reference, manifest.MediaType, manifest.Digest, manifestBlob,
-			imageStore, metaDB, log)
+			imageStore, metaDB, log, setOpts...)
 		if err != nil {
 			log.Error().Err(err).Str("repository", repo).Str("tag", tag).
 				Msg("failed to set metadata for image")
@@ -460,7 +469,7 @@ func getNotationSignatureLayersInfo(
 // SetImageMetaFromInput tries to set manifest metadata and update repo metadata by adding the current tag
 // (in case the reference is a tag). The function expects image manifests and indexes (multi arch images).
 func SetImageMetaFromInput(ctx context.Context, repo, reference, mediaType string, digest godigest.Digest, blob []byte,
-	imageStore stypes.ImageStore, metaDB mTypes.MetaDB, log log.Logger,
+	imageStore stypes.ImageStore, metaDB mTypes.MetaDB, log log.Logger, setOpts ...mTypes.SetRepoReferenceOption,
 ) error {
 	var imageMeta mTypes.ImageMeta
 
@@ -533,14 +542,6 @@ func SetImageMetaFromInput(ctx context.Context, repo, reference, mediaType strin
 		imageMeta = convert.GetImageIndexMeta(indexContent, int64(len(blob)), digest)
 	} else {
 		return nil
-	}
-
-	// The push time only lives in the metaDB; when it is lost, the manifest blob's storage
-	// mod time is the closest remaining record of when the image was pushed. Pass it as a
-	// hint so a metaDB rebuild doesn't stamp every image with the current time.
-	setOpts := []mTypes.SetRepoReferenceOption{}
-	if found, _, modTime, err := imageStore.StatBlob(repo, digest); err == nil && found {
-		setOpts = append(setOpts, mTypes.WithPushTimestamp(modTime))
 	}
 
 	err := metaDB.SetRepoReference(ctx, repo, reference, imageMeta, setOpts...)

--- a/pkg/meta/parse_test.go
+++ b/pkg/meta/parse_test.go
@@ -436,6 +436,37 @@ func TestParseStorageDynamoWrapper(t *testing.T) {
 func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) {
 	ctx := context.Background()
 
+	Convey("Push timestamp falls back to the manifest blob storage mod time", func() {
+		imageStore := local.NewImageStore(rootDir, false, false,
+			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+
+		storeController := storage.StoreController{DefaultStore: imageStore}
+
+		image := CreateRandomImage() //nolint:staticcheck
+
+		err := WriteImageToFileSystem(image, repo, "tag1", storeController)
+		So(err, ShouldBeNil)
+
+		// Backdate the manifest blob: after a metaDB loss the real push time is gone,
+		// so the storage mod time is the only remaining record of when it was pushed.
+		manifestDigest := image.ManifestDescriptor.Digest
+		blobPath := path.Join(rootDir, repo, "blobs", manifestDigest.Algorithm().String(), manifestDigest.Encoded())
+		pushedAt := time.Now().Add(-72 * time.Hour)
+
+		err = os.Chtimes(blobPath, pushedAt, pushedAt)
+		So(err, ShouldBeNil)
+
+		err = meta.ParseStorage(metaDB, storeController, log) //nolint: contextcheck
+		So(err, ShouldBeNil)
+
+		repoMeta, err := metaDB.GetRepoMeta(ctx, repo)
+		So(err, ShouldBeNil)
+
+		stats, ok := repoMeta.Statistics[manifestDigest.String()]
+		So(ok, ShouldBeTrue)
+		So(stats.PushTimestamp, ShouldHappenWithin, time.Minute, pushedAt)
+	})
+
 	Convey("Test with simple case", func() {
 		imageStore := local.NewImageStore(rootDir, false, false,
 			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
@@ -704,7 +735,8 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 		err = metaDB.SetRepoMeta(repo, repoMeta)
 		So(err, ShouldBeNil)
 
-		// metaDB should detect that pushTimestamp is 0 and update it.
+		// metaDB should detect that pushTimestamp is 0 and repopulate it
+		// (from the manifest blob's storage mod time, so close to the original push).
 		err = meta.ParseStorage(metaDB, storeController, log) //nolint: contextcheck
 		So(err, ShouldBeNil)
 
@@ -713,7 +745,7 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 
 		So(repoMeta.Statistics[image.DigestStr()].DownloadCount, ShouldEqual, 1)
 		So(repoMeta.DownloadCount, ShouldEqual, 1)
-		So(repoMeta.Statistics[image.DigestStr()].PushTimestamp, ShouldHappenAfter, oldPushTimestamp)
+		So(repoMeta.Statistics[image.DigestStr()].PushTimestamp, ShouldHappenWithin, time.Minute, oldPushTimestamp)
 	})
 
 	Convey("Parse 2 times and check correct update of the metaDB for modified and deleted repos", func() {

--- a/pkg/meta/parse_test.go
+++ b/pkg/meta/parse_test.go
@@ -450,7 +450,7 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 		// Backdate the manifest blob: after a metaDB loss the real push time is gone,
 		// so the storage mod time is the only remaining record of when it was pushed.
 		manifestDigest := image.ManifestDescriptor.Digest
-		blobPath := path.Join(rootDir, repo, "blobs", manifestDigest.Algorithm().String(), manifestDigest.Encoded())
+		blobPath := imageStore.BlobPath(repo, manifestDigest)
 		pushedAt := time.Now().Add(-72 * time.Hour)
 
 		err = os.Chtimes(blobPath, pushedAt, pushedAt)

--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -836,13 +836,13 @@ func (rc *RedisDB) SetRepoReference(ctx context.Context, repo string,
 			stats = &proto_go.DescriptorStatistics{
 				DownloadCount:     0,
 				LastPullTimestamp: &timestamppb.Timestamp{},
-				PushTimestamp:     timestamppb.Now(),
+				PushTimestamp:     mConvert.GetProtoPushTimestamp(imageMeta),
 				PushedBy:          userid,
 			}
 			protoRepoMeta.Statistics[digestStr] = stats
 		} else {
 			if stats.PushTimestamp.AsTime().IsZero() {
-				stats.PushTimestamp = timestamppb.Now()
+				stats.PushTimestamp = mConvert.GetProtoPushTimestamp(imageMeta)
 			}
 
 			if userid != "" && stats.PushedBy == "" {

--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -733,11 +733,13 @@ func (rc *RedisDB) SetImageMeta(digest godigest.Digest, imageMeta mTypes.ImageMe
 //
 //nolint:gocyclo // Complex function handling multiple metadata updates (referrers, tags, statistics, signatures, blobs)
 func (rc *RedisDB) SetRepoReference(ctx context.Context, repo string,
-	reference string, imageMeta mTypes.ImageMeta,
+	reference string, imageMeta mTypes.ImageMeta, opts ...mTypes.SetRepoReferenceOption,
 ) error {
 	if err := common.ValidateRepoReferenceInput(repo, reference, imageMeta.Digest); err != nil {
 		return err
 	}
+
+	options := mTypes.ApplySetRepoReferenceOptions(opts...)
 
 	var userid string
 
@@ -836,13 +838,13 @@ func (rc *RedisDB) SetRepoReference(ctx context.Context, repo string,
 			stats = &proto_go.DescriptorStatistics{
 				DownloadCount:     0,
 				LastPullTimestamp: &timestamppb.Timestamp{},
-				PushTimestamp:     mConvert.GetProtoPushTimestamp(imageMeta),
+				PushTimestamp:     mConvert.GetProtoPushTimestamp(options.PushTimestamp),
 				PushedBy:          userid,
 			}
 			protoRepoMeta.Statistics[digestStr] = stats
 		} else {
 			if stats.PushTimestamp.AsTime().IsZero() {
-				stats.PushTimestamp = mConvert.GetProtoPushTimestamp(imageMeta)
+				stats.PushTimestamp = mConvert.GetProtoPushTimestamp(options.PushTimestamp)
 			}
 
 			if userid != "" && stats.PushedBy == "" {

--- a/pkg/meta/types/types.go
+++ b/pkg/meta/types/types.go
@@ -73,7 +73,8 @@ type MetaDB interface { //nolint:interfacebloat
 	SetImageMeta(digest godigest.Digest, imageMeta ImageMeta) error
 
 	// SetRepoReference sets the given image data to the repo metadata.
-	SetRepoReference(ctx context.Context, repo string, reference string, imageMeta ImageMeta) error
+	SetRepoReference(ctx context.Context, repo string, reference string, imageMeta ImageMeta,
+		opts ...SetRepoReferenceOption) error
 
 	// SearchRepos searches for repos given a search string
 	SearchRepos(ctx context.Context, searchText string) ([]RepoMeta, error)
@@ -241,10 +242,36 @@ type ImageMeta struct {
 	Size      int64           // Size refers to the image descriptor, a manifest or a index (if multiarch)
 	Index     *ispec.Index    // If the image is multiarch the Index will be non-nil
 	Manifests []ManifestMeta  // All manifests under the image, 1 for simple images and many for multiarch
+}
+
+// SetRepoReferenceOptions holds optional per-call hints for SetRepoReference.
+type SetRepoReferenceOptions struct {
 	// PushTimestamp is an optional hint for when the image was pushed, used only when a new statistics
 	// entry is created (e.g. the manifest blob storage mod time on a storage re-parse). Zero means
 	// unknown and the metaDB falls back to the current time.
 	PushTimestamp time.Time
+}
+
+// SetRepoReferenceOption sets an optional hint on SetRepoReferenceOptions.
+type SetRepoReferenceOption func(*SetRepoReferenceOptions)
+
+// WithPushTimestamp hints when the image was pushed (e.g. the manifest blob storage mod time
+// on a storage re-parse).
+func WithPushTimestamp(pushTimestamp time.Time) SetRepoReferenceOption {
+	return func(opts *SetRepoReferenceOptions) {
+		opts.PushTimestamp = pushTimestamp
+	}
+}
+
+// ApplySetRepoReferenceOptions resolves the given options into a SetRepoReferenceOptions struct.
+func ApplySetRepoReferenceOptions(opts ...SetRepoReferenceOption) SetRepoReferenceOptions {
+	options := SetRepoReferenceOptions{}
+
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	return options
 }
 
 // ManifestMeta represents all data related to an image manifests (found from the image contents itself).

--- a/pkg/meta/types/types.go
+++ b/pkg/meta/types/types.go
@@ -241,6 +241,10 @@ type ImageMeta struct {
 	Size      int64           // Size refers to the image descriptor, a manifest or a index (if multiarch)
 	Index     *ispec.Index    // If the image is multiarch the Index will be non-nil
 	Manifests []ManifestMeta  // All manifests under the image, 1 for simple images and many for multiarch
+	// PushTimestamp is an optional hint for when the image was pushed, used only when a new statistics
+	// entry is created (e.g. the manifest blob storage mod time on a storage re-parse). Zero means
+	// unknown and the metaDB falls back to the current time.
+	PushTimestamp time.Time
 }
 
 // ManifestMeta represents all data related to an image manifests (found from the image contents itself).

--- a/pkg/test/mocks/repo_db_mock.go
+++ b/pkg/test/mocks/repo_db_mock.go
@@ -320,7 +320,7 @@ func (sdm MetaDBMock) SetImageMeta(digest godigest.Digest, imageMeta mTypes.Imag
 }
 
 func (sdm MetaDBMock) SetRepoReference(ctx context.Context, repo string, reference string,
-	imageMeta mTypes.ImageMeta,
+	imageMeta mTypes.ImageMeta, _ ...mTypes.SetRepoReferenceOption,
 ) error {
 	if sdm.SetRepoReferenceFn != nil {
 		return sdm.SetRepoReferenceFn(ctx, repo, reference, imageMeta)


### PR DESCRIPTION
The push timestamp only lives in the metaDB. When the metaDB is lost (e.g. a non-persistent cache backend restarts) the storage parse recreated every statistics entry with time.Now(), stamping all images with the startup time. Retention policies based on push time (pushedWithin, mostRecentlyPushedCount) then saw one identical fake timestamp and expired every tag at the same moment.

Pass the manifest blob's storage mod time as a hint through ImageMeta and prefer it over time.Now() when a new statistics entry is created. On object storage blobs are immutable, so the mod time is the original upload time and a metaDB rebuild reconstructs the real push dates.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
