### PR TITLE
fix(api): reject backslash in OIDC callback redirect to prevent open redirect

### DIFF
--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -598,6 +598,12 @@ func ValidateCallbackUI(callbackUI string, allowOrigins []string) string {
 		return "/"
 	}
 
+	// Reject backslash in the path — browsers may normalize /\evil.com to //evil.com
+	// (open redirect). url.Parse decodes %5C, so this also covers encoded forms.
+	if strings.Contains(parsed.Path, `\`) {
+		return "/"
+	}
+
 	// Reject protocol-relative URLs (e.g. //evil.com/path)
 	if strings.HasPrefix(callbackUI, "//") {
 		return "/"

--- a/pkg/api/authn_test.go
+++ b/pkg/api/authn_test.go
@@ -140,6 +140,11 @@ func TestValidateCallbackUI(t *testing.T) {
 		},
 		{name: "header injection rejected (newline)", input: "/v2/\nSet-Cookie: x=y", expected: "/"},
 		{name: "header injection rejected (carriage return)", input: "/v2/\rSet-Cookie: x=y", expected: "/"},
+		{name: "backslash open redirect rejected", input: "/\\evil.com", expected: "/"},
+		{name: "leading backslash open redirect rejected", input: "\\\\evil.com", expected: "/"},
+		{name: "backslash in path rejected", input: "/v2\\evil.com", expected: "/"},
+		{name: "encoded backslash open redirect rejected", input: "/%5Cevil.com", expected: "/"},
+		{name: "encoded backslash lowercase rejected", input: "/%5cevil.com", expected: "/"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Cherry-pick https://github.com/project-zot/zot/pull/4211 and fix comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
