### PR TITLE
fix(gc): respect in-progress .sync sessions when removing repos

### DIFF
--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -20,6 +20,7 @@ import (
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
 	"zotregistry.dev/zot/v2/pkg/compat"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	"zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/retention"
@@ -195,15 +196,23 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 		return err
 	}
 
+	// gc stale sync staging sessions
+	sessionsDeleted, err := gc.removeStaleSyncSessions(repo, gc.opts.Delay)
+	if err != nil {
+		return err
+	}
+
 	if !gc.opts.ImageRetention.DryRun {
 		monitoring.IncGCDeleted(gc.metrics, "manifest", manifestsDeleted)
 		monitoring.IncGCDeleted(gc.metrics, "blob", blobsDeleted)
 		monitoring.IncGCDeleted(gc.metrics, "upload", uploadsDeleted)
+		monitoring.IncGCDeleted(gc.metrics, "syncSession", sessionsDeleted)
 	}
 
 	return nil
 }
 
+// removeStaleManifestEntries removes manifest/index descriptors whose blobs no longer exist in storage.
 func (gc GarbageCollect) removeStaleManifestEntries(repo string, index *ispec.Index) error {
 	if gc.opts.ImageRetention.DryRun {
 		return nil
@@ -884,6 +893,65 @@ func (gc GarbageCollect) removeBlobUploads(repo string, delay time.Duration) (in
 	return deleted, aggregatedErr
 }
 
+// removeStaleSyncSessions deletes sync staging sessions (<repo>/.sync/<uuid>)
+// which are past their gc delay. These are left behind when a sync is
+// interrupted; live sessions are protected by the delay.
+func (gc GarbageCollect) removeStaleSyncSessions(repo string, delay time.Duration) (int, error) {
+	gc.log.Debug().Str("module", "gc").Str("repository", repo).Msg("cleaning stale sync staging sessions")
+
+	repoSyncDir := path.Join(gc.imgStore.RootDir(), repo, constants.SyncBlobUploadDir)
+	if !gc.imgStore.DirExists(repoSyncDir) {
+		// The repository or .sync directory may have already been removed
+		return 0, nil
+	}
+
+	sessions, err := gc.imgStore.ListSyncSessions(repo)
+	if err != nil {
+		// A PathNotFoundError from the underlying driver means .sync is empty or absent
+		var pathNotFoundErr driver.PathNotFoundError
+		if errors.As(err, &pathNotFoundErr) {
+			return 0, nil
+		}
+
+		gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).Msg("failed to list sync sessions")
+
+		return 0, err
+	}
+
+	var aggregatedErr error
+
+	deleted := 0
+
+	for _, id := range sessions {
+		_, size, modtime, err := gc.imgStore.StatSyncSession(repo, id)
+		if err != nil {
+			gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).Str("session", id).
+				Msg("failed to stat sync session")
+
+			aggregatedErr = errors.Join(aggregatedErr, err)
+
+			continue
+		}
+
+		if modtime.Add(delay).After(time.Now()) {
+			// Do not delete sync sessions which have been updated recently
+			continue
+		}
+
+		err = gc.imgStore.DeleteSyncSession(repo, id)
+		if err != nil {
+			gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).Str("session", id).
+				Str("size", strconv.FormatInt(size, 10)).Str("modified", modtime.String()).Msg("failed to delete sync session")
+
+			aggregatedErr = errors.Join(aggregatedErr, err)
+		} else {
+			deleted++
+		}
+	}
+
+	return deleted, aggregatedErr
+}
+
 // removeUnreferencedBlobs gc all blobs which are not referenced by any manifest found in repo's index.json.
 func (gc GarbageCollect) removeUnreferencedBlobs(repo string, delay time.Duration, log zlog.Logger,
 ) (int, error) {
@@ -942,7 +1010,6 @@ func (gc GarbageCollect) removeUnreferencedBlobs(repo string, delay time.Duratio
 		}
 	}
 
-	// if we removed all blobs from repo
 	removeRepo := len(gcBlobs) > 0 && len(gcBlobs) == len(allBlobs)
 
 	reaped, err := gc.imgStore.CleanupRepo(repo, gcBlobs, removeRepo)

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -1760,3 +1760,178 @@ func TestCleanupRepoMissingBlob(t *testing.T) {
 		So(count, ShouldEqual, 1)
 	})
 }
+
+func TestRemoveStaleSyncSessions(t *testing.T) {
+	Convey("removeStaleSyncSessions reaps stale sessions and keeps recent ones", t, func() {
+		dir := t.TempDir()
+
+		audit := zlog.NewAuditLogger("debug", "")
+		log := zlog.NewTestLogger()
+
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
+			RootDir:     dir,
+			Name:        "cache",
+			UseRelPaths: true,
+		}, log)
+		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
+
+		falseVal := false
+		gcOptions := Options{
+			Delay: 1 * time.Hour,
+			ImageRetention: config.ImageRetention{
+				Delay:    storageConstants.DefaultGCDelay,
+				Policies: []config.RetentionPolicy{{Repositories: []string{"**"}, DeleteUntagged: &falseVal}},
+			},
+		}
+
+		imgStore.InitRepo(context.Background(), repoName)
+
+		syncDir := path.Join(dir, repoName, ".sync")
+		err := os.MkdirAll(syncDir, 0o755)
+		So(err, ShouldBeNil)
+
+		older := time.Now().Add(-2 * time.Hour)
+
+		staleDir := path.Join(syncDir, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+		err = os.MkdirAll(staleDir, 0o755)
+		So(err, ShouldBeNil)
+		err = os.Chtimes(staleDir, older, older)
+		So(err, ShouldBeNil)
+
+		// fresh session (recent)
+		freshDir := path.Join(syncDir, "bbbbbbbb-cccc-dddd-eeee-ffffffffffffff")
+		err = os.MkdirAll(freshDir, 0o755)
+		So(err, ShouldBeNil)
+
+		gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+		deleted, err := gc.removeStaleSyncSessions(repoName, gc.opts.Delay)
+		So(err, ShouldBeNil)
+		So(deleted, ShouldEqual, 1)
+
+		// stale session should be gone
+		_, err = os.Stat(staleDir)
+		So(os.IsNotExist(err), ShouldBeTrue)
+		// fresh session should remain
+		_, err = os.Stat(freshDir)
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestRemoveStaleSyncSessionsNoSessions(t *testing.T) {
+	Convey("SyncSessions returns 0 when no .sync directory exists", t, func() {
+		dir := t.TempDir()
+
+		audit := zlog.NewAuditLogger("debug", "")
+		log := zlog.NewTestLogger()
+
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
+			RootDir:     dir,
+			Name:        "cache",
+			UseRelPaths: true,
+		}, log)
+		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
+
+		falseVal := false
+		gcOptions := Options{
+			Delay: 1 * time.Hour,
+			ImageRetention: config.ImageRetention{
+				Delay:    storageConstants.DefaultGCDelay,
+				Policies: []config.RetentionPolicy{{Repositories: []string{"**"}, DeleteUntagged: &falseVal}},
+			},
+		}
+
+		imgStore.InitRepo(context.Background(), repoName)
+
+		gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+		deleted, err := gc.removeStaleSyncSessions(repoName, gc.opts.Delay)
+		So(err, ShouldBeNil)
+		So(deleted, ShouldEqual, 0)
+	})
+}
+
+func TestGCReaperSyncSessionsWithRepoRemoval(t *testing.T) {
+	Convey("stale session blocks repo removal and is reaped; empty repo left in place", t, func() {
+		dir := t.TempDir()
+
+		audit := zlog.NewAuditLogger("debug", "")
+		log := zlog.NewTestLogger()
+
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
+			RootDir:     dir,
+			Name:        "cache",
+			UseRelPaths: true,
+		}, log)
+
+		falseVal := false
+		gcOptions := Options{
+			Delay: 1 * time.Hour,
+			ImageRetention: config.ImageRetention{
+				Delay:    storageConstants.DefaultGCDelay,
+				Policies: []config.RetentionPolicy{{Repositories: []string{"**"}, DeleteUntagged: &falseVal}},
+			},
+		}
+
+		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
+		imgStore.InitRepo(context.Background(), repoName)
+
+		// Upload a blob then remove it from the index so it becomes unreferenced
+		content := []byte("disappearing blob")
+		digest := godigest.FromBytes(content)
+		_, _, err := imgStore.FullBlobUpload(context.Background(), repoName, bytes.NewReader(content), digest)
+		So(err, ShouldBeNil)
+
+		// Write an empty index so this blob is unreferenced
+		idx := ispec.Index{Manifests: []ispec.Descriptor{}}
+		err = imgStore.PutIndexContent(repoName, idx)
+		So(err, ShouldBeNil)
+
+		// Create a stale sync session
+		syncDir := path.Join(dir, repoName, ".sync")
+		err = os.MkdirAll(syncDir, 0o755)
+		So(err, ShouldBeNil)
+		staleDir := path.Join(syncDir, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+		err = os.MkdirAll(staleDir, 0o755)
+		So(err, ShouldBeNil)
+		older := time.Now().Add(-2 * time.Hour)
+		err = os.Chtimes(staleDir, older, older)
+		So(err, ShouldBeNil)
+
+		// Age the blob so it is eligible for garbage collection (older than the 1h delay).
+		blobPath := path.Join(dir, repoName, "blobs", digest.Algorithm().String(), digest.Encoded())
+		err = os.Chtimes(blobPath, older, older)
+		So(err, ShouldBeNil)
+
+		gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+		ctx := context.Background()
+
+		// A single GC pass: removeUnreferencedBlobs reaps the unreferenced blob, the
+		// in-progress sync session blocks CleanupRepo from removing the repo, and
+		// removeStaleSyncSessions then reaps the now-stale session.
+		err = gc.CleanRepo(ctx, repoName)
+		So(err, ShouldBeNil)
+
+		// Stale session should be gone after pass 1
+		_, err = os.Stat(staleDir)
+		So(os.IsNotExist(err), ShouldBeTrue)
+
+		// Blob should also be gone (unreferenced and past delay).
+		_, err = os.Stat(blobPath)
+		So(os.IsNotExist(err), ShouldBeTrue)
+
+		// The repo directory still exists - GC does not remove empty repos.
+		repoDir := path.Join(dir, repoName)
+		_, err = os.Stat(repoDir)
+		So(err, ShouldBeNil)
+	})
+}

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -936,6 +936,45 @@ func (is *ImageStore) ListBlobUploads(repo string) ([]string, error) {
 	return blobUploads, err
 }
 
+// syncSessionPath returns the full path for a sync staging session directory.
+func (is *ImageStore) syncSessionPath(repo, id string) string {
+	return path.Join(is.rootDir, repo, syncConstants.SyncBlobUploadDir, id)
+}
+
+// ListSyncSessions lists sync staging session IDs (<uuid>) under <repo>/.sync.
+func (is *ImageStore) ListSyncSessions(repo string) ([]string, error) {
+	sessionPaths, err := is.storeDriver.List(path.Join(is.rootDir, repo, syncConstants.SyncBlobUploadDir))
+	if err != nil {
+		return nil, err
+	}
+	sessions := make([]string, 0, len(sessionPaths))
+	for _, sessionPath := range sessionPaths {
+		sessions = append(sessions, path.Base(sessionPath))
+	}
+	return sessions, nil
+}
+
+// StatSyncSession returns the existence, size, and modtime of a sync session directory.
+func (is *ImageStore) StatSyncSession(repo, id string) (bool, int64, time.Time, error) {
+	sessionPath := is.syncSessionPath(repo, id)
+	binfo, err := is.storeDriver.Stat(sessionPath)
+	if err != nil {
+		is.log.Debug().Err(err).Str("session", id).Msg("failed to stat sync session")
+		return false, -1, time.Time{}, err
+	}
+	return true, binfo.Size(), binfo.ModTime(), nil
+}
+
+// DeleteSyncSession removes a sync staging session directory.
+func (is *ImageStore) DeleteSyncSession(repo, id string) error {
+	sessionPath := is.syncSessionPath(repo, id)
+	if err := is.storeDriver.Delete(sessionPath); err != nil {
+		is.log.Error().Err(err).Str("session", id).Msg("failed to delete sync session")
+		return err
+	}
+	return nil
+}
+
 // StatBlobUpload verifies if a blob upload is present inside a repository. The caller function MUST lock from outside.
 func (is *ImageStore) StatBlobUpload(repo, uuid string) (bool, int64, time.Time, error) {
 	blobUploadPath := is.BlobUploadPath(repo, uuid)
@@ -1974,9 +2013,11 @@ func (is *ImageStore) CleanupRepo(repo string, blobs []godigest.Digest, removeRe
 	}
 
 	blobUploads, _ := is.ListBlobUploads(repo)
+	syncSessions, _ := is.ListSyncSessions(repo)
 
-	// if removeRepo flag is true and we cleanup all blobs and there are no blobs currently being uploaded.
-	if removeRepo && count == len(blobs) && count > 0 && len(blobUploads) == 0 {
+	// if removeRepo flag is true and there are no uploads or sync sessions currently in-progress.
+	if removeRepo && count == len(blobs) && count > 0 &&
+		len(blobUploads) == 0 && len(syncSessions) == 0 {
 		is.log.Info().Str("repository", repo).Msg("removed all blobs, removing repo")
 
 		if err := is.storeDriver.Delete(path.Join(is.rootDir, repo)); err != nil {

--- a/pkg/storage/imagestore/imagestore_test.go
+++ b/pkg/storage/imagestore/imagestore_test.go
@@ -18,6 +18,7 @@ import (
 
 	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/storage/gcs"
 	"zotregistry.dev/zot/v2/pkg/storage/imagestore"
@@ -252,5 +253,92 @@ func TestCleanupRepoFailsOnDeleteImageManifest(t *testing.T) {
 		count, err := store.CleanupRepo(repo, []godigest.Digest{manifestDigest}, false)
 		So(err, ShouldNotBeNil)
 		So(count, ShouldEqual, 0)
+	})
+}
+
+func TestCleanupRepoToleratesSyncSessions(t *testing.T) {
+	Convey("CleanupRepo rejects .sync sessions", t, func() {
+		dir := t.TempDir()
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		defer metrics.Stop()
+
+		store := local.NewImageStore(dir, true, true, log, metrics, nil, nil, nil, nil)
+		repo := "repo"
+		ctx := context.Background()
+
+		content := []byte("test-layer")
+		digest := godigest.FromBytes(content)
+		_, _, err := store.FullBlobUpload(ctx, repo, bytes.NewReader(content), digest)
+		So(err, ShouldBeNil)
+
+		cblob, cdigest := GetRandomImageConfig()
+		_, _, err = store.FullBlobUpload(ctx, repo, bytes.NewReader(cblob), cdigest)
+		So(err, ShouldBeNil)
+
+		manifest := ispec.Manifest{
+			Config: ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageConfig,
+				Digest:    cdigest,
+				Size:      int64(len(cblob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: ispec.MediaTypeImageLayer,
+					Digest:    digest,
+					Size:      int64(len(content)),
+				},
+			},
+		}
+		manifest.SchemaVersion = 2
+
+		body, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+
+		manifestDigest := godigest.FromBytes(body)
+		_, _, err = store.PutImageManifest(ctx, repo, "1.0", ispec.MediaTypeImageManifest, body, nil)
+		So(err, ShouldBeNil)
+
+		Convey("sync session blocks repo removal", func() {
+			syncDir := path.Join(dir, repo, syncConstants.SyncBlobUploadDir, "a1b2c3d4-e5f6-7890-abcd-ef1234567890")
+			err = os.MkdirAll(syncDir, 0o755)
+			So(err, ShouldBeNil)
+
+			err = os.WriteFile(path.Join(syncDir, "staging"), []byte("data"), 0o644)
+			So(err, ShouldBeNil)
+
+			allBlobs := []godigest.Digest{manifestDigest}
+
+			count, err := store.CleanupRepo(repo, allBlobs, true)
+			So(err, ShouldBeNil)
+			So(count, ShouldEqual, 1)
+
+			_, statErr := os.Stat(path.Join(dir, repo))
+			So(statErr, ShouldBeNil)
+		})
+
+		Convey("removal proceeds without sync session", func() {
+			allBlobs := []godigest.Digest{manifestDigest}
+
+			_, err = store.CleanupRepo(repo, allBlobs, true)
+			So(err, ShouldBeNil)
+
+			_, statErr := os.Stat(path.Join(dir, repo))
+			So(os.IsNotExist(statErr), ShouldBeTrue)
+		})
+
+		Convey("empty .sync dir does not block removal", func() {
+			syncDir := path.Join(dir, repo, syncConstants.SyncBlobUploadDir)
+			err = os.MkdirAll(syncDir, 0o755)
+			So(err, ShouldBeNil)
+
+			allBlobs := []godigest.Digest{manifestDigest}
+
+			_, err = store.CleanupRepo(repo, allBlobs, true)
+			So(err, ShouldBeNil)
+
+			_, statErr := os.Stat(path.Join(dir, repo))
+			So(os.IsNotExist(statErr), ShouldBeTrue)
+		})
 	})
 }

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -72,6 +72,9 @@ type ImageStore interface { //nolint:interfacebloat
 	VerifyBlobDigestValue(repo string, digest godigest.Digest) error
 	GetAllDedupeReposCandidates(digest godigest.Digest) ([]string, error)
 	GetBlobRedirectURL(r *http.Request, repo string, digest godigest.Digest) (string, error)
+	ListSyncSessions(repo string) ([]string, error)
+	StatSyncSession(repo, id string) (bool, int64, time.Time, error)
+	DeleteSyncSession(repo, id string) error
 }
 
 type Driver interface { //nolint:interfacebloat

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -66,6 +66,9 @@ type MockedImageStore struct {
 	VerifyBlobDigestValueFn       func(repo string, digest godigest.Digest) error
 	GetAllDedupeReposCandidatesFn func(digest godigest.Digest) ([]string, error)
 	GetBlobRedirectURLFn          func(r *http.Request, repo string, digest godigest.Digest) (string, error)
+	ListSyncSessionsFn            func(repo string) ([]string, error)
+	StatSyncSessionFn             func(repo, id string) (bool, int64, time.Time, error)
+	DeleteSyncSessionFn           func(repo, id string) error
 }
 
 func (is MockedImageStore) StatIndex(repo string) (bool, int64, time.Time, error) {
@@ -360,6 +363,30 @@ func (is MockedImageStore) GetBlobRedirectURL(
 	}
 
 	return "", nil
+}
+
+func (is MockedImageStore) ListSyncSessions(repo string) ([]string, error) {
+	if is.ListSyncSessionsFn != nil {
+		return is.ListSyncSessionsFn(repo)
+	}
+
+	return []string{}, nil
+}
+
+func (is MockedImageStore) StatSyncSession(repo, id string) (bool, int64, time.Time, error) {
+	if is.StatSyncSessionFn != nil {
+		return is.StatSyncSessionFn(repo, id)
+	}
+
+	return true, 0, time.Time{}, nil
+}
+
+func (is MockedImageStore) DeleteSyncSession(repo, id string) error {
+	if is.DeleteSyncSessionFn != nil {
+		return is.DeleteSyncSessionFn(repo, id)
+	}
+
+	return nil
 }
 
 func (is MockedImageStore) DeleteBlobUpload(repo string, uuid string) error {


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

#4240

**What does this PR do / Why do we need it**:

`ImageStore.CleanupRepo` deletes an entire repository directory when garbage collection finds every committed blob unreferenced. Its "no in-flight writes" guard only checked the `.uploads/` directory (`ListBlobUploads`) and ignored the on-demand sync staging directory `.sync/<uuid>/`. As a result, GC could remove a repository out from under a live on-demand pull that is staging blobs into it (the default sync config with no `downloadDir`), corrupting the in-flight sync.

This PR closes that race with two mirrored changes:

1. Guard (`pkg/storage/imagestore/imagestore.go`): `CleanupRepo` now also skips repo removal while `<repo>/.sync/` contains any session directory, exactly as it already does for a non-empty `.uploads/`.
2. Reaper (`pkg/storage/gc/gc.go`): a new `removeStaleSyncSessions` deletes `.sync/<uuid>` staging sessions older than the GC delay, mirroring the existing `removeBlobUploads` reaper. Without it, a session left behind by a crashed/interrupted sync would block repo removal forever (and leak disk). It runs at the end of `cleanRepo`, after `removeUnreferencedBlobs` (and thus after the `CleanupRepo` guard), so a freshly created session's blobs are never reaped out from under it within the same pass.

Known limitation (disclosed): a `.sync/<uuid>` directory's mtime only advances when its _direct_ children change, so a single download running longer than the GC delay could still be reaped mid-flight. Severity is low — the GC delay defaults to 1 hour (`DefaultGCDelay`), well above realistic staging times — and this is strictly better than the prior behavior, which deleted live sessions unconditionally via repo removal. A related follow-up is intentionally out of scope: `CommitAll` (`pkg/extensions/sync/destination.go`) silently returns `nil` when its session directory has vanished; it should fail loudly instead.

**Testing done on this change**:

New unit tests were added covering both halves of the fix, exercised against the real on-disk staging layout (`<repo>/.sync/<uuid>/`):

- `TestCleanupRepoToleratesSyncSessions` (`pkg/storage/imagestore`) — an in-progress `.sync` session blocks repo removal; removal proceeds when none exists; an empty `.sync/` dir does not block removal.
- `TestRemoveStaleSyncSessions` (`pkg/storage/gc`) — a stale session (old mtime) is reaped while a fresh one is kept.
- `TestRemoveStaleSyncSessionsNoSessions` — no `.sync` directory ⇒ zero deletions, no error.
- `TestGCReaperSyncSessionsWithRepoRemoval` — a repo with an unreferenced blob plus a stale session: the guard blocks repo removal while the session is present, the blob is GC'd, and the reaper removes the stale session (empty repos are intentionally left in place).

```bash
$ go test ./pkg/storage/gc/... ./pkg/storage/imagestore/...
ok      zotregistry.dev/zot/v2/pkg/storage/gc          15.4s
ok      zotregistry.dev/zot/v2/pkg/storage/imagestore  0.1s

$ go test ./pkg/storage/gc/... -run 'TestRemoveStaleSyncSessions|TestGCReaperSyncSessions' -v
--- PASS: TestRemoveStaleSyncSessions
--- PASS: TestRemoveStaleSyncSessionsNoSessions
--- PASS: TestGCReaperSyncSessionsWithRepoRemoval

$ go test ./pkg/storage/imagestore/... -run TestCleanupRepoToleratesSyncSessions -v
--- PASS: TestCleanupRepoToleratesSyncSessions
```

**Will this break upgrades or downgrades?**

No. This changes only runtime garbage-collection behavior. There is no on-disk format change, no config schema change, and no API change — the .sync/<uuid> staging layout already exists. A binary on either side of this change reads and writes the same storage. Safe to upgrade or downgrade.

**Does this PR introduce any user-facing change?**:

No API or configuration change. Behaviorally, garbage collection no longer deletes a repository while an on-demand sync is staging into it, and it now reaps stale `.sync` staging sessions. GC deletion metrics gain one new label value, `syncSession`, alongside the existing `manifest/blob/upload`.

```release-note
Garbage collection no longer removes a repository directory while an on-demand sync is
staging blobs into it, and now reaps stale sync staging sessions (`.sync/<uuid>`) left
behind by interrupted syncs. GC deletion metrics gain a new `syncSession` label value.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.