### PR TITLE
feat: send an http event when an image has been scanned

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -380,7 +380,7 @@ func (c *Controller) Init() error {
 
 func (c *Controller) InitCVEInfo() {
 	// Enable CVE extension if extension config is provided
-	c.CveScanner = ext.GetCveScanner(c.Config, c.StoreController, c.MetaDB, c.Log)
+	c.CveScanner = ext.GetCveScanner(c.Config, c.StoreController, c.MetaDB, c.EventRecorder, c.Log)
 }
 
 func (c *Controller) InitImageStore() error {
@@ -565,7 +565,8 @@ func (c *Controller) StartBackgroundTasks() {
 	c.StoreController.DefaultStore.RunDedupeBlobs(time.Duration(0), c.taskScheduler)
 
 	// Always call EnableSearchExtension to ensure proper logging, even when search is disabled
-	ext.EnableSearchExtension(c.Config, c.StoreController, c.MetaDB, c.taskScheduler, c.CveScanner, c.Log)
+	ext.EnableSearchExtension(c.Config, c.StoreController, c.MetaDB, c.taskScheduler,
+		c.CveScanner, c.Log)
 
 	// Always call EnableMetricsExtension to ensure proper logging, even when metrics is disabled
 	storageConfig := c.Config.CopyStorageConfig()

--- a/pkg/cli/client/cve_cmd_test.go
+++ b/pkg/cli/client/cve_cmd_test.go
@@ -313,11 +313,11 @@ func TestCVEDiffList(t *testing.T) {
 	// MetaDB loaded with initial data, now mock the scanner
 	// Setup test CVE data in mock scanner
 	scanner := mocks.CveScannerMock{
-		ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+		ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 			repo, ref, _, _ := zcommon.GetRepoReference(image)
 
 			if zcommon.IsDigest(ref) {
-				return getCveResults(ref), nil
+				return cvemodel.ScanResult{CVEMap: getCveResults(ref)}, nil
 			}
 
 			repoMeta, _ := ctlr.MetaDB.GetRepoMeta(ctx, repo)
@@ -326,7 +326,7 @@ func TestCVEDiffList(t *testing.T) {
 				panic("unexpected tag '" + ref + "', test might be wrong")
 			}
 
-			return getCveResults(repoMeta.Tags[ref].Digest), nil
+			return cvemodel.ScanResult{CVEMap: getCveResults(repoMeta.Tags[ref].Digest)}, nil
 		},
 		GetCachedResultFn: func(digestStr string) map[string]cvemodel.CVE {
 			return getCveResults(digestStr)
@@ -898,8 +898,8 @@ func TestCVESort(t *testing.T) {
 	}
 
 	ctlr.CveScanner = mocks.CveScannerMock{
-		ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
-			return map[string]cvemodel.CVE{
+		ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
+			return cvemodel.ScanResult{CVEMap: map[string]cvemodel.CVE{
 				"CVE-2023-1255": {
 					ID:       "CVE-2023-1255",
 					Severity: "LOW",
@@ -925,7 +925,7 @@ func TestCVESort(t *testing.T) {
 					Severity: "MEDIUM",
 					Title:    "Excessive time spent checking DH q parameter and arguments",
 				},
-			}, nil
+			}}, nil
 		},
 	}
 
@@ -1032,10 +1032,10 @@ func getMockCveScanner(metaDB mTypes.MetaDB) cveinfo.Scanner {
 	// MetaDB loaded with initial data now mock the scanner
 	// Setup test CVE data in mock scanner
 	scanner := mocks.CveScannerMock{
-		ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+		ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 			if strings.Contains(image, "zot-cve-test@sha256:db573b01") ||
 				image == "zot-cve-test:0.0.1" {
-				return map[string]cvemodel.CVE{
+				return cvemodel.ScanResult{CVEMap: map[string]cvemodel.CVE{
 					"CVE-1": {
 						ID:          "CVE-1",
 						Severity:    "CRITICAL",
@@ -1066,11 +1066,11 @@ func getMockCveScanner(metaDB mTypes.MetaDB) cveinfo.Scanner {
 						Title:       "Title for CVE-5",
 						Description: "Description of CVE-5",
 					},
-				}, nil
+				}}, nil
 			}
 
 			// By default the image has no vulnerabilities
-			return map[string]cvemodel.CVE{}, nil
+			return cvemodel.ScanResult{CVEMap: map[string]cvemodel.CVE{}}, nil
 		},
 		IsImageFormatScannableFn: func(repo string, reference string) (bool, error) {
 			// Almost same logic compared to actual Trivy specific implementation

--- a/pkg/extensions/events/common.go
+++ b/pkg/extensions/events/common.go
@@ -16,6 +16,7 @@ const (
 	ImageUpdatedEventType      EventType = "zotregistry.image.updated"
 	ImageDeletedEventType      EventType = "zotregistry.image.deleted"
 	ImageLintFailedEventType   EventType = "zotregistry.image.lint_failed"
+	ImageScannedEventType      EventType = "zotregistry.image.scanned"
 	RepositoryCreatedEventType EventType = "zotregistry.repository.created"
 )
 
@@ -39,6 +40,17 @@ type RequestInfo struct {
 type EventContext struct {
 	Actor   *ActorInfo   `json:"actor,omitempty"`
 	Request *RequestInfo `json:"request,omitempty"`
+}
+
+type ImageScanSummary struct {
+	Count         int    `json:"count"`
+	FixableCount  int    `json:"fixableCount"`
+	UnknownCount  int    `json:"unknownCount"`
+	LowCount      int    `json:"lowCount"`
+	MediumCount   int    `json:"mediumCount"`
+	HighCount     int    `json:"highCount"`
+	CriticalCount int    `json:"criticalCount"`
+	MaxSeverity   string `json:"maxSeverity"`
 }
 
 type eventContextKey struct{}
@@ -66,4 +78,5 @@ type Recorder interface {
 	ImageUpdated(name, reference, digest, mediaType, manifest string, ectx *EventContext)
 	ImageDeleted(name, reference, digest, mediaType string, ectx *EventContext)
 	ImageLintFailed(name, reference, digest, mediaType, manifest string, ectx *EventContext)
+	ImageScanned(name, reference, digest, mediaType string, summary ImageScanSummary, ectx *EventContext)
 }

--- a/pkg/extensions/events/events.go
+++ b/pkg/extensions/events/events.go
@@ -123,6 +123,27 @@ func (r eventRecorder) ImageLintFailed(name, reference, digest, mediaType, manif
 	r.publish(event)
 }
 
+func (r eventRecorder) ImageScanned(name, reference, digest, mediaType string,
+	summary ImageScanSummary, ectx *EventContext,
+) {
+	event, err := newEventBuilder().
+		WithEventType(ImageScannedEventType).
+		WithDataField("name", name).
+		WithDataField("reference", reference).
+		WithDataField("digest", digest).
+		WithDataField("mediaType", mediaType).
+		WithDataField("summary", summary).
+		WithEventContext(ectx).
+		Build()
+	if err != nil {
+		r.log.Warn().Err(err).Msg("failed to create event")
+
+		return
+	}
+
+	r.publish(event)
+}
+
 func getTLSConfig(config eventsconf.SinkConfig) (*tls.Config, error) {
 	tlsConfig := &tls.Config{
 		MinVersion: tls.VersionTLS12,

--- a/pkg/extensions/events/events_test.go
+++ b/pkg/extensions/events/events_test.go
@@ -79,6 +79,12 @@ func TestEvents(t *testing.T) {
 			ev := <-sink.store
 			So(ev.Type(), ShouldEqual, events.ImageLintFailedEventType.String())
 		})
+		Convey("image scanned", func() {
+			recorder.ImageScanned("test", "v1", "", string(types.OCIManifestSchema1),
+				events.ImageScanSummary{Count: 1, HighCount: 1, FixableCount: 1, MaxSeverity: "HIGH"}, nil)
+			ev := <-sink.store
+			So(ev.Type(), ShouldEqual, events.ImageScannedEventType.String())
+		})
 	})
 }
 
@@ -144,6 +150,30 @@ func TestEventsWithContext(t *testing.T) {
 
 			_, hasRequest := data["request"]
 			So(hasRequest, ShouldBeFalse)
+		})
+		Convey("image scanned includes summary", func() {
+			recorder.ImageScanned("test", "v1", "sha256:abc", string(types.OCIManifestSchema1),
+				events.ImageScanSummary{
+					Count:         2,
+					FixableCount:  1,
+					LowCount:      1,
+					HighCount:     1,
+					MaxSeverity:   "HIGH",
+					CriticalCount: 0,
+				}, ectx)
+			ev := <-sink.store
+			So(ev.Type(), ShouldEqual, events.ImageScannedEventType.String())
+
+			var data map[string]any
+			err := ev.DataAs(&data)
+			So(err, ShouldBeNil)
+
+			summary, ok := data["summary"].(map[string]any)
+			So(ok, ShouldBeTrue)
+			So(summary["count"], ShouldEqual, float64(2))
+			So(summary["fixableCount"], ShouldEqual, float64(1))
+			So(summary["highCount"], ShouldEqual, float64(1))
+			So(summary["maxSeverity"], ShouldEqual, "HIGH")
 		})
 	})
 }
@@ -225,6 +255,13 @@ func TestHTTPSinkEvents(t *testing.T) {
 			e := getEvent(t, eventChan)
 			So(e, ShouldNotBeNil)
 			So(e.Type(), ShouldEqual, events.ImageLintFailedEventType.String())
+		})
+		Convey("image scanned", func() {
+			recorder.ImageScanned("test", "v1", "", string(types.OCIManifestSchema1),
+				events.ImageScanSummary{Count: 1, MaxSeverity: "LOW"}, nil)
+			e := getEvent(t, eventChan)
+			So(e, ShouldNotBeNil)
+			So(e.Type(), ShouldEqual, events.ImageScannedEventType.String())
 		})
 	})
 }
@@ -440,6 +477,29 @@ func TestNATSSinkEvents(t *testing.T) {
 			e := getEvent(t, eventChan)
 			So(e, ShouldNotBeNil)
 			So(e.Type(), ShouldEqual, events.ImageLintFailedEventType.String())
+		})
+		Convey("image scanned", func() {
+			natsServer, natsURL := setupTestNATSServer(t)
+			defer natsServer.Shutdown()
+
+			testChannel := "test-events-" + randomString()
+
+			recorder, err := createRecorder(t, natsURL, testChannel)
+			So(err, ShouldBeNil)
+			defer recorder.Close()
+
+			eventChan := make(chan *cloudevents.Event, 1)
+
+			nc, err := createSubscription(t, natsURL, testChannel, eventChan)
+			So(err, ShouldBeNil)
+			defer nc.Close()
+
+			recorder.ImageScanned("test", "v1", "", string(types.OCIManifestSchema1),
+				events.ImageScanSummary{Count: 1, MaxSeverity: "LOW"}, nil)
+
+			e := getEvent(t, eventChan)
+			So(e, ShouldNotBeNil)
+			So(e.Type(), ShouldEqual, events.ImageScannedEventType.String())
 		})
 	})
 }

--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -42,8 +42,8 @@ func GetCveScanner(conf *config.Config, storeController storage.StoreController,
 	cveConfig := extensionsConfig.GetSearchCVEConfig()
 
 	// WithEventRecorder is safe to apply even when eventRecorder is nil: the scanner
-	// only publishes events when both metaDB and eventRecorder are non-nil.
-	return cveinfo.NewScanner(storeController, metaDB, cveConfig, log, cveinfo.WithEventRecorder(metaDB, eventRecorder))
+	// only publishes events when eventRecorder is non-nil.
+	return cveinfo.NewScanner(storeController, metaDB, cveConfig, log, cveinfo.WithEventRecorder(eventRecorder))
 }
 
 func EnableSearchExtension(conf *config.Config, storeController storage.StoreController,

--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -12,6 +12,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	"zotregistry.dev/zot/v2/pkg/extensions/events"
 	"zotregistry.dev/zot/v2/pkg/extensions/search"
 	cveinfo "zotregistry.dev/zot/v2/pkg/extensions/search/cve"
 	"zotregistry.dev/zot/v2/pkg/extensions/search/gql_generated"
@@ -30,7 +31,7 @@ func IsBuiltWithSearchExtension() bool {
 }
 
 func GetCveScanner(conf *config.Config, storeController storage.StoreController,
-	metaDB mTypes.MetaDB, log log.Logger,
+	metaDB mTypes.MetaDB, eventRecorder events.Recorder, log log.Logger,
 ) CveScanner {
 	// Get extensions config safely
 	extensionsConfig := conf.CopyExtensionsConfig()
@@ -40,11 +41,14 @@ func GetCveScanner(conf *config.Config, storeController storage.StoreController,
 
 	cveConfig := extensionsConfig.GetSearchCVEConfig()
 
-	return cveinfo.NewScanner(storeController, metaDB, cveConfig, log)
+	// WithEventRecorder is safe to apply even when eventRecorder is nil: the scanner
+	// only publishes events when both metaDB and eventRecorder are non-nil.
+	return cveinfo.NewScanner(storeController, metaDB, cveConfig, log, cveinfo.WithEventRecorder(metaDB, eventRecorder))
 }
 
 func EnableSearchExtension(conf *config.Config, storeController storage.StoreController,
-	metaDB mTypes.MetaDB, taskScheduler *scheduler.Scheduler, cveScanner CveScanner, log log.Logger,
+	metaDB mTypes.MetaDB, taskScheduler *scheduler.Scheduler, cveScanner CveScanner,
+	log log.Logger,
 ) {
 	// Get extensions config safely
 	extensionsConfig := conf.CopyExtensionsConfig()

--- a/pkg/extensions/extension_search_disabled.go
+++ b/pkg/extensions/extension_search_disabled.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/extensions/events"
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/scheduler"
@@ -15,7 +16,7 @@ import (
 type CveScanner any
 
 func GetCveScanner(config *config.Config, storeController storage.StoreController,
-	metaDB mTypes.MetaDB, log log.Logger,
+	metaDB mTypes.MetaDB, eventRecorder events.Recorder, log log.Logger,
 ) CveScanner {
 	return nil
 }
@@ -26,7 +27,8 @@ func IsBuiltWithSearchExtension() bool {
 
 // EnableSearchExtension ...
 func EnableSearchExtension(config *config.Config, storeController storage.StoreController,
-	metaDB mTypes.MetaDB, scheduler *scheduler.Scheduler, cveScanner CveScanner, log log.Logger,
+	metaDB mTypes.MetaDB, scheduler *scheduler.Scheduler, cveScanner CveScanner,
+	log log.Logger,
 ) {
 	log.Warn().Msg("skipping enabling search extension because given zot binary doesn't include this feature," +
 		"please build a binary that does so")

--- a/pkg/extensions/search/cve/cve.go
+++ b/pkg/extensions/search/cve/cve.go
@@ -31,7 +31,7 @@ type CveInfo interface {
 }
 
 type Scanner interface {
-	ScanImage(ctx context.Context, image string) (map[string]cvemodel.CVE, error)
+	ScanImage(ctx context.Context, image string) (cvemodel.ScanResult, error)
 	IsImageFormatScannable(repo, ref string) (bool, error)
 	IsImageMediaScannable(repo, digestStr, mediaType string) (bool, error)
 	IsResultCached(digestStr string) bool
@@ -88,7 +88,7 @@ func (cveinfo BaseCveInfo) GetImageListForCVE(ctx context.Context, repo, cveID s
 				continue
 			}
 
-			cveMap, err := cveinfo.Scanner.ScanImage(ctx, zcommon.GetFullImageName(repo, tag))
+			scanResult, err := cveinfo.Scanner.ScanImage(ctx, zcommon.GetFullImageName(repo, tag))
 			if err != nil {
 				if zcommon.IsContextDone(ctx) {
 					return imgList, err
@@ -99,7 +99,7 @@ func (cveinfo BaseCveInfo) GetImageListForCVE(ctx context.Context, repo, cveID s
 				continue
 			}
 
-			if _, hasCVE := cveMap[cveID]; hasCVE {
+			if _, hasCVE := scanResult.CVEMap[cveID]; hasCVE {
 				imgList = append(imgList, cvemodel.TagInfo{
 					Tag: tag,
 					Descriptor: cvemodel.Descriptor{
@@ -283,7 +283,7 @@ func (cveinfo *BaseCveInfo) isManifestVulnerable(ctx context.Context, repo, tag,
 		return true
 	}
 
-	cveMap, err := cveinfo.Scanner.ScanImage(ctx, zcommon.GetFullImageName(repo, manifestDigestStr))
+	scanResult, err := cveinfo.Scanner.ScanImage(ctx, zcommon.GetFullImageName(repo, manifestDigestStr))
 	if err != nil {
 		cveinfo.Log.Debug().Str("image", image).Str("cve-id", cveID).
 			Msg("scanning failed, adding as a vulnerable image")
@@ -293,7 +293,7 @@ func (cveinfo *BaseCveInfo) isManifestVulnerable(ctx context.Context, repo, tag,
 
 	hasCVE := false
 
-	for id := range cveMap {
+	for id := range scanResult.CVEMap {
 		if id == cveID {
 			hasCVE = true
 
@@ -398,19 +398,19 @@ func (cveinfo BaseCveInfo) GetCVEListForImage(ctx context.Context, repo, ref str
 
 	image := zcommon.GetFullImageName(repo, ref)
 
-	cveMap, err := cveinfo.Scanner.ScanImage(ctx, image)
+	scanResult, err := cveinfo.Scanner.ScanImage(ctx, image)
 	if err != nil {
 		return []cvemodel.CVE{}, imageCVESummary, zcommon.PageInfo{}, err
 	}
 
-	imageCVESummary = initCVESummaryFromCVEMap(cveMap)
+	imageCVESummary = initCVESummaryFromCVEMap(scanResult.CVEMap)
 
 	pageFinder, err := NewCvePageFinder(pageInput.Limit, pageInput.Offset, pageInput.SortBy)
 	if err != nil {
 		return []cvemodel.CVE{}, imageCVESummary, zcommon.PageInfo{}, err
 	}
 
-	filterCVEMap(cveMap, searchedCVE, excludedCVE, severity, pageFinder)
+	filterCVEMap(scanResult.CVEMap, searchedCVE, excludedCVE, severity, pageFinder)
 
 	cveList, pageInfo := pageFinder.Page()
 

--- a/pkg/extensions/search/cve/cve.go
+++ b/pkg/extensions/search/cve/cve.go
@@ -46,9 +46,11 @@ type BaseCveInfo struct {
 }
 
 func NewScanner(storeController storage.StoreController, metaDB mTypes.MetaDB,
-	cveConfig *extconf.CVEConfig, log log.Logger,
+	cveConfig *extconf.CVEConfig, log log.Logger, opts ...ScannerOption,
 ) Scanner {
-	return trivy.NewScanner(storeController, metaDB, cveConfig, log)
+	trivyScanner := trivy.NewScanner(storeController, metaDB, cveConfig, log)
+
+	return NewDecoratedScanner(trivyScanner, log, opts...)
 }
 
 func NewCVEInfo(scanner Scanner, metaDB mTypes.MetaDB, log log.Logger) *BaseCveInfo {

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -929,18 +929,18 @@ func TestCVEStruct(t *testing.T) { //nolint:gocyclo
 		// MetaDB loaded with initial data, now mock the scanner
 		// Setup test CVE data in mock scanner
 		scanner := mocks.CveScannerMock{
-			ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+			ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 				result := cache.Get(image)
 				// Will not match sending the repo:tag as a parameter, but we don't care
 				if result != nil {
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				repo, ref, isTag := zcommon.GetImageDirAndReference(image)
 				if isTag {
 					foundRef, ok := imageMap[image]
 					if !ok {
-						return nil, ErrBadTest
+						return cvemodel.ScanResult{}, ErrBadTest
 					}
 					ref = foundRef
 				}
@@ -962,7 +962,7 @@ func TestCVEStruct(t *testing.T) { //nolint:gocyclo
 
 					cache.Add(ref, result)
 
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				if repo == repo1 && slices.Contains([]string{image12Digest, image21Digest}, ref) {
@@ -989,7 +989,7 @@ func TestCVEStruct(t *testing.T) { //nolint:gocyclo
 
 					cache.Add(ref, result)
 
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				if repo == repo1 && ref == image13Digest {
@@ -1004,7 +1004,7 @@ func TestCVEStruct(t *testing.T) { //nolint:gocyclo
 
 					cache.Add(ref, result)
 
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				// As a minor release on 1.0.0 banch
@@ -1027,12 +1027,12 @@ func TestCVEStruct(t *testing.T) { //nolint:gocyclo
 
 					cache.Add(ref, result)
 
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				// Unexpected error while scanning
 				if repo == repo7 {
-					return map[string]cvemodel.CVE{}, ErrFailedScan
+					return cvemodel.ScanResult{CVEMap: map[string]cvemodel.CVE{}}, ErrFailedScan
 				}
 
 				if (repo == repoMultiarch && ref == indexDigest) ||
@@ -1055,7 +1055,7 @@ func TestCVEStruct(t *testing.T) { //nolint:gocyclo
 
 					cache.Add(ref, result)
 
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				if repo == repo8 && ref == image81Digest {
@@ -1106,14 +1106,14 @@ func TestCVEStruct(t *testing.T) { //nolint:gocyclo
 
 					cache.Add(ref, result)
 
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				// By default the image has no vulnerabilities
 				result = map[string]cvemodel.CVE{}
 				cache.Add(ref, result)
 
-				return result, nil
+				return cvemodel.ScanResult{CVEMap: result}, nil
 			},
 			IsImageFormatScannableFn: func(repo string, reference string) (bool, error) {
 				if repo == repoMultiarch {
@@ -1570,9 +1570,9 @@ func TestCVEStruct(t *testing.T) { //nolint:gocyclo
 		t.Log("\nTest errors while scanning\n")
 
 		faultyScanner := mocks.CveScannerMock{
-			ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+			ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 				// Could be any type of error, let's reuse this one
-				return nil, zerr.ErrScanNotSupported
+				return cvemodel.ScanResult{}, zerr.ErrScanNotSupported
 			},
 		}
 
@@ -1626,8 +1626,8 @@ func TestCVEStruct(t *testing.T) { //nolint:gocyclo
 			IsImageFormatScannableFn: func(repo, reference string) (bool, error) {
 				return true, nil
 			},
-			ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
-				return nil, zerr.ErrTypeAssertionFailed
+			ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
+				return cvemodel.ScanResult{}, zerr.ErrTypeAssertionFailed
 			},
 		}, MetaDB: metaDB}
 
@@ -1638,8 +1638,8 @@ func TestCVEStruct(t *testing.T) { //nolint:gocyclo
 			IsImageFormatScannableFn: func(repo, reference string) (bool, error) {
 				return true, nil
 			},
-			ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
-				return nil, zerr.ErrTypeAssertionFailed
+			ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
+				return cvemodel.ScanResult{}, zerr.ErrTypeAssertionFailed
 			},
 		}, MetaDB: metaDB}
 		_, _, _, err = cveInfo.GetCVEDiffListForImages(ctx, "repo8:1.0.0", "repo1:0.1.0", "", "", pageInput)
@@ -1650,14 +1650,14 @@ func TestCVEStruct(t *testing.T) { //nolint:gocyclo
 			IsImageFormatScannableFn: func(repo, reference string) (bool, error) {
 				return true, nil
 			},
-			ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+			ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 				if try == 1 {
-					return nil, zerr.ErrTypeAssertionFailed
+					return cvemodel.ScanResult{}, zerr.ErrTypeAssertionFailed
 				}
 
 				try++
 
-				return make(map[string]cvemodel.CVE), nil
+				return cvemodel.ScanResult{CVEMap: make(map[string]cvemodel.CVE)}, nil
 			},
 		}, MetaDB: metaDB}
 		_, _, _, err = cveInfo.GetCVEDiffListForImages(ctx, "repo8:1.0.0", "repo6:0.1.0", "", "", pageInput)

--- a/pkg/extensions/search/cve/model/models.go
+++ b/pkg/extensions/search/cve/model/models.go
@@ -52,6 +52,10 @@ type Package struct {
 	FixedVersion     string `json:"FixedVersion"`
 }
 
+// NotSpecified is used in place of Package.FixedVersion/PackagePath when the
+// scanner has no fix available or no path, so the field is never empty.
+const NotSpecified = "Not Specified"
+
 const (
 	unScanned = iota
 	none

--- a/pkg/extensions/search/cve/model/models.go
+++ b/pkg/extensions/search/cve/model/models.go
@@ -120,3 +120,14 @@ type TagInfo struct {
 	Manifests  []DescriptorInfo
 	Timestamp  time.Time
 }
+
+// ScanResult is the outcome of a Scanner.ScanImage call: the CVE map plus the digest and
+// media type actually scanned and whether the result was served from cache. Scanners resolve
+// this identity/cache info internally while scanning, so returning it here spares callers a
+// second metaDB round trip to learn what was scanned.
+type ScanResult struct {
+	CVEMap    map[string]CVE
+	Digest    string
+	MediaType string
+	WasCached bool
+}

--- a/pkg/extensions/search/cve/pagination_test.go
+++ b/pkg/extensions/search/cve/pagination_test.go
@@ -72,7 +72,7 @@ func TestCVEPagination(t *testing.T) {
 
 		// Setup test CVE data in mock scanner
 		scanner := mocks.CveScannerMock{
-			ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+			ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 				cveMap := map[string]cvemodel.CVE{}
 
 				if image == "repo1:0.1.0" {
@@ -98,7 +98,7 @@ func TestCVEPagination(t *testing.T) {
 				}
 
 				// By default the image has no vulnerabilities
-				return cveMap, nil
+				return cvemodel.ScanResult{CVEMap: cveMap}, nil
 			},
 		}
 

--- a/pkg/extensions/search/cve/scan.go
+++ b/pkg/extensions/search/cve/scan.go
@@ -290,7 +290,7 @@ func (s *scanner) ScanImage(ctx context.Context, image string) (map[string]cvemo
 // manifests inside a multiarch index, so a tag cannot be required here. ok is false when
 // resolution failed; a warning has already been logged and the caller should skip both the
 // cache check and publishing.
-func (s *scanner) resolveDigestForEvent(ctx context.Context, image string) (repo, ref, digest string, ok bool) {
+func (s *scanner) resolveDigestForEvent(ctx context.Context, image string) (string, string, string, bool) {
 	repo, ref, isTag := zcommon.GetImageDirAndReference(image)
 
 	// When isTag is false, ref is already the digest ScanImage was called with.

--- a/pkg/extensions/search/cve/scan.go
+++ b/pkg/extensions/search/cve/scan.go
@@ -3,8 +3,14 @@ package cveinfo
 import (
 	"context"
 	"fmt"
+	"slices"
 	"sync"
 
+	godigest "github.com/opencontainers/go-digest"
+
+	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	"zotregistry.dev/zot/v2/pkg/extensions/events"
+	cvemodel "zotregistry.dev/zot/v2/pkg/extensions/search/cve/model"
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	reqCtx "zotregistry.dev/zot/v2/pkg/requestcontext"
@@ -190,7 +196,8 @@ func (st *scanTask) DoWork(ctx context.Context) error {
 
 	// We cache the results internally in the scanner
 	// so we can discard the actual results for now
-	if _, err := st.generator.scanner.ScanImage(ctx, image); err != nil {
+	_, err := st.generator.scanner.ScanImage(ctx, image)
+	if err != nil {
 		st.generator.log.Error().Err(err).Str("image", image).Msg("failed to perform scheduled cve scan for image")
 		st.generator.addError(st.digest, err)
 
@@ -209,4 +216,129 @@ func (st *scanTask) String() string {
 
 func (st *scanTask) Name() string {
 	return "ScanTask"
+}
+
+// ScannerOption configures optional, cross-cutting behavior on a scanner
+// (e.g. event publishing). Additional scanner features should be added as
+// new options rather than new wrapper types.
+type ScannerOption func(*scanner)
+
+// WithEventRecorder makes the scanner publish an ImageScanned event via
+// eventRecorder after each successful ScanImage call. metaDB is used to
+// resolve tags for the scanned digest.
+func WithEventRecorder(metaDB mTypes.MetaDB, eventRecorder events.Recorder) ScannerOption {
+	return func(s *scanner) {
+		s.metaDB = metaDB
+		s.eventRecorder = eventRecorder
+	}
+}
+
+// NewDecoratedScanner wraps base with optional cross-cutting behavior
+// configured via opts.
+func NewDecoratedScanner(base Scanner, log log.Logger, opts ...ScannerOption) Scanner {
+	scanner := &scanner{Scanner: base, log: log}
+
+	for _, opt := range opts {
+		// a nil option (e.g. from a conditionally-omitted call site) is a no-op, not a panic
+		if opt == nil {
+			continue
+		}
+
+		opt(scanner)
+	}
+
+	return scanner
+}
+
+type scanner struct {
+	Scanner
+
+	metaDB        mTypes.MetaDB
+	eventRecorder events.Recorder
+	log           log.Logger
+}
+
+func (s *scanner) ScanImage(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+	cveMap, err := s.Scanner.ScanImage(ctx, image)
+	if err == nil {
+		s.publishScanEvent(ctx, image, cveMap)
+	}
+
+	return cveMap, err
+}
+
+// publishScanEvent emits one ImageScanned event using whatever reference (tag
+// or digest) ScanImage was called with, mirroring how ImageDeleted/ImageLintFailed
+// pass the caller's reference through as-is. ScanImage is also invoked with the
+// digest of untagged manifests, e.g. the individual manifests inside a multiarch
+// index, so a tag cannot be required here.
+func (s *scanner) publishScanEvent(ctx context.Context, image string, cveMap map[string]cvemodel.CVE) {
+	if s.eventRecorder == nil || s.metaDB == nil {
+		return
+	}
+
+	repo, ref, isTag := zcommon.GetImageDirAndReference(image)
+
+	// When isTag is false, ref is already the digest ScanImage was called with.
+	digest := ref
+	if isTag {
+		// Use the caller's ctx as-is rather than a synthetic elevated identity: GetRepoMeta
+		// performs no per-repo access check (unlike the Filter*/Search* methods), so a real
+		// request ctx is just as capable here, and this keeps event publishing subject to
+		// whatever access control GetRepoMeta may apply in the future.
+		repoMeta, err := s.metaDB.GetRepoMeta(ctx, repo)
+		if err != nil {
+			s.log.Warn().Err(err).Str("repository", repo).Str("reference", ref).
+				Msg("failed to load repo metadata for image scanned event")
+
+			return
+		}
+
+		descriptor, ok := repoMeta.Tags[ref]
+		if !ok {
+			s.log.Warn().Str("repository", repo).Str("reference", ref).
+				Msg("skipping image scanned event because tag was not found in repo metadata")
+
+			return
+		}
+
+		digest = descriptor.Digest
+	}
+
+	imageMeta, err := s.metaDB.GetImageMeta(godigest.Digest(digest))
+	if err != nil {
+		s.log.Warn().Err(err).Str("repository", repo).Str("digest", digest).
+			Msg("failed to load image metadata for image scanned event")
+
+		return
+	}
+
+	summary := getImageScanSummary(cveMap)
+	ectx := events.EventContextFromContext(ctx)
+
+	s.eventRecorder.ImageScanned(repo, ref, digest, imageMeta.MediaType, summary, ectx)
+}
+
+func getImageScanSummary(cveMap map[string]cvemodel.CVE) events.ImageScanSummary {
+	cveSummary := initCVESummaryFromCVEMap(cveMap)
+	summary := events.ImageScanSummary{
+		Count:         cveSummary.Count,
+		UnknownCount:  cveSummary.UnknownCount,
+		LowCount:      cveSummary.LowCount,
+		MediumCount:   cveSummary.MediumCount,
+		HighCount:     cveSummary.HighCount,
+		CriticalCount: cveSummary.CriticalCount,
+		MaxSeverity:   cveSummary.MaxSeverity,
+	}
+
+	for _, cve := range cveMap {
+		if slices.ContainsFunc(cve.PackageList, func(pack cvemodel.Package) bool {
+			// the scanner uses cvemodel.NotSpecified, never "", when there is no fix
+			return pack.FixedVersion != "" && pack.FixedVersion != cvemodel.NotSpecified
+		}) {
+			summary.FixableCount++
+		}
+	}
+
+	return summary
 }

--- a/pkg/extensions/search/cve/scan.go
+++ b/pkg/extensions/search/cve/scan.go
@@ -6,8 +6,6 @@ import (
 	"slices"
 	"sync"
 
-	godigest "github.com/opencontainers/go-digest"
-
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
 	"zotregistry.dev/zot/v2/pkg/extensions/events"
 	cvemodel "zotregistry.dev/zot/v2/pkg/extensions/search/cve/model"
@@ -221,12 +219,10 @@ func (st *scanTask) Name() string {
 // ScannerOption configures additional features and settings on a scanner.
 type ScannerOption func(*scanner)
 
-// WithEventRecorder makes the scanner publish an ImageScanned event via
-// eventRecorder after each successful ScanImage call. metaDB is used to
-// resolve tags for the scanned digest.
-func WithEventRecorder(metaDB mTypes.MetaDB, eventRecorder events.Recorder) ScannerOption {
+// WithEventRecorder makes the scanner publish an ImageScanned event via eventRecorder
+// after each ScanImage call that wasn't served from cache.
+func WithEventRecorder(eventRecorder events.Recorder) ScannerOption {
 	return func(s *scanner) {
-		s.metaDB = metaDB
 		s.eventRecorder = eventRecorder
 	}
 }
@@ -251,90 +247,32 @@ func NewDecoratedScanner(base Scanner, log log.Logger, opts ...ScannerOption) Sc
 type scanner struct {
 	Scanner
 
-	metaDB        mTypes.MetaDB
 	eventRecorder events.Recorder
 	log           log.Logger
 }
 
-func (s *scanner) ScanImage(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
-	if s.eventRecorder == nil || s.metaDB == nil {
-		return s.Scanner.ScanImage(ctx, image)
+func (s *scanner) ScanImage(ctx context.Context, image string) (cvemodel.ScanResult, error) {
+	result, err := s.Scanner.ScanImage(ctx, image)
+	if err == nil && s.eventRecorder != nil && !result.WasCached {
+		// image is whatever reference (tag or digest) the caller passed in; ScanImage is also
+		// invoked with the digest of untagged manifests, e.g. the individual manifests inside a
+		// multiarch index, so a tag cannot be assumed here. result.Digest/MediaType are what the
+		// underlying Scanner already resolved and actually scanned, with no extra metaDB calls.
+		repo, ref, _ := zcommon.GetImageDirAndReference(image)
+		s.publishScanEvent(ctx, repo, ref, result.Digest, result.MediaType, result.CVEMap)
 	}
 
-	repo, ref, digest, ok := s.resolveDigestForEvent(ctx, image)
-
-	// Check the cache before scanning: the trivy scanner's ScanImage returns cached results
-	// directly without running a new scan, so checking after would see "cached" even for a
-	// scan that just ran, and no event would ever be published for repeated CVE queries.
-	wasCached := ok && s.IsResultCached(digest)
-
-	// Scan by the digest resolved above rather than image's original tag, so the digest
-	// recorded in the event always matches what was actually scanned even if the tag is
-	// moved to point elsewhere between resolution above and the scan below.
-	scanTarget := image
-	if ok {
-		scanTarget = zcommon.GetFullImageName(repo, digest)
-	}
-
-	cveMap, err := s.Scanner.ScanImage(ctx, scanTarget)
-	if err == nil && ok && !wasCached {
-		s.publishScanEvent(ctx, repo, ref, digest, cveMap)
-	}
-
-	return cveMap, err
+	return result, err
 }
 
-// resolveDigestForEvent resolves image (whatever reference, tag or digest, ScanImage was
-// called with) to the repo/ref/digest needed to check the cache and publish an event.
-// ScanImage is also invoked with the digest of untagged manifests, e.g. the individual
-// manifests inside a multiarch index, so a tag cannot be required here. ok is false when
-// resolution failed; a warning has already been logged and the caller should skip both the
-// cache check and publishing.
-func (s *scanner) resolveDigestForEvent(ctx context.Context, image string) (string, string, string, bool) {
-	repo, ref, isTag := zcommon.GetImageDirAndReference(image)
-
-	// When isTag is false, ref is already the digest ScanImage was called with.
-	if !isTag {
-		return repo, ref, ref, true
-	}
-
-	// Use the caller's ctx as-is rather than a synthetic elevated identity: GetRepoMeta
-	// performs no per-repo access check (unlike the Filter*/Search* methods), so a real
-	// request ctx is just as capable here, and this keeps event publishing subject to
-	// whatever access control GetRepoMeta may apply in the future.
-	repoMeta, err := s.metaDB.GetRepoMeta(ctx, repo)
-	if err != nil {
-		s.log.Warn().Err(err).Str("repository", repo).Str("reference", ref).
-			Msg("failed to load repo metadata for image scanned event")
-
-		return repo, ref, "", false
-	}
-
-	descriptor, found := repoMeta.Tags[ref]
-	if !found {
-		s.log.Warn().Str("repository", repo).Str("reference", ref).
-			Msg("skipping image scanned event because tag was not found in repo metadata")
-
-		return repo, ref, "", false
-	}
-
-	return repo, ref, descriptor.Digest, true
-}
-
-// publishScanEvent emits one ImageScanned event for the already-resolved repo/ref/digest.
-func (s *scanner) publishScanEvent(ctx context.Context, repo, ref, digest string, cveMap map[string]cvemodel.CVE) {
-	imageMeta, err := s.metaDB.GetImageMeta(godigest.Digest(digest))
-	if err != nil {
-		s.log.Warn().Err(err).Str("repository", repo).Str("digest", digest).
-			Msg("failed to load image metadata for image scanned event")
-
-		return
-	}
-
+// publishScanEvent emits one ImageScanned event for the given repo/ref/digest/mediaType.
+func (s *scanner) publishScanEvent(ctx context.Context, repo, ref, digest, mediaType string,
+	cveMap map[string]cvemodel.CVE,
+) {
 	summary := getImageScanSummary(cveMap)
 	ectx := events.EventContextFromContext(ctx)
 
-	s.eventRecorder.ImageScanned(repo, ref, digest, imageMeta.MediaType, summary, ectx)
+	s.eventRecorder.ImageScanned(repo, ref, digest, mediaType, summary, ectx)
 }
 
 func getImageScanSummary(cveMap map[string]cvemodel.CVE) events.ImageScanSummary {

--- a/pkg/extensions/search/cve/scan.go
+++ b/pkg/extensions/search/cve/scan.go
@@ -218,9 +218,7 @@ func (st *scanTask) Name() string {
 	return "ScanTask"
 }
 
-// ScannerOption configures optional, cross-cutting behavior on a scanner
-// (e.g. event publishing). Additional scanner features should be added as
-// new options rather than new wrapper types.
+// ScannerOption configures additional features and settings on a scanner.
 type ScannerOption func(*scanner)
 
 // WithEventRecorder makes the scanner publish an ImageScanned event via
@@ -259,52 +257,72 @@ type scanner struct {
 }
 
 func (s *scanner) ScanImage(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
-	cveMap, err := s.Scanner.ScanImage(ctx, image)
-	if err == nil {
-		s.publishScanEvent(ctx, image, cveMap)
+	if s.eventRecorder == nil || s.metaDB == nil {
+		return s.Scanner.ScanImage(ctx, image)
+	}
+
+	repo, ref, digest, ok := s.resolveDigestForEvent(ctx, image)
+
+	// Check the cache before scanning: the trivy scanner's ScanImage returns cached results
+	// directly without running a new scan, so checking after would see "cached" even for a
+	// scan that just ran, and no event would ever be published for repeated CVE queries.
+	wasCached := ok && s.IsResultCached(digest)
+
+	// Scan by the digest resolved above rather than image's original tag, so the digest
+	// recorded in the event always matches what was actually scanned even if the tag is
+	// moved to point elsewhere between resolution above and the scan below.
+	scanTarget := image
+	if ok {
+		scanTarget = zcommon.GetFullImageName(repo, digest)
+	}
+
+	cveMap, err := s.Scanner.ScanImage(ctx, scanTarget)
+	if err == nil && ok && !wasCached {
+		s.publishScanEvent(ctx, repo, ref, digest, cveMap)
 	}
 
 	return cveMap, err
 }
 
-// publishScanEvent emits one ImageScanned event using whatever reference (tag
-// or digest) ScanImage was called with, mirroring how ImageDeleted/ImageLintFailed
-// pass the caller's reference through as-is. ScanImage is also invoked with the
-// digest of untagged manifests, e.g. the individual manifests inside a multiarch
-// index, so a tag cannot be required here.
-func (s *scanner) publishScanEvent(ctx context.Context, image string, cveMap map[string]cvemodel.CVE) {
-	if s.eventRecorder == nil || s.metaDB == nil {
-		return
-	}
-
+// resolveDigestForEvent resolves image (whatever reference, tag or digest, ScanImage was
+// called with) to the repo/ref/digest needed to check the cache and publish an event.
+// ScanImage is also invoked with the digest of untagged manifests, e.g. the individual
+// manifests inside a multiarch index, so a tag cannot be required here. ok is false when
+// resolution failed; a warning has already been logged and the caller should skip both the
+// cache check and publishing.
+func (s *scanner) resolveDigestForEvent(ctx context.Context, image string) (repo, ref, digest string, ok bool) {
 	repo, ref, isTag := zcommon.GetImageDirAndReference(image)
 
 	// When isTag is false, ref is already the digest ScanImage was called with.
-	digest := ref
-	if isTag {
-		// Use the caller's ctx as-is rather than a synthetic elevated identity: GetRepoMeta
-		// performs no per-repo access check (unlike the Filter*/Search* methods), so a real
-		// request ctx is just as capable here, and this keeps event publishing subject to
-		// whatever access control GetRepoMeta may apply in the future.
-		repoMeta, err := s.metaDB.GetRepoMeta(ctx, repo)
-		if err != nil {
-			s.log.Warn().Err(err).Str("repository", repo).Str("reference", ref).
-				Msg("failed to load repo metadata for image scanned event")
-
-			return
-		}
-
-		descriptor, ok := repoMeta.Tags[ref]
-		if !ok {
-			s.log.Warn().Str("repository", repo).Str("reference", ref).
-				Msg("skipping image scanned event because tag was not found in repo metadata")
-
-			return
-		}
-
-		digest = descriptor.Digest
+	if !isTag {
+		return repo, ref, ref, true
 	}
 
+	// Use the caller's ctx as-is rather than a synthetic elevated identity: GetRepoMeta
+	// performs no per-repo access check (unlike the Filter*/Search* methods), so a real
+	// request ctx is just as capable here, and this keeps event publishing subject to
+	// whatever access control GetRepoMeta may apply in the future.
+	repoMeta, err := s.metaDB.GetRepoMeta(ctx, repo)
+	if err != nil {
+		s.log.Warn().Err(err).Str("repository", repo).Str("reference", ref).
+			Msg("failed to load repo metadata for image scanned event")
+
+		return repo, ref, "", false
+	}
+
+	descriptor, found := repoMeta.Tags[ref]
+	if !found {
+		s.log.Warn().Str("repository", repo).Str("reference", ref).
+			Msg("skipping image scanned event because tag was not found in repo metadata")
+
+		return repo, ref, "", false
+	}
+
+	return repo, ref, descriptor.Digest, true
+}
+
+// publishScanEvent emits one ImageScanned event for the already-resolved repo/ref/digest.
+func (s *scanner) publishScanEvent(ctx context.Context, repo, ref, digest string, cveMap map[string]cvemodel.CVE) {
 	imageMeta, err := s.metaDB.GetImageMeta(godigest.Digest(digest))
 	if err != nil {
 		s.log.Warn().Err(err).Str("repository", repo).Str("digest", digest).

--- a/pkg/extensions/search/cve/scan_test.go
+++ b/pkg/extensions/search/cve/scan_test.go
@@ -20,7 +20,6 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
-	"zotregistry.dev/zot/v2/pkg/extensions/events"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
 	cveinfo "zotregistry.dev/zot/v2/pkg/extensions/search/cve"
 	cvecache "zotregistry.dev/zot/v2/pkg/extensions/search/cve/cache"
@@ -41,47 +40,6 @@ var (
 	ErrBadTest    = errors.New("there is a bug in the test")
 	ErrFailedScan = errors.New("scan has failed intentionally")
 )
-
-type scanEventCall struct {
-	name      string
-	reference string
-	digest    string
-	mediaType string
-	summary   events.ImageScanSummary
-}
-
-type scanEventRecorder struct {
-	calls []scanEventCall
-}
-
-func (r *scanEventRecorder) Close() {}
-
-func (r *scanEventRecorder) RepositoryCreated(name string, ectx *events.EventContext) {}
-
-func (r *scanEventRecorder) ImageUpdated(name, reference, digest, mediaType, manifest string,
-	ectx *events.EventContext,
-) {
-}
-
-func (r *scanEventRecorder) ImageDeleted(name, reference, digest, mediaType string, ectx *events.EventContext) {
-}
-
-func (r *scanEventRecorder) ImageLintFailed(name, reference, digest, mediaType, manifest string,
-	ectx *events.EventContext,
-) {
-}
-
-func (r *scanEventRecorder) ImageScanned(name, reference, digest, mediaType string,
-	summary events.ImageScanSummary, ectx *events.EventContext,
-) {
-	r.calls = append(r.calls, scanEventCall{
-		name:      name,
-		reference: reference,
-		digest:    digest,
-		mediaType: mediaType,
-		summary:   summary,
-	})
-}
 
 func TestScanGeneratorWithMockedData(t *testing.T) { //nolint: gocyclo
 	Convey("Test CVE scanning task scheduler with diverse mocked data", t, func() {
@@ -258,18 +216,18 @@ func TestScanGeneratorWithMockedData(t *testing.T) { //nolint: gocyclo
 		// MetaDB loaded with initial data, now mock the scanner
 		// Setup test CVE data in mock scanner
 		scanner := mocks.CveScannerMock{
-			ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+			ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 				result := cache.Get(image)
 				// Will not match sending the repo:tag as a parameter, but we don't care
 				if result != nil {
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				repo, ref, isTag := zcommon.GetImageDirAndReference(image)
 				if isTag {
 					foundRef, ok := imageMap[image]
 					if !ok {
-						return nil, ErrBadTest
+						return cvemodel.ScanResult{}, ErrBadTest
 					}
 					ref = foundRef
 				}
@@ -287,7 +245,7 @@ func TestScanGeneratorWithMockedData(t *testing.T) { //nolint: gocyclo
 
 					cache.Add(ref, result)
 
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				if repo == repo1 && slices.Contains([]string{image12Digest, image21Digest}, ref) {
@@ -314,7 +272,7 @@ func TestScanGeneratorWithMockedData(t *testing.T) { //nolint: gocyclo
 
 					cache.Add(ref, result)
 
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				if repo == repo1 && ref == image13Digest {
@@ -329,7 +287,7 @@ func TestScanGeneratorWithMockedData(t *testing.T) { //nolint: gocyclo
 
 					cache.Add(ref, result)
 
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				// As a minor release on 1.0.0 banch
@@ -352,12 +310,12 @@ func TestScanGeneratorWithMockedData(t *testing.T) { //nolint: gocyclo
 
 					cache.Add(ref, result)
 
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				// Unexpected error while scanning
 				if repo == "repo7" {
-					return map[string]cvemodel.CVE{}, ErrFailedScan
+					return cvemodel.ScanResult{CVEMap: map[string]cvemodel.CVE{}}, ErrFailedScan
 				}
 
 				if (repo == repoIndex && ref == indexDigest) ||
@@ -380,14 +338,14 @@ func TestScanGeneratorWithMockedData(t *testing.T) { //nolint: gocyclo
 
 					cache.Add(ref, result)
 
-					return result, nil
+					return cvemodel.ScanResult{CVEMap: result}, nil
 				}
 
 				// By default the image has no vulnerabilities
 				result = map[string]cvemodel.CVE{}
 				cache.Add(ref, result)
 
-				return result, nil
+				return cvemodel.ScanResult{CVEMap: result}, nil
 			},
 			IsImageFormatScannableFn: func(repo string, reference string) (bool, error) {
 				if repo == repoIndex {
@@ -595,7 +553,8 @@ func TestScanGeneratorWithRealData(t *testing.T) {
 
 		So(scanner.IsResultCached(image.DigestStr()), ShouldBeTrue)
 
-		cveMap, err := scanner.ScanImage(context.Background(), "zot-test:0.0.1")
+		scanResult, err := scanner.ScanImage(context.Background(), "zot-test:0.0.1")
+		cveMap := scanResult.CVEMap
 		So(err, ShouldBeNil)
 		t.Logf("cveMap: %v", cveMap)
 		// As of September 22 2023 there are 5 CVEs:
@@ -620,37 +579,67 @@ func TestScanGeneratorWithRealData(t *testing.T) {
 	})
 }
 
-func mockScannerReturningCVEs() mocks.CveScannerMock {
+// mockScannerReturningCVEs returns a fixed CVE map alongside a resolved digest/mediaType,
+// mimicking what the real trivy scanner resolves internally via metaDB (see
+// trivy.Scanner.ScanImage) so the ScannerOption-decorated wrapper's event has something
+// real to report without the wrapper doing any metaDB lookups of its own.
+func mockScannerReturningCVEs(metaDB mTypes.MetaDB) mocks.CveScannerMock {
 	return mocks.CveScannerMock{
-		ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
-			return map[string]cvemodel.CVE{
-				"CVE-1": {
-					Severity: cvemodel.SeverityHigh,
-					PackageList: []cvemodel.Package{{
-						Name:         "openssl",
-						FixedVersion: "1.0.1",
-					}},
+		ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
+			repo, ref, isTag := zcommon.GetImageDirAndReference(image)
+
+			digest := ref
+			if isTag {
+				repoMeta, err := metaDB.GetRepoMeta(ctx, repo)
+				if err != nil {
+					return cvemodel.ScanResult{}, err
+				}
+
+				descriptor, ok := repoMeta.Tags[ref]
+				if !ok {
+					return cvemodel.ScanResult{}, ErrBadTest
+				}
+
+				digest = descriptor.Digest
+			}
+
+			imageMeta, err := metaDB.GetImageMeta(godigest.Digest(digest))
+			if err != nil {
+				return cvemodel.ScanResult{}, err
+			}
+
+			return cvemodel.ScanResult{
+				CVEMap: map[string]cvemodel.CVE{
+					"CVE-1": {
+						Severity: cvemodel.SeverityHigh,
+						PackageList: []cvemodel.Package{{
+							Name:         "openssl",
+							FixedVersion: "1.0.1",
+						}},
+					},
+					"CVE-2": {
+						Severity: cvemodel.SeverityLow,
+						PackageList: []cvemodel.Package{{
+							// matches the real trivy scanner, which uses this sentinel
+							// (never "") when no fix is available
+							Name:         "busybox",
+							FixedVersion: cvemodel.NotSpecified,
+						}},
+					},
 				},
-				"CVE-2": {
-					Severity: cvemodel.SeverityLow,
-					PackageList: []cvemodel.Package{{
-						// matches the real trivy scanner, which uses this sentinel
-						// (never "") when no fix is available
-						Name:         "busybox",
-						FixedVersion: cvemodel.NotSpecified,
-					}},
-				},
+				Digest:    digest,
+				MediaType: imageMeta.MediaType,
 			}, nil
 		},
 	}
 }
 
-func checkScanEventSummary(call scanEventCall) {
-	So(call.summary.Count, ShouldEqual, 2)
-	So(call.summary.FixableCount, ShouldEqual, 1)
-	So(call.summary.LowCount, ShouldEqual, 1)
-	So(call.summary.HighCount, ShouldEqual, 1)
-	So(call.summary.MaxSeverity, ShouldEqual, cvemodel.SeverityHigh)
+func checkScanEventSummary(call mocks.ImageScannedCall) {
+	So(call.Summary.Count, ShouldEqual, 2)
+	So(call.Summary.FixableCount, ShouldEqual, 1)
+	So(call.Summary.LowCount, ShouldEqual, 1)
+	So(call.Summary.HighCount, ShouldEqual, 1)
+	So(call.Summary.MaxSeverity, ShouldEqual, cvemodel.SeverityHigh)
 }
 
 func TestScanGeneratorPublishesScanEvents(t *testing.T) {
@@ -670,9 +659,9 @@ func TestScanGeneratorPublishesScanEvents(t *testing.T) {
 		err = metaDB.SetRepoReference(context.Background(), "repo", "stable", image.AsImageMeta())
 		So(err, ShouldBeNil)
 
-		recorder := &scanEventRecorder{}
-		scanner := cveinfo.NewDecoratedScanner(mockScannerReturningCVEs(), log.NewTestLogger(),
-			cveinfo.WithEventRecorder(metaDB, recorder))
+		recorder := &mocks.EventRecorderMock{}
+		scanner := cveinfo.NewDecoratedScanner(mockScannerReturningCVEs(metaDB), log.NewTestLogger(),
+			cveinfo.WithEventRecorder(recorder))
 
 		// the scheduled generator always scans by digest, regardless of how many tags point to it
 		generator := cveinfo.NewScanTaskGenerator(metaDB, scanner, log.NewTestLogger())
@@ -683,13 +672,13 @@ func TestScanGeneratorPublishesScanEvents(t *testing.T) {
 		err = task.DoWork(context.Background())
 		So(err, ShouldBeNil)
 
-		So(recorder.calls, ShouldHaveLength, 1)
+		So(recorder.ImageScannedCalls, ShouldHaveLength, 1)
 
-		call := recorder.calls[0]
-		So(call.name, ShouldEqual, "repo")
-		So(call.reference, ShouldEqual, image.DigestStr())
-		So(call.digest, ShouldEqual, image.DigestStr())
-		So(call.mediaType, ShouldEqual, image.AsImageMeta().MediaType)
+		call := recorder.ImageScannedCalls[0]
+		So(call.Name, ShouldEqual, "repo")
+		So(call.Reference, ShouldEqual, image.DigestStr())
+		So(call.Digest, ShouldEqual, image.DigestStr())
+		So(call.MediaType, ShouldEqual, image.AsImageMeta().MediaType)
 		checkScanEventSummary(call)
 	})
 
@@ -709,25 +698,26 @@ func TestScanGeneratorPublishesScanEvents(t *testing.T) {
 		err = metaDB.SetImageMeta(image.Digest(), image.AsImageMeta())
 		So(err, ShouldBeNil)
 
-		recorder := &scanEventRecorder{}
-		scanner := cveinfo.NewDecoratedScanner(mockScannerReturningCVEs(), log.NewTestLogger(),
-			cveinfo.WithEventRecorder(metaDB, recorder))
+		recorder := &mocks.EventRecorderMock{}
+		scanner := cveinfo.NewDecoratedScanner(mockScannerReturningCVEs(metaDB), log.NewTestLogger(),
+			cveinfo.WithEventRecorder(recorder))
 
-		cveMap, err := scanner.ScanImage(context.Background(), "repo@"+image.DigestStr())
+		scanResult, err := scanner.ScanImage(context.Background(), "repo@"+image.DigestStr())
+		cveMap := scanResult.CVEMap
 		So(err, ShouldBeNil)
 		So(cveMap, ShouldNotBeEmpty)
 
-		So(recorder.calls, ShouldHaveLength, 1)
+		So(recorder.ImageScannedCalls, ShouldHaveLength, 1)
 
-		call := recorder.calls[0]
-		So(call.name, ShouldEqual, "repo")
-		So(call.reference, ShouldEqual, image.DigestStr())
-		So(call.digest, ShouldEqual, image.DigestStr())
-		So(call.mediaType, ShouldEqual, image.AsImageMeta().MediaType)
+		call := recorder.ImageScannedCalls[0]
+		So(call.Name, ShouldEqual, "repo")
+		So(call.Reference, ShouldEqual, image.DigestStr())
+		So(call.Digest, ShouldEqual, image.DigestStr())
+		So(call.MediaType, ShouldEqual, image.AsImageMeta().MediaType)
 		checkScanEventSummary(call)
 	})
 
-	Convey("scanning by tag scans the resolved digest, not the tag", t, func() {
+	Convey("wrapper forwards the caller's reference as-is and trusts the scanner's resolved digest", t, func() {
 		params := boltdb.DBParameters{
 			RootDir: t.TempDir(),
 		}
@@ -742,27 +732,29 @@ func TestScanGeneratorPublishesScanEvents(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		var scannedImage string
-		mockScanner := mockScannerReturningCVEs()
-		mockScanner.ScanImageFn = func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+		mockScanner := mockScannerReturningCVEs(metaDB)
+		innerScanImageFn := mockScanner.ScanImageFn
+		mockScanner.ScanImageFn = func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 			scannedImage = image
 
-			return mockScannerReturningCVEs().ScanImageFn(ctx, image)
+			return innerScanImageFn(ctx, image)
 		}
 
-		recorder := &scanEventRecorder{}
+		recorder := &mocks.EventRecorderMock{}
 		scanner := cveinfo.NewDecoratedScanner(mockScanner, log.NewTestLogger(),
-			cveinfo.WithEventRecorder(metaDB, recorder))
+			cveinfo.WithEventRecorder(recorder))
 
 		_, err = scanner.ScanImage(context.Background(), "repo:1.0.0")
 		So(err, ShouldBeNil)
 
-		// the tag is resolved to its digest before the underlying scanner is invoked, so a tag
-		// moved mid-scan can't cause the event to report a digest that wasn't actually scanned
-		So(scannedImage, ShouldEqual, "repo@"+image.DigestStr())
+		// the wrapper does no tag resolution of its own: it forwards the caller's reference
+		// unchanged and relies on the underlying scanner's returned digest for the event, since
+		// the scanner already resolves this internally while scanning (see trivy.Scanner.ScanImage)
+		So(scannedImage, ShouldEqual, "repo:1.0.0")
 
-		So(recorder.calls, ShouldHaveLength, 1)
-		So(recorder.calls[0].reference, ShouldEqual, "1.0.0")
-		So(recorder.calls[0].digest, ShouldEqual, image.DigestStr())
+		So(recorder.ImageScannedCalls, ShouldHaveLength, 1)
+		So(recorder.ImageScannedCalls[0].Reference, ShouldEqual, "1.0.0")
+		So(recorder.ImageScannedCalls[0].Digest, ShouldEqual, image.DigestStr())
 	})
 
 	Convey("repeated scans of an already-cached digest publish only the first event", t, func() {
@@ -779,26 +771,30 @@ func TestScanGeneratorPublishesScanEvents(t *testing.T) {
 		err = metaDB.SetRepoReference(context.Background(), "repo", "1.0.0", image.AsImageMeta())
 		So(err, ShouldBeNil)
 
-		// simulates the trivy scanner, which returns cached results directly from ScanImage
+		// simulates the trivy scanner, which reports WasCached directly from ScanImage
 		// without running a new scan once a digest has already been scanned once
 		cached := false
-		mockScanner := mockScannerReturningCVEs()
-		mockScanner.IsResultCachedFn = func(digest string) bool {
-			return cached
+		mockScanner := mockScannerReturningCVEs(metaDB)
+		innerScanImageFn := mockScanner.ScanImageFn
+		mockScanner.ScanImageFn = func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
+			result, err := innerScanImageFn(ctx, image)
+			result.WasCached = cached
+
+			return result, err
 		}
 
-		recorder := &scanEventRecorder{}
+		recorder := &mocks.EventRecorderMock{}
 		scanner := cveinfo.NewDecoratedScanner(mockScanner, log.NewTestLogger(),
-			cveinfo.WithEventRecorder(metaDB, recorder))
+			cveinfo.WithEventRecorder(recorder))
 
 		_, err = scanner.ScanImage(context.Background(), "repo:1.0.0")
 		So(err, ShouldBeNil)
-		So(recorder.calls, ShouldHaveLength, 1)
+		So(recorder.ImageScannedCalls, ShouldHaveLength, 1)
 
 		cached = true
 
 		_, err = scanner.ScanImage(context.Background(), "repo:1.0.0")
 		So(err, ShouldBeNil)
-		So(recorder.calls, ShouldHaveLength, 1)
+		So(recorder.ImageScannedCalls, ShouldHaveLength, 1)
 	})
 }

--- a/pkg/extensions/search/cve/scan_test.go
+++ b/pkg/extensions/search/cve/scan_test.go
@@ -20,6 +20,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
+	"zotregistry.dev/zot/v2/pkg/extensions/events"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
 	cveinfo "zotregistry.dev/zot/v2/pkg/extensions/search/cve"
 	cvecache "zotregistry.dev/zot/v2/pkg/extensions/search/cve/cache"
@@ -40,6 +41,47 @@ var (
 	ErrBadTest    = errors.New("there is a bug in the test")
 	ErrFailedScan = errors.New("scan has failed intentionally")
 )
+
+type scanEventCall struct {
+	name      string
+	reference string
+	digest    string
+	mediaType string
+	summary   events.ImageScanSummary
+}
+
+type scanEventRecorder struct {
+	calls []scanEventCall
+}
+
+func (r *scanEventRecorder) Close() {}
+
+func (r *scanEventRecorder) RepositoryCreated(name string, ectx *events.EventContext) {}
+
+func (r *scanEventRecorder) ImageUpdated(name, reference, digest, mediaType, manifest string,
+	ectx *events.EventContext,
+) {
+}
+
+func (r *scanEventRecorder) ImageDeleted(name, reference, digest, mediaType string, ectx *events.EventContext) {
+}
+
+func (r *scanEventRecorder) ImageLintFailed(name, reference, digest, mediaType, manifest string,
+	ectx *events.EventContext,
+) {
+}
+
+func (r *scanEventRecorder) ImageScanned(name, reference, digest, mediaType string,
+	summary events.ImageScanSummary, ectx *events.EventContext,
+) {
+	r.calls = append(r.calls, scanEventCall{
+		name:      name,
+		reference: reference,
+		digest:    digest,
+		mediaType: mediaType,
+		summary:   summary,
+	})
+}
 
 func TestScanGeneratorWithMockedData(t *testing.T) { //nolint: gocyclo
 	Convey("Test CVE scanning task scheduler with diverse mocked data", t, func() {
@@ -575,5 +617,113 @@ func TestScanGeneratorWithRealData(t *testing.T) {
 		So(cveSummary.Count, ShouldBeGreaterThanOrEqualTo, 5)
 		// As of September 22 the max severity is MEDIUM, but new CVEs could appear in the future
 		So([]string{"MEDIUM", "HIGH", "CRITICAL", "UNKNOWN"}, ShouldContain, cveSummary.MaxSeverity)
+	})
+}
+
+func mockScannerReturningCVEs() mocks.CveScannerMock {
+	return mocks.CveScannerMock{
+		ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+			return map[string]cvemodel.CVE{
+				"CVE-1": {
+					Severity: cvemodel.SeverityHigh,
+					PackageList: []cvemodel.Package{{
+						Name:         "openssl",
+						FixedVersion: "1.0.1",
+					}},
+				},
+				"CVE-2": {
+					Severity: cvemodel.SeverityLow,
+					PackageList: []cvemodel.Package{{
+						// matches the real trivy scanner, which uses this sentinel
+						// (never "") when no fix is available
+						Name:         "busybox",
+						FixedVersion: cvemodel.NotSpecified,
+					}},
+				},
+			}, nil
+		},
+	}
+}
+
+func checkScanEventSummary(call scanEventCall) {
+	So(call.summary.Count, ShouldEqual, 2)
+	So(call.summary.FixableCount, ShouldEqual, 1)
+	So(call.summary.LowCount, ShouldEqual, 1)
+	So(call.summary.HighCount, ShouldEqual, 1)
+	So(call.summary.MaxSeverity, ShouldEqual, cvemodel.SeverityHigh)
+}
+
+func TestScanGeneratorPublishesScanEvents(t *testing.T) {
+	Convey("scheduled scans publish a single event using the scanned digest", t, func() {
+		params := boltdb.DBParameters{
+			RootDir: t.TempDir(),
+		}
+		boltDriver, err := boltdb.GetBoltDriver(params)
+		So(err, ShouldBeNil)
+
+		metaDB, err := boltdb.New(boltDriver, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		image := CreateImageWith().DefaultLayers().DefaultConfig().Build()
+		err = metaDB.SetRepoReference(context.Background(), "repo", "1.0.0", image.AsImageMeta())
+		So(err, ShouldBeNil)
+		err = metaDB.SetRepoReference(context.Background(), "repo", "stable", image.AsImageMeta())
+		So(err, ShouldBeNil)
+
+		recorder := &scanEventRecorder{}
+		scanner := cveinfo.NewDecoratedScanner(mockScannerReturningCVEs(), log.NewTestLogger(),
+			cveinfo.WithEventRecorder(metaDB, recorder))
+
+		// the scheduled generator always scans by digest, regardless of how many tags point to it
+		generator := cveinfo.NewScanTaskGenerator(metaDB, scanner, log.NewTestLogger())
+		task, err := generator.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldNotBeNil)
+
+		err = task.DoWork(context.Background())
+		So(err, ShouldBeNil)
+
+		So(recorder.calls, ShouldHaveLength, 1)
+
+		call := recorder.calls[0]
+		So(call.name, ShouldEqual, "repo")
+		So(call.reference, ShouldEqual, image.DigestStr())
+		So(call.digest, ShouldEqual, image.DigestStr())
+		So(call.mediaType, ShouldEqual, image.AsImageMeta().MediaType)
+		checkScanEventSummary(call)
+	})
+
+	Convey("scanning an untagged manifest digest still publishes an event", t, func() {
+		params := boltdb.DBParameters{
+			RootDir: t.TempDir(),
+		}
+		boltDriver, err := boltdb.GetBoltDriver(params)
+		So(err, ShouldBeNil)
+
+		metaDB, err := boltdb.New(boltDriver, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		// simulates a manifest that only exists inside a multiarch index, so it
+		// has no tag of its own in repoMeta.Tags
+		image := CreateImageWith().DefaultLayers().DefaultConfig().Build()
+		err = metaDB.SetImageMeta(image.Digest(), image.AsImageMeta())
+		So(err, ShouldBeNil)
+
+		recorder := &scanEventRecorder{}
+		scanner := cveinfo.NewDecoratedScanner(mockScannerReturningCVEs(), log.NewTestLogger(),
+			cveinfo.WithEventRecorder(metaDB, recorder))
+
+		cveMap, err := scanner.ScanImage(context.Background(), "repo@"+image.DigestStr())
+		So(err, ShouldBeNil)
+		So(cveMap, ShouldNotBeEmpty)
+
+		So(recorder.calls, ShouldHaveLength, 1)
+
+		call := recorder.calls[0]
+		So(call.name, ShouldEqual, "repo")
+		So(call.reference, ShouldEqual, image.DigestStr())
+		So(call.digest, ShouldEqual, image.DigestStr())
+		So(call.mediaType, ShouldEqual, image.AsImageMeta().MediaType)
+		checkScanEventSummary(call)
 	})
 }

--- a/pkg/extensions/search/cve/scan_test.go
+++ b/pkg/extensions/search/cve/scan_test.go
@@ -726,4 +726,79 @@ func TestScanGeneratorPublishesScanEvents(t *testing.T) {
 		So(call.mediaType, ShouldEqual, image.AsImageMeta().MediaType)
 		checkScanEventSummary(call)
 	})
+
+	Convey("scanning by tag scans the resolved digest, not the tag", t, func() {
+		params := boltdb.DBParameters{
+			RootDir: t.TempDir(),
+		}
+		boltDriver, err := boltdb.GetBoltDriver(params)
+		So(err, ShouldBeNil)
+
+		metaDB, err := boltdb.New(boltDriver, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		image := CreateImageWith().DefaultLayers().DefaultConfig().Build()
+		err = metaDB.SetRepoReference(context.Background(), "repo", "1.0.0", image.AsImageMeta())
+		So(err, ShouldBeNil)
+
+		var scannedImage string
+		mockScanner := mockScannerReturningCVEs()
+		mockScanner.ScanImageFn = func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+			scannedImage = image
+
+			return mockScannerReturningCVEs().ScanImageFn(ctx, image)
+		}
+
+		recorder := &scanEventRecorder{}
+		scanner := cveinfo.NewDecoratedScanner(mockScanner, log.NewTestLogger(),
+			cveinfo.WithEventRecorder(metaDB, recorder))
+
+		_, err = scanner.ScanImage(context.Background(), "repo:1.0.0")
+		So(err, ShouldBeNil)
+
+		// the tag is resolved to its digest before the underlying scanner is invoked, so a tag
+		// moved mid-scan can't cause the event to report a digest that wasn't actually scanned
+		So(scannedImage, ShouldEqual, "repo@"+image.DigestStr())
+
+		So(recorder.calls, ShouldHaveLength, 1)
+		So(recorder.calls[0].reference, ShouldEqual, "1.0.0")
+		So(recorder.calls[0].digest, ShouldEqual, image.DigestStr())
+	})
+
+	Convey("repeated scans of an already-cached digest publish only the first event", t, func() {
+		params := boltdb.DBParameters{
+			RootDir: t.TempDir(),
+		}
+		boltDriver, err := boltdb.GetBoltDriver(params)
+		So(err, ShouldBeNil)
+
+		metaDB, err := boltdb.New(boltDriver, log.NewTestLogger())
+		So(err, ShouldBeNil)
+
+		image := CreateImageWith().DefaultLayers().DefaultConfig().Build()
+		err = metaDB.SetRepoReference(context.Background(), "repo", "1.0.0", image.AsImageMeta())
+		So(err, ShouldBeNil)
+
+		// simulates the trivy scanner, which returns cached results directly from ScanImage
+		// without running a new scan once a digest has already been scanned once
+		cached := false
+		mockScanner := mockScannerReturningCVEs()
+		mockScanner.IsResultCachedFn = func(digest string) bool {
+			return cached
+		}
+
+		recorder := &scanEventRecorder{}
+		scanner := cveinfo.NewDecoratedScanner(mockScanner, log.NewTestLogger(),
+			cveinfo.WithEventRecorder(metaDB, recorder))
+
+		_, err = scanner.ScanImage(context.Background(), "repo:1.0.0")
+		So(err, ShouldBeNil)
+		So(recorder.calls, ShouldHaveLength, 1)
+
+		cached = true
+
+		_, err = scanner.ScanImage(context.Background(), "repo:1.0.0")
+		So(err, ShouldBeNil)
+		So(recorder.calls, ShouldHaveLength, 1)
+	})
 }

--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -553,7 +553,7 @@ func (scanner Scanner) GetCachedResult(digest string) map[string]cvemodel.CVE {
 	return scanner.cache.Get(digest)
 }
 
-func (scanner Scanner) ScanImage(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+func (scanner Scanner) ScanImage(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 	var (
 		originalImageInput = image
 		digest             string
@@ -567,7 +567,7 @@ func (scanner Scanner) ScanImage(ctx context.Context, image string) (map[string]
 	if isTag {
 		imgDescriptor, err := getImageDescriptor(ctx, scanner.metaDB, repo, ref)
 		if err != nil {
-			return map[string]cvemodel.CVE{}, err
+			return cvemodel.ScanResult{}, err
 		}
 
 		digest = imgDescriptor.Digest
@@ -577,35 +577,41 @@ func (scanner Scanner) ScanImage(ctx context.Context, image string) (map[string]
 
 		found, mediaType = findMediaTypeForDigest(scanner.metaDB, godigest.Digest(ref))
 		if !found {
-			return map[string]cvemodel.CVE{}, zerr.ErrManifestNotFound
+			return cvemodel.ScanResult{}, zerr.ErrManifestNotFound
 		}
 	}
 
 	var (
-		cveIDMap map[string]cvemodel.CVE
-		err      error
+		cveIDMap  map[string]cvemodel.CVE
+		wasCached bool
+		err       error
 	)
 
 	if mediaType == ispec.MediaTypeImageIndex ||
 		compat.IsCompatibleManifestListMediaType(mediaType) {
-		cveIDMap, err = scanner.scanIndex(ctx, repo, digest)
+		cveIDMap, wasCached, err = scanner.scanIndex(ctx, repo, digest)
 	} else if mediaType == ispec.MediaTypeImageManifest ||
 		compat.IsCompatibleManifestMediaType(mediaType) {
-		cveIDMap, err = scanner.scanManifest(ctx, repo, digest)
+		cveIDMap, wasCached, err = scanner.scanManifest(ctx, repo, digest)
 	}
 
 	if err != nil {
 		scanner.log.Error().Err(err).Str("image", originalImageInput).Msg("failed to scan image")
 
-		return map[string]cvemodel.CVE{}, err
+		return cvemodel.ScanResult{}, err
 	}
 
-	return cveIDMap, nil
+	return cvemodel.ScanResult{
+		CVEMap:    cveIDMap,
+		Digest:    digest,
+		MediaType: mediaType,
+		WasCached: wasCached,
+	}, nil
 }
 
-func (scanner Scanner) scanManifest(ctx context.Context, repo, digest string) (map[string]cvemodel.CVE, error) {
+func (scanner Scanner) scanManifest(ctx context.Context, repo, digest string) (map[string]cvemodel.CVE, bool, error) {
 	if cachedMap := scanner.cache.Get(digest); cachedMap != nil {
-		return cachedMap, nil
+		return cachedMap, true, nil
 	}
 
 	cveidMap := map[string]cvemodel.CVE{}
@@ -620,7 +626,7 @@ func (scanner Scanner) scanManifest(ctx context.Context, repo, digest string) (m
 	}
 
 	if err != nil { //nolint: wsl
-		return cveidMap, err
+		return cveidMap, false, err
 	}
 
 	// SBOM persistence is best-effort: CVE scanning should still complete even if
@@ -699,7 +705,7 @@ func (scanner Scanner) scanManifest(ctx context.Context, repo, digest string) (m
 
 	scanner.cache.Add(digest, cveidMap)
 
-	return cveidMap, nil
+	return cveidMap, false, nil
 }
 
 func (scanner Scanner) storeSBOMAsOCIArtifact(ctx context.Context,
@@ -884,27 +890,29 @@ func getNVDReference(references []string) (string, bool) {
 	return "", false
 }
 
-func (scanner Scanner) scanIndex(ctx context.Context, repo, digest string) (map[string]cvemodel.CVE, error) {
+func (scanner Scanner) scanIndex(ctx context.Context, repo, digest string) (map[string]cvemodel.CVE, bool, error) {
 	if cachedMap := scanner.cache.Get(digest); cachedMap != nil {
-		return cachedMap, nil
+		return cachedMap, true, nil
 	}
 
 	indexData, err := scanner.metaDB.GetImageMeta(godigest.Digest(digest))
 	if err != nil {
-		return map[string]cvemodel.CVE{}, err
+		return map[string]cvemodel.CVE{}, false, err
 	}
 
 	if indexData.Index == nil {
-		return map[string]cvemodel.CVE{}, zerr.ErrUnexpectedMediaType
+		return map[string]cvemodel.CVE{}, false, zerr.ErrUnexpectedMediaType
 	}
 
 	indexCveIDMap := map[string]cvemodel.CVE{}
 
 	for _, manifest := range indexData.Index.Manifests {
 		if isScannable, err := scanner.isManifestScannable(manifest.Digest.String()); isScannable && err == nil {
-			manifestCveIDMap, err := scanner.scanManifest(ctx, repo, manifest.Digest.String())
+			// the per-manifest cache status doesn't matter here: it's the aggregate index-level
+			// cache check above that determines whether this ScanImage call is a cache hit
+			manifestCveIDMap, _, err := scanner.scanManifest(ctx, repo, manifest.Digest.String())
 			if err != nil {
-				return nil, err
+				return nil, false, err
 			}
 
 			maps.Copy(indexCveIDMap, manifestCveIDMap)
@@ -913,7 +921,7 @@ func (scanner Scanner) scanIndex(ctx context.Context, repo, digest string) (map[
 
 	scanner.cache.Add(digest, indexCveIDMap)
 
-	return indexCveIDMap, nil
+	return indexCveIDMap, false, nil
 }
 
 // UpdateDB downloads the Trivy DB / Cache under the store root directory.

--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -639,14 +639,14 @@ func (scanner Scanner) scanManifest(ctx context.Context, repo, digest string) (m
 			if vulnerability.FixedVersion != "" {
 				fixedVersion = vulnerability.FixedVersion
 			} else {
-				fixedVersion = "Not Specified"
+				fixedVersion = cvemodel.NotSpecified
 			}
 
 			var packagePath string
 			if vulnerability.PkgPath != "" {
 				packagePath = vulnerability.PkgPath
 			} else {
-				packagePath = "Not Specified"
+				packagePath = cvemodel.NotSpecified
 			}
 
 			_, ok := cveidMap[vulnerability.VulnerabilityID]

--- a/pkg/extensions/search/cve/trivy/scanner_internal_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_internal_test.go
@@ -269,18 +269,21 @@ func TestMultipleStoragePath(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// Scanning image in default store
-		cveMap, err := scanner.ScanImage(ctx, img0)
+		scanResult, err := scanner.ScanImage(ctx, img0)
+		cveMap := scanResult.CVEMap
 
 		So(err, ShouldBeNil)
 		So(len(cveMap), ShouldEqual, 0)
 
 		// Scanning image in substore
-		cveMap, err = scanner.ScanImage(ctx, img1)
+		scanResult, err = scanner.ScanImage(ctx, img1)
+		cveMap = scanResult.CVEMap
 		So(err, ShouldBeNil)
 		So(len(cveMap), ShouldEqual, 0)
 
 		// Scanning image which does not exist
-		cveMap, err = scanner.ScanImage(ctx, "a/test/image2:tag100")
+		scanResult, err = scanner.ScanImage(ctx, "a/test/image2:tag100")
+		cveMap = scanResult.CVEMap
 		So(err, ShouldNotBeNil)
 		So(len(cveMap), ShouldEqual, 0)
 

--- a/pkg/extensions/search/cve/trivy/scanner_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_test.go
@@ -69,7 +69,8 @@ func TestScanBigTestFile(t *testing.T) {
 		err = scanner.UpdateDB(context.Background())
 		So(err, ShouldBeNil)
 
-		cveMap, err := scanner.ScanImage(context.Background(), "zot-test:0.0.1")
+		scanResult, err := scanner.ScanImage(context.Background(), "zot-test:0.0.1")
+		cveMap := scanResult.CVEMap
 		So(err, ShouldBeNil)
 		So(cveMap, ShouldNotBeNil)
 	})
@@ -117,24 +118,28 @@ func TestScanningByDigest(t *testing.T) {
 		err = scanner.UpdateDB(ctx)
 		So(err, ShouldBeNil)
 
-		cveMap, err := scanner.ScanImage(ctx, "multi-arch@"+vulnImage.DigestStr())
+		scanResult, err := scanner.ScanImage(ctx, "multi-arch@"+vulnImage.DigestStr())
+		cveMap := scanResult.CVEMap
 		So(err, ShouldBeNil)
 		t.Logf("cveMap=%v\n", cveMap)
 		So(cveMap, ShouldContainKey, Vulnerability1ID)
 		So(cveMap, ShouldContainKey, Vulnerability2ID)
 		So(cveMap, ShouldContainKey, Vulnerability3ID)
 
-		cveMap, err = scanner.ScanImage(ctx, "multi-arch@"+simpleImage.DigestStr())
+		scanResult, err = scanner.ScanImage(ctx, "multi-arch@"+simpleImage.DigestStr())
+		cveMap = scanResult.CVEMap
 		So(err, ShouldBeNil)
 		So(cveMap, ShouldBeEmpty)
 
-		cveMap, err = scanner.ScanImage(ctx, "multi-arch@"+multiArch.DigestStr())
+		scanResult, err = scanner.ScanImage(ctx, "multi-arch@"+multiArch.DigestStr())
+		cveMap = scanResult.CVEMap
 		So(err, ShouldBeNil)
 		So(cveMap, ShouldContainKey, Vulnerability1ID)
 		So(cveMap, ShouldContainKey, Vulnerability2ID)
 		So(cveMap, ShouldContainKey, Vulnerability3ID)
 
-		cveMap, err = scanner.ScanImage(ctx, "multi-arch:multi-arch-tag")
+		scanResult, err = scanner.ScanImage(ctx, "multi-arch:multi-arch-tag")
+		cveMap = scanResult.CVEMap
 		So(err, ShouldBeNil)
 		So(cveMap, ShouldContainKey, Vulnerability1ID)
 		So(cveMap, ShouldContainKey, Vulnerability2ID)
@@ -205,7 +210,8 @@ func TestVulnerableLayer(t *testing.T) {
 		err = scanner.UpdateDB(context.Background())
 		So(err, ShouldBeNil)
 
-		cveMap, err := scanner.ScanImage(context.Background(), "repo@"+img.DigestStr())
+		scanResult, err := scanner.ScanImage(context.Background(), "repo@"+img.DigestStr())
+		cveMap := scanResult.CVEMap
 		So(err, ShouldBeNil)
 		t.Logf("cveMap: %v", cveMap)
 		// As of September 17 2023 there are 5 CVEs:
@@ -281,7 +287,8 @@ func TestVulnerableLayer(t *testing.T) {
 		err = scanner.UpdateDB(context.Background())
 		So(err, ShouldBeNil)
 
-		cveMap, err := scanner.ScanImage(context.Background(), "repo@"+img.DigestStr())
+		scanResult, err := scanner.ScanImage(context.Background(), "repo@"+img.DigestStr())
+		cveMap := scanResult.CVEMap
 		So(err, ShouldBeNil)
 		t.Logf("cveMap: %v", cveMap)
 
@@ -412,7 +419,8 @@ func TestWithTempDirErrorHandling(t *testing.T) {
 		_, err = os.Stat(tempDirPath)
 		So(err, ShouldNotBeNil)
 
-		cveMap, err := scanner.ScanImage(context.Background(), "repo@"+img.DigestStr())
+		scanResult, err := scanner.ScanImage(context.Background(), "repo@"+img.DigestStr())
+		cveMap := scanResult.CVEMap
 		So(err, ShouldBeNil)
 		t.Logf("cveMap: %v", cveMap)
 		// As of September 17 2023 there are 5 CVEs:

--- a/pkg/extensions/search/resolver_test.go
+++ b/pkg/extensions/search/resolver_test.go
@@ -1174,11 +1174,11 @@ func TestCVEResolvers(t *testing.T) { //nolint:gocyclo
 	// MetaDB loaded with initial data, now mock the scanner
 	// Setup test CVE data in mock scanner
 	scanner := mocks.CveScannerMock{
-		ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+		ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 			repo, ref, _, _ := common.GetRepoReference(image)
 
 			if common.IsDigest(ref) {
-				return getCveResults(ref), nil
+				return cvemodel.ScanResult{CVEMap: getCveResults(ref)}, nil
 			}
 
 			repoMeta, _ := metaDB.GetRepoMeta(ctx, repo)
@@ -1187,7 +1187,7 @@ func TestCVEResolvers(t *testing.T) { //nolint:gocyclo
 				panic("unexpected tag '" + ref + "', test might be wrong")
 			}
 
-			return getCveResults(repoMeta.Tags[ref].Digest), nil
+			return cvemodel.ScanResult{CVEMap: getCveResults(repoMeta.Tags[ref].Digest)}, nil
 		},
 		GetCachedResultFn: func(digestStr string) map[string]cvemodel.CVE {
 			return getCveResults(digestStr)
@@ -1444,8 +1444,8 @@ func TestCVEResolvers(t *testing.T) { //nolint:gocyclo
 
 			canceledScanner := scanner
 
-			canceledScanner.ScanImageFn = func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
-				return nil, ctx.Err()
+			canceledScanner.ScanImageFn = func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
+				return cvemodel.ScanResult{}, ctx.Err()
 			}
 
 			cveInfo.Scanner = canceledScanner
@@ -2037,11 +2037,11 @@ func TestCVEResolvers(t *testing.T) { //nolint:gocyclo
 		// MetaDB loaded with initial data, now mock the scanner
 		// Setup test CVE data in mock scanner
 		scanner := mocks.CveScannerMock{
-			ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+			ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 				repo, ref, _, _ := common.GetRepoReference(image)
 
 				if common.IsDigest(ref) {
-					return getCveResults(ref), nil
+					return cvemodel.ScanResult{CVEMap: getCveResults(ref)}, nil
 				}
 
 				repoMeta, _ := metaDB.GetRepoMeta(ctx, repo)
@@ -2050,7 +2050,7 @@ func TestCVEResolvers(t *testing.T) { //nolint:gocyclo
 					panic("unexpected tag '" + ref + "', test might be wrong")
 				}
 
-				return getCveResults(repoMeta.Tags[ref].Digest), nil
+				return cvemodel.ScanResult{CVEMap: getCveResults(repoMeta.Tags[ref].Digest)}, nil
 			},
 			GetCachedResultFn: func(digestStr string) map[string]cvemodel.CVE {
 				return getCveResults(digestStr)

--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -294,8 +294,8 @@ func getMockCveScanner(metaDB mTypes.MetaDB) cveinfo.Scanner {
 	}
 
 	scanner := mocks.CveScannerMock{
-		ScanImageFn: func(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
-			return getCveResults(image), nil
+		ScanImageFn: func(ctx context.Context, image string) (cvemodel.ScanResult, error) {
+			return cvemodel.ScanResult{CVEMap: getCveResults(image)}, nil
 		},
 		GetCachedResultFn: func(digestStr string) map[string]cvemodel.CVE {
 			return getCveResults(digestStr)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -296,69 +296,6 @@ func TestStorageNew(t *testing.T) {
 	})
 }
 
-type captureImageEvents struct {
-	mu              sync.Mutex
-	imageUpdated    []imageUpdatedCall
-	imageDeleted    []imageDeletedCall
-	imageLintFailed []imageLintFailedCall
-}
-
-type imageUpdatedCall struct {
-	repo, reference, digest, mediaType, manifest string
-}
-
-type imageDeletedCall struct {
-	repo, reference, digest, mediaType string
-}
-
-type imageLintFailedCall struct {
-	repo, reference, digest, mediaType, manifest string
-}
-
-func (c *captureImageEvents) Close() {}
-
-// RepositoryCreated can be emitted by the image store (e.g. on first index.json
-// creation), but none of these tests assert on it, so this is an intentional no-op.
-func (c *captureImageEvents) RepositoryCreated(string, *events.EventContext) {}
-
-func (c *captureImageEvents) ImageUpdated(name, reference, digest, mediaType, manifest string,
-	ectx *events.EventContext,
-) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.imageUpdated = append(c.imageUpdated, imageUpdatedCall{
-		repo: name, reference: reference, digest: digest, mediaType: mediaType, manifest: manifest,
-	})
-}
-
-func (c *captureImageEvents) ImageDeleted(name, reference, digest, mediaType string, ectx *events.EventContext) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.imageDeleted = append(c.imageDeleted, imageDeletedCall{
-		repo: name, reference: reference, digest: digest, mediaType: mediaType,
-	})
-}
-
-func (c *captureImageEvents) ImageLintFailed(name, reference, digest, mediaType, manifest string,
-	ectx *events.EventContext,
-) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	c.imageLintFailed = append(c.imageLintFailed, imageLintFailedCall{
-		repo: name, reference: reference, digest: digest, mediaType: mediaType, manifest: manifest,
-	})
-}
-
-// ImageScanned is emitted only by the cve package (see cve/scan.go), never by pkg/storage,
-// so unlike RepositoryCreated above, these tests could never trigger it in the first place.
-func (c *captureImageEvents) ImageScanned(name, reference, digest, mediaType string,
-	summary events.ImageScanSummary, ectx *events.EventContext,
-) {
-}
-
 // TestPutImageManifestExtraTagsAndEvents covers extra-tag digest pushes, index updates, and ImageUpdated events.
 // One Convey uses createObjectsStore (nil recorder); the rest use newLocalImageStoreWithEventRecorder.
 func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
@@ -435,7 +372,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 	})
 
 	Convey("digest push with multiple extra tags applies tags, emits ImageUpdated per tag, idempotent replay", t, func() {
-		eventCapture := &captureImageEvents{}
+		eventCapture := &mocks.EventRecorderMock{}
 		imgStore := newLocalImageStoreWithEventRecorder(t, eventCapture)
 
 		repo := "mquery"
@@ -481,36 +418,36 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 			So(slices.Contains(tags, qt), ShouldBeTrue)
 		}
 
-		eventCapture.mu.Lock()
-		So(len(eventCapture.imageUpdated), ShouldEqual, 3)
+		eventCapture.Lock()
+		So(len(eventCapture.ImageUpdatedCalls), ShouldEqual, 3)
 
 		wantRefs := map[string]struct{}{"v1.2.3": {}, "v1.2": {}, "latest": {}}
 
-		for _, imageUpd := range eventCapture.imageUpdated {
-			So(imageUpd.repo, ShouldEqual, repo)
-			So(imageUpd.digest, ShouldEqual, manifestDigest.String())
-			So(imageUpd.mediaType, ShouldEqual, ispec.MediaTypeImageManifest)
-			So(imageUpd.manifest, ShouldEqual, string(manifestBuf))
-			_, ok := wantRefs[imageUpd.reference]
+		for _, imageUpd := range eventCapture.ImageUpdatedCalls {
+			So(imageUpd.Name, ShouldEqual, repo)
+			So(imageUpd.Digest, ShouldEqual, manifestDigest.String())
+			So(imageUpd.MediaType, ShouldEqual, ispec.MediaTypeImageManifest)
+			So(imageUpd.Manifest, ShouldEqual, string(manifestBuf))
+			_, ok := wantRefs[imageUpd.Reference]
 			So(ok, ShouldBeTrue)
 
-			delete(wantRefs, imageUpd.reference)
+			delete(wantRefs, imageUpd.Reference)
 		}
 
 		So(len(wantRefs), ShouldEqual, 0)
-		eventCapture.mu.Unlock()
+		eventCapture.Unlock()
 
 		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, extraTags)
 		So(err, ShouldBeNil)
 
-		eventCapture.mu.Lock()
-		So(len(eventCapture.imageUpdated), ShouldEqual, 3)
-		eventCapture.mu.Unlock()
+		eventCapture.Lock()
+		So(len(eventCapture.ImageUpdatedCalls), ShouldEqual, 3)
+		eventCapture.Unlock()
 	})
 
 	Convey("digest push then digest+tags removes untagged index row for that digest", t, func() {
-		eventCapture := &captureImageEvents{}
+		eventCapture := &mocks.EventRecorderMock{}
 		imgStore := newLocalImageStoreWithEventRecorder(t, eventCapture)
 
 		repo := "strip-untagged"
@@ -544,12 +481,12 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldBeNil)
 
-		eventCapture.mu.Lock()
-		So(len(eventCapture.imageUpdated), ShouldEqual, 1)
-		So(eventCapture.imageUpdated[0].repo, ShouldEqual, repo)
-		So(eventCapture.imageUpdated[0].reference, ShouldEqual, manifestDigest.String())
-		So(eventCapture.imageUpdated[0].digest, ShouldEqual, manifestDigest.String())
-		eventCapture.mu.Unlock()
+		eventCapture.Lock()
+		So(len(eventCapture.ImageUpdatedCalls), ShouldEqual, 1)
+		So(eventCapture.ImageUpdatedCalls[0].Name, ShouldEqual, repo)
+		So(eventCapture.ImageUpdatedCalls[0].Reference, ShouldEqual, manifestDigest.String())
+		So(eventCapture.ImageUpdatedCalls[0].Digest, ShouldEqual, manifestDigest.String())
+		eventCapture.Unlock()
 
 		So(countUntaggedIndexEntriesForDigest(t, imgStore, repo, manifestDigest), ShouldEqual, 1)
 
@@ -559,11 +496,11 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 			ispec.MediaTypeImageManifest, manifestBuf, extraTags)
 		So(err, ShouldBeNil)
 
-		eventCapture.mu.Lock()
-		So(len(eventCapture.imageUpdated), ShouldEqual, 2)
-		So(eventCapture.imageUpdated[1].reference, ShouldEqual, "after-tag")
-		So(eventCapture.imageUpdated[1].digest, ShouldEqual, manifestDigest.String())
-		eventCapture.mu.Unlock()
+		eventCapture.Lock()
+		So(len(eventCapture.ImageUpdatedCalls), ShouldEqual, 2)
+		So(eventCapture.ImageUpdatedCalls[1].Reference, ShouldEqual, "after-tag")
+		So(eventCapture.ImageUpdatedCalls[1].Digest, ShouldEqual, manifestDigest.String())
+		eventCapture.Unlock()
 
 		So(countUntaggedIndexEntriesForDigest(t, imgStore, repo, manifestDigest), ShouldEqual, 0)
 
@@ -573,7 +510,7 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 	})
 
 	Convey("digest push with tag subset is no-op for index and events; new tag adds one event", t, func() {
-		eventCapture := &captureImageEvents{}
+		eventCapture := &mocks.EventRecorderMock{}
 		imgStore := newLocalImageStoreWithEventRecorder(t, eventCapture)
 
 		repo := "tag-subset"
@@ -615,9 +552,9 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 			So(slices.Contains(tags, qt), ShouldBeTrue)
 		}
 
-		eventCapture.mu.Lock()
-		So(len(eventCapture.imageUpdated), ShouldEqual, 3)
-		eventCapture.mu.Unlock()
+		eventCapture.Lock()
+		So(len(eventCapture.ImageUpdatedCalls), ShouldEqual, 3)
+		eventCapture.Unlock()
 
 		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, []string{"tag-b"})
@@ -630,9 +567,9 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 			So(slices.Contains(tags, qt), ShouldBeTrue)
 		}
 
-		eventCapture.mu.Lock()
-		So(len(eventCapture.imageUpdated), ShouldEqual, 3)
-		eventCapture.mu.Unlock()
+		eventCapture.Lock()
+		So(len(eventCapture.ImageUpdatedCalls), ShouldEqual, 3)
+		eventCapture.Unlock()
 
 		_, _, err = imgStore.PutImageManifest(context.Background(), repo, manifestDigest.String(),
 			ispec.MediaTypeImageManifest, manifestBuf, []string{"tag-d"})
@@ -646,18 +583,18 @@ func TestPutImageManifestExtraTagsAndEvents(t *testing.T) {
 			So(slices.Contains(tags, qt), ShouldBeTrue)
 		}
 
-		eventCapture.mu.Lock()
-		So(len(eventCapture.imageUpdated), ShouldEqual, 4)
-		So(eventCapture.imageUpdated[3].reference, ShouldEqual, "tag-d")
-		So(eventCapture.imageUpdated[3].digest, ShouldEqual, manifestDigest.String())
-		So(eventCapture.imageUpdated[3].manifest, ShouldEqual, string(manifestBuf))
-		eventCapture.mu.Unlock()
+		eventCapture.Lock()
+		So(len(eventCapture.ImageUpdatedCalls), ShouldEqual, 4)
+		So(eventCapture.ImageUpdatedCalls[3].Reference, ShouldEqual, "tag-d")
+		So(eventCapture.ImageUpdatedCalls[3].Digest, ShouldEqual, manifestDigest.String())
+		So(eventCapture.ImageUpdatedCalls[3].Manifest, ShouldEqual, string(manifestBuf))
+		eventCapture.Unlock()
 	})
 }
 
 func TestDeleteImageManifestEvents(t *testing.T) {
 	Convey("delete by tag emits ImageDeleted with manifest digest and tag reference", t, func() {
-		eventCapture := &captureImageEvents{}
+		eventCapture := &mocks.EventRecorderMock{}
 		imgStore := newLocalImageStoreWithEventRecorder(t, eventCapture)
 
 		repo := "delrepo"
@@ -694,17 +631,17 @@ func TestDeleteImageManifestEvents(t *testing.T) {
 		err = imgStore.DeleteImageManifest(context.Background(), repo, tag, false)
 		So(err, ShouldBeNil)
 
-		eventCapture.mu.Lock()
-		So(len(eventCapture.imageDeleted), ShouldEqual, 1)
-		So(eventCapture.imageDeleted[0].repo, ShouldEqual, repo)
-		So(eventCapture.imageDeleted[0].reference, ShouldEqual, tag)
-		So(eventCapture.imageDeleted[0].digest, ShouldEqual, manifestDigest.String())
-		So(eventCapture.imageDeleted[0].mediaType, ShouldEqual, ispec.MediaTypeImageManifest)
-		eventCapture.mu.Unlock()
+		eventCapture.Lock()
+		So(len(eventCapture.ImageDeletedCalls), ShouldEqual, 1)
+		So(eventCapture.ImageDeletedCalls[0].Name, ShouldEqual, repo)
+		So(eventCapture.ImageDeletedCalls[0].Reference, ShouldEqual, tag)
+		So(eventCapture.ImageDeletedCalls[0].Digest, ShouldEqual, manifestDigest.String())
+		So(eventCapture.ImageDeletedCalls[0].MediaType, ShouldEqual, ispec.MediaTypeImageManifest)
+		eventCapture.Unlock()
 	})
 
 	Convey("delete by digest emits ImageDeleted with digest reference", t, func() {
-		eventCapture := &captureImageEvents{}
+		eventCapture := &mocks.EventRecorderMock{}
 		imgStore := newLocalImageStoreWithEventRecorder(t, eventCapture)
 
 		repo := "delrepo-digest"
@@ -740,16 +677,16 @@ func TestDeleteImageManifestEvents(t *testing.T) {
 		err = imgStore.DeleteImageManifest(context.Background(), repo, manifestDigest.String(), false)
 		So(err, ShouldBeNil)
 
-		eventCapture.mu.Lock()
-		So(len(eventCapture.imageDeleted), ShouldEqual, 1)
-		So(eventCapture.imageDeleted[0].repo, ShouldEqual, repo)
-		So(eventCapture.imageDeleted[0].reference, ShouldEqual, manifestDigest.String())
-		So(eventCapture.imageDeleted[0].digest, ShouldEqual, manifestDigest.String())
-		eventCapture.mu.Unlock()
+		eventCapture.Lock()
+		So(len(eventCapture.ImageDeletedCalls), ShouldEqual, 1)
+		So(eventCapture.ImageDeletedCalls[0].Name, ShouldEqual, repo)
+		So(eventCapture.ImageDeletedCalls[0].Reference, ShouldEqual, manifestDigest.String())
+		So(eventCapture.ImageDeletedCalls[0].Digest, ShouldEqual, manifestDigest.String())
+		eventCapture.Unlock()
 	})
 
 	Convey("delete of missing reference does not emit ImageDeleted", t, func() {
-		eventCapture := &captureImageEvents{}
+		eventCapture := &mocks.EventRecorderMock{}
 		imgStore := newLocalImageStoreWithEventRecorder(t, eventCapture)
 
 		repo := "delrepo-missing"
@@ -784,9 +721,9 @@ func TestDeleteImageManifestEvents(t *testing.T) {
 		err = imgStore.DeleteImageManifest(context.Background(), repo, "missing", false)
 		So(err, ShouldNotBeNil)
 
-		eventCapture.mu.Lock()
-		So(len(eventCapture.imageDeleted), ShouldEqual, 0)
-		eventCapture.mu.Unlock()
+		eventCapture.Lock()
+		So(len(eventCapture.ImageDeletedCalls), ShouldEqual, 0)
+		eventCapture.Unlock()
 	})
 }
 
@@ -827,7 +764,7 @@ func TestImageLintFailedEvents(t *testing.T) {
 	}
 
 	Convey("tag push that fails lint emits ImageLintFailed for the tag reference", t, func() {
-		eventCapture := &captureImageEvents{}
+		eventCapture := &mocks.EventRecorderMock{}
 		imgStore := newLocalImageStoreWithEventRecorderAndLinter(t, eventCapture, failingLinter)
 
 		repo := "lintrepo"
@@ -837,17 +774,17 @@ func TestImageLintFailedEvents(t *testing.T) {
 			ispec.MediaTypeImageManifest, manifestBuf, nil)
 		So(err, ShouldNotBeNil)
 
-		eventCapture.mu.Lock()
-		So(len(eventCapture.imageLintFailed), ShouldEqual, 1)
-		So(eventCapture.imageLintFailed[0].repo, ShouldEqual, repo)
-		So(eventCapture.imageLintFailed[0].reference, ShouldEqual, "v1")
-		So(eventCapture.imageLintFailed[0].digest, ShouldEqual, manifestDigest.String())
-		So(eventCapture.imageLintFailed[0].mediaType, ShouldEqual, ispec.MediaTypeImageManifest)
-		eventCapture.mu.Unlock()
+		eventCapture.Lock()
+		So(len(eventCapture.ImageLintFailedCalls), ShouldEqual, 1)
+		So(eventCapture.ImageLintFailedCalls[0].Name, ShouldEqual, repo)
+		So(eventCapture.ImageLintFailedCalls[0].Reference, ShouldEqual, "v1")
+		So(eventCapture.ImageLintFailedCalls[0].Digest, ShouldEqual, manifestDigest.String())
+		So(eventCapture.ImageLintFailedCalls[0].MediaType, ShouldEqual, ispec.MediaTypeImageManifest)
+		eventCapture.Unlock()
 	})
 
 	Convey("digest push with extra tags that fails lint emits a single ImageLintFailed", t, func() {
-		eventCapture := &captureImageEvents{}
+		eventCapture := &mocks.EventRecorderMock{}
 		imgStore := newLocalImageStoreWithEventRecorderAndLinter(t, eventCapture, failingLinter)
 
 		repo := "lintrepo-multi"
@@ -859,13 +796,13 @@ func TestImageLintFailedEvents(t *testing.T) {
 			ispec.MediaTypeImageManifest, manifestBuf, extraTags)
 		So(err, ShouldNotBeNil)
 
-		eventCapture.mu.Lock()
+		eventCapture.Lock()
 		// lint is a property of the manifest, not the tag(s), so only one event is emitted.
-		So(len(eventCapture.imageLintFailed), ShouldEqual, 1)
-		So(eventCapture.imageLintFailed[0].repo, ShouldEqual, repo)
-		So(eventCapture.imageLintFailed[0].digest, ShouldEqual, manifestDigest.String())
-		So(eventCapture.imageLintFailed[0].reference, ShouldEqual, extraTags[0])
-		eventCapture.mu.Unlock()
+		So(len(eventCapture.ImageLintFailedCalls), ShouldEqual, 1)
+		So(eventCapture.ImageLintFailedCalls[0].Name, ShouldEqual, repo)
+		So(eventCapture.ImageLintFailedCalls[0].Digest, ShouldEqual, manifestDigest.String())
+		So(eventCapture.ImageLintFailedCalls[0].Reference, ShouldEqual, extraTags[0])
+		eventCapture.Unlock()
 	})
 }
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -317,6 +317,8 @@ type imageLintFailedCall struct {
 
 func (c *captureImageEvents) Close() {}
 
+// RepositoryCreated can be emitted by the image store (e.g. on first index.json
+// creation), but none of these tests assert on it, so this is an intentional no-op.
 func (c *captureImageEvents) RepositoryCreated(string, *events.EventContext) {}
 
 func (c *captureImageEvents) ImageUpdated(name, reference, digest, mediaType, manifest string,
@@ -348,6 +350,13 @@ func (c *captureImageEvents) ImageLintFailed(name, reference, digest, mediaType,
 	c.imageLintFailed = append(c.imageLintFailed, imageLintFailedCall{
 		repo: name, reference: reference, digest: digest, mediaType: mediaType, manifest: manifest,
 	})
+}
+
+// ImageScanned is emitted only by the cve package (see cve/scan.go), never by pkg/storage,
+// so unlike RepositoryCreated above, these tests could never trigger it in the first place.
+func (c *captureImageEvents) ImageScanned(name, reference, digest, mediaType string,
+	summary events.ImageScanSummary, ectx *events.EventContext,
+) {
 }
 
 // TestPutImageManifestExtraTagsAndEvents covers extra-tag digest pushes, index updates, and ImageUpdated events.

--- a/pkg/test/mocks/cve_mock.go
+++ b/pkg/test/mocks/cve_mock.go
@@ -79,7 +79,7 @@ type CveScannerMock struct {
 	IsImageMediaScannableFn  func(repo string, digest, mediaType string) (bool, error)
 	IsResultCachedFn         func(digest string) bool
 	GetCachedResultFn        func(digest string) map[string]cvemodel.CVE
-	ScanImageFn              func(ctx context.Context, image string) (map[string]cvemodel.CVE, error)
+	ScanImageFn              func(ctx context.Context, image string) (cvemodel.ScanResult, error)
 	UpdateDBFn               func(ctx context.Context) error
 }
 
@@ -115,12 +115,12 @@ func (scanner CveScannerMock) GetCachedResult(digest string) map[string]cvemodel
 	return map[string]cvemodel.CVE{}
 }
 
-func (scanner CveScannerMock) ScanImage(ctx context.Context, image string) (map[string]cvemodel.CVE, error) {
+func (scanner CveScannerMock) ScanImage(ctx context.Context, image string) (cvemodel.ScanResult, error) {
 	if scanner.ScanImageFn != nil {
 		return scanner.ScanImageFn(ctx, image)
 	}
 
-	return map[string]cvemodel.CVE{}, nil
+	return cvemodel.ScanResult{CVEMap: map[string]cvemodel.CVE{}}, nil
 }
 
 func (scanner CveScannerMock) UpdateDB(ctx context.Context) error {

--- a/pkg/test/mocks/event_recorder_mock.go
+++ b/pkg/test/mocks/event_recorder_mock.go
@@ -1,0 +1,103 @@
+package mocks
+
+import (
+	"sync"
+
+	"zotregistry.dev/zot/v2/pkg/extensions/events"
+)
+
+type RepositoryCreatedCall struct {
+	Name string
+	Ectx *events.EventContext
+}
+
+type ImageUpdatedCall struct {
+	Name, Reference, Digest, MediaType, Manifest string
+	Ectx                                         *events.EventContext
+}
+
+type ImageDeletedCall struct {
+	Name, Reference, Digest, MediaType string
+	Ectx                               *events.EventContext
+}
+
+type ImageLintFailedCall struct {
+	Name, Reference, Digest, MediaType, Manifest string
+	Ectx                                         *events.EventContext
+}
+
+type ImageScannedCall struct {
+	Name, Reference, Digest, MediaType string
+	Summary                            events.ImageScanSummary
+	Ectx                               *events.EventContext
+}
+
+// EventRecorderMock is a thread-safe events.Recorder test double that records every
+// call it receives, for tests that assert on what was published without needing a
+// bespoke fake per package.
+type EventRecorderMock struct {
+	mu sync.Mutex
+
+	RepositoryCreatedCalls []RepositoryCreatedCall
+	ImageUpdatedCalls      []ImageUpdatedCall
+	ImageDeletedCalls      []ImageDeletedCall
+	ImageLintFailedCalls   []ImageLintFailedCall
+	ImageScannedCalls      []ImageScannedCall
+}
+
+func (r *EventRecorderMock) Close() {}
+
+// Lock/Unlock let callers read a consistent view across multiple *Calls fields
+// (e.g. while a background goroutine may still be recording events concurrently).
+func (r *EventRecorderMock) Lock() { r.mu.Lock() }
+
+func (r *EventRecorderMock) Unlock() { r.mu.Unlock() }
+
+func (r *EventRecorderMock) RepositoryCreated(name string, ectx *events.EventContext) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.RepositoryCreatedCalls = append(r.RepositoryCreatedCalls, RepositoryCreatedCall{Name: name, Ectx: ectx})
+}
+
+func (r *EventRecorderMock) ImageUpdated(name, reference, digest, mediaType, manifest string,
+	ectx *events.EventContext,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.ImageUpdatedCalls = append(r.ImageUpdatedCalls, ImageUpdatedCall{
+		Name: name, Reference: reference, Digest: digest, MediaType: mediaType, Manifest: manifest, Ectx: ectx,
+	})
+}
+
+func (r *EventRecorderMock) ImageDeleted(name, reference, digest, mediaType string, ectx *events.EventContext) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.ImageDeletedCalls = append(r.ImageDeletedCalls, ImageDeletedCall{
+		Name: name, Reference: reference, Digest: digest, MediaType: mediaType, Ectx: ectx,
+	})
+}
+
+func (r *EventRecorderMock) ImageLintFailed(name, reference, digest, mediaType, manifest string,
+	ectx *events.EventContext,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.ImageLintFailedCalls = append(r.ImageLintFailedCalls, ImageLintFailedCall{
+		Name: name, Reference: reference, Digest: digest, MediaType: mediaType, Manifest: manifest, Ectx: ectx,
+	})
+}
+
+func (r *EventRecorderMock) ImageScanned(name, reference, digest, mediaType string,
+	summary events.ImageScanSummary, ectx *events.EventContext,
+) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.ImageScannedCalls = append(r.ImageScannedCalls, ImageScannedCall{
+		Name: name, Reference: reference, Digest: digest, MediaType: mediaType, Summary: summary, Ectx: ectx,
+	})
+}

--- a/test/blackbox/ci.sh
+++ b/test/blackbox/ci.sh
@@ -19,7 +19,7 @@ tests=("pushpull" "pushpull_authn" "delete_images" "referrers" "sbom" "metadata"
       "annotations" "detect_manifest_collision" "cve" "sync" "sync_docker" "sync_replica_cluster"
       "scrub" "garbage_collect" "metrics" "metrics_minimal" "multiarch_index" "docker_compat" "redis_local" "redis_session_store"
       "events_nats" "events_http" "events_nats_lint_failure" "events_http_lint_failure" "events_sink_failure" "events_config_decoding"
-      "fips140" "fips140_authn" "openid_claim_mapping" "upgrade" "upgrade_minimal" "dynamic_tls" "quota")
+      "fips140" "fips140_authn" "openid_claim_mapping" "upgrade" "upgrade_minimal" "dynamic_tls" "quota" "events_http_scan")
 
 for test in ${tests[*]}; do
     ${BATS} ${BATS_FLAGS} ${SCRIPTPATH}/${test}.bats > ${test}.log & pids+=($!)

--- a/test/blackbox/events_http_scan.bats
+++ b/test/blackbox/events_http_scan.bats
@@ -44,9 +44,7 @@ function setup_file() {
     # Setup zot server
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
-    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
     mkdir -p ${zot_root_dir}
-    mkdir -p ${oci_data_dir}
     zot_port=$(get_free_port_for_service "zot")
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     # readTimeout/writeTimeout must exceed how long a cold trivy scan of golang:1.20 can take
@@ -141,6 +139,12 @@ function wait_for_event_count() {
     [ "$status" -eq 0 ]
 
     sleep 10     # wait a little to populate metadb
+
+    # Event delivery is asynchronous (fired from a goroutine per publish), so wait for the
+    # push-triggered events (RepositoryCreated + ImageUpdated, this being a new repo's first
+    # push) to actually arrive before resetting, or a late arrival could be miscounted as the
+    # scan-triggered event below.
+    wait_for_event_count "${output_path}" 2
 
     # Reset the event counter so only the scan-triggered event is counted
     run curl -XGET http://127.0.0.1:${http_server_port}/reset

--- a/test/blackbox/events_http_scan.bats
+++ b/test/blackbox/events_http_scan.bats
@@ -1,0 +1,168 @@
+# Note: Intended to be run as "make run-blackbox-tests" or "make run-blackbox-ci"
+#       Makefile target installs & checks all necessary tooling
+#       Extra tools that are not covered in Makefile target needs to be added in verify_prerequisites()
+
+load helpers_zot
+load helpers_events
+load ../port_helper
+
+function verify_prerequisites() {
+    if ! command -v curl >/dev/null 2>&1; then
+        echo "you need to install curl as a prerequisite to running the tests" >&3
+        return 1
+    fi
+
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "you need to install jq as a prerequisite to running the tests" >&3
+        return 1
+    fi
+
+    if ! command -v docker >/dev/null 2>&1; then
+        echo "you need to install docker as a prerequisite to running the tests" >&3
+        return 1
+    fi
+}
+
+function setup_file() {
+    # Use unique config name based on test file name and test run to avoid conflicts
+    export REGISTRY_NAME=$(basename "${BASH_SOURCE[0]}" .bats)-$(basename "${BATS_FILE_TMPDIR}")
+
+    # verify prerequisites are available
+    if ! verify_prerequisites; then
+        exit 1
+    fi
+
+    # Setup http server
+    http_server_port=$(get_free_port_for_service "http")
+    http_event_dir="${BATS_FILE_TMPDIR}/http_events"
+    http_server_start http_receiver_scan "${http_server_port}" "${http_event_dir}"
+    echo ${http_server_port} > ${BATS_FILE_TMPDIR}/http_server.port
+    wait_for_http_server $http_server_port
+
+    skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.20 oci:${TEST_DATA_DIR}/golang:1.20
+
+    # Setup zot server
+    local zot_root_dir=${BATS_FILE_TMPDIR}/zot
+    local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
+    local oci_data_dir=${BATS_FILE_TMPDIR}/oci
+    mkdir -p ${zot_root_dir}
+    mkdir -p ${oci_data_dir}
+    zot_port=$(get_free_port_for_service "zot")
+    echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
+    # readTimeout/writeTimeout must exceed how long a cold trivy scan of golang:1.20 can take
+    # (observed 83s in CI vs. the 60s Go http.Server default): if the server's WriteTimeout
+    # fires while the CVEListForImage handler is still mid-scan, Go's http.Transport silently
+    # retries the (idempotent) GET on the client side, and the abandoned first handler keeps
+    # running to completion regardless, so both it and the retry publish an ImageScanned event
+    # for the same scan, causing an intermittent duplicate.
+    cat > ${zot_config_file}<<EOF
+{
+    "distSpecVersion": "1.1.1",
+    "storage": {
+        "rootDirectory": "${zot_root_dir}"
+    },
+    "http": {
+        "address": "0.0.0.0",
+        "port": "${zot_port}",
+        "readTimeout": "5m",
+        "writeTimeout": "5m"
+    },
+    "log": {
+        "level": "debug",
+        "output": "${BATS_FILE_TMPDIR}/zot.log"
+    },
+    "extensions": {
+        "search": {
+            "enable": true,
+            "cve": {
+                "updateInterval": "24h"
+            }
+        },
+        "events": {
+            "enable": true,
+            "sinks": [{
+                "type": "http",
+                "address": "http://127.0.0.1:${http_server_port}/events",
+                "timeout": "15s",
+                "credentials": {
+                    "username": "jane.joe",
+                    "password": "opensesame"
+                }
+            }]
+        }
+    }
+}
+EOF
+    zot_serve ${ZOT_PATH} ${zot_config_file}
+    wait_zot_reachable ${zot_port}
+
+    # setup zli to add zot registry to configs
+    local registry_url="http://127.0.0.1:${zot_port}/"
+    zli_add_config ${REGISTRY_NAME} ${registry_url}
+}
+
+function teardown_file() {
+    zot_stop_all
+    http_server_stop http_receiver_scan
+    zli_delete_config ${REGISTRY_NAME}
+}
+
+function wait_for_event_count() {
+    local output_path="$1"
+    local expected_count="$2"
+    local timeout_seconds="${3:-30}"
+    local elapsed=0
+    local count=0
+
+    while [ "$elapsed" -lt "$timeout_seconds" ]; do
+        count=$(find "${output_path}" -type f | wc -l)
+        if [ "$count" -eq "$expected_count" ]; then
+            return 0
+        fi
+
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+
+    echo "timed out waiting for ${expected_count} events, found ${count}" >&3
+
+    return 1
+}
+
+@test "http/publish image scanned event" {
+    http_server_port=$(cat ${BATS_FILE_TMPDIR}/http_server.port)
+    zot_port=$(cat ${BATS_FILE_TMPDIR}/zot.port)
+    output_path=${BATS_FILE_TMPDIR}/http_events
+
+    # Push a new image tag
+    run skopeo --insecure-policy copy --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/golang:1.20 \
+        docker://127.0.0.1:${zot_port}/golang:1.20
+    [ "$status" -eq 0 ]
+
+    sleep 10     # wait a little to populate metadb
+
+    # Reset the event counter so only the scan-triggered event is counted
+    run curl -XGET http://127.0.0.1:${http_server_port}/reset
+    [ "$status" -eq 0 ]
+    [ -d "${output_path}" ] && rm -f "${output_path}"/*.json
+
+    # Triggers a CVE scan synchronously, which should publish an image scanned event
+    run ${ZLI_PATH} cve list golang:1.20 --config ${REGISTRY_NAME}
+    [ "$status" -eq 0 ]
+
+    # Check the correct number of events were generated
+    wait_for_event_count "${output_path}" 1
+    count=$(find "${output_path}" -type f | wc -l)
+    [ "$count" -eq 1 ]
+
+    # Validate the event
+    result=$(jq '.' ${output_path}/1.json)
+    [ $(echo "${result}" | jq -r '.headers["Ce-Type"]') = "zotregistry.image.scanned" ]
+    [ $(echo "${result}" | jq -r '.body.name') = "golang" ]
+    [ $(echo "${result}" | jq -r '.body.reference') = "1.20" ]
+    [ $(echo "${result}" | jq -r '.body.digest') != "" ]
+    [ $(echo "${result}" | jq -r '.body.digest') != "null" ]
+    [ $(echo "${result}" | jq -r '.body.summary.count') != "null" ]
+    [ $(echo "${result}" | jq -r '.body.summary.maxSeverity') != "null" ]
+}

--- a/test/blackbox/events_http_scan.bats
+++ b/test/blackbox/events_http_scan.bats
@@ -37,7 +37,7 @@ function setup_file() {
     http_event_dir="${BATS_FILE_TMPDIR}/http_events"
     http_server_start http_receiver_scan "${http_server_port}" "${http_event_dir}"
     echo ${http_server_port} > ${BATS_FILE_TMPDIR}/http_server.port
-    wait_for_http_server $http_server_port
+    wait_for_http_server $http_server_port http_receiver_scan
 
     skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.20 oci:${TEST_DATA_DIR}/golang:1.20
 

--- a/test/blackbox/garbage_collect.bats
+++ b/test/blackbox/garbage_collect.bats
@@ -38,16 +38,21 @@ function setup_file() {
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
+    # gcDelay/retention.delay must comfortably exceed how long the "push image index" test's
+    # 17-image multi-arch busybox push can take: individual platform manifests are only
+    # referenced by the top-level index once it's uploaded last, so they look untagged/orphaned
+    # to GC for the whole duration of that push. A too-short delay here previously let GC delete
+    # a platform manifest out from under an in-progress push, failing it with "manifest invalid".
     cat > ${zot_config_file}<<EOF
 {
     "distSpecVersion": "1.1.1",
     "storage": {
         "rootDirectory": "${zot_root_dir}",
         "gc": true,
-        "gcDelay": "30s",
-        "gcInterval": "1s",
+        "gcDelay": "3m",
+        "gcInterval": "5s",
         "retention": {
-            "delay": "40s",
+            "delay": "4m",
             "policies": [
                 {
                     "repositories": ["**"],
@@ -162,8 +167,8 @@ EOF
         docker://127.0.0.1:${zot_port}/busybox:latest
     [ "$status" -eq 0 ]
 
-    # sleep past gc delay
-    sleep 100
+    # sleep past gc delay (retention.delay is 4m, see setup_file)
+    sleep 300
 
     # gc should have removed artifacts
     run regctl artifact get --subject 127.0.0.1:${zot_port}/alpine:3.17.3

--- a/test/blackbox/garbage_collect.bats
+++ b/test/blackbox/garbage_collect.bats
@@ -38,21 +38,16 @@ function setup_file() {
     echo ${zot_port} > ${BATS_FILE_TMPDIR}/zot.port
     mkdir -p ${zot_root_dir}
     mkdir -p ${oci_data_dir}
-    # gcDelay/retention.delay must comfortably exceed how long the "push image index" test's
-    # 17-image multi-arch busybox push can take: individual platform manifests are only
-    # referenced by the top-level index once it's uploaded last, so they look untagged/orphaned
-    # to GC for the whole duration of that push. A too-short delay here previously let GC delete
-    # a platform manifest out from under an in-progress push, failing it with "manifest invalid".
     cat > ${zot_config_file}<<EOF
 {
     "distSpecVersion": "1.1.1",
     "storage": {
         "rootDirectory": "${zot_root_dir}",
         "gc": true,
-        "gcDelay": "3m",
-        "gcInterval": "5s",
+        "gcDelay": "30s",
+        "gcInterval": "1s",
         "retention": {
-            "delay": "4m",
+            "delay": "40s",
             "policies": [
                 {
                     "repositories": ["**"],
@@ -167,8 +162,8 @@ EOF
         docker://127.0.0.1:${zot_port}/busybox:latest
     [ "$status" -eq 0 ]
 
-    # sleep past gc delay (retention.delay is 4m, see setup_file)
-    sleep 300
+    # sleep past gc delay
+    sleep 100
 
     # gc should have removed artifacts
     run regctl artifact get --subject 127.0.0.1:${zot_port}/alpine:3.17.3

--- a/test/blackbox/helpers_redis.bash
+++ b/test/blackbox/helpers_redis.bash
@@ -2,9 +2,6 @@
 function redis_start() {
   local cname="$1" # container name
   local free_port="$2"
-  # pinned to the ghcr mirror (not bare "redis") so this doesn't depend on reaching Docker Hub,
-  # matching every other blackbox helper container; see helpers_events.bash for what happens
-  # when a helper container isn't self-contained like this.
   docker run -d --name ${cname} -p ${free_port}:6379 ghcr.io/project-zot/ci-images/redis:7.4.2
 }
 

--- a/test/blackbox/helpers_redis.bash
+++ b/test/blackbox/helpers_redis.bash
@@ -2,7 +2,10 @@
 function redis_start() {
   local cname="$1" # container name
   local free_port="$2"
-  docker run -d --name ${cname} -p ${free_port}:6379 redis
+  # pinned to the ghcr mirror (not bare "redis") so this doesn't depend on reaching Docker Hub,
+  # matching every other blackbox helper container; see helpers_events.bash for what happens
+  # when a helper container isn't self-contained like this.
+  docker run -d --name ${cname} -p ${free_port}:6379 ghcr.io/project-zot/ci-images/redis:7.4.2
 }
 
 function redis_stop() {

--- a/test/ports.json
+++ b/test/ports.json
@@ -466,5 +466,15 @@
       "begin": 11530,
       "end": 11539
     }
+  },
+  "blackbox/events_http_scan.bats": {
+    "http": {
+      "begin": 11540,
+      "end": 11549
+    },
+    "zot": {
+      "begin": 11550,
+      "end": 11559
+    }
   }
 }


### PR DESCRIPTION
Implements sending an HTTP event when Zot finishes an image scan.

Fixes #4251

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
