### PR TITLE
fix(storage): check table existence before CreateTable in dynamodb cache

### DIFF
--- a/pkg/storage/cache/dynamodb.go
+++ b/pkg/storage/cache/dynamodb.go
@@ -81,9 +81,22 @@ func (d *DynamoDBDriver) NewTable(tableName string) error {
 
 		// tableExists and CreateTable aren't atomic, so still tolerate a benign race where
 		// another zot instance created the table between the check above and this call.
+		// ResourceInUseException can also occur while a table is being deleted, so confirm
+		// the table actually exists before treating the error as benign.
 		var inUseErr *types.ResourceInUseException
-		if err != nil && !errors.As(err, &inUseErr) {
-			return err
+		if err != nil {
+			if !errors.As(err, &inUseErr) {
+				return err
+			}
+
+			exists, existsErr := d.tableExists(tableName)
+			if existsErr != nil {
+				return existsErr
+			}
+
+			if !exists {
+				return err
+			}
 		}
 	}
 

--- a/pkg/storage/cache/dynamodb.go
+++ b/pkg/storage/cache/dynamodb.go
@@ -33,8 +33,8 @@ type Blob struct {
 }
 
 // tableExists checks for the table via DescribeTable rather than attempting CreateTable
-// and inspecting the error. This allows callers that only have read/write item permissions on an
-// existing table (but not dynamodb:CreateTable) to work.
+// and inspecting the error. This allows callers that have dynamodb:DescribeTable (and read/write item
+// permissions) on an existing table, but not dynamodb:CreateTable, to work.
 func (d *DynamoDBDriver) tableExists(tableName string) (bool, error) {
 	_, err := d.client.DescribeTable(context.TODO(), &dynamodb.DescribeTableInput{
 		TableName: aws.String(tableName),

--- a/pkg/storage/cache/dynamodb.go
+++ b/pkg/storage/cache/dynamodb.go
@@ -2,8 +2,8 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"slices"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -32,29 +32,60 @@ type Blob struct {
 	OriginalBlobPath  string   `dynamodbav:"OriginalBlobPath,string"`
 }
 
-func (d *DynamoDBDriver) NewTable(tableName string) error {
-	//nolint:mnd
-	_, err := d.client.CreateTable(context.TODO(), &dynamodb.CreateTableInput{
-		TableName: &tableName,
-		AttributeDefinitions: []types.AttributeDefinition{
-			{
-				AttributeName: aws.String("Digest"),
-				AttributeType: types.ScalarAttributeTypeS,
-			},
-		},
-		KeySchema: []types.KeySchemaElement{
-			{
-				AttributeName: aws.String("Digest"),
-				KeyType:       types.KeyTypeHash,
-			},
-		},
-		ProvisionedThroughput: &types.ProvisionedThroughput{
-			ReadCapacityUnits:  aws.Int64(10),
-			WriteCapacityUnits: aws.Int64(5),
-		},
+// tableExists checks for the table via DescribeTable rather than attempting CreateTable
+// and inspecting the error: callers that only have read/write item permissions on an
+// existing table (but not dynamodb:CreateTable) would otherwise get an AccessDeniedException
+// from CreateTable instead of ever finding out the table is already there. See #4259.
+func (d *DynamoDBDriver) tableExists(tableName string) (bool, error) {
+	_, err := d.client.DescribeTable(context.TODO(), &dynamodb.DescribeTableInput{
+		TableName: aws.String(tableName),
 	})
-	if err != nil && !strings.Contains(err.Error(), "Table already exists") {
+	if err == nil {
+		return true, nil
+	}
+
+	var notFoundErr *types.ResourceNotFoundException
+	if errors.As(err, &notFoundErr) {
+		return false, nil
+	}
+
+	return false, err
+}
+
+func (d *DynamoDBDriver) NewTable(tableName string) error {
+	exists, err := d.tableExists(tableName)
+	if err != nil {
 		return err
+	}
+
+	if !exists {
+		//nolint:mnd
+		_, err := d.client.CreateTable(context.TODO(), &dynamodb.CreateTableInput{
+			TableName: &tableName,
+			AttributeDefinitions: []types.AttributeDefinition{
+				{
+					AttributeName: aws.String("Digest"),
+					AttributeType: types.ScalarAttributeTypeS,
+				},
+			},
+			KeySchema: []types.KeySchemaElement{
+				{
+					AttributeName: aws.String("Digest"),
+					KeyType:       types.KeyTypeHash,
+				},
+			},
+			ProvisionedThroughput: &types.ProvisionedThroughput{
+				ReadCapacityUnits:  aws.Int64(10),
+				WriteCapacityUnits: aws.Int64(5),
+			},
+		})
+
+		// tableExists and CreateTable aren't atomic, so still tolerate a benign race where
+		// another zot instance created the table between the check above and this call.
+		var inUseErr *types.ResourceInUseException
+		if err != nil && !errors.As(err, &inUseErr) {
+			return err
+		}
 	}
 
 	d.tableName = tableName

--- a/pkg/storage/cache/dynamodb.go
+++ b/pkg/storage/cache/dynamodb.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
 	godigest "github.com/opencontainers/go-digest"
 
 	zerr "zotregistry.dev/zot/v2/errors"
@@ -51,10 +52,24 @@ func (d *DynamoDBDriver) tableExists(tableName string) (bool, error) {
 	return false, err
 }
 
+// isAccessDenied reports whether err is an AWS AccessDeniedException. This isn't a
+// modeled DynamoDB exception type, so it's matched via the generic smithy API error.
+func isAccessDenied(err error) bool {
+	var apiErr smithy.APIError
+
+	return errors.As(err, &apiErr) && apiErr.ErrorCode() == "AccessDeniedException"
+}
+
 func (d *DynamoDBDriver) NewTable(tableName string) error {
 	exists, err := d.tableExists(tableName)
 	if err != nil {
-		return err
+		// DescribeTable may be denied for callers that only have dynamodb:CreateTable (and
+		// not dynamodb:DescribeTable); fall back to attempting CreateTable directly below.
+		if !isAccessDenied(err) {
+			return err
+		}
+
+		exists = false
 	}
 
 	if !exists {
@@ -82,19 +97,21 @@ func (d *DynamoDBDriver) NewTable(tableName string) error {
 		// tableExists and CreateTable aren't atomic, so still tolerate a benign race where
 		// another zot instance created the table between the check above and this call.
 		// ResourceInUseException can also occur while a table is being deleted, so confirm
-		// the table actually exists before treating the error as benign.
+		// the table actually exists before treating the error as benign. If the caller isn't
+		// permitted to call DescribeTable either (dynamodb:CreateTable-only IAM policies),
+		// there's no way to confirm further, so fall back to treating it as benign.
 		var inUseErr *types.ResourceInUseException
 		if err != nil {
 			if !errors.As(err, &inUseErr) {
 				return err
 			}
 
-			exists, existsErr := d.tableExists(tableName)
-			if existsErr != nil {
-				return existsErr
-			}
+			confirmedExists, existsErr := d.tableExists(tableName)
 
-			if !exists {
+			switch {
+			case existsErr != nil && !isAccessDenied(existsErr):
+				return existsErr
+			case existsErr == nil && !confirmedExists:
 				return err
 			}
 		}

--- a/pkg/storage/cache/dynamodb.go
+++ b/pkg/storage/cache/dynamodb.go
@@ -74,7 +74,7 @@ func (d *DynamoDBDriver) NewTable(tableName string) error {
 
 	if !exists {
 		//nolint:mnd
-		_, err := d.client.CreateTable(context.TODO(), &dynamodb.CreateTableInput{
+		_, err = d.client.CreateTable(context.TODO(), &dynamodb.CreateTableInput{
 			TableName: &tableName,
 			AttributeDefinitions: []types.AttributeDefinition{
 				{

--- a/pkg/storage/cache/dynamodb.go
+++ b/pkg/storage/cache/dynamodb.go
@@ -33,9 +33,8 @@ type Blob struct {
 }
 
 // tableExists checks for the table via DescribeTable rather than attempting CreateTable
-// and inspecting the error: callers that only have read/write item permissions on an
-// existing table (but not dynamodb:CreateTable) would otherwise get an AccessDeniedException
-// from CreateTable instead of ever finding out the table is already there. See #4259.
+// and inspecting the error. This allows callers that only have read/write item permissions on an
+// existing table (but not dynamodb:CreateTable) to work.
 func (d *DynamoDBDriver) tableExists(tableName string) (bool, error) {
 	_, err := d.client.DescribeTable(context.TODO(), &dynamodb.DescribeTableInput{
 		TableName: aws.String(tableName),

--- a/pkg/storage/cache/dynamodb_internal_test.go
+++ b/pkg/storage/cache/dynamodb_internal_test.go
@@ -20,7 +20,7 @@ import (
 // denyCreateTableTransport simulates an IAM policy that allows DescribeTable/GetItem/etc.
 // but denies dynamodb:CreateTable, by intercepting only CreateTable calls and returning
 // the same AccessDeniedException shape AWS returns; every other action is forwarded to
-// the real (localstack) endpoint. This reproduces https://github.com/project-zot/zot/issues/4259.
+// the real (localstack) endpoint.
 type denyCreateTableTransport struct {
 	base http.RoundTripper
 }

--- a/pkg/storage/cache/dynamodb_internal_test.go
+++ b/pkg/storage/cache/dynamodb_internal_test.go
@@ -144,6 +144,22 @@ func TestNewTableWithoutDescribeTablePermission(t *testing.T) {
 			deniedDriver := newDenyDescribeTableDriver(t)
 			So(deniedDriver.NewTable(tableName), ShouldBeNil)
 			So(deniedDriver.tableName, ShouldEqual, tableName)
+
+			// confirm CreateTable actually ran (rather than NewTable returning nil
+			// without ever creating the table) via an unwrapped client
+			endpoint := os.Getenv("DYNAMODBMOCK_ENDPOINT")
+
+			plainCfg, err := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion("us-east-2"))
+			So(err, ShouldBeNil)
+
+			plainClient := dynamodb.NewFromConfig(plainCfg, func(o *dynamodb.Options) {
+				o.BaseEndpoint = aws.String(endpoint)
+			})
+
+			_, err = plainClient.DescribeTable(context.Background(), &dynamodb.DescribeTableInput{
+				TableName: aws.String(tableName),
+			})
+			So(err, ShouldBeNil)
 		})
 
 		Convey("table already exists", func() {

--- a/pkg/storage/cache/dynamodb_internal_test.go
+++ b/pkg/storage/cache/dynamodb_internal_test.go
@@ -27,8 +27,8 @@ type denyCreateTableTransport struct {
 
 func (t *denyCreateTableTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if req.Header.Get("X-Amz-Target") == "DynamoDB_20120810.CreateTable" {
-		body := `{"__type":"com.amazonaws.dynamodb.v20120810#AccessDeniedException",` +
-			`"Message":"User: arn:aws:iam::123456789012:user/zot is not authorized to perform: ` +
+		body := `{"__type":"com.amazon.coral.service#AccessDeniedException",` +
+			`"message":"User: arn:aws:iam::123456789012:user/zot is not authorized to perform: ` +
 			`dynamodb:CreateTable on resource: arn:aws:dynamodb:us-east-2:123456789012:table/BlobTable"}`
 
 		return &http.Response{

--- a/pkg/storage/cache/dynamodb_internal_test.go
+++ b/pkg/storage/cache/dynamodb_internal_test.go
@@ -1,0 +1,87 @@
+package cache
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/log"
+	tskip "zotregistry.dev/zot/v2/pkg/test/skip"
+)
+
+// denyCreateTableTransport simulates an IAM policy that allows DescribeTable/GetItem/etc.
+// but denies dynamodb:CreateTable, by intercepting only CreateTable calls and returning
+// the same AccessDeniedException shape AWS returns; every other action is forwarded to
+// the real (localstack) endpoint. This reproduces https://github.com/project-zot/zot/issues/4259.
+type denyCreateTableTransport struct {
+	base http.RoundTripper
+}
+
+func (t *denyCreateTableTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("X-Amz-Target") == "DynamoDB_20120810.CreateTable" {
+		body := `{"__type":"com.amazonaws.dynamodb.v20120810#AccessDeniedException",` +
+			`"Message":"User: arn:aws:iam::123456789012:user/zot is not authorized to perform: ` +
+			`dynamodb:CreateTable on resource: arn:aws:dynamodb:us-east-2:123456789012:table/BlobTable"}`
+
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Status:     "400 Bad Request",
+			Header: http.Header{
+				"Content-Type":     []string{"application/x-amz-json-1.0"},
+				"X-Amzn-Errortype": []string{"AccessDeniedException"},
+			},
+			Body:    io.NopCloser(bytes.NewBufferString(body)),
+			Request: req,
+		}, nil
+	}
+
+	return t.base.RoundTrip(req)
+}
+
+func TestNewTableWithoutCreateTablePermission(t *testing.T) {
+	tskip.SkipDynamo(t)
+
+	Convey("NewTable succeeds against a pre-existing table without dynamodb:CreateTable permission", t, func() {
+		endpoint := os.Getenv("DYNAMODBMOCK_ENDPOINT")
+
+		httpClient := &http.Client{Transport: &denyCreateTableTransport{base: http.DefaultTransport}}
+
+		cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+			awsconfig.WithRegion("us-east-2"),
+			awsconfig.WithHTTPClient(httpClient),
+		)
+		So(err, ShouldBeNil)
+
+		client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+
+		const tableName = "Issue4259PreExistingTable"
+
+		// create the table up front using a plain client (unaffected by the interceptor,
+		// since it's not a CreateTable call through the deny-wrapped client)
+		plainCfg, err := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion("us-east-2"))
+		So(err, ShouldBeNil)
+
+		plainClient := dynamodb.NewFromConfig(plainCfg, func(o *dynamodb.Options) {
+			o.BaseEndpoint = aws.String(endpoint)
+		})
+
+		driver := &DynamoDBDriver{client: plainClient, log: log.NewTestLogger()}
+		So(driver.NewTable(tableName), ShouldBeNil)
+
+		// now exercise NewTable again through the client that denies CreateTable: since the
+		// table already exists, DescribeTable should short-circuit before CreateTable is ever called
+		deniedDriver := &DynamoDBDriver{client: client, log: log.NewTestLogger()}
+		So(deniedDriver.NewTable(tableName), ShouldBeNil)
+		So(deniedDriver.tableName, ShouldEqual, tableName)
+	})
+}

--- a/pkg/storage/cache/dynamodb_internal_test.go
+++ b/pkg/storage/cache/dynamodb_internal_test.go
@@ -85,3 +85,87 @@ func TestNewTableWithoutCreateTablePermission(t *testing.T) {
 		So(deniedDriver.tableName, ShouldEqual, tableName)
 	})
 }
+
+// denyDescribeTableTransport simulates an IAM policy that allows CreateTable/GetItem/etc.
+// but denies dynamodb:DescribeTable, by intercepting only DescribeTable calls and returning
+// an AccessDeniedException; every other action is forwarded to the real (localstack) endpoint.
+type denyDescribeTableTransport struct {
+	base http.RoundTripper
+}
+
+func (t *denyDescribeTableTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.Header.Get("X-Amz-Target") == "DynamoDB_20120810.DescribeTable" {
+		body := `{"__type":"com.amazon.coral.service#AccessDeniedException",` +
+			`"message":"User: arn:aws:iam::123456789012:user/zot is not authorized to perform: ` +
+			`dynamodb:DescribeTable on resource: arn:aws:dynamodb:us-east-2:123456789012:table/BlobTable"}`
+
+		return &http.Response{
+			StatusCode: http.StatusBadRequest,
+			Status:     "400 Bad Request",
+			Header: http.Header{
+				"Content-Type":     []string{"application/x-amz-json-1.0"},
+				"X-Amzn-Errortype": []string{"AccessDeniedException"},
+			},
+			Body:    io.NopCloser(bytes.NewBufferString(body)),
+			Request: req,
+		}, nil
+	}
+
+	return t.base.RoundTrip(req)
+}
+
+func newDenyDescribeTableDriver(t *testing.T) *DynamoDBDriver {
+	t.Helper()
+
+	endpoint := os.Getenv("DYNAMODBMOCK_ENDPOINT")
+
+	httpClient := &http.Client{Transport: &denyDescribeTableTransport{base: http.DefaultTransport}}
+
+	cfg, err := awsconfig.LoadDefaultConfig(context.Background(),
+		awsconfig.WithRegion("us-east-2"),
+		awsconfig.WithHTTPClient(httpClient),
+	)
+	So(err, ShouldBeNil)
+
+	client := dynamodb.NewFromConfig(cfg, func(o *dynamodb.Options) {
+		o.BaseEndpoint = aws.String(endpoint)
+	})
+
+	return &DynamoDBDriver{client: client, log: log.NewTestLogger()}
+}
+
+func TestNewTableWithoutDescribeTablePermission(t *testing.T) {
+	tskip.SkipDynamo(t)
+
+	Convey("NewTable falls back to CreateTable when dynamodb:DescribeTable is denied", t, func() {
+		Convey("table does not exist yet", func() {
+			const tableName = "Issue4259NewTableNoDescribe"
+
+			deniedDriver := newDenyDescribeTableDriver(t)
+			So(deniedDriver.NewTable(tableName), ShouldBeNil)
+			So(deniedDriver.tableName, ShouldEqual, tableName)
+		})
+
+		Convey("table already exists", func() {
+			const tableName = "Issue4259ExistingTableNoDescribe"
+
+			endpoint := os.Getenv("DYNAMODBMOCK_ENDPOINT")
+
+			plainCfg, err := awsconfig.LoadDefaultConfig(context.Background(), awsconfig.WithRegion("us-east-2"))
+			So(err, ShouldBeNil)
+
+			plainClient := dynamodb.NewFromConfig(plainCfg, func(o *dynamodb.Options) {
+				o.BaseEndpoint = aws.String(endpoint)
+			})
+
+			driver := &DynamoDBDriver{client: plainClient, log: log.NewTestLogger()}
+			So(driver.NewTable(tableName), ShouldBeNil)
+
+			// CreateTable will fail with ResourceInUseException; since confirming via DescribeTable
+			// is also denied, that should still be tolerated as benign.
+			deniedDriver := newDenyDescribeTableDriver(t)
+			So(deniedDriver.NewTable(tableName), ShouldBeNil)
+			So(deniedDriver.tableName, ShouldEqual, tableName)
+		})
+	})
+}


### PR DESCRIPTION
The storage-cache DynamoDB driver's NewTable always called CreateTable on startup and only tolerated the error when it happened to contain "Table already exists" (a ResourceInUseException, returned when the caller has CreateTable permission and the table exists). When the caller instead lacks dynamodb:CreateTable entirely -- even with full read/write/describe access to an existing table -- IAM denies the API call before DynamoDB ever checks the table's existence, so the driver got an AccessDeniedException it didn't recognize and zot failed to start.

Add tableExists (via DescribeTable, which the caller does have permission for) and only call CreateTable when the table is genuinely missing, mirroring the pattern already used by the metaDB DynamoDB driver in pkg/meta/dynamodb/dynamodb.go. Use errors.As against the typed SDK exceptions instead of matching on err.Error() substrings.

Added an internal regression test that intercepts only the CreateTable call against a real (localstack) DynamoDB endpoint to simulate the IAM policy from the report, proving it fails on the old code and passes with this fix.

Fixes https://github.com/project-zot/zot/issues/4259

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
