### PR TITLE
fix(ci): stabilize blackbox GC and HTTP events tests

### DIFF
--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -7702,9 +7702,8 @@ func TestSyncImageIndex(t *testing.T) {
 				dcm.StartAndWait(dctlr.Config.HTTP.Port)
 				defer dcm.StopServer()
 
-				// give it time to set up sync
-				t.Logf("waitsync(%s, %s)", dctlr.Config.Storage.RootDirectory, "index")
-				waitSync(dctlr.Config.Storage.RootDirectory, "index")
+				// Wait for SyncRepo to finish processing all tags for the "index" repo.
+				So(waitFinishedSyncingRepo(dctlr.Config.Log.Output, "index", 60*time.Second), ShouldBeTrue)
 
 				resp, err = resty.R().SetHeader("Content-Type", ispec.MediaTypeImageIndex).
 					Get(destBaseURL + "/v2/index/manifests/root")
@@ -8506,4 +8505,45 @@ func waitSyncFinish(logPath string) bool {
 	}
 
 	return found
+}
+
+// syncRepoLogEntry is a subset of a zot JSON log line used by waitFinishedSyncingRepo.
+type syncRepoLogEntry struct {
+	Message string `json:"message"`
+	Repo    string `json:"repo"`
+}
+
+// waitFinishedSyncingRepo polls logPath until a JSON line reports finished sync for repo.
+// Unmarshaling avoids depending on JSON key order in the log line.
+func waitFinishedSyncingRepo(logPath, repo string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(logPath)
+		if err != nil {
+			// Tolerate missing log while the server is still starting; fail fast otherwise.
+			if !errors.Is(err, os.ErrNotExist) {
+				panic(err)
+			}
+		} else {
+			for line := range strings.SplitSeq(string(data), "\n") {
+				if line == "" {
+					continue
+				}
+
+				var entry syncRepoLogEntry
+				if err := json.Unmarshal([]byte(line), &entry); err != nil {
+					continue
+				}
+
+				if entry.Message == "sync: finished syncing repo" && entry.Repo == repo {
+					return true
+				}
+			}
+		}
+
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	return false
 }

--- a/test/blackbox/events_http.bats
+++ b/test/blackbox/events_http.bats
@@ -34,7 +34,7 @@ function setup_file() {
     http_event_dir="${BATS_FILE_TMPDIR}/http_events"
     http_server_start http_receiver "${http_server_port}" "${http_event_dir}"
     echo ${http_server_port} > ${BATS_FILE_TMPDIR}/http_server.port
-    wait_for_http_server $http_server_port
+    wait_for_http_server $http_server_port http_receiver
 
     skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.20 oci:${TEST_DATA_DIR}/golang:1.20
 

--- a/test/blackbox/events_http_lint_failure.bats
+++ b/test/blackbox/events_http_lint_failure.bats
@@ -39,7 +39,7 @@ function setup_file() {
     http_event_dir="${BATS_FILE_TMPDIR}/http_events"
     http_server_start http_receiver_lint "${http_server_port}" "${http_event_dir}"
     echo ${http_server_port} > ${BATS_FILE_TMPDIR}/http_server.port
-    wait_for_http_server $http_server_port
+    wait_for_http_server $http_server_port http_receiver_lint
 
     skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.20 oci:${TEST_DATA_DIR}/golang:1.20
 

--- a/test/blackbox/events_sink_failure.bats
+++ b/test/blackbox/events_sink_failure.bats
@@ -33,7 +33,7 @@ function setup_file() {
     http_server_port=$(get_free_port_for_service "http")
     http_event_dir="${BATS_FILE_TMPDIR}/http_events"
     http_server_start http_receiver_failure "${http_server_port}" "${http_event_dir}"
-    wait_for_http_server $http_server_port
+    wait_for_http_server $http_server_port http_receiver_failure
 
     skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.20 oci:${TEST_DATA_DIR}/golang:1.20
 

--- a/test/blackbox/garbage_collect.bats
+++ b/test/blackbox/garbage_collect.bats
@@ -21,8 +21,15 @@ function setup_file() {
         exit 1
     fi
 
-    # Download test data to folder common for the entire suite, not just this file
-    skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.20 oci:${TEST_DATA_DIR}/golang:1.20
+    # Prefetch fixtures into a local OCI layout (same pattern as metadata.bats /
+    # anonymous_policy.bats / alpine above). Network fetch happens here, before
+    # zot GC is running; tests only copy oci: -> docker://localhost.
+    skopeo --insecure-policy copy --format=oci \
+        docker://ghcr.io/project-zot/test-images/alpine:3.17.3 \
+        oci:${TEST_DATA_DIR}/alpine:3.17.3
+    skopeo --insecure-policy copy --format=oci --multi-arch=all \
+        docker://public.ecr.aws/docker/library/busybox:latest \
+        oci:${TEST_DATA_DIR}/busybox:latest
     # Setup zot server
     local zot_root_dir=${BATS_FILE_TMPDIR}/zot
     local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
@@ -76,15 +83,15 @@ function teardown_file() {
 @test "push image" {
     zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
     run skopeo --insecure-policy copy --dest-tls-verify=false \
-        oci:${TEST_DATA_DIR}/golang:1.20 \
-        docker://127.0.0.1:${zot_port}/golang:1.20
+        oci:${TEST_DATA_DIR}/alpine:3.17.3 \
+        docker://127.0.0.1:${zot_port}/alpine:3.17.3
     [ "$status" -eq 0 ]
     run curl http://127.0.0.1:${zot_port}/v2/_catalog
     [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.repositories[]') = '"golang"' ]
-    run curl http://127.0.0.1:${zot_port}/v2/golang/tags/list
+    [ $(echo "${lines[-1]}" | jq '.repositories[]') = '"alpine"' ]
+    run curl http://127.0.0.1:${zot_port}/v2/alpine/tags/list
     [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.20"' ]
+    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"3.17.3"' ]
 }
 
 @test "push image index" {
@@ -92,12 +99,12 @@ function teardown_file() {
     # --multi-arch below pushes an image index (containing many images) instead
     # of an image manifest (single image)
     run skopeo --insecure-policy copy --format=oci --dest-tls-verify=false --multi-arch=all \
-        docker://public.ecr.aws/docker/library/busybox:latest \
+        oci:${TEST_DATA_DIR}/busybox:latest \
         docker://127.0.0.1:${zot_port}/busybox:latest
     [ "$status" -eq 0 ]
     run curl http://127.0.0.1:${zot_port}/v2/_catalog
     [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.repositories[0]') = '"busybox"' ]
+    echo "${lines[-1]}" | jq -e '.repositories | index("busybox") != null'
     run curl http://127.0.0.1:${zot_port}/v2/busybox/tags/list
     [ "$status" -eq 0 ]
     [ $(echo "${lines[-1]}" | jq '.tags[]') = '"latest"' ]
@@ -107,18 +114,18 @@ function teardown_file() {
     zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
     # attach signature to image
     echo "{\"artifact\": \"\", \"signature\": \"pat hancock\"}" > signature.json
-    run oras attach --disable-path-validation --plain-http 127.0.0.1:${zot_port}/golang:1.20 --artifact-type 'signature/example' ./signature.json:application/json
+    run oras attach --disable-path-validation --plain-http 127.0.0.1:${zot_port}/alpine:3.17.3 --artifact-type 'signature/example' ./signature.json:application/json
     [ "$status" -eq 0 ]
     # attach sbom to image
-    echo "{\"version\": \"0.0.0.0\", \"artifact\": \"'127.0.0.1:${zot_port}/golang:1.20'\", \"contents\": \"good\"}" > sbom.json
-    run oras attach --disable-path-validation --plain-http 127.0.0.1:${zot_port}/golang:1.20 --artifact-type 'sbom/example' ./sbom.json:application/json
+    echo "{\"version\": \"0.0.0.0\", \"artifact\": \"'127.0.0.1:${zot_port}/alpine:3.17.3'\", \"contents\": \"good\"}" > sbom.json
+    run oras attach --disable-path-validation --plain-http 127.0.0.1:${zot_port}/alpine:3.17.3 --artifact-type 'sbom/example' ./sbom.json:application/json
     [ "$status" -eq 0 ]
 
     # attach signature to index image
     run oras attach --disable-path-validation --plain-http 127.0.0.1:${zot_port}/busybox:latest --artifact-type 'signature/example' ./signature.json:application/json
     [ "$status" -eq 0 ]
     # attach sbom to index image
-    echo "{\"version\": \"0.0.0.0\", \"artifact\": \"'127.0.0.1:${zot_port}/golang:1.20'\", \"contents\": \"good\"}" > sbom.json
+    echo "{\"version\": \"0.0.0.0\", \"artifact\": \"'127.0.0.1:${zot_port}/alpine:3.17.3'\", \"contents\": \"good\"}" > sbom.json
     run oras attach --disable-path-validation --plain-http 127.0.0.1:${zot_port}/busybox:latest --artifact-type 'sbom/example' ./sbom.json:application/json
     [ "$status" -eq 0 ]
 }
@@ -128,12 +135,12 @@ function teardown_file() {
     run regctl registry set 127.0.0.1:${zot_port} --tls disabled
     [ "$status" -eq 0 ]
 
-    run regctl artifact put --artifact-type application/vnd.example.artifact --subject 127.0.0.1:${zot_port}/golang:1.20 <<EOF
+    run regctl artifact put --artifact-type application/vnd.example.artifact --subject 127.0.0.1:${zot_port}/alpine:3.17.3 <<EOF
 this is an artifact
 EOF
     [ "$status" -eq 0 ]
 
-    run regctl artifact get --subject 127.0.0.1:${zot_port}/golang:1.20
+    run regctl artifact get --subject 127.0.0.1:${zot_port}/alpine:3.17.3
     [ "$status" -eq 0 ]
 
     run regctl artifact put --artifact-type application/vnd.example.artifact --subject 127.0.0.1:${zot_port}/busybox:latest <<EOF
@@ -148,7 +155,7 @@ EOF
 @test "garbage collect all artifacts after image delete" {
     zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
     run skopeo --insecure-policy delete --tls-verify=false \
-        docker://127.0.0.1:${zot_port}/golang:1.20
+        docker://127.0.0.1:${zot_port}/alpine:3.17.3
     [ "$status" -eq 0 ]
 
     run skopeo --insecure-policy delete --tls-verify=false \
@@ -159,13 +166,13 @@ EOF
     sleep 100
 
     # gc should have removed artifacts
-    run regctl artifact get --subject 127.0.0.1:${zot_port}/golang:1.20
+    run regctl artifact get --subject 127.0.0.1:${zot_port}/alpine:3.17.3
     [ "$status" -eq 1 ]
 
     run regctl artifact get --subject 127.0.0.1:${zot_port}/busybox:latest
     [ "$status" -eq 1 ]
 
-    run oras discover --plain-http -o json 127.0.0.1:${zot_port}/golang:1.20
+    run oras discover --plain-http -o json 127.0.0.1:${zot_port}/alpine:3.17.3
     [ "$status" -eq 1 ]
 
     run oras discover --plain-http -o json 127.0.0.1:${zot_port}/busybox:latest
@@ -176,5 +183,3 @@ EOF
     [ "$status" -eq 0 ]
     [ $(echo "${lines[-1]}" | jq -r '.repositories | length') -eq 0 ]
 }
-
-

--- a/test/blackbox/helpers_events.bash
+++ b/test/blackbox/helpers_events.bash
@@ -37,69 +37,84 @@ function http_server_start() {
 
     echo "# starting HTTP server container '${cname}' on port ${port}..." >&3
 
+    # Use stdlib only (no pip install) so readiness is not gated on PyPI.
     docker run -d --rm --name "${cname}" \
         -p "${port}:8080" \
         -v "${dir}":/data \
         ghcr.io/project-zot/ci-images/python:3.11 sh -c ' \
-            echo "Installing Flask..." >&2 && \
-            pip install flask > /dev/null 2>&1 && \
-            echo "Flask installed, starting server..." >&2 && \
             echo "
-import os
+import base64
 import json
-from flask import Flask, request, Response
-
-app = Flask(__name__)
-counter = 0
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 USERNAME = \"jane.joe\"
 PASSWORD = \"opensesame\"
+counter = 0
 
-def check_auth(auth):
-    return auth and auth.username == USERNAME and auth.password == PASSWORD
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        return
 
-def authenticate():
-    return Response(
-        \"Unauthorized\", 401,
-        {\"WWW-Authenticate\": \"Basic realm=\\\"Login Required\\\"\"}
-    )
+    def _unauthorized(self):
+        self.send_response(401)
+        self.send_header(\"WWW-Authenticate\", \"Basic realm=\\\"Login Required\\\"\")
+        self.end_headers()
+        self.wfile.write(b\"Unauthorized\")
 
-@app.route(\"/reset\", methods=[\"GET\"])
-def reset_counter():
-    global counter
-    counter = 0
-    return \"\", 200
+    def _authorized(self):
+        auth = self.headers.get(\"Authorization\", \"\")
+        if not auth.startswith(\"Basic \"):
+            return False
+        try:
+            decoded = base64.b64decode(auth[6:]).decode(\"utf-8\")
+        except Exception:
+            return False
+        user, _, password = decoded.partition(\":\")
+        return user == USERNAME and password == PASSWORD
 
-@app.route(\"/events\", methods=[\"POST\"])
-def receive_event():
-    auth = request.authorization
-    if not check_auth(auth):
-      return authenticate
+    def do_GET(self):
+        global counter
+        if self.path != \"/reset\":
+            self.send_response(404)
+            self.end_headers()
+            return
+        counter = 0
+        self.send_response(200)
+        self.end_headers()
 
-    global counter
-    counter += 1
-    method = request.method
-    headers = dict(request.headers)
-    raw_data = request.data.decode(\"utf-8\", errors=\"replace\")
-    try:
-        body = json.loads(raw_data)
-    except Exception:
-        body = raw_data  # fallback to plain text
+    def do_POST(self):
+        global counter
+        if self.path != \"/events\":
+            self.send_response(404)
+            self.end_headers()
+            return
+        if not self._authorized():
+            self._unauthorized()
+            return
+        try:
+            length = int(self.headers.get(\"Content-Length\", \"0\"))
+        except ValueError:
+            self.send_response(400)
+            self.end_headers()
+            return
+        raw_data = self.rfile.read(length).decode(\"utf-8\", errors=\"replace\")
+        try:
+            body = json.loads(raw_data)
+        except Exception:
+            body = raw_data
+        counter += 1
+        event = {
+            \"method\": self.command,
+            \"headers\": dict(self.headers),
+            \"body\": body,
+        }
+        with open(f\"/data/{counter}.json\", \"w\") as f:
+            json.dump(event, f, indent=2)
+        self.send_response(200)
+        self.end_headers()
 
-    event = {
-        \"method\": method,
-        \"headers\": headers,
-        \"body\": body
-    }
-
-    filename = f\"/data/{counter}.json\"
-
-    with open(filename, \"w\") as f:
-        json.dump(event, f, indent=2)
-
-    return \"\", 200
-
-app.run(host=\"0.0.0.0\", port=8080)
+# Single-threaded so counter + /data/{n}.json stay deterministic under concurrent POSTs.
+HTTPServer((\"0.0.0.0\", 8080), Handler).serve_forever()
             " > app.py && python app.py
 '
 
@@ -107,11 +122,11 @@ app.run(host=\"0.0.0.0\", port=8080)
     sleep 2
 
     # Check if container is running
-    if docker ps --format "table {{.Names}}" | grep -q "^${cname}$"; then
+    if docker ps --format "{{.Names}}" | grep -qx "${cname}"; then
         echo "# HTTP server container '${cname}' started successfully" >&3
     else
         echo "# WARNING: HTTP server container '${cname}' may not have started properly" >&3
-        docker logs "${cname}" 2>&1 | head -10 >&3
+        docker logs "${cname}" >&3 2>&1 || true
     fi
 }
 
@@ -122,23 +137,35 @@ function http_server_stop() {
 
 function wait_for_http_server() {
     local port="$1"
-    local timeout=30
+    local cname="${2:-}"
+    local timeout=60
+    local start_ts=$SECONDS
     local elapsed=0
+    local last_log=0
 
     echo "# waiting for HTTP server on port ${port}..." >&3
 
-    while [ "$elapsed" -lt "$timeout" ]; do
-        if curl --silent --fail --output /dev/null "http://127.0.0.1:${port}/reset"; then
+    while [ $((SECONDS - start_ts)) -lt "$timeout" ]; do
+        if curl --silent --fail --connect-timeout 3 --max-time 5 \
+            --output /dev/null "http://127.0.0.1:${port}/reset"; then
+            elapsed=$((SECONDS - start_ts))
             echo "# HTTP server ready on port ${port} after ${elapsed}s" >&3
             return 0
         fi
         sleep 1
-        elapsed=$((elapsed + 1))
-        if [ $((elapsed % 5)) -eq 0 ]; then
+        elapsed=$((SECONDS - start_ts))
+        if [ $((elapsed - last_log)) -ge 5 ]; then
             echo "# still waiting for HTTP server on port ${port}... (${elapsed}s elapsed)" >&3
+            last_log=$elapsed
         fi
     done
 
-    echo "# HTTP server failed to start on port ${port} after ${timeout}s" >&3
+    elapsed=$((SECONDS - start_ts))
+    echo "# HTTP server failed to start on port ${port} after ${elapsed}s" >&3
+    if [ -n "${cname}" ]; then
+        echo "# docker logs for '${cname}':" >&3
+        docker logs "${cname}" >&3 2>&1 || true
+        docker inspect "${cname}" --format '{{.State.Status}} {{.State.Error}}' >&3 2>&1 || true
+    fi
     return 1
 }


### PR DESCRIPTION
Use a small alpine image in garbage_collect so pushes finish within gcDelay, and replace the Flask/pip HTTP sink with a stdlib server so events tests are not gated on PyPI install time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
