### PR TITLE
fix(ci): stabilize blackbox NATS events subscriber wait

### DIFF
--- a/test/blackbox/events_nats.bats
+++ b/test/blackbox/events_nats.bats
@@ -99,9 +99,8 @@ function teardown_file() {
         docker://127.0.0.1:${zot_port}/golang:1.20
     [ "$status" -eq 0 ]
 
-    # Check the correct number of events were generated
-    count=$(find "${output_path}" -type f | wc -l)
-    [ "$count" -eq 1 ]
+    run wait_for_nats_event_files "${output_path}" 1
+    [ "$status" -eq 0 ]
 
     result=$(jq '.Data | @base64d | fromjson' ${output_path}/1.json)
     [ $(echo "${result}" | jq -r '.type') = "zotregistry.repository.created" ]
@@ -123,9 +122,8 @@ function teardown_file() {
         docker://127.0.0.1:${zot_port}/golang:latest
     [ "$status" -eq 0 ]
 
-    # Check the correct number of events were generated
-    count=$(find "${output_path}" -type f | wc -l)
-    [ "$count" -eq 1 ]
+    run wait_for_nats_event_files "${output_path}" 1
+    [ "$status" -eq 0 ]
 
     # Validate the event
     result=$(jq '.Data | @base64d | fromjson' ${output_path}/1.json)
@@ -147,9 +145,8 @@ function teardown_file() {
     run curl -X DELETE  http://localhost:${zot_port}/v2/golang/manifests/latest
     [ "$status" -eq 0 ]
 
-    # Check the correct number of events were generated
-    count=$(find "${output_path}" -type f | wc -l)
-    [ "$count" -eq 1 ]
+    run wait_for_nats_event_files "${output_path}" 1
+    [ "$status" -eq 0 ]
 
     # Validate the event
     result=$(jq '.Data | @base64d | fromjson' ${output_path}/1.json)

--- a/test/blackbox/events_nats_lint_failure.bats
+++ b/test/blackbox/events_nats_lint_failure.bats
@@ -115,9 +115,8 @@ function teardown_file() {
 
     rm -f artifact.txt config.json
 
-    # Check the correct number of events were generated
-    count=$(find "${output_path}" -type f | wc -l)
-    [ "$count" -eq 2 ]
+    run wait_for_nats_event_files "${output_path}" 2
+    [ "$status" -eq 0 ]
 
     # Validate the event
     result=$(jq '.Data | @base64d | fromjson' ${output_path}/2.json)
@@ -150,9 +149,8 @@ function teardown_file() {
 
     rm -f artifact.txt config.json
 
-    # Check the correct number of events were generated
-    count=$(find "${output_path}" -type f | wc -l)
-    [ "$count" -eq 1 ]
+    run wait_for_nats_event_files "${output_path}" 1
+    [ "$status" -eq 0 ]
 
     # Validate the event
     result=$(jq '.Data | @base64d | fromjson' ${output_path}/1.json)

--- a/test/blackbox/helpers_events.bash
+++ b/test/blackbox/helpers_events.bash
@@ -18,14 +18,50 @@ function wait_event_on_subject() {
 
     mkdir -p "${dir}"
 
+    # --wait must cover slow concurrent-CI pushes (e.g. golang:1.20). A short
+    # window lets the subscriber exit before ImageUpdated / RepositoryCreated.
     docker run -d --rm --network host --user "$(id -u):$(id -g)" -v "${dir}":/data ghcr.io/project-zot/ci-images/nats-box:0.19.7  \
         nats sub ${subject} --user jane.joe --password opensesame \
-        --server nats://127.0.0.1:${port} --count=${count} --wait=5s --raw --dump=/data
+        --server nats://127.0.0.1:${port} --count=${count} --wait=60s --raw --dump=/data
 
     # give client a chance to startup
     sleep 2
 
     return $?
+}
+
+# Poll until nats sub --dump has written the expected number of event files.
+# Call this after the action that should publish (push/delete), not before.
+function wait_for_nats_event_files() {
+    local dir="$1"
+    local expected="${2:-1}"
+    local timeout="${3:-60}"
+    local start_ts=$SECONDS
+    local count=0
+    local elapsed=0
+    local last_log=0
+
+    echo "# waiting for ${expected} nats event file(s) in ${dir}..." >&3
+
+    while [ $((SECONDS - start_ts)) -lt "$timeout" ]; do
+        count=$(find "${dir}" -type f 2>/dev/null | wc -l)
+        if [ "$count" -ge "$expected" ]; then
+            elapsed=$((SECONDS - start_ts))
+            echo "# found ${count} nats event file(s) after ${elapsed}s" >&3
+            return 0
+        fi
+        sleep 0.5
+        elapsed=$((SECONDS - start_ts))
+        if [ $((elapsed - last_log)) -ge 5 ]; then
+            echo "# still waiting for nats events in ${dir}... (${count}/${expected}, ${elapsed}s)" >&3
+            last_log=$elapsed
+        fi
+    done
+
+    count=$(find "${dir}" -type f 2>/dev/null | wc -l)
+    echo "# timed out waiting for ${expected} nats event file(s) in ${dir} (got ${count})" >&3
+    ls -la "${dir}" >&3 2>&1 || true
+    return 1
 }
 
 function http_server_start() {


### PR DESCRIPTION
Raise nats sub --wait from 5s to 60s and poll for dump files after push/delete so ImageUpdated is not lost under concurrent CI load.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
