### PR TITLE
fix(api): require update for digest multi-tag overwrites

### DIFF
--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -19,6 +20,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/cel"
 	"zotregistry.dev/zot/v2/pkg/common"
 	"zotregistry.dev/zot/v2/pkg/log"
+	zreg "zotregistry.dev/zot/v2/pkg/regexp"
 	reqCtx "zotregistry.dev/zot/v2/pkg/requestcontext"
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 )
@@ -696,17 +698,36 @@ func DistSpecAuthzHandler(ctlr *Controller) mux.MiddlewareFunc {
 			}
 
 			if request.Method == http.MethodPut || request.Method == http.MethodPatch || request.Method == http.MethodPost {
-				// assume user wants to create
 				action = constants.CreatePermission
-				// if we get a reference (tag)
+
 				if ok {
 					is := ctlr.StoreController.GetImageStore(resource)
 
 					tags, err := is.GetImageTags(resource)
-					if err == nil && slices.Contains(tags, reference) {
-						// if repo exists and request's tag exists then action is UPDATE
-						action = constants.UpdatePermission
+					repoTags, repoTagErr := repoTagsForManifestWriteAuthz(tags, err)
+					if repoTagErr != nil {
+						// Fail closed if we cannot verify current tags for this repo.
+						ctlr.Log.Error().Err(repoTagErr).Str("repository", resource).
+							Msg("unable to verify permissions on existing tags")
+						response.WriteHeader(http.StatusInternalServerError)
+
+						return
 					}
+
+					// Collect and enforce every create/update check for this write
+					// (path tag and/or digest ?tag=), then allow the request.
+					denyReason, allowed := authorizeManifestWrite(
+						acCtrlr, request, userAc, resource, reference, repoTags, request.URL.Query()["tag"])
+					if !allowed {
+						common.AuthzFailWithReason(response, request, userAc.GetUsername(),
+							realm, failDelay, denyReason)
+
+						return
+					}
+
+					next.ServeHTTP(response, request) //nolint:contextcheck
+
+					return
 				}
 			}
 
@@ -722,6 +743,148 @@ func DistSpecAuthzHandler(ctlr *Controller) mux.MiddlewareFunc {
 			}
 		})
 	}
+}
+
+// manifestWriteAuthzCheck is one (permission, reference) pair required for a manifest write.
+type manifestWriteAuthzCheck struct {
+	action    string
+	reference string
+}
+
+// manifestWriteAuthzChecks returns every (permission, reference) check required for a
+// manifest PUT/POST/PATCH.
+//
+// Two path shapes are handled separately:
+//
+//  1. Tag path — PUT .../manifests/<tag>
+//     The route handler rejects tag= query params on this path. Authz only decides
+//     create vs update for the path tag itself.
+//
+//  2. Digest path — PUT .../manifests/<digest>?tag=...
+//     Each valid ?tag= is authorized by name (update if it already exists, create if
+//     new). The digest path reference is also authorized: create when any new tag is
+//     introduced or when there are no tag ops; update when any existing tag is moved.
+//     Mixed requests therefore require both create and update on the digest (for CEL
+//     conditions that key off referenceType=digest) in addition to the per-tag checks.
+func manifestWriteAuthzChecks(repoTags []string, reference string, rawTagQuery []string) []manifestWriteAuthzCheck {
+	// Tag path: ?tag= query params are not valid here.
+	if !common.IsDigest(reference) {
+		action := constants.CreatePermission
+		if slices.Contains(repoTags, reference) {
+			action = constants.UpdatePermission
+		}
+
+		return []manifestWriteAuthzCheck{{
+			action:    action,
+			reference: reference,
+		}}
+	}
+
+	// Digest path: authorize each ?tag= by name, then the digest itself.
+	existingQueryTags, newQueryTags := classifyDigestQueryTags(repoTags, rawTagQuery)
+
+	checks := make([]manifestWriteAuthzCheck, 0, len(existingQueryTags)+len(newQueryTags)+2)
+
+	for _, tag := range existingQueryTags {
+		checks = append(checks, manifestWriteAuthzCheck{
+			action:    constants.UpdatePermission,
+			reference: tag,
+		})
+	}
+
+	for _, tag := range newQueryTags {
+		checks = append(checks, manifestWriteAuthzCheck{
+			action:    constants.CreatePermission,
+			reference: tag,
+		})
+	}
+
+	// Digest path reference (CEL may use req.referenceType == "digest").
+	if len(newQueryTags) > 0 || len(existingQueryTags) == 0 {
+		checks = append(checks, manifestWriteAuthzCheck{
+			action:    constants.CreatePermission,
+			reference: reference,
+		})
+	}
+
+	if len(existingQueryTags) > 0 {
+		checks = append(checks, manifestWriteAuthzCheck{
+			action:    constants.UpdatePermission,
+			reference: reference,
+		})
+	}
+
+	return checks
+}
+
+// authorizeManifestWrite verifies the user has every permission required for this
+// manifest write (see manifestWriteAuthzChecks). When allowed is false, the deny
+// reason should be surfaced to the client.
+func authorizeManifestWrite(
+	acCtrlr *AccessController, request *http.Request, userAc *reqCtx.UserAccessControl,
+	resource, reference string, repoTags, rawTagQuery []string,
+) (string, bool) {
+	for _, check := range manifestWriteAuthzChecks(repoTags, reference, rawTagQuery) {
+		can, reason := acCtrlr.can(request, userAc, check.action, resource, check.reference)
+		if !can {
+			return reason, false
+		}
+	}
+
+	return "", true
+}
+
+// classifyDigestQueryTags splits valid tag= query values into those that already
+// exist in the repository and those that are new (both deduplicated, in query order).
+// Empty and invalid values are skipped so authz can still enforce permissions when
+// mixed with params the route handler will later reject with 400.
+func classifyDigestQueryTags(existingRepoTags, rawTagQuery []string) ([]string, []string) {
+	seenExisting := map[string]struct{}{}
+	seenNew := map[string]struct{}{}
+
+	existing := make([]string, 0, len(rawTagQuery))
+	newTags := make([]string, 0, len(rawTagQuery))
+
+	for _, rawTag := range rawTagQuery {
+		cleanedTag := strings.TrimSpace(rawTag)
+		if cleanedTag == "" || !zreg.IsDistributionSpecTag(cleanedTag) {
+			continue
+		}
+
+		if slices.Contains(existingRepoTags, cleanedTag) {
+			if _, ok := seenExisting[cleanedTag]; ok {
+				continue
+			}
+
+			seenExisting[cleanedTag] = struct{}{}
+			existing = append(existing, cleanedTag)
+
+			continue
+		}
+
+		if _, ok := seenNew[cleanedTag]; ok {
+			continue
+		}
+
+		seenNew[cleanedTag] = struct{}{}
+		newTags = append(newTags, cleanedTag)
+	}
+
+	return existing, newTags
+}
+
+// repoTagsForManifestWriteAuthz returns the repository tags to use for manifest
+// write authz checks and fails closed on unexpected storage errors.
+func repoTagsForManifestWriteAuthz(tags []string, err error) ([]string, error) {
+	if err == nil {
+		return tags, nil
+	}
+
+	if errors.Is(err, zerr.ErrRepoNotFound) {
+		return []string{}, nil
+	}
+
+	return nil, err
 }
 
 func MetricsAuthzHandler(ctlr *Controller) mux.MiddlewareFunc {

--- a/pkg/api/authz_internal_test.go
+++ b/pkg/api/authz_internal_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"crypto/tls"
+	"errors"
+	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api/constants"
 	"zotregistry.dev/zot/v2/pkg/log"
 	reqCtx "zotregistry.dev/zot/v2/pkg/requestcontext"
+	zerr "zotregistry.dev/zot/v2/errors"
 )
 
 // permitted returns just the bool from AccessController.isPermitted; tests
@@ -762,5 +765,294 @@ func TestAdminPolicyConditions(t *testing.T) {
 		bob.SetUsername("bob")
 		can, _ := ac.can(httpReqTLS, bob, constants.ReadPermission, "any/repo", "ref")
 		assert.False(t, can)
+	})
+}
+
+func TestClassifyDigestQueryTags(t *testing.T) {
+	t.Parallel()
+
+	existingRepoTags := []string{"stable", "latest", "dev"}
+
+	existing, newTags := classifyDigestQueryTags(existingRepoTags, []string{"new", "stable"})
+	assert.Equal(t, []string{"stable"}, existing)
+	assert.Equal(t, []string{"new"}, newTags)
+
+	existing, newTags = classifyDigestQueryTags(existingRepoTags, []string{"", "bad/ref", "stable", "latest", "stable"})
+	assert.Equal(t, []string{"stable", "latest"}, existing)
+	assert.Empty(t, newTags)
+
+	existing, newTags = classifyDigestQueryTags(existingRepoTags, []string{"brand-new", "bad/ref", "", "brand-new"})
+	assert.Empty(t, existing)
+	assert.Equal(t, []string{"brand-new"}, newTags)
+
+	existing, newTags = classifyDigestQueryTags(existingRepoTags, nil)
+	assert.Empty(t, existing)
+	assert.Empty(t, newTags)
+
+	existing, newTags = classifyDigestQueryTags(existingRepoTags, []string{"  edge  ", "edge", "stable", "  "})
+	assert.Equal(t, []string{"stable"}, existing)
+	assert.Equal(t, []string{"edge"}, newTags)
+}
+
+func TestManifestWriteAuthzChecks(t *testing.T) {
+	t.Parallel()
+
+	repoTags := []string{"stable", "dev"}
+	digest := "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	t.Run("tag path overwrite requires update on that tag", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, []manifestWriteAuthzCheck{
+			{action: constants.UpdatePermission, reference: "stable"},
+		}, manifestWriteAuthzChecks(repoTags, "stable", []string{"ignored-by-route"}))
+	})
+
+	t.Run("tag path first push requires create on that tag", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, []manifestWriteAuthzCheck{
+			{action: constants.CreatePermission, reference: "v1"},
+		}, manifestWriteAuthzChecks(repoTags, "v1", nil))
+	})
+
+	t.Run("digest with only new tags requires create on each tag and digest", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, []manifestWriteAuthzCheck{
+			{action: constants.CreatePermission, reference: "brand-new"},
+			{action: constants.CreatePermission, reference: "edge"},
+			{action: constants.CreatePermission, reference: digest},
+		}, manifestWriteAuthzChecks(repoTags, digest, []string{"brand-new", "edge"}))
+	})
+
+	t.Run("digest overwriting existing tags requires update on each tag and digest", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, []manifestWriteAuthzCheck{
+			{action: constants.UpdatePermission, reference: "stable"},
+			{action: constants.UpdatePermission, reference: "dev"},
+			{action: constants.UpdatePermission, reference: digest},
+		}, manifestWriteAuthzChecks(repoTags, digest, []string{"stable", "dev"}))
+	})
+
+	t.Run("digest mix requires per-tag create/update plus create and update on digest", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, []manifestWriteAuthzCheck{
+			{action: constants.UpdatePermission, reference: "stable"},
+			{action: constants.CreatePermission, reference: "brand-new"},
+			{action: constants.CreatePermission, reference: digest},
+			{action: constants.UpdatePermission, reference: digest},
+		}, manifestWriteAuthzChecks(repoTags, digest, []string{"stable", "brand-new"}))
+	})
+
+	t.Run("digest with no tag query requires create on digest", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, []manifestWriteAuthzCheck{
+			{action: constants.CreatePermission, reference: digest},
+		}, manifestWriteAuthzChecks(repoTags, digest, nil))
+	})
+
+	t.Run("digest with only invalid tag query requires create on digest", func(t *testing.T) {
+		t.Parallel()
+
+		assert.Equal(t, []manifestWriteAuthzCheck{
+			{action: constants.CreatePermission, reference: digest},
+		}, manifestWriteAuthzChecks(repoTags, digest, []string{"", "bad/ref"}))
+	})
+}
+
+func TestAuthorizeManifestWrite(t *testing.T) {
+	t.Parallel()
+
+	digest := "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+	repoTags := []string{"stable", "dev"}
+	req := httptest.NewRequest(http.MethodPut, "/v2/repo/manifests/"+digest, nil)
+
+	makeAC := func(actions []string, conditions []config.Condition) *AccessController {
+		cfg := &config.AccessControlConfig{
+			Repositories: config.Repositories{
+				"**": config.PolicyGroup{Policies: []config.Policy{{
+					Users:      []string{"alice"},
+					Actions:    actions,
+					Conditions: conditions,
+				}}},
+			},
+		}
+		programs, err := CompileAccessControl(cfg)
+		if err != nil {
+			t.Fatalf("CompileAccessControl: %v", err)
+		}
+		cfg.StoreCompiledConditions(programs)
+
+		return &AccessController{Config: cfg, Log: log.NewLogger("debug", "")}
+	}
+
+	alice := reqCtx.NewUserAccessControl()
+	alice.SetUsername("alice")
+
+	t.Run("create and update allow digest mix", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]string{
+			constants.ReadPermission,
+			constants.CreatePermission,
+			constants.UpdatePermission,
+		}, nil)
+
+		reason, allowed := authorizeManifestWrite(ac, req, alice, "repo", digest, repoTags,
+			[]string{"stable", "brand-new"})
+		assert.True(t, allowed)
+		assert.Empty(t, reason)
+	})
+
+	t.Run("create-only denied when overwriting existing tag", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]string{
+			constants.ReadPermission,
+			constants.CreatePermission,
+		}, nil)
+
+		reason, allowed := authorizeManifestWrite(ac, req, alice, "repo", digest, repoTags,
+			[]string{"stable", "brand-new"})
+		assert.False(t, allowed)
+		assert.Empty(t, reason)
+	})
+
+	t.Run("update-only denied when creating new tag", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]string{
+			constants.ReadPermission,
+			constants.UpdatePermission,
+		}, nil)
+
+		reason, allowed := authorizeManifestWrite(ac, req, alice, "repo", digest, repoTags,
+			[]string{"stable", "brand-new"})
+		assert.False(t, allowed)
+		assert.Empty(t, reason)
+	})
+
+	t.Run("update-only allows overwrite of existing tags only", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]string{
+			constants.ReadPermission,
+			constants.UpdatePermission,
+		}, nil)
+
+		reason, allowed := authorizeManifestWrite(ac, req, alice, "repo", digest, repoTags,
+			[]string{"stable"})
+		assert.True(t, allowed)
+		assert.Empty(t, reason)
+	})
+
+	t.Run("create-only allows new tags only", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]string{
+			constants.ReadPermission,
+			constants.CreatePermission,
+		}, nil)
+
+		reason, allowed := authorizeManifestWrite(ac, req, alice, "repo", digest, repoTags,
+			[]string{"brand-new"})
+		assert.True(t, allowed)
+		assert.Empty(t, reason)
+	})
+
+	t.Run("tag path overwrite allowed with update", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]string{
+			constants.ReadPermission,
+			constants.UpdatePermission,
+		}, nil)
+
+		reason, allowed := authorizeManifestWrite(ac, req, alice, "repo", "stable", repoTags, nil)
+		assert.True(t, allowed)
+		assert.Empty(t, reason)
+	})
+
+	t.Run("tag path first push allowed with create", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]string{
+			constants.ReadPermission,
+			constants.CreatePermission,
+		}, nil)
+
+		reason, allowed := authorizeManifestWrite(ac, req, alice, "repo", "v1", repoTags, nil)
+		assert.True(t, allowed)
+		assert.Empty(t, reason)
+	})
+
+	t.Run("CEL denial on existing query tag surfaces message", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]string{
+			constants.ReadPermission,
+			constants.CreatePermission,
+			constants.UpdatePermission,
+		}, []config.Condition{{
+			Expression: `req.action != "update" || req.tag != "stable"`,
+			Message:    "stable tag is immutable",
+		}})
+
+		reason, allowed := authorizeManifestWrite(ac, req, alice, "repo", digest, repoTags,
+			[]string{"stable", "brand-new"})
+		assert.False(t, allowed)
+		assert.Equal(t, "stable tag is immutable", reason)
+	})
+
+	t.Run("CEL denial on digest path surfaces message", func(t *testing.T) {
+		t.Parallel()
+
+		ac := makeAC([]string{
+			constants.ReadPermission,
+			constants.CreatePermission,
+			constants.UpdatePermission,
+		}, []config.Condition{{
+			Expression: `req.referenceType != "digest"`,
+			Message:    "digest path reference not permitted",
+		}})
+
+		reason, allowed := authorizeManifestWrite(ac, req, alice, "repo", digest, repoTags,
+			[]string{"stable"})
+		assert.False(t, allowed)
+		assert.Equal(t, "digest path reference not permitted", reason)
+	})
+}
+
+func TestRepoTagsForManifestWriteAuthz(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no error returns discovered tags", func(t *testing.T) {
+		t.Parallel()
+
+		tags := []string{"stable", "dev"}
+		got, err := repoTagsForManifestWriteAuthz(tags, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, tags, got)
+	})
+
+	t.Run("repo not found maps to empty tags", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := repoTagsForManifestWriteAuthz([]string{"ignored"}, zerr.ErrRepoNotFound)
+		assert.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("unexpected storage error is returned", func(t *testing.T) {
+		t.Parallel()
+
+		expected := errors.New("storage backend unavailable")
+		got, err := repoTagsForManifestWriteAuthz(nil, expected)
+		assert.Nil(t, got)
+		assert.ErrorIs(t, err, expected)
 	})
 }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -5813,11 +5813,8 @@ func TestAuthorizationMountBlob(t *testing.T) {
 
 func TestAuthorizationForTagUpdate(t *testing.T) {
 	Convey("Test authorization for updating tags including latest", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
@@ -5857,7 +5854,7 @@ func TestAuthorizationForTagUpdate(t *testing.T) {
 			ctlr.Config.Storage.RootDirectory = dir
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(port)
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
 
 			userClient := resty.New()
@@ -5938,6 +5935,56 @@ func TestAuthorizationForTagUpdate(t *testing.T) {
 				So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
 			})
 
+			Convey("Digest multi-tag push overwriting an existing tag should fail without UPDATE permission", func() {
+				err := UploadImageWithBasicAuth(img, baseURL, testRepo, "stable", username, password)
+				So(err, ShouldBeNil)
+
+				imgAttacker := CreateImageWith().
+					RandomLayers(1, 22).
+					RandomConfig().
+					Build()
+
+				// Blobs may be uploaded with create; only the digest?tag= manifest write is denied.
+				err = UploadImageWithBasicAuth(imgAttacker, baseURL, testRepo, "attacker", username, password)
+				So(err, ShouldBeNil)
+
+				manifestBlob, err := json.Marshal(imgAttacker.Manifest)
+				So(err, ShouldBeNil)
+
+				manifestPutURL, err := url.Parse(baseURL + fmt.Sprintf("/v2/%s/manifests/%s",
+					testRepo, imgAttacker.ManifestDescriptor.Digest.String()))
+				So(err, ShouldBeNil)
+				manifestPutURL.RawQuery = "tag=stable"
+
+				resp, err := userClient.R().
+					SetHeader("Content-Type", ispec.MediaTypeImageManifest).
+					SetBody(manifestBlob).
+					Put(manifestPutURL.String())
+				So(err, ShouldBeNil)
+				So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
+
+				// Trusted tag must still point at the original image.
+				resp, err = userClient.R().Get(baseURL + fmt.Sprintf("/v2/%s/manifests/stable", testRepo))
+				So(err, ShouldBeNil)
+				So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+				So(resp.Header().Get(constants.DistContentDigestKey), ShouldEqual, img.ManifestDescriptor.Digest.String())
+			})
+
+			Convey("Digest multi-tag push with a new tag should succeed with CREATE permission", func() {
+				imgNew := CreateImageWith().
+					RandomLayers(1, 18).
+					RandomConfig().
+					Build()
+
+				err := UploadImageWithOpts(imgNew, baseURL, testRepo, imgNew.ManifestDescriptor.Digest.String(),
+					WithBasicAuth(username, password), WithExtraTags("brand-new"))
+				So(err, ShouldBeNil)
+
+				resp, err := userClient.R().Get(baseURL + fmt.Sprintf("/v2/%s/manifests/brand-new", testRepo))
+				So(err, ShouldBeNil)
+				So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			})
+
 			Convey("Updating tags should succeed with UPDATE permission", func() {
 				// Add UPDATE permission
 				conf.HTTP.AccessControl.Repositories[testRepo] = config.PolicyGroup{
@@ -5978,10 +6025,525 @@ func TestAuthorizationForTagUpdate(t *testing.T) {
 
 				err = UploadImageWithBasicAuth(imgUpdated2, baseURL, testRepo, "latest", username, password)
 				So(err, ShouldBeNil)
+
+				// Digest multi-tag overwrite of an existing tag also requires (and is allowed with) UPDATE
+				imgUpdated3 := CreateImageWith().
+					RandomLayers(1, 28).
+					RandomConfig().
+					Build()
+
+				err = UploadImageWithOpts(imgUpdated3, baseURL, testRepo, imgUpdated3.ManifestDescriptor.Digest.String(),
+					WithBasicAuth(username, password), WithExtraTags("v3.0"))
+				So(err, ShouldBeNil)
+
+				resp, err := userClient.R().Get(baseURL + fmt.Sprintf("/v2/%s/manifests/v3.0", testRepo))
+				So(err, ShouldBeNil)
+				So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+				So(resp.Header().Get(constants.DistContentDigestKey),
+					ShouldEqual, imgUpdated3.ManifestDescriptor.Digest.String())
 			})
 
 			So(seedUser, ShouldBeGreaterThan, 0)
 			So(seedPass, ShouldBeGreaterThan, 0)
+		})
+
+		Convey("Digest multi-tag overwrite also authorizes the path digest reference", func() {
+			testRepo := "digest-ref-check"
+
+			// Tag-path writes are allowed; digest path references are denied by condition.
+			// Checking only ?tag= (tag refs) would incorrectly allow the request; the path
+			// digest must still be authorized.
+			conf.HTTP.AccessControl = &config.AccessControlConfig{
+				Repositories: config.Repositories{
+					testRepo: config.PolicyGroup{
+						Policies: []config.Policy{
+							{
+								Users: []string{username},
+								Actions: []string{
+									constants.ReadPermission,
+									constants.CreatePermission,
+									constants.UpdatePermission,
+								},
+								Conditions: []config.Condition{
+									{
+										Expression: `req.referenceType != "digest"`,
+										Message:    "digest path reference not permitted",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			dir := t.TempDir()
+			ctlr := api.NewController(conf)
+			ctlr.Config.Storage.RootDirectory = dir
+
+			cm := test.NewControllerManager(ctlr)
+			baseURL := cm.StartAndWait()
+			defer cm.StopServer()
+
+			userClient := resty.New()
+			userClient.SetBasicAuth(username, password)
+
+			img := CreateImageWith().
+				RandomLayers(1, 10).
+				RandomConfig().
+				Build()
+
+			err := UploadImageWithBasicAuth(img, baseURL, testRepo, "stable", username, password)
+			So(err, ShouldBeNil)
+
+			imgUpdated := CreateImageWith().
+				RandomLayers(1, 12).
+				RandomConfig().
+				Build()
+
+			// Upload blobs/tags that use non-digest path refs first, then attempt digest?tag=.
+			err = UploadImageWithBasicAuth(imgUpdated, baseURL, testRepo, "candidate", username, password)
+			So(err, ShouldBeNil)
+
+			manifestBlob, err := json.Marshal(imgUpdated.Manifest)
+			So(err, ShouldBeNil)
+
+			manifestPutURL, err := url.Parse(baseURL + fmt.Sprintf("/v2/%s/manifests/%s",
+				testRepo, imgUpdated.ManifestDescriptor.Digest.String()))
+			So(err, ShouldBeNil)
+			manifestPutURL.RawQuery = "tag=stable"
+
+			resp, err := userClient.R().
+				SetHeader("Content-Type", ispec.MediaTypeImageManifest).
+				SetBody(manifestBlob).
+				Put(manifestPutURL.String())
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
+
+			resp, err = userClient.R().Get(baseURL + fmt.Sprintf("/v2/%s/manifests/stable", testRepo))
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			So(resp.Header().Get(constants.DistContentDigestKey), ShouldEqual, img.ManifestDescriptor.Digest.String())
+		})
+
+		Convey("Digest multi-tag push evaluates CEL for every existing query tag", func() {
+			testRepo := "digest-multitag-cel"
+
+			// Allow updates of any tag except stable.
+			conf.HTTP.AccessControl = &config.AccessControlConfig{
+				Repositories: config.Repositories{
+					testRepo: config.PolicyGroup{
+						Policies: []config.Policy{
+							{
+								Users: []string{username},
+								Actions: []string{
+									constants.ReadPermission,
+									constants.CreatePermission,
+									constants.UpdatePermission,
+								},
+								Conditions: []config.Condition{
+									{
+										Expression: `req.action != "update" || req.tag != "stable"`,
+										Message:    "stable tag is immutable",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			dir := t.TempDir()
+			ctlr := api.NewController(conf)
+			ctlr.Config.Storage.RootDirectory = dir
+
+			cm := test.NewControllerManager(ctlr)
+			baseURL := cm.StartAndWait()
+			defer cm.StopServer()
+
+			userClient := resty.New()
+			userClient.SetBasicAuth(username, password)
+
+			img := CreateImageWith().
+				RandomLayers(1, 10).
+				RandomConfig().
+				Build()
+
+			err := UploadImageWithBasicAuth(img, baseURL, testRepo, "stable", username, password)
+			So(err, ShouldBeNil)
+			err = UploadImageWithBasicAuth(img, baseURL, testRepo, "dev", username, password)
+			So(err, ShouldBeNil)
+
+			imgUpdated := CreateImageWith().
+				RandomLayers(1, 14).
+				RandomConfig().
+				Build()
+
+			err = UploadImageWithBasicAuth(imgUpdated, baseURL, testRepo, "candidate", username, password)
+			So(err, ShouldBeNil)
+
+			manifestBlob, err := json.Marshal(imgUpdated.Manifest)
+			So(err, ShouldBeNil)
+
+			// Updating only dev should succeed.
+			devURL, err := url.Parse(baseURL + fmt.Sprintf("/v2/%s/manifests/%s",
+				testRepo, imgUpdated.ManifestDescriptor.Digest.String()))
+			So(err, ShouldBeNil)
+			devURL.RawQuery = "tag=dev"
+
+			resp, err := userClient.R().
+				SetHeader("Content-Type", ispec.MediaTypeImageManifest).
+				SetBody(manifestBlob).
+				Put(devURL.String())
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+			// Including stable in the same request must fail even if dev is allowed.
+			bothURL, err := url.Parse(baseURL + fmt.Sprintf("/v2/%s/manifests/%s",
+				testRepo, imgUpdated.ManifestDescriptor.Digest.String()))
+			So(err, ShouldBeNil)
+			q := bothURL.Query()
+			q.Add("tag", "dev")
+			q.Add("tag", "stable")
+			bothURL.RawQuery = q.Encode()
+
+			resp, err = userClient.R().
+				SetHeader("Content-Type", ispec.MediaTypeImageManifest).
+				SetBody(manifestBlob).
+				Put(bothURL.String())
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
+
+			resp, err = userClient.R().Get(baseURL + fmt.Sprintf("/v2/%s/manifests/stable", testRepo))
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			So(resp.Header().Get(constants.DistContentDigestKey), ShouldEqual, img.ManifestDescriptor.Digest.String())
+		})
+
+		Convey("Digest multi-tag mix of new and existing tags requires create and update", func() {
+			testRepo := "digest-mix-create-update"
+
+			adminUser, _ := test.GenerateRandomString()
+			adminPass, _ := test.GenerateRandomString()
+			adminUser = strings.ToLower(adminUser)
+
+			htpasswd := test.GetBcryptCredString(username, password) +
+				test.GetBcryptCredString(adminUser, adminPass)
+			conf.HTTP.Auth = &config.AuthConfig{
+				HTPasswd: config.AuthHTPasswd{
+					Path: test.MakeHtpasswdFileFromString(t, htpasswd),
+				},
+			}
+
+			// Writer is update-only; admin seeds existing tags with create.
+			conf.HTTP.AccessControl = &config.AccessControlConfig{
+				Repositories: config.Repositories{
+					testRepo: config.PolicyGroup{
+						Policies: []config.Policy{
+							{
+								Users: []string{username},
+								Actions: []string{
+									constants.ReadPermission,
+									constants.UpdatePermission,
+								},
+							},
+							{
+								Users: []string{adminUser},
+								Actions: []string{
+									constants.ReadPermission,
+									constants.CreatePermission,
+									constants.UpdatePermission,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			dir := t.TempDir()
+			ctlr := api.NewController(conf)
+			ctlr.Config.Storage.RootDirectory = dir
+
+			cm := test.NewControllerManager(ctlr)
+			baseURL := cm.StartAndWait()
+			defer cm.StopServer()
+
+			img := CreateImageWith().
+				RandomLayers(1, 10).
+				RandomConfig().
+				Build()
+
+			err := UploadImageWithBasicAuth(img, baseURL, testRepo, "stable", adminUser, adminPass)
+			So(err, ShouldBeNil)
+
+			imgUpdated := CreateImageWith().
+				RandomLayers(1, 16).
+				RandomConfig().
+				Build()
+
+			err = UploadImageWithBasicAuth(imgUpdated, baseURL, testRepo, "candidate", adminUser, adminPass)
+			So(err, ShouldBeNil)
+
+			manifestBlob, err := json.Marshal(imgUpdated.Manifest)
+			So(err, ShouldBeNil)
+
+			mixURL, err := url.Parse(baseURL + fmt.Sprintf("/v2/%s/manifests/%s",
+				testRepo, imgUpdated.ManifestDescriptor.Digest.String()))
+			So(err, ShouldBeNil)
+			q := mixURL.Query()
+			q.Add("tag", "stable")
+			q.Add("tag", "brand-new")
+			mixURL.RawQuery = q.Encode()
+
+			userClient := resty.New()
+			userClient.SetBasicAuth(username, password)
+
+			resp, err := userClient.R().
+				SetHeader("Content-Type", ispec.MediaTypeImageManifest).
+				SetBody(manifestBlob).
+				Put(mixURL.String())
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
+
+			resp, err = userClient.R().Get(baseURL + fmt.Sprintf("/v2/%s/manifests/stable", testRepo))
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			So(resp.Header().Get(constants.DistContentDigestKey), ShouldEqual, img.ManifestDescriptor.Digest.String())
+		})
+
+		Convey("Digest multi-tag mix fails for create-only writer", func() {
+			testRepo := "digest-mix-create-only"
+
+			adminUser, _ := test.GenerateRandomString()
+			adminPass, _ := test.GenerateRandomString()
+			adminUser = strings.ToLower(adminUser)
+
+			htpasswd := test.GetBcryptCredString(username, password) +
+				test.GetBcryptCredString(adminUser, adminPass)
+			conf.HTTP.Auth = &config.AuthConfig{
+				HTPasswd: config.AuthHTPasswd{
+					Path: test.MakeHtpasswdFileFromString(t, htpasswd),
+				},
+			}
+
+			conf.HTTP.AccessControl = &config.AccessControlConfig{
+				Repositories: config.Repositories{
+					testRepo: config.PolicyGroup{
+						Policies: []config.Policy{
+							{
+								Users: []string{username},
+								Actions: []string{
+									constants.ReadPermission,
+									constants.CreatePermission,
+								},
+							},
+							{
+								Users: []string{adminUser},
+								Actions: []string{
+									constants.ReadPermission,
+									constants.CreatePermission,
+									constants.UpdatePermission,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			dir := t.TempDir()
+			ctlr := api.NewController(conf)
+			ctlr.Config.Storage.RootDirectory = dir
+
+			cm := test.NewControllerManager(ctlr)
+			baseURL := cm.StartAndWait()
+			defer cm.StopServer()
+
+			img := CreateImageWith().
+				RandomLayers(1, 10).
+				RandomConfig().
+				Build()
+
+			err := UploadImageWithBasicAuth(img, baseURL, testRepo, "stable", adminUser, adminPass)
+			So(err, ShouldBeNil)
+
+			imgUpdated := CreateImageWith().
+				RandomLayers(1, 17).
+				RandomConfig().
+				Build()
+
+			err = UploadImageWithBasicAuth(imgUpdated, baseURL, testRepo, "candidate", adminUser, adminPass)
+			So(err, ShouldBeNil)
+
+			manifestBlob, err := json.Marshal(imgUpdated.Manifest)
+			So(err, ShouldBeNil)
+
+			mixURL, err := url.Parse(baseURL + fmt.Sprintf("/v2/%s/manifests/%s",
+				testRepo, imgUpdated.ManifestDescriptor.Digest.String()))
+			So(err, ShouldBeNil)
+			q := mixURL.Query()
+			q.Add("tag", "stable")
+			q.Add("tag", "brand-new")
+			mixURL.RawQuery = q.Encode()
+
+			userClient := resty.New()
+			userClient.SetBasicAuth(username, password)
+
+			resp, err := userClient.R().
+				SetHeader("Content-Type", ispec.MediaTypeImageManifest).
+				SetBody(manifestBlob).
+				Put(mixURL.String())
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
+
+			resp, err = userClient.R().Get(baseURL + fmt.Sprintf("/v2/%s/manifests/stable", testRepo))
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			So(resp.Header().Get(constants.DistContentDigestKey), ShouldEqual, img.ManifestDescriptor.Digest.String())
+		})
+
+		Convey("Digest multi-tag mix succeeds with create and update", func() {
+			testRepo := "digest-mix-both"
+
+			conf.HTTP.AccessControl = &config.AccessControlConfig{
+				Repositories: config.Repositories{
+					testRepo: config.PolicyGroup{
+						Policies: []config.Policy{
+							{
+								Users: []string{username},
+								Actions: []string{
+									constants.ReadPermission,
+									constants.CreatePermission,
+									constants.UpdatePermission,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			dir := t.TempDir()
+			ctlr := api.NewController(conf)
+			ctlr.Config.Storage.RootDirectory = dir
+
+			cm := test.NewControllerManager(ctlr)
+			baseURL := cm.StartAndWait()
+			defer cm.StopServer()
+
+			img := CreateImageWith().
+				RandomLayers(1, 10).
+				RandomConfig().
+				Build()
+
+			err := UploadImageWithBasicAuth(img, baseURL, testRepo, "stable", username, password)
+			So(err, ShouldBeNil)
+
+			imgUpdated := CreateImageWith().
+				RandomLayers(1, 19).
+				RandomConfig().
+				Build()
+
+			err = UploadImageWithOpts(imgUpdated, baseURL, testRepo, imgUpdated.ManifestDescriptor.Digest.String(),
+				WithBasicAuth(username, password), WithExtraTags("stable", "brand-new"))
+			So(err, ShouldBeNil)
+
+			userClient := resty.New()
+			userClient.SetBasicAuth(username, password)
+
+			for _, tag := range []string{"stable", "brand-new"} {
+				resp, err := userClient.R().Get(baseURL + fmt.Sprintf("/v2/%s/manifests/%s", testRepo, tag))
+				So(err, ShouldBeNil)
+				So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+				So(resp.Header().Get(constants.DistContentDigestKey),
+					ShouldEqual, imgUpdated.ManifestDescriptor.Digest.String())
+			}
+		})
+
+		Convey("Digest overwrite of existing tag succeeds with update-only permission", func() {
+			testRepo := "digest-update-only"
+
+			adminUser, _ := test.GenerateRandomString()
+			adminPass, _ := test.GenerateRandomString()
+			adminUser = strings.ToLower(adminUser)
+
+			htpasswd := test.GetBcryptCredString(username, password) +
+				test.GetBcryptCredString(adminUser, adminPass)
+			conf.HTTP.Auth = &config.AuthConfig{
+				HTPasswd: config.AuthHTPasswd{
+					Path: test.MakeHtpasswdFileFromString(t, htpasswd),
+				},
+			}
+
+			conf.HTTP.AccessControl = &config.AccessControlConfig{
+				Repositories: config.Repositories{
+					testRepo: config.PolicyGroup{
+						Policies: []config.Policy{
+							{
+								Users: []string{username},
+								Actions: []string{
+									constants.ReadPermission,
+									constants.UpdatePermission,
+								},
+							},
+							{
+								Users: []string{adminUser},
+								Actions: []string{
+									constants.ReadPermission,
+									constants.CreatePermission,
+									constants.UpdatePermission,
+								},
+							},
+						},
+					},
+				},
+			}
+
+			dir := t.TempDir()
+			ctlr := api.NewController(conf)
+			ctlr.Config.Storage.RootDirectory = dir
+
+			cm := test.NewControllerManager(ctlr)
+			baseURL := cm.StartAndWait()
+			defer cm.StopServer()
+
+			img := CreateImageWith().
+				RandomLayers(1, 10).
+				RandomConfig().
+				Build()
+
+			err := UploadImageWithBasicAuth(img, baseURL, testRepo, "stable", adminUser, adminPass)
+			So(err, ShouldBeNil)
+
+			imgUpdated := CreateImageWith().
+				RandomLayers(1, 21).
+				RandomConfig().
+				Build()
+
+			// Seed blobs under a throwaway tag; update-only writer then retags via digest?tag=.
+			err = UploadImageWithBasicAuth(imgUpdated, baseURL, testRepo, "candidate", adminUser, adminPass)
+			So(err, ShouldBeNil)
+
+			manifestBlob, err := json.Marshal(imgUpdated.Manifest)
+			So(err, ShouldBeNil)
+
+			overwriteURL, err := url.Parse(baseURL + fmt.Sprintf("/v2/%s/manifests/%s",
+				testRepo, imgUpdated.ManifestDescriptor.Digest.String()))
+			So(err, ShouldBeNil)
+			overwriteURL.RawQuery = "tag=stable"
+
+			userClient := resty.New()
+			userClient.SetBasicAuth(username, password)
+
+			resp, err := userClient.R().
+				SetHeader("Content-Type", ispec.MediaTypeImageManifest).
+				SetBody(manifestBlob).
+				Put(overwriteURL.String())
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+			resp, err = userClient.R().Get(baseURL + fmt.Sprintf("/v2/%s/manifests/stable", testRepo))
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+			So(resp.Header().Get(constants.DistContentDigestKey),
+				ShouldEqual, imgUpdated.ManifestDescriptor.Digest.String())
 		})
 	})
 }


### PR DESCRIPTION
## Summary

Create-only writers could reassign existing tags via:

```text
PUT /v2/<repo>/manifests/<digest>?tag=<existing>
```

because authz only treated the path reference as an overwrite. This PR:

- requires `update` for every existing `?tag=` value (CEL is evaluated per tag)
- still authorizes the path digest reference after those checks
- requires `create` as well when a digest multi-tag push mixes new tags with overwrites

## Test plan

- [x] Create-only user denied on digest `?tag=` overwrite; trusted tag unchanged
- [x] Create-only user can still add a new tag via digest `?tag=`
- [x] Update permission allows digest `?tag=` overwrite
- [x] CEL denying digest path refs still fails after per-tag checks
- [x] CEL allowing `dev` but denying `stable` fails on `?tag=dev&tag=stable`
- [x] Update-only user denied when mixing existing + new `?tag=` values

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
