### PR TITLE
feat(sync): support RFC 8693 token exchange in oauth2 helper

### DIFF
--- a/examples/config-sync-oauth2-token-exchange.json
+++ b/examples/config-sync-oauth2-token-exchange.json
@@ -1,0 +1,41 @@
+{
+    "distSpecVersion": "1.1.1",
+    "storage": {
+        "rootDirectory": "/tmp/zot"
+    },
+    "http": {
+        "address": "0.0.0.0",
+        "port": "8080"
+    },
+    "log": {
+        "level": "debug"
+    },
+    "extensions": {
+        "sync": {
+            "downloadDir": "/tmp/zot",
+            "registries": [
+                {
+                    "urls": [
+                        "https://registry.example.com"
+                    ],
+                    "onDemand": true,
+                    "maxRetries": 5,
+                    "retryDelay": "2m",
+                    "credentialHelper": "oauth2",
+                    "oauth2CredentialHelper": {
+                        "tokenURL": "https://sts.example.com/v1/token",
+                        "assertionFile": "./examples/sync-oauth2-assertion.jwt",
+                        "grantType": "urn:ietf:params:oauth:grant-type:token-exchange",
+                        "audience": "//sts.example.com/pools/the-pool/providers/the-provider",
+                        "subjectTokenType": "urn:ietf:params:oauth:token-type:jwt",
+                        "requestedTokenType": "urn:ietf:params:oauth:token-type:access_token",
+                        "scopes": [
+                            "repository:pull"
+                        ],
+                        "username": "<token>"
+                    }
+                }
+            ]
+        }
+    }
+}

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -283,6 +283,109 @@ func TestLoadConfigurationSyncCredentialHelper(t *testing.T) {
 		err := cli.LoadConfiguration(cfg, tmpfile)
 		So(err, ShouldNotBeNil)
 	})
+
+	Convey("the token-exchange grant loads with its RFC 8693 fields", t, func() {
+		content := `{
+			"storage": {"rootDirectory": "/tmp/zot"},
+			"http": {"address": "127.0.0.1", "port": "8080"},
+			"extensions": {
+				"sync": {
+					"registries": [
+						{
+							"urls": ["https://registry.example.com"],
+							"onDemand": true,
+							"credentialHelper": "oauth2",
+							"oauth2CredentialHelper": {
+								"tokenURL": "https://sts.example.com/v1/token",
+								"assertionFile": "/run/secrets/subject-token",
+								"grantType": "urn:ietf:params:oauth:grant-type:token-exchange",
+								"audience": "//sts.example.com/pools/the-pool/providers/the-provider",
+								"subjectTokenType": "urn:ietf:params:oauth:token-type:jwt",
+								"requestedTokenType": "urn:ietf:params:oauth:token-type:access_token",
+								"username": "oauth2accesstoken"
+							}
+						}
+					]
+				}
+			}
+		}`
+
+		tmpfile := MakeTempFileWithContent(t, "zot-sync-oauth2-token-exchange.json", content)
+		cfg := config.New()
+
+		err := cli.LoadConfiguration(cfg, tmpfile)
+		So(err, ShouldBeNil)
+
+		registries := cfg.Extensions.Sync.Registries
+		So(registries, ShouldHaveLength, 1)
+
+		oauth2Config, err := syncconf.OAuth2HelperConfigFromMap(registries[0].Oauth2CredentialHelper)
+		So(err, ShouldBeNil)
+		So(oauth2Config.GrantType, ShouldEqual, syncconf.TokenExchangeGrantType)
+		So(oauth2Config.Audience, ShouldEqual, "//sts.example.com/pools/the-pool/providers/the-provider")
+		So(oauth2Config.SubjectTokenType, ShouldEqual, "urn:ietf:params:oauth:token-type:jwt")
+		So(oauth2Config.RequestedTokenType, ShouldEqual, "urn:ietf:params:oauth:token-type:access_token")
+		So(oauth2Config.Validate(), ShouldBeNil)
+	})
+
+	Convey("the token-exchange grant without an audience fails at load time", t, func() {
+		content := `{
+			"storage": {"rootDirectory": "/tmp/zot"},
+			"http": {"address": "127.0.0.1", "port": "8080"},
+			"extensions": {
+				"sync": {
+					"registries": [
+						{
+							"urls": ["https://registry.example.com"],
+							"onDemand": true,
+							"credentialHelper": "oauth2",
+							"oauth2CredentialHelper": {
+								"tokenURL": "https://sts.example.com/v1/token",
+								"assertionFile": "/run/secrets/subject-token",
+								"grantType": "urn:ietf:params:oauth:grant-type:token-exchange"
+							}
+						}
+					]
+				}
+			}
+		}`
+
+		tmpfile := MakeTempFileWithContent(t, "zot-sync-oauth2-no-audience.json", content)
+		cfg := config.New()
+
+		err := cli.LoadConfiguration(cfg, tmpfile)
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("an audience without the token-exchange grant fails at load time", t, func() {
+		content := `{
+			"storage": {"rootDirectory": "/tmp/zot"},
+			"http": {"address": "127.0.0.1", "port": "8080"},
+			"extensions": {
+				"sync": {
+					"registries": [
+						{
+							"urls": ["https://registry.example.com"],
+							"onDemand": true,
+							"credentialHelper": "oauth2",
+							"oauth2CredentialHelper": {
+								"tokenURL": "https://idp.example.com/token",
+								"assertionFile": "/run/secrets/assertion.jwt",
+								"grantType": "urn:ietf:params:oauth:grant-type:jwt-bearer",
+								"audience": "//sts.example.com/pools/the-pool/providers/the-provider"
+							}
+						}
+					]
+				}
+			}
+		}`
+
+		tmpfile := MakeTempFileWithContent(t, "zot-sync-oauth2-stray-audience.json", content)
+		cfg := config.New()
+
+		err := cli.LoadConfiguration(cfg, tmpfile)
+		So(err, ShouldNotBeNil)
+	})
 }
 
 func TestLoadConfigurationInjectsHTTPTimeoutDefaults(t *testing.T) {

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -7,11 +7,19 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+// TokenExchangeGrantType is the RFC 8693 token exchange grant, used to trade a subject
+// token issued by an external identity provider for an access token minted by a security
+// token service.
+const TokenExchangeGrantType = "urn:ietf:params:oauth:grant-type:token-exchange" //nolint:gosec // not a credential
+
 var (
 	errOAuth2HelperConfigMissing = errors.New("oauth2 credential helper requires an oauth2CredentialHelper config")
 	errOAuth2TokenURLMissing     = errors.New("oauth2 credential helper requires a tokenURL")
 	errOAuth2AssertionMissing    = errors.New("oauth2 credential helper requires an assertionFile or a signingFile")
 	errOAuth2AssertionConflict   = errors.New("oauth2 credential helper allows only assertionFile or signingFile")
+	errOAuth2AudienceMissing     = errors.New("the oauth2 token-exchange grant requires an audience")
+	errOAuth2ExchangeOnlyFields  = errors.New(
+		"oauth2 audience, subjectTokenType and requestedTokenType require the token-exchange grant")
 )
 
 // CredentialsFile is a map where key is registry address.
@@ -60,15 +68,24 @@ type RegistryConfig struct {
 //     refresh. zot never holds a private key; single-use semantics, if any, are owned by the platform.
 //   - SigningFile: a private key and claims that zot uses to mint a fresh, single-use assertion
 //     (unique "jti") on every refresh, then exchanges it for a short-lived access token.
+//
+// With the RFC 8693 token-exchange grant the assertion is sent as the subject token rather
+// than as a client credential, which is what a security token service such as Google STS
+// expects when federating an external workload identity.
 type OAuth2HelperConfig struct {
 	TokenURL         string   // OAuth2 token endpoint
 	AssertionFile    string   // file holding a pre-signed JWT assertion, re-read on every refresh
 	SigningFile      string   // file holding the signing key and claims used to mint assertions in-code
-	GrantType        string   // "client_credentials" (default) or the jwt-bearer grant URN
+	GrantType        string   // "client_credentials" (default), the jwt-bearer or the token-exchange grant URN
 	ClientID         string   // optional OAuth2 client identifier
 	ClientSecretFile string   // file holding the optional OAuth2 client secret, sent in the request body
 	Scopes           []string // optional OAuth2 scopes
 	Username         string   // registry username paired with the token, defaults to "<token>"
+
+	// The fields below apply to the token-exchange grant only.
+	Audience           string // required, identifies the target of the exchange
+	SubjectTokenType   string // type of the exchanged token, defaults to the JWT token type
+	RequestedTokenType string // type asked of the endpoint, defaults to the access-token type
 }
 
 // decodeOauth2CredentialHelper decodes the generic Oauth2CredentialHelper dictionary
@@ -122,6 +139,20 @@ func (config *OAuth2HelperConfig) Validate() error {
 
 	if hasAssertionFile && hasSigningFile {
 		return errOAuth2AssertionConflict
+	}
+
+	// The RFC 8693 fields are meaningless outside the token-exchange grant, so reject them
+	// there rather than silently ignoring a misconfiguration.
+	if config.GrantType != TokenExchangeGrantType {
+		if config.Audience != "" || config.SubjectTokenType != "" || config.RequestedTokenType != "" {
+			return errOAuth2ExchangeOnlyFields
+		}
+
+		return nil
+	}
+
+	if config.Audience == "" {
+		return errOAuth2AudienceMissing
 	}
 
 	return nil

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -2,6 +2,8 @@ package sync
 
 import (
 	"errors"
+	"net/url"
+	"strings"
 	"time"
 
 	"github.com/mitchellh/mapstructure"
@@ -22,7 +24,15 @@ var (
 	errOAuth2ExchangeOnlyFields = errors.New(
 		"oauth2 credential helper allows audience, subjectTokenType and requestedTokenType " +
 			"only when grantType is " + TokenExchangeGrantType)
+	errOAuth2TokenTypeNotURI = errors.New(
+		"oauth2 credential helper requires subjectTokenType and requestedTokenType to be absolute URIs")
 )
+
+// hasValue reports whether a configuration value holds anything other than blanks, so that
+// a whitespace-only entry is rejected the same way an omitted one is.
+func hasValue(value string) bool {
+	return strings.TrimSpace(value) != ""
+}
 
 // CredentialsFile is a map where key is registry address.
 type CredentialsFile map[string]Credentials
@@ -129,12 +139,12 @@ func (config *OAuth2HelperConfig) Validate() error {
 		return errOAuth2HelperConfigMissing
 	}
 
-	if config.TokenURL == "" {
+	if !hasValue(config.TokenURL) {
 		return errOAuth2TokenURLMissing
 	}
 
-	hasAssertionFile := config.AssertionFile != ""
-	hasSigningFile := config.SigningFile != ""
+	hasAssertionFile := hasValue(config.AssertionFile)
+	hasSigningFile := hasValue(config.SigningFile)
 
 	if !hasAssertionFile && !hasSigningFile {
 		return errOAuth2AssertionMissing
@@ -147,15 +157,30 @@ func (config *OAuth2HelperConfig) Validate() error {
 	// The RFC 8693 fields are meaningless outside the token-exchange grant, so reject them
 	// there rather than silently ignoring a misconfiguration.
 	if config.GrantType != TokenExchangeGrantType {
-		if config.Audience != "" || config.SubjectTokenType != "" || config.RequestedTokenType != "" {
+		if hasValue(config.Audience) || hasValue(config.SubjectTokenType) || hasValue(config.RequestedTokenType) {
 			return errOAuth2ExchangeOnlyFields
 		}
 
 		return nil
 	}
 
-	if config.Audience == "" {
+	if !hasValue(config.Audience) {
 		return errOAuth2AudienceMissing
+	}
+
+	/* RFC 8693 identifies token types by URI. The registered ones are URNs, but the spec
+	allows other schemes, so require an absolute URI rather than the "urn" scheme: that
+	still rejects a bare word such as "jwt". The audience deliberately gets no such check,
+	because it is a logical name rather than a URI, and the workload identity audience
+	Google expects carries no scheme at all. */
+	for _, tokenType := range []string{config.SubjectTokenType, config.RequestedTokenType} {
+		if !hasValue(tokenType) {
+			continue // optional, a default applies
+		}
+
+		if parsed, err := url.Parse(tokenType); err != nil || !parsed.IsAbs() {
+			return errOAuth2TokenTypeNotURI
+		}
 	}
 
 	return nil

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -17,9 +17,11 @@ var (
 	errOAuth2TokenURLMissing     = errors.New("oauth2 credential helper requires a tokenURL")
 	errOAuth2AssertionMissing    = errors.New("oauth2 credential helper requires an assertionFile or a signingFile")
 	errOAuth2AssertionConflict   = errors.New("oauth2 credential helper allows only assertionFile or signingFile")
-	errOAuth2AudienceMissing     = errors.New("the oauth2 token-exchange grant requires an audience")
-	errOAuth2ExchangeOnlyFields  = errors.New(
-		"oauth2 audience, subjectTokenType and requestedTokenType require the token-exchange grant")
+	errOAuth2AudienceMissing     = errors.New(
+		"oauth2 credential helper requires an audience when grantType is " + TokenExchangeGrantType)
+	errOAuth2ExchangeOnlyFields = errors.New(
+		"oauth2 credential helper allows audience, subjectTokenType and requestedTokenType " +
+			"only when grantType is " + TokenExchangeGrantType)
 )
 
 // CredentialsFile is a map where key is registry address.
@@ -60,7 +62,7 @@ type RegistryConfig struct {
 }
 
 // OAuth2HelperConfig holds the options used by the "oauth2" credential helper,
-// which exchanges a JWT assertion for a short-lived registry access token.
+// which exchanges a signed assertion for a short-lived registry access token.
 //
 // The assertion comes from one of two mutually exclusive sources, exactly one of which must be set:
 //   - AssertionFile: a pre-signed JWT issued and rotated by an external platform (e.g. a Kubernetes
@@ -71,10 +73,11 @@ type RegistryConfig struct {
 //
 // With the RFC 8693 token-exchange grant the assertion is sent as the subject token rather
 // than as a client credential, which is what a security token service such as Google STS
-// expects when federating an external workload identity.
+// expects when federating an external workload identity. That grant also accepts subject
+// tokens that are not JWTs, declared through SubjectTokenType.
 type OAuth2HelperConfig struct {
 	TokenURL         string   // OAuth2 token endpoint
-	AssertionFile    string   // file holding a pre-signed JWT assertion, re-read on every refresh
+	AssertionFile    string   // file holding the pre-signed assertion, re-read on every refresh
 	SigningFile      string   // file holding the signing key and claims used to mint assertions in-code
 	GrantType        string   // "client_credentials" (default), the jwt-bearer or the token-exchange grant URN
 	ClientID         string   // optional OAuth2 client identifier
@@ -84,7 +87,7 @@ type OAuth2HelperConfig struct {
 
 	// The fields below apply to the token-exchange grant only.
 	Audience           string // required, identifies the target of the exchange
-	SubjectTokenType   string // type of the exchanged token, defaults to the JWT token type
+	SubjectTokenType   string // type of the subject token being exchanged, defaults to the JWT token type
 	RequestedTokenType string // type asked of the endpoint, defaults to the access-token type
 }
 

--- a/pkg/extensions/sync/oauth2_credential_helper.go
+++ b/pkg/extensions/sync/oauth2_credential_helper.go
@@ -38,6 +38,10 @@ const (
 	jwtBearerGrantType         = "urn:ietf:params:oauth:grant-type:jwt-bearer" //nolint:gosec // not a credential
 	clientAssertionType        = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
 
+	// RFC 8693 token type URNs, used when no explicit type is configured.
+	defaultSubjectTokenType   = "urn:ietf:params:oauth:token-type:jwt"          //nolint:gosec // not a credential
+	defaultRequestedTokenType = "urn:ietf:params:oauth:token-type:access_token" //nolint:gosec // not a credential
+
 	oauth2TokenUser = "<token>"
 )
 
@@ -144,9 +148,19 @@ func (credHelper *oauth2CredentialsHelper) requestValues(assertion, clientSecret
 	grantType := credHelper.grantType()
 	values.Set("grant_type", grantType)
 
-	if grantType == jwtBearerGrantType {
+	switch grantType {
+	case jwtBearerGrantType:
 		values.Set("assertion", assertion)
-	} else {
+	case syncconf.TokenExchangeGrantType:
+		/* RFC 8693 exchanges an existing token for another one, so the assertion identifies
+		the workload being federated rather than proving the client's own identity. */
+		values.Set("subject_token", assertion)
+		values.Set("subject_token_type",
+			firstNonEmpty(credHelper.config.SubjectTokenType, defaultSubjectTokenType))
+		values.Set("requested_token_type",
+			firstNonEmpty(credHelper.config.RequestedTokenType, defaultRequestedTokenType))
+		values.Set("audience", credHelper.config.Audience)
+	default:
 		values.Set("client_assertion_type", clientAssertionType)
 		values.Set("client_assertion", assertion)
 	}

--- a/pkg/extensions/sync/oauth2_credential_helper_test.go
+++ b/pkg/extensions/sync/oauth2_credential_helper_test.go
@@ -357,6 +357,151 @@ func TestOAuth2CredentialsHelper(t *testing.T) {
 			So(claims["jti"], ShouldNotBeEmpty)
 		})
 
+		Convey("token-exchange grant sends the RFC 8693 parameters", func() {
+			var receivedBody url.Values
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = r.ParseForm()
+				receivedBody = r.Form
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"the-access-token","expires_in":3600}`))
+			}))
+			defer server.Close()
+
+			assertionFile := writeAssertionFile(t, "the-subject-token")
+
+			credentialHelper, err := sync.NewOAuth2CredentialHelper(log.NewTestLogger(),
+				&syncconf.OAuth2HelperConfig{
+					TokenURL:      server.URL,
+					AssertionFile: assertionFile,
+					GrantType:     syncconf.TokenExchangeGrantType,
+					Audience:      "//sts.example.com/pools/the-pool/providers/the-provider",
+					Username:      "oauth2accesstoken",
+				})
+			So(err, ShouldBeNil)
+
+			creds, err := credentialHelper.GetCredentials([]string{registryURL})
+			So(err, ShouldBeNil)
+			So(creds[remoteAddress].Username, ShouldEqual, "oauth2accesstoken")
+			So(creds[remoteAddress].Password, ShouldEqual, "the-access-token")
+
+			So(receivedBody.Get("grant_type"), ShouldEqual, syncconf.TokenExchangeGrantType)
+			So(receivedBody.Get("subject_token"), ShouldEqual, "the-subject-token")
+			So(receivedBody.Get("audience"), ShouldEqual,
+				"//sts.example.com/pools/the-pool/providers/the-provider")
+
+			// the token types fall back to the RFC 8693 defaults
+			So(receivedBody.Get("subject_token_type"), ShouldEqual, "urn:ietf:params:oauth:token-type:jwt")
+			So(receivedBody.Get("requested_token_type"), ShouldEqual,
+				"urn:ietf:params:oauth:token-type:access_token")
+
+			// the subject token must not be presented as a client credential
+			So(receivedBody.Get("assertion"), ShouldBeEmpty)
+			So(receivedBody.Get("client_assertion"), ShouldBeEmpty)
+			So(receivedBody.Get("client_assertion_type"), ShouldBeEmpty)
+		})
+
+		Convey("token-exchange token types can be overridden", func() {
+			var receivedBody url.Values
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = r.ParseForm()
+				receivedBody = r.Form
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"the-access-token","expires_in":3600}`))
+			}))
+			defer server.Close()
+
+			credentialHelper, err := sync.NewOAuth2CredentialHelper(log.NewTestLogger(),
+				//nolint:gosec // token type URNs, not credentials
+				&syncconf.OAuth2HelperConfig{
+					TokenURL:           server.URL,
+					AssertionFile:      writeAssertionFile(t, "the-subject-token"),
+					GrantType:          syncconf.TokenExchangeGrantType,
+					Audience:           "the-audience",
+					SubjectTokenType:   "urn:ietf:params:oauth:token-type:id_token",
+					RequestedTokenType: "urn:ietf:params:oauth:token-type:jwt",
+				})
+			So(err, ShouldBeNil)
+
+			_, err = credentialHelper.GetCredentials([]string{registryURL})
+			So(err, ShouldBeNil)
+			So(receivedBody.Get("subject_token_type"), ShouldEqual, "urn:ietf:params:oauth:token-type:id_token")
+			So(receivedBody.Get("requested_token_type"), ShouldEqual, "urn:ietf:params:oauth:token-type:jwt")
+		})
+
+		Convey("token-exchange re-reads the subject token on every refresh", func() {
+			var subjectTokens []string
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_ = r.ParseForm()
+				subjectTokens = append(subjectTokens, r.Form.Get("subject_token"))
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"access_token":"the-access-token","expires_in":3600}`))
+			}))
+			defer server.Close()
+
+			assertionFile := writeAssertionFile(t, "first-subject-token")
+
+			credentialHelper, err := sync.NewOAuth2CredentialHelper(log.NewTestLogger(),
+				&syncconf.OAuth2HelperConfig{
+					TokenURL:      server.URL,
+					AssertionFile: assertionFile,
+					GrantType:     syncconf.TokenExchangeGrantType,
+					Audience:      "the-audience",
+				})
+			So(err, ShouldBeNil)
+
+			_, err = credentialHelper.GetCredentials([]string{registryURL})
+			So(err, ShouldBeNil)
+
+			// the platform rotates the token on disk
+			So(os.WriteFile(assertionFile, []byte("second-subject-token"), 0o600), ShouldBeNil)
+
+			_, err = credentialHelper.RefreshCredentials(remoteAddress)
+			So(err, ShouldBeNil)
+
+			So(subjectTokens, ShouldResemble, []string{"first-subject-token", "second-subject-token"})
+		})
+
+		Convey("The token-exchange grant requires an audience", func() {
+			_, err := sync.NewOAuth2CredentialHelper(log.NewTestLogger(),
+				//nolint:gosec // test token endpoint URL, not a credential
+				&syncconf.OAuth2HelperConfig{
+					TokenURL:      "https://sts.example.com/token",
+					AssertionFile: writeAssertionFile(t, "the-subject-token"),
+					GrantType:     syncconf.TokenExchangeGrantType,
+				})
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("The RFC 8693 fields are rejected for the other grants", func() {
+			for _, grantType := range []string{"", "client_credentials", "urn:ietf:params:oauth:grant-type:jwt-bearer"} {
+				_, err := sync.NewOAuth2CredentialHelper(log.NewTestLogger(),
+					//nolint:gosec // test token endpoint URL, not a credential
+					&syncconf.OAuth2HelperConfig{
+						TokenURL:      "https://idp.example.com/token",
+						AssertionFile: writeAssertionFile(t, "the-jwt-assertion"),
+						GrantType:     grantType,
+						Audience:      "the-audience",
+					})
+				So(err, ShouldNotBeNil)
+
+				_, err = sync.NewOAuth2CredentialHelper(log.NewTestLogger(),
+					//nolint:gosec // test token endpoint URL, not a credential
+					&syncconf.OAuth2HelperConfig{
+						TokenURL:         "https://idp.example.com/token",
+						AssertionFile:    writeAssertionFile(t, "the-jwt-assertion"),
+						GrantType:        grantType,
+						SubjectTokenType: "urn:ietf:params:oauth:token-type:jwt",
+					})
+				So(err, ShouldNotBeNil)
+			}
+		})
+
 		Convey("Signing config claims override the defaults", func() {
 			var receivedBody url.Values
 

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -974,6 +974,76 @@ func TestOAuth2HelperConfigValidate(t *testing.T) {
 		}
 		So(config.Validate(), ShouldBeNil)
 	})
+
+	Convey("a blank value counts as unset", t, func() {
+		Convey("for tokenURL", func() {
+			config := &syncconf.OAuth2HelperConfig{
+				TokenURL:    "   ",
+				SigningFile: "/run/secrets/signing-config.json",
+			}
+			So(config.Validate(), ShouldNotBeNil)
+		})
+
+		Convey("for the assertion sources", func() {
+			config := &syncconf.OAuth2HelperConfig{
+				TokenURL:      "https://idp.example.com/token",
+				AssertionFile: "  ",
+				SigningFile:   "\t",
+			}
+			So(config.Validate(), ShouldNotBeNil)
+		})
+
+		Convey("for the token-exchange audience", func() {
+			config := &syncconf.OAuth2HelperConfig{
+				TokenURL:      "https://sts.googleapis.com/v1/token",
+				AssertionFile: "/run/secrets/assertion.jwt",
+				GrantType:     syncconf.TokenExchangeGrantType,
+				Audience:      " ",
+			}
+			So(config.Validate(), ShouldNotBeNil)
+		})
+	})
+
+	Convey("token types are checked for URI shape", t, func() {
+		newConfig := func(subjectTokenType, requestedTokenType string) *syncconf.OAuth2HelperConfig {
+			return &syncconf.OAuth2HelperConfig{
+				TokenURL:           "https://sts.googleapis.com/v1/token",
+				AssertionFile:      "/run/secrets/assertion.jwt",
+				GrantType:          syncconf.TokenExchangeGrantType,
+				Audience:           "//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/v",
+				SubjectTokenType:   subjectTokenType,
+				RequestedTokenType: requestedTokenType,
+			}
+		}
+
+		Convey("a bare word is rejected", func() {
+			So(newConfig("jwt", "").Validate(), ShouldNotBeNil)
+			So(newConfig("", "access_token").Validate(), ShouldNotBeNil)
+		})
+
+		Convey("the registered URNs are accepted", func() {
+			config := newConfig("urn:ietf:params:oauth:token-type:jwt",
+				"urn:ietf:params:oauth:token-type:access_token")
+			So(config.Validate(), ShouldBeNil)
+		})
+
+		/* RFC 8693 section 3 permits token type identifiers outside the urn scheme, so the
+		check must not insist on one. */
+		Convey("a non-urn URI is accepted", func() {
+			So(newConfig("https://schemas.example.com/legacy-token", "").Validate(), ShouldBeNil)
+		})
+
+		Convey("leaving them unset is fine, the defaults apply", func() {
+			So(newConfig("", "").Validate(), ShouldBeNil)
+		})
+
+		/* The audience is a logical name, not a URI: the one Google expects has no scheme,
+		so it must not be held to the same check. */
+		Convey("the scheme-less audience Google expects stays valid", func() {
+			So(newConfig("", "").Audience, ShouldStartWith, "//")
+			So(newConfig("", "").Validate(), ShouldBeNil)
+		})
+	})
 }
 
 func TestSyncLegacyCosignTagsSyncReferrers(t *testing.T) {


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Fixes #4267

**What does this PR do / Why do we need it**:

Adds the RFC 8693 token-exchange grant to the `oauth2` sync credential helper, so that sync can obtain a short-lived registry token from a security token service. Motivation and background are in #4267.

- `OAuth2HelperConfig` gains three optional fields — `audience`, `subjectTokenType` and `requestedTokenType` — read only for this grant.
- `requestValues` sends the assertion as `subject_token`, with `subject_token_type`, `requested_token_type` and `audience`. The two types default to the RFC 8693 JWT and access-token URNs.
- Validation requires `audience` for this grant and rejects the three fields under any other grant, so a misconfiguration fails at load time.
- New example config.

The token response shape is unchanged, so `fetchToken`, the token cache and the refresh machinery are untouched. The change is scoped away from `service.go` so it does not conflict with #4209.

**Testing done on this change**:

Unit tests in `oauth2_credential_helper_test.go` cover the parameters sent, the token-type defaults and overrides, the subject token being re-read on every refresh, and both validation rules. Config loading tests in `root_test.go` cover the same rules.

Also verified end to end against a real workload identity pool and Google Artifact Registry: with only a short-lived subject token on disk, zot pulls a real image through as a pull-through cache — matching manifest digest, byte-identical layer, persisted to local storage.

**Automation added to e2e**:
No. The grant needs a live security token service to exercise meaningfully, so coverage is unit tests plus the manual run above.

**Will this break upgrades or downgrades?**
No. The three fields are optional and only read when `grantType` is the token-exchange URN, which no existing configuration can be using successfully today.

**Does this PR introduce any user-facing change?**:
Yes, additive only: three new optional keys under `oauth2CredentialHelper`.

**release-note**
The sync `oauth2` credential helper now supports the RFC 8693 token-exchange grant, enabling Workload Identity Federation against registries such as Google Artifact Registry with no long-lived credential on disk. New optional keys under `oauth2CredentialHelper`: `audience` (required for this grant), `subjectTokenType` and `requestedTokenType`.
