### PR TITLE
fix(sync): refresh helper credentials on every sync entry point

### DIFF
--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -312,6 +312,12 @@ func (service *BaseService) getNextRepoFromCatalog(lastRepo string) string {
 func (service *BaseService) GetNextRepo(lastRepo string) (string, error) {
 	var err error
 
+	/* Refresh before taking the read lock: a refresh reinitializes the client under the
+	write lock, which a held read lock would deadlock against. */
+	if err := service.refreshRegistryTemporaryCredentials(); err != nil {
+		service.log.Error().Err(err).Msg("failed to refresh credentials")
+	}
+
 	if len(service.repositories) == 0 {
 		service.clientLock.RLock()
 		service.repositories, err = service.remote.GetRepositories(context.Background())
@@ -385,6 +391,12 @@ func (service *BaseService) SyncImage(ctx context.Context, repo, reference strin
 func (service *BaseService) SyncReferrers(ctx context.Context, repo string,
 	subjectDigestStr string, referenceTypes []string,
 ) error {
+	/* Refresh before taking the read lock: a refresh reinitializes the client under the
+	write lock, which a held read lock would deadlock against. */
+	if err := service.refreshRegistryTemporaryCredentials(); err != nil {
+		service.log.Error().Err(err).Msg("failed to refresh credentials")
+	}
+
 	service.clientLock.RLock()
 	defer service.clientLock.RUnlock()
 
@@ -467,6 +479,10 @@ func (service *BaseService) SyncReferrers(ctx context.Context, repo string,
 func (service *BaseService) SyncRepo(ctx context.Context, repo string) error {
 	service.log.Info().Str("repo", repo).Str("registry", service.remote.GetHostName()).
 		Msg("sync: syncing repo")
+
+	if err := service.refreshRegistryTemporaryCredentials(); err != nil {
+		service.log.Error().Err(err).Msg("failed to refresh credentials")
+	}
 
 	var err error
 

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -2206,3 +2206,108 @@ func TestECRRefreshCredentialsPersistsExpiry(t *testing.T) {
 		So(helper.AreCredentialsValid("111111111111.dkr.ecr.us-east-1.amazonaws.com"), ShouldBeFalse)
 	})
 }
+
+// countingCredentialHelper records how often each CredentialHelper method is invoked so
+// that tests can assert which sync entry points drive a credential refresh.
+type countingCredentialHelper struct {
+	valid        bool
+	getCalls     atomic.Int64
+	refreshCalls atomic.Int64
+}
+
+func (helper *countingCredentialHelper) GetCredentials(urls []string) (syncconf.CredentialsFile, error) {
+	helper.getCalls.Add(1)
+
+	credentials := make(syncconf.CredentialsFile)
+	for _, url := range urls {
+		credentials[StripRegistryTransport(url)] = syncconf.Credentials{Username: "user", Password: "initial"}
+	}
+
+	return credentials, nil
+}
+
+func (helper *countingCredentialHelper) AreCredentialsValid(_ string) bool {
+	return helper.valid
+}
+
+func (helper *countingCredentialHelper) RefreshCredentials(_ string) (syncconf.Credentials, error) {
+	helper.refreshCalls.Add(1)
+
+	return syncconf.Credentials{Username: "user", Password: "refreshed"}, nil
+}
+
+func TestCredentialRefreshOnEverySyncEntryPoint(t *testing.T) {
+	Convey("Expiring helper credentials are refreshed by every sync entry point", t, func() {
+		// an unroutable upstream: the entry points fail fast, after the refresh has run
+		newService := func(helper CredentialHelper, credentialHelperName string) *BaseService {
+			logger := log.NewTestLogger()
+
+			service := &BaseService{
+				config: syncconf.RegistryConfig{
+					URLs:             []string{"http://127.0.0.1:1"},
+					CredentialHelper: credentialHelperName,
+					SyncTimeout:      time.Second,
+				},
+				credentials:      syncconf.CredentialsFile{},
+				credentialHelper: helper,
+				contentManager:   NewContentManager(nil, logger),
+				tagsCache:        newTagsCache(defaultExpireMinutes),
+				log:              logger,
+			}
+
+			So(service.init(), ShouldBeNil)
+
+			return service
+		}
+
+		Convey("GetNextRepo refreshes them", func() {
+			helper := &countingCredentialHelper{}
+			service := newService(helper, "oauth2")
+
+			_, _ = service.GetNextRepo("")
+			So(helper.refreshCalls.Load(), ShouldBeGreaterThan, 0)
+		})
+
+		Convey("SyncRepo refreshes them", func() {
+			helper := &countingCredentialHelper{}
+			service := newService(helper, "oauth2")
+
+			_ = service.SyncRepo(context.Background(), "some/repo")
+			So(helper.refreshCalls.Load(), ShouldBeGreaterThan, 0)
+		})
+
+		Convey("SyncReferrers refreshes them", func() {
+			helper := &countingCredentialHelper{}
+			service := newService(helper, "oauth2")
+
+			_ = service.SyncReferrers(context.Background(), "some/repo", godigest.FromString("s").String(), nil)
+			So(helper.refreshCalls.Load(), ShouldBeGreaterThan, 0)
+		})
+
+		Convey("SyncImage keeps refreshing them", func() {
+			helper := &countingCredentialHelper{}
+			service := newService(helper, "oauth2")
+
+			_ = service.SyncImage(context.Background(), "some/repo", "latest")
+			So(helper.refreshCalls.Load(), ShouldBeGreaterThan, 0)
+		})
+
+		Convey("Credentials that are still valid are left alone", func() {
+			helper := &countingCredentialHelper{valid: true}
+			service := newService(helper, "oauth2")
+
+			_ = service.SyncRepo(context.Background(), "some/repo")
+			_, _ = service.GetNextRepo("")
+			So(helper.refreshCalls.Load(), ShouldEqual, 0)
+		})
+
+		Convey("No refresh happens when no credential helper is configured", func() {
+			helper := &countingCredentialHelper{}
+			service := newService(helper, "")
+
+			_ = service.SyncRepo(context.Background(), "some/repo")
+			_, _ = service.GetNextRepo("")
+			So(helper.refreshCalls.Load(), ShouldEqual, 0)
+		})
+	})
+}

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -2309,5 +2309,47 @@ func TestCredentialRefreshOnEverySyncEntryPoint(t *testing.T) {
 			_, _ = service.GetNextRepo("")
 			So(helper.refreshCalls.Load(), ShouldEqual, 0)
 		})
+
+		Convey("A refresh that fails is logged rather than returned to the caller", func() {
+			/* a regular file where a certificate directory is expected makes the client
+			reinitialization at the end of the refresh fail */
+			brokenCertDir := path.Join(t.TempDir(), "certs")
+			So(os.WriteFile(brokenCertDir, []byte("not a directory"), 0o600), ShouldBeNil)
+
+			newBrokenService := func() (*BaseService, string) {
+				service := newService(&countingCredentialHelper{}, "oauth2")
+				service.config.CertDir = brokenCertDir
+
+				refreshErr := service.refreshRegistryTemporaryCredentials()
+				So(refreshErr, ShouldNotBeNil)
+
+				return service, refreshErr.Error()
+			}
+
+			Convey("GetNextRepo goes on to query the upstream", func() {
+				service, refreshErr := newBrokenService()
+
+				_, err := service.GetNextRepo("")
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldNotEqual, refreshErr)
+			})
+
+			Convey("SyncRepo goes on to query the upstream", func() {
+				service, refreshErr := newBrokenService()
+
+				err := service.SyncRepo(context.Background(), "some/repo")
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldNotEqual, refreshErr)
+			})
+
+			Convey("SyncReferrers goes on to query the upstream", func() {
+				service, refreshErr := newBrokenService()
+
+				err := service.SyncReferrers(context.Background(), "some/repo",
+					godigest.FromString("s").String(), nil)
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldNotEqual, refreshErr)
+			})
+		})
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
Fixes #4268

**What does this PR do / Why do we need it**:

`refreshRegistryTemporaryCredentials` was only called from `SyncImage`, so a registry driven by `pollInterval` kept using whatever credentials the helper returned at startup. Both built-in helpers hand out expiring tokens, so periodic sync eventually starts failing against the upstream.

This calls it from `GetNextRepo`, `SyncRepo` and `SyncReferrers` as well.

Each call is placed before any read lock is taken. Since #4272, `refreshRegistryTemporaryCredentials` acquires `clientLock` for reading and then for writing, so calling it while a read lock is held would deadlock. `SyncReferrers` in particular took `clientLock.RLock()` as its first statement, so the refresh goes above it.

One correction to the issue as I filed it: `SyncReferrers` is an on-demand path (`on_demand.go`, `routes.go`), not a periodic one. So the gap is slightly wider than "periodic sync only" — an `onDemand`-only deployment serving `GET /v2/<name>/referrers/<digest>` was also using stale credentials.

**Testing done on this change**:

Added `TestCredentialRefreshOnEverySyncEntryPoint` in `sync_internal_test.go`, using a counting `CredentialHelper` against an unroutable upstream so each entry point fails fast after the refresh has run. It asserts that `GetNextRepo`, `SyncRepo`, `SyncReferrers` and `SyncImage` all refresh expiring credentials, that valid credentials are left alone, that nothing happens when no helper is configured, and that a refresh that fails is logged rather than returned to the caller. Passes under `-race`.

Also measured against a real zot with the `oauth2` helper and a token endpoint returning a short `expires_in`, configured with `pollInterval: 2s` and `onDemand: false`. Before the change the token endpoint was hit exactly once, at startup, over 14 seconds of polling while the scheduler was successfully syncing images. After the change it is hit on every poll cycle.

**Note on #4272**:

Rebased on top of it, and the merge-order question I raised earlier no longer applies: the data race in `refreshRegistryTemporaryCredentials` is fixed on main. Its fast path also keeps this cheap — when nothing has expired a refresh costs a read lock and one `AreCredentialsValid` call per host, so calling it per repo on every poll cycle is not a concern.

**Will this break upgrades or downgrades?**
No.

**Does this PR introduce any user-facing change?**:
No, other than credentials now being refreshed when they should have been.

**release-note**
Sync now refreshes credential-helper tokens for periodic (`pollInterval`) sync and for on-demand referrer syncs, not just for on-demand image pulls. Previously those paths kept using the credentials obtained at startup and failed once the token expired.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
