### PR TITLE
fix(sync): guard credential refresh under clientLock

### DIFF
--- a/pkg/extensions/sync/ecr_credential_helper.go
+++ b/pkg/extensions/sync/ecr_credential_helper.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -44,6 +45,7 @@ type ecrCredential struct {
 }
 
 type ecrCredentialsHelper struct {
+	mu                 sync.RWMutex
 	credentials        map[string]ecrCredential
 	log                log.Logger
 	getCredentialsFunc func(string) (ecrCredential, error)
@@ -153,7 +155,10 @@ func (credHelper *ecrCredentialsHelper) GetCredentials(urls []string) (syncconf.
 			Username: ecrCred.username,
 			Password: ecrCred.password,
 		}
+
+		credHelper.mu.Lock()
 		credHelper.credentials[remoteAddress] = ecrCred
+		credHelper.mu.Unlock()
 	}
 
 	return ecrCredentials, nil
@@ -161,7 +166,10 @@ func (credHelper *ecrCredentialsHelper) GetCredentials(urls []string) (syncconf.
 
 // AreCredentialsValid checks if the credentials for a given remote address are still valid.
 func (credHelper *ecrCredentialsHelper) AreCredentialsValid(remoteAddress string) bool {
+	credHelper.mu.RLock()
 	expiry := credHelper.credentials[remoteAddress].expiry
+	credHelper.mu.RUnlock()
+
 	expiryDuration := time.Duration(expiryWindow) * time.Hour
 
 	if time.Until(expiry) <= expiryDuration {
@@ -189,6 +197,10 @@ func (credHelper *ecrCredentialsHelper) RefreshCredentials(
 	if err != nil {
 		return syncconf.Credentials{}, fmt.Errorf("%w %s: %w", errFailedToGetECRCredentials, remoteAddress, err)
 	}
+
+	credHelper.mu.Lock()
+	credHelper.credentials[remoteAddress] = ecrCred
+	credHelper.mu.Unlock()
 
 	return syncconf.Credentials{Username: ecrCred.username, Password: ecrCred.password}, nil
 }

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -174,6 +174,12 @@ func (service *BaseService) init() error {
 	service.clientLock.Lock()
 	defer service.clientLock.Unlock()
 
+	return service.initClient()
+}
+
+// initClient rebuilds the registry client from the current credentials.
+// Caller must hold clientLock for writing.
+func (service *BaseService) initClient() error {
 	client, hosts, err := newClient(service.config, service.credentials, service.log)
 	if err != nil {
 		service.log.Err(err).Msg("failed to create registry client")
@@ -198,12 +204,35 @@ func (service *BaseService) init() error {
 // If the credentials are expired, it attempts to refresh them and updates the service configuration.
 func (service *BaseService) refreshRegistryTemporaryCredentials() error {
 	// Exit early if no CredentialHelper is configured.
-	if service.config.CredentialHelper == "" {
+	if service.config.CredentialHelper == "" || service.credentialHelper == nil {
 		return nil
 	}
 
+	// Fast path: skip the write lock and client reinit when nothing has expired.
+	service.clientLock.RLock()
+	needsRefresh := false
+
 	for _, host := range service.hosts {
-		// Exit early if the credentials are valid.
+		if !service.credentialHelper.AreCredentialsValid(host.Hostname) {
+			needsRefresh = true
+
+			break
+		}
+	}
+
+	service.clientLock.RUnlock()
+
+	if !needsRefresh {
+		return nil
+	}
+
+	service.clientLock.Lock()
+	defer service.clientLock.Unlock()
+
+	credentialsUpdated := false
+
+	for _, host := range service.hosts {
+		// Re-check under the write lock: another refresher may have won the race.
 		if service.credentialHelper.AreCredentialsValid(host.Hostname) {
 			continue
 		}
@@ -225,10 +254,15 @@ func (service *BaseService) refreshRegistryTemporaryCredentials() error {
 
 		// Update the service's credentials map with the new set of credentials.
 		service.credentials[host.Hostname] = credentials
+		credentialsUpdated = true
+	}
+
+	if !credentialsUpdated {
+		return nil
 	}
 
 	// Reinitialize regclient with new credentials
-	return service.init()
+	return service.initClient()
 }
 
 func (service *BaseService) CanRetryOnError() bool {

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -17,6 +17,8 @@ import (
 	"os"
 	"path"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1996,5 +1998,211 @@ func TestHTTPRetryDelayBounds(t *testing.T) {
 			So(delayInit, ShouldEqual, retryDelay)
 			So(delayMax, ShouldEqual, maxRetryDelay)
 		})
+	})
+}
+
+func TestRefreshRegistryTemporaryCredentialsConcurrent(t *testing.T) {
+	Convey("Concurrent on-demand credential refresh must not race on the credentials map", t, func() {
+		logger := log.NewTestLogger()
+
+		service := &BaseService{
+			config: syncconf.RegistryConfig{
+				URLs: []string{
+					"https://111111111111.dkr.ecr.us-east-1.amazonaws.com",
+					"https://222222222222.dkr.ecr.us-east-1.amazonaws.com",
+					"https://333333333333.dkr.ecr.us-east-1.amazonaws.com",
+					"https://444444444444.dkr.ecr.us-east-1.amazonaws.com",
+				},
+				CredentialHelper: "ecr",
+			},
+			credentials:      syncconf.CredentialsFile{},
+			credentialHelper: NewECRCredentialHelper(logger, GetMockECRCredentials),
+			log:              logger,
+		}
+
+		So(service.init(), ShouldBeNil)
+		So(len(service.hosts), ShouldEqual, len(service.config.URLs))
+
+		var (
+			wg          sync.WaitGroup
+			errMu       sync.Mutex
+			refreshErrs []error
+		)
+
+		for range 10 {
+			wg.Add(1)
+
+			go func() {
+				defer wg.Done()
+
+				for range 3 {
+					if err := service.refreshRegistryTemporaryCredentials(); err != nil {
+						errMu.Lock()
+						refreshErrs = append(refreshErrs, err)
+						errMu.Unlock()
+					}
+				}
+			}()
+		}
+
+		wg.Wait()
+
+		So(refreshErrs, ShouldBeEmpty)
+		So(len(service.credentials), ShouldEqual, len(service.hosts))
+
+		// Credentials are still valid after the concurrent refresh wave, so further
+		// calls must be a no-op (no client reinit failure path, no map growth).
+		So(service.refreshRegistryTemporaryCredentials(), ShouldBeNil)
+		So(len(service.credentials), ShouldEqual, len(service.hosts))
+	})
+
+	Convey("Nil credential helper is a no-op even when CredentialHelper is set", t, func() {
+		service := &BaseService{
+			config: syncconf.RegistryConfig{
+				URLs:             []string{"https://111111111111.dkr.ecr.us-east-1.amazonaws.com"},
+				CredentialHelper: "ecr",
+			},
+			credentials: syncconf.CredentialsFile{},
+			log:         log.NewTestLogger(),
+		}
+
+		So(service.init(), ShouldBeNil)
+		So(service.refreshRegistryTemporaryCredentials(), ShouldBeNil)
+		So(len(service.credentials), ShouldEqual, 0)
+	})
+}
+
+// stubCredentialHelper is a test double for refreshRegistryTemporaryCredentials branches.
+type stubCredentialHelper struct {
+	validFn    func(url string) bool
+	refreshErr error
+	username   string
+	password   string
+}
+
+func (helper *stubCredentialHelper) AreCredentialsValid(url string) bool {
+	if helper.validFn != nil {
+		return helper.validFn(url)
+	}
+
+	return false
+}
+
+func (helper *stubCredentialHelper) GetCredentials(urls []string) (syncconf.CredentialsFile, error) {
+	return syncconf.CredentialsFile{}, nil
+}
+
+func (helper *stubCredentialHelper) RefreshCredentials(url string) (syncconf.Credentials, error) {
+	if helper.refreshErr != nil {
+		return syncconf.Credentials{}, helper.refreshErr
+	}
+
+	username := helper.username
+	if username == "" {
+		username = "user"
+	}
+
+	password := helper.password
+	if password == "" {
+		password = "token"
+	}
+
+	return syncconf.Credentials{Username: username, Password: password}, nil
+}
+
+func TestRefreshRegistryTemporaryCredentialsBranches(t *testing.T) {
+	Convey("refreshRegistryTemporaryCredentials branch coverage", t, func() {
+		newService := func(helper CredentialHelper) *BaseService {
+			service := &BaseService{
+				config: syncconf.RegistryConfig{
+					URLs:             []string{"https://111111111111.dkr.ecr.us-east-1.amazonaws.com"},
+					CredentialHelper: "ecr",
+				},
+				credentials:      syncconf.CredentialsFile{},
+				credentialHelper: helper,
+				log:              log.NewTestLogger(),
+			}
+
+			So(service.init(), ShouldBeNil)
+
+			return service
+		}
+
+		Convey("Empty CredentialHelper name is a no-op even with a non-nil helper", func() {
+			helper := &stubCredentialHelper{}
+			service := newService(helper)
+			service.config.CredentialHelper = ""
+
+			So(service.refreshRegistryTemporaryCredentials(), ShouldBeNil)
+			So(len(service.credentials), ShouldEqual, 0)
+		})
+
+		Convey("A failed RefreshCredentials leaves the credentials map unchanged", func() {
+			helper := &stubCredentialHelper{refreshErr: errors.New("refresh failed")}
+			service := newService(helper)
+
+			So(service.refreshRegistryTemporaryCredentials(), ShouldBeNil)
+			So(len(service.credentials), ShouldEqual, 0)
+		})
+
+		Convey("Credentials that become valid under the write lock skip reinit", func() {
+			// First AreCredentialsValid (RLock fast path) is false so we take the write lock;
+			// the re-check under the write lock is true, so nothing is updated and initClient
+			// is skipped.
+			var checks atomic.Int64
+			helper := &stubCredentialHelper{
+				validFn: func(string) bool {
+					return checks.Add(1) > 1
+				},
+			}
+			service := newService(helper)
+
+			So(service.refreshRegistryTemporaryCredentials(), ShouldBeNil)
+			So(len(service.credentials), ShouldEqual, 0)
+			So(checks.Load(), ShouldBeGreaterThanOrEqualTo, int64(2))
+		})
+
+		Convey("initClient failure after a successful refresh is returned to the caller", func() {
+			brokenCertDir := path.Join(t.TempDir(), "certs")
+			So(os.WriteFile(brokenCertDir, []byte("not a directory"), 0o600), ShouldBeNil)
+
+			helper := &stubCredentialHelper{username: "user", password: "refreshed"}
+			service := newService(helper)
+			service.config.CertDir = brokenCertDir
+
+			err := service.refreshRegistryTemporaryCredentials()
+			So(err, ShouldNotBeNil)
+			So(service.credentials[service.hosts[0].Hostname].Password, ShouldEqual, "refreshed")
+		})
+	})
+}
+
+func TestECRRefreshCredentialsPersistsExpiry(t *testing.T) {
+	Convey("ECR RefreshCredentials stores expiry so credentials become valid", t, func() {
+		remoteAddress := "111111111111.dkr.ecr.us-east-1.amazonaws.com"
+		helper := NewECRCredentialHelper(log.NewTestLogger(), GetMockECRCredentials)
+
+		So(helper.AreCredentialsValid(remoteAddress), ShouldBeFalse)
+
+		creds, err := helper.RefreshCredentials(remoteAddress)
+		So(err, ShouldBeNil)
+		So(creds.Username, ShouldEqual, "mockUsername")
+		So(helper.AreCredentialsValid(remoteAddress), ShouldBeTrue)
+
+		// GetCredentials also populates the helper map under its mutex.
+		file, err := helper.GetCredentials([]string{"https://" + remoteAddress})
+		So(err, ShouldBeNil)
+		So(file[remoteAddress].Username, ShouldEqual, "mockUsername")
+		So(helper.AreCredentialsValid(remoteAddress), ShouldBeTrue)
+	})
+
+	Convey("ECR RefreshCredentials surfaces retrieval errors", t, func() {
+		helper := NewECRCredentialHelper(log.NewTestLogger(), func(string) (ecrCredential, error) {
+			return ecrCredential{}, errors.New("aws unavailable")
+		})
+
+		_, err := helper.RefreshCredentials("111111111111.dkr.ecr.us-east-1.amazonaws.com")
+		So(err, ShouldNotBeNil)
+		So(helper.AreCredentialsValid("111111111111.dkr.ecr.us-east-1.amazonaws.com"), ShouldBeFalse)
 	})
 }


### PR DESCRIPTION
Prevent concurrent map writes when refreshing helper credentials, skip client reinit when tokens are still valid, and persist ECR expiry so repeated refreshes do not keep treating tokens as expired.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
