### PR TITLE
fix(gql): fix Vulnerabilities skip key

### DIFF
--- a/pkg/extensions/search/base_image_list_gql_test.go
+++ b/pkg/extensions/search/base_image_list_gql_test.go
@@ -1,0 +1,237 @@
+//go:build search
+
+package search_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	godigest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/resty.v1"
+
+	"zotregistry.dev/zot/v2/pkg/api"
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
+	cvemodel "zotregistry.dev/zot/v2/pkg/extensions/search/cve/model"
+	. "zotregistry.dev/zot/v2/pkg/test/common"
+	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+func TestBaseImageListGql(t *testing.T) {
+	rootDir := t.TempDir()
+
+	conf := config.New()
+	conf.HTTP.Port = "0"
+	conf.Storage.RootDirectory = rootDir
+	defaultVal := true
+
+	updateDuration, _ := time.ParseDuration("1h")
+	trivyConfig := &extconf.TrivyConfig{
+		DBRepository: "ghcr.io/project-zot/trivy-db",
+	}
+	cveConfig := &extconf.CVEConfig{
+		UpdateInterval: updateDuration,
+		Trivy:          trivyConfig,
+	}
+	searchConfig := &extconf.SearchConfig{
+		BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+		CVE:        cveConfig,
+	}
+	conf.Extensions = &extconf.ExtensionConfig{
+		Search: searchConfig,
+	}
+
+	ctlr := api.NewController(conf)
+
+	if err := ctlr.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	testScanner := mocks.NewTestCveScanner()
+	ctlr.CveScanner = testScanner
+
+	go func() {
+		if err := ctlr.Run(); !errors.Is(err, http.ErrServerClosed) {
+			panic(err)
+		}
+	}()
+
+	defer ctlr.Shutdown()
+
+	ctlrManager := NewControllerManager(ctlr)
+
+	ctlrManager.WaitServerReady()
+	baseURL := ctlrManager.BaseURL()
+
+	Convey("Base image with vulnerability should have correct data in response", t, func() {
+		// create test images
+		config := ispec.Image{
+			Platform: ispec.Platform{
+				Architecture: "amd64",
+				OS:           "linux",
+			},
+			RootFS: ispec.RootFS{
+				Type:    "layers",
+				DiffIDs: []godigest.Digest{},
+			},
+			Author: "ZotUser",
+		}
+
+		configBlob, err := json.Marshal(config)
+		So(err, ShouldBeNil)
+
+		configDigest := godigest.FromBytes(configBlob)
+
+		layers := [][]byte{
+			{10, 11, 10, 11},
+			{11, 11, 11, 11},
+		}
+
+		manifest := ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+			},
+		}
+
+		baseImage := Image{
+			Manifest: manifest,
+			Config:   config,
+			Layers:   layers,
+		}
+
+		err = UploadImage(
+			baseImage, baseURL, "test-repo", "latest",
+		)
+		So(err, ShouldBeNil)
+
+		// create image with more layers than the original
+		layers = [][]byte{
+			{10, 11, 10, 11},
+			{11, 11, 11, 11},
+			{10, 10, 10, 11},
+		}
+
+		manifest = ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+			},
+		}
+
+		err = UploadImage(
+			Image{
+				Manifest: manifest,
+				Config:   config,
+				Layers:   layers,
+			}, baseURL, "more-layers", "latest",
+		)
+		So(err, ShouldBeNil)
+
+		testScanner.SetCveDataForImage(baseImage.Digest().String(), map[string]cvemodel.CVE{
+			"CVE1": {
+				ID:          "CVE1",
+				Severity:    "MEDIUM",
+				Title:       "Title CVE1",
+				Description: "Description CVE1",
+			},
+			"CVE2": {
+				ID:          "CVE2",
+				Severity:    "HIGH",
+				Title:       "Title CVE2",
+				Description: "Description CVE2",
+			},
+		})
+
+		query := `
+			{
+				BaseImageList(image:"more-layers:latest"){
+					Results{
+						RepoName
+						Tag
+						Vulnerabilities {
+							MaxSeverity
+							Count
+						}
+					}
+				}
+			}`
+
+		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		var responseStruct zcommon.BaseImageListResponse
+		err = json.Unmarshal(resp.Body(), &responseStruct)
+		So(err, ShouldBeNil)
+		So(len(responseStruct.Results), ShouldEqual, 1)
+
+		respImg := responseStruct.Results[0]
+		So(respImg.RepoName, ShouldEqual, "test-repo")
+		So(respImg.Vulnerabilities.Count, ShouldEqual, 2)
+		So(respImg.Vulnerabilities.MaxSeverity, ShouldEqual, "HIGH")
+
+		// empty the cve data for the image and verify that the vulnerabilities count is 0
+		testScanner.SetCveDataForImage(baseImage.Digest().String(), map[string]cvemodel.CVE{})
+
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+		err = json.Unmarshal(resp.Body(), &responseStruct)
+		So(err, ShouldBeNil)
+		So(len(responseStruct.Results), ShouldEqual, 1)
+
+		respImg = responseStruct.Results[0]
+		So(respImg.RepoName, ShouldEqual, "test-repo")
+		So(respImg.Vulnerabilities.Count, ShouldEqual, 0)
+		So(respImg.Vulnerabilities.MaxSeverity, ShouldEqual, "NONE")
+	})
+}

--- a/pkg/extensions/search/derived_image_list_gql_test.go
+++ b/pkg/extensions/search/derived_image_list_gql_test.go
@@ -1,0 +1,237 @@
+//go:build search
+
+package search_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	godigest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/resty.v1"
+
+	"zotregistry.dev/zot/v2/pkg/api"
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
+	cvemodel "zotregistry.dev/zot/v2/pkg/extensions/search/cve/model"
+	. "zotregistry.dev/zot/v2/pkg/test/common"
+	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+func TestDerivedImageListGql(t *testing.T) {
+	rootDir := t.TempDir()
+
+	conf := config.New()
+	conf.HTTP.Port = "0"
+	conf.Storage.RootDirectory = rootDir
+	defaultVal := true
+
+	updateDuration, _ := time.ParseDuration("1h")
+	trivyConfig := &extconf.TrivyConfig{
+		DBRepository: "ghcr.io/project-zot/trivy-db",
+	}
+	cveConfig := &extconf.CVEConfig{
+		UpdateInterval: updateDuration,
+		Trivy:          trivyConfig,
+	}
+	searchConfig := &extconf.SearchConfig{
+		BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+		CVE:        cveConfig,
+	}
+	conf.Extensions = &extconf.ExtensionConfig{
+		Search: searchConfig,
+	}
+
+	ctlr := api.NewController(conf)
+
+	if err := ctlr.Init(); err != nil {
+		t.Fatal(err)
+	}
+
+	testScanner := mocks.NewTestCveScanner()
+	ctlr.CveScanner = testScanner
+
+	go func() {
+		if err := ctlr.Run(); !errors.Is(err, http.ErrServerClosed) {
+			panic(err)
+		}
+	}()
+
+	defer ctlr.Shutdown()
+
+	ctlrManager := NewControllerManager(ctlr)
+
+	ctlrManager.WaitServerReady()
+	baseURL := ctlrManager.BaseURL()
+
+	Convey("Derived image with vulnerability should have correct data in response", t, func() {
+		// create test images
+		config := ispec.Image{
+			Platform: ispec.Platform{
+				Architecture: "amd64",
+				OS:           "linux",
+			},
+			RootFS: ispec.RootFS{
+				Type:    "layers",
+				DiffIDs: []godigest.Digest{},
+			},
+			Author: "ZotUser",
+		}
+
+		configBlob, err := json.Marshal(config)
+		So(err, ShouldBeNil)
+
+		configDigest := godigest.FromBytes(configBlob)
+
+		layers := [][]byte{
+			{10, 11, 10, 11},
+			{11, 11, 11, 11},
+		}
+
+		manifest := ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+			},
+		}
+
+		err = UploadImage(
+			Image{
+				Manifest: manifest,
+				Config:   config,
+				Layers:   layers,
+			}, baseURL, "test-repo", "latest",
+		)
+		So(err, ShouldBeNil)
+
+		// create image with more layers than the original
+		layers = [][]byte{
+			{10, 11, 10, 11},
+			{11, 11, 11, 11},
+			{10, 10, 10, 11},
+		}
+
+		manifest = ispec.Manifest{
+			Versioned: specs.Versioned{
+				SchemaVersion: 2,
+			},
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.image.config.v1+json",
+				Digest:    configDigest,
+				Size:      int64(len(configBlob)),
+			},
+			Layers: []ispec.Descriptor{
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[0]),
+					Size:      int64(len(layers[0])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[1]),
+					Size:      int64(len(layers[1])),
+				},
+				{
+					MediaType: "application/vnd.oci.image.layer.v1.tar",
+					Digest:    godigest.FromBytes(layers[2]),
+					Size:      int64(len(layers[2])),
+				},
+			},
+		}
+
+		img := Image{
+			Manifest: manifest,
+			Config:   config,
+			Layers:   layers,
+		}
+
+		err = UploadImage(
+			img, baseURL, "more-layers", "latest",
+		)
+		So(err, ShouldBeNil)
+
+		testScanner.SetCveDataForImage(img.Digest().String(), map[string]cvemodel.CVE{
+			"CVE1": {
+				ID:          "CVE1",
+				Severity:    "MEDIUM",
+				Title:       "Title CVE1",
+				Description: "Description CVE1",
+			},
+			"CVE2": {
+				ID:          "CVE2",
+				Severity:    "HIGH",
+				Title:       "Title CVE2",
+				Description: "Description CVE2",
+			},
+		})
+
+		query := `
+			{
+				DerivedImageList(image:"test-repo:latest"){
+					Results{
+						RepoName
+						Tag
+						Vulnerabilities {
+							MaxSeverity
+							Count
+						}
+					}
+				}
+			}`
+
+		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		var responseStruct zcommon.DerivedImageListResponse
+		err = json.Unmarshal(resp.Body(), &responseStruct)
+		So(err, ShouldBeNil)
+		So(len(responseStruct.Results), ShouldEqual, 1)
+
+		respImg := responseStruct.Results[0]
+		So(respImg.RepoName, ShouldEqual, "more-layers")
+		So(respImg.Vulnerabilities.Count, ShouldEqual, 2)
+		So(respImg.Vulnerabilities.MaxSeverity, ShouldEqual, "HIGH")
+
+		// empty the cve data for the image and verify that the vulnerabilities count is 0
+		testScanner.SetCveDataForImage(img.Digest().String(), map[string]cvemodel.CVE{})
+
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+		err = json.Unmarshal(resp.Body(), &responseStruct)
+		So(err, ShouldBeNil)
+		So(len(responseStruct.Results), ShouldEqual, 1)
+
+		respImg = responseStruct.Results[0]
+		So(respImg.RepoName, ShouldEqual, "more-layers")
+		So(respImg.Vulnerabilities.Count, ShouldEqual, 0)
+		So(respImg.Vulnerabilities.MaxSeverity, ShouldEqual, "NONE")
+	})
+}

--- a/pkg/extensions/search/image_list_for_digest_gql_test.go
+++ b/pkg/extensions/search/image_list_for_digest_gql_test.go
@@ -1,0 +1,167 @@
+//go:build search
+
+package search_test
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/resty.v1"
+
+	"zotregistry.dev/zot/v2/pkg/api"
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
+	. "zotregistry.dev/zot/v2/pkg/test/common"
+	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
+)
+
+func TestImageListForDigestGql(t *testing.T) {
+	Convey("Test ImageListForDigest with vulnerability scan enabled", t, func() {
+		rootDir := t.TempDir()
+
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		conf.Storage.RootDirectory = rootDir
+		defaultVal := true
+
+		updateDuration, _ := time.ParseDuration("1h")
+		trivyConfig := &extconf.TrivyConfig{
+			DBRepository: "ghcr.io/project-zot/trivy-db",
+		}
+		cveConfig := &extconf.CVEConfig{
+			UpdateInterval: updateDuration,
+			Trivy:          trivyConfig,
+		}
+		searchConfig := &extconf.SearchConfig{
+			BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+			CVE:        cveConfig,
+		}
+		conf.Extensions = &extconf.ExtensionConfig{
+			Search: searchConfig,
+		}
+
+		ctlr := api.NewController(conf)
+
+		if err := ctlr.Init(); err != nil {
+			t.Fatal(err)
+		}
+
+		ctlr.CveScanner = getMockCveScanner(ctlr.MetaDB)
+
+		go func() {
+			if err := ctlr.Run(); !errors.Is(err, http.ErrServerClosed) {
+				panic(err)
+			}
+		}()
+
+		defer ctlr.Shutdown()
+
+		cm := NewControllerManager(ctlr)
+		cm.WaitServerReady()
+		baseURL := cm.BaseURL()
+
+		uploadedImage := CreateDefaultImage()
+
+		createdTime := time.Date(2010, 1, 1, 12, 0, 0, 0, time.UTC)
+		createdTimeL2 := time.Date(2010, 2, 1, 12, 0, 0, 0, time.UTC)
+		config := ispec.Image{
+			Platform: ispec.Platform{
+				Architecture: "amd64",
+				OS:           "linux",
+			},
+			RootFS: ispec.RootFS{
+				Type:    "layers",
+				DiffIDs: []godigest.Digest{},
+			},
+			Author: "ZotUser",
+			History: []ispec.History{
+				{
+					Created:    &createdTime,
+					CreatedBy:  "go test data",
+					Author:     "ZotUser",
+					Comment:    "Test history comment",
+					EmptyLayer: true,
+				},
+				{
+					Created:    &createdTimeL2,
+					CreatedBy:  "go test data 2",
+					Author:     "ZotUser",
+					Comment:    "Test history comment2",
+					EmptyLayer: false,
+				},
+			},
+		}
+
+		image := CreateImageWith().RandomLayers(1, 100).ImageConfig(config).Build()
+
+		err := UploadImage(uploadedImage, baseURL, "zot-cve-test", "0.0.1")
+		So(err, ShouldBeNil)
+
+		err = UploadImage(image, baseURL, "zot-no-vuln", "0.0.1")
+		So(err, ShouldBeNil)
+
+		// Verify image with vulnerabilities returns correct data
+		query := fmt.Sprintf(`{
+			ImageListForDigest(id:"%s") {
+				Results {
+					RepoName
+					Tag
+					Vulnerabilities {
+						MaxSeverity
+						Count
+					}
+				}
+			}
+		}`, uploadedImage.Digest())
+		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		var responseStruct zcommon.ImagesForDigest
+		err = json.Unmarshal(resp.Body(), &responseStruct)
+		So(err, ShouldBeNil)
+		So(len(responseStruct.Results), ShouldEqual, 1)
+
+		img := responseStruct.Results[0]
+		So(img.RepoName, ShouldEqual, "zot-cve-test")
+		So(img.Vulnerabilities.Count, ShouldEqual, 4)
+		So(img.Vulnerabilities.MaxSeverity, ShouldEqual, "CRITICAL")
+
+		// Verify image with no vulnerabilities returns empty vulnerability data
+		query = fmt.Sprintf(`{
+			ImageListForDigest(id:"%s") {
+				Results {
+					RepoName
+					Tag
+					Vulnerabilities {
+						MaxSeverity
+						Count
+					}
+				}
+			}
+		}`, image.Digest())
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		err = json.Unmarshal(resp.Body(), &responseStruct)
+		So(err, ShouldBeNil)
+		So(len(responseStruct.Results), ShouldEqual, 1)
+
+		img = responseStruct.Results[0]
+		So(img.RepoName, ShouldEqual, "zot-no-vuln")
+		So(img.Vulnerabilities.Count, ShouldEqual, 0)
+		So(img.Vulnerabilities.MaxSeverity, ShouldEqual, "NONE")
+	})
+}

--- a/pkg/extensions/search/image_list_gql_test.go
+++ b/pkg/extensions/search/image_list_gql_test.go
@@ -1,0 +1,166 @@
+//go:build search
+
+package search_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/resty.v1"
+
+	"zotregistry.dev/zot/v2/pkg/api"
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
+	. "zotregistry.dev/zot/v2/pkg/test/common"
+	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
+)
+
+func TestImageListGql(t *testing.T) {
+	Convey("Test ImageList with vulnerability scan enabled", t, func() {
+		rootDir := t.TempDir()
+
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		conf.Storage.RootDirectory = rootDir
+		defaultVal := true
+
+		updateDuration, _ := time.ParseDuration("1h")
+		trivyConfig := &extconf.TrivyConfig{
+			DBRepository: "ghcr.io/project-zot/trivy-db",
+		}
+		cveConfig := &extconf.CVEConfig{
+			UpdateInterval: updateDuration,
+			Trivy:          trivyConfig,
+		}
+		searchConfig := &extconf.SearchConfig{
+			BaseConfig: extconf.BaseConfig{Enable: &defaultVal},
+			CVE:        cveConfig,
+		}
+		conf.Extensions = &extconf.ExtensionConfig{
+			Search: searchConfig,
+		}
+
+		ctlr := api.NewController(conf)
+
+		if err := ctlr.Init(); err != nil {
+			t.Fatal(err)
+		}
+
+		ctlr.CveScanner = getMockCveScanner(ctlr.MetaDB)
+
+		go func() {
+			if err := ctlr.Run(); !errors.Is(err, http.ErrServerClosed) {
+				panic(err)
+			}
+		}()
+
+		defer ctlr.Shutdown()
+
+		cm := NewControllerManager(ctlr)
+		cm.WaitServerReady()
+		baseURL := cm.BaseURL()
+
+		uploadedImage := CreateDefaultImage()
+
+		createdTime := time.Date(2010, 1, 1, 12, 0, 0, 0, time.UTC)
+		createdTimeL2 := time.Date(2010, 2, 1, 12, 0, 0, 0, time.UTC)
+		config := ispec.Image{
+			Platform: ispec.Platform{
+				Architecture: "amd64",
+				OS:           "linux",
+			},
+			RootFS: ispec.RootFS{
+				Type:    "layers",
+				DiffIDs: []godigest.Digest{},
+			},
+			Author: "ZotUser",
+			History: []ispec.History{
+				{
+					Created:    &createdTime,
+					CreatedBy:  "go test data",
+					Author:     "ZotUser",
+					Comment:    "Test history comment",
+					EmptyLayer: true,
+				},
+				{
+					Created:    &createdTimeL2,
+					CreatedBy:  "go test data 2",
+					Author:     "ZotUser",
+					Comment:    "Test history comment2",
+					EmptyLayer: false,
+				},
+			},
+		}
+
+		image := CreateImageWith().RandomLayers(1, 100).ImageConfig(config).Build()
+
+		err := UploadImage(uploadedImage, baseURL, "zot-cve-test", "0.0.1")
+		So(err, ShouldBeNil)
+
+		err = UploadImage(image, baseURL, "zot-no-vuln", "0.0.1")
+		So(err, ShouldBeNil)
+
+		// Verify image with vulnerabilities returns correct data
+		query := `{
+			ImageList(repo:"zot-cve-test") {
+				Results {
+					RepoName
+					Tag
+					Vulnerabilities {
+						MaxSeverity
+						Count
+					}
+				}
+			}
+		}`
+		resp, err := resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		var responseStruct zcommon.ImageListResponse
+		err = json.Unmarshal(resp.Body(), &responseStruct)
+		So(err, ShouldBeNil)
+		So(len(responseStruct.Results), ShouldEqual, 1)
+
+		img := responseStruct.Results[0]
+		So(img.RepoName, ShouldEqual, "zot-cve-test")
+		So(img.Vulnerabilities.Count, ShouldEqual, 4)
+		So(img.Vulnerabilities.MaxSeverity, ShouldEqual, "CRITICAL")
+
+		// Verify image with no vulnerabilities returns empty vulnerability data
+		query = `{
+			ImageList(repo:"zot-no-vuln") {
+				Results {
+					RepoName
+					Tag
+					Vulnerabilities {
+						MaxSeverity
+						Count
+					}
+				}
+			}
+		}`
+		resp, err = resty.R().Get(baseURL + graphqlQueryPrefix + "?query=" + url.QueryEscape(query))
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+
+		err = json.Unmarshal(resp.Body(), &responseStruct)
+		So(err, ShouldBeNil)
+		So(len(responseStruct.Results), ShouldEqual, 1)
+
+		img = responseStruct.Results[0]
+		So(img.RepoName, ShouldEqual, "zot-no-vuln")
+		So(img.Vulnerabilities.Count, ShouldEqual, 0)
+		So(img.Vulnerabilities.MaxSeverity, ShouldEqual, "NONE")
+	})
+}

--- a/pkg/extensions/search/resolver.go
+++ b/pkg/extensions/search/resolver.go
@@ -115,7 +115,7 @@ func getImageListForDigest(ctx context.Context, digest string, metaDB mTypes.Met
 	}
 
 	skip := convert.SkipQGLField{
-		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Images.Vulnerabilities"),
+		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Results.Vulnerabilities"),
 	}
 
 	pageInput := pagination.PageInput{
@@ -1096,7 +1096,7 @@ func derivedImageList(ctx context.Context, image string, digest *string, metaDB 
 	}
 
 	skip := convert.SkipQGLField{
-		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Vulnerabilities"),
+		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Results.Vulnerabilities"),
 	}
 
 	imageRepo, imageTag := zcommon.GetImageDirAndTag(image)
@@ -1195,7 +1195,7 @@ func baseImageList(ctx context.Context, image string, digest *string, metaDB mTy
 	}
 
 	skip := convert.SkipQGLField{
-		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Vulnerabilities"),
+		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Results.Vulnerabilities"),
 	}
 
 	imageRepo, imageTag := zcommon.GetImageDirAndTag(image)
@@ -1508,7 +1508,7 @@ func getImageList(ctx context.Context, repo string, metaDB mTypes.MetaDB, cveInf
 	}
 
 	skip := convert.SkipQGLField{
-		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Images.Vulnerabilities"),
+		Vulnerabilities: canSkipField(convert.GetPreloads(ctx), "Results.Vulnerabilities"),
 	}
 
 	pageInput := pagination.PageInput{

--- a/pkg/test/mocks/cve_mock.go
+++ b/pkg/test/mocks/cve_mock.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"context"
+	"sync"
 
 	"zotregistry.dev/zot/v2/pkg/common"
 	cvemodel "zotregistry.dev/zot/v2/pkg/extensions/search/cve/model"
@@ -128,5 +129,63 @@ func (scanner CveScannerMock) UpdateDB(ctx context.Context) error {
 		return scanner.UpdateDBFn(ctx)
 	}
 
+	return nil
+}
+
+type TestCveScanner struct {
+	sync.RWMutex
+
+	cveDataStore map[string]map[string]cvemodel.CVE
+}
+
+func NewTestCveScanner() *TestCveScanner {
+	return &TestCveScanner{
+		cveDataStore: make(map[string]map[string]cvemodel.CVE),
+	}
+}
+
+func (scanner *TestCveScanner) SetCveDataForImage(digestOrTag string, cveData map[string]cvemodel.CVE) {
+	scanner.Lock()
+	defer scanner.Unlock()
+	scanner.cveDataStore[digestOrTag] = cveData
+}
+
+func (scanner *TestCveScanner) ScanImage(ctx context.Context, image string) (cvemodel.ScanResult, error) {
+	scanner.RLock()
+	defer scanner.RUnlock()
+	if cveData, exists := scanner.cveDataStore[image]; exists {
+		return cvemodel.ScanResult{CVEMap: cveData}, nil
+	}
+
+	return cvemodel.ScanResult{CVEMap: map[string]cvemodel.CVE{}}, nil
+}
+
+func (scanner *TestCveScanner) IsImageFormatScannable(repo string, reference string) (bool, error) {
+	return true, nil
+}
+
+func (scanner *TestCveScanner) IsImageMediaScannable(repo string, digest, mediaType string) (bool, error) {
+	return true, nil
+}
+
+func (scanner *TestCveScanner) IsResultCached(digest string) bool {
+	scanner.RLock()
+	defer scanner.RUnlock()
+	_, exists := scanner.cveDataStore[digest]
+
+	return exists
+}
+
+func (scanner *TestCveScanner) GetCachedResult(digest string) map[string]cvemodel.CVE {
+	scanner.RLock()
+	defer scanner.RUnlock()
+	if cveData, exists := scanner.cveDataStore[digest]; exists {
+		return cveData
+	}
+
+	return map[string]cvemodel.CVE{}
+}
+
+func (scanner *TestCveScanner) UpdateDB(ctx context.Context) error {
 	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
Fixes #4245 

**What does this PR do / Why do we need it**:
Corrects the key for fetching Vulnerabilities list in DerivedImageList, BaseImageList, ImageList, and ImageListForDigest GQL queries to fix a bug where the Vulnerabilities information was never returned to the user as the key was incorrect.

**If an issue # is not available please add repro steps and logs showing the issue**:
N/A

**Testing done on this change**:
Covered by Unit Tests

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
No, fixes functionality that was expected to work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
