### PR TITLE
feat(sync): add a Google Artifact Registry credential helper

### DIFF
--- a/examples/config-sync-gcp-credential-helper.json
+++ b/examples/config-sync-gcp-credential-helper.json
@@ -1,0 +1,30 @@
+{
+    "distSpecVersion": "1.1.1",
+    "storage": {
+        "rootDirectory": "/tmp/zot"
+    },
+    "http": {
+        "address": "0.0.0.0",
+        "port": "8080"
+    },
+    "log": {
+        "level": "debug"
+    },
+    "extensions": {
+        "sync": {
+            "credentialsFile": "",
+            "downloadDir": "/tmp/zot",
+            "registries": [
+                {
+                    "urls": [
+                        "https://REGION-docker.pkg.dev"
+                    ],
+                    "onDemand": true,
+                    "maxRetries": 5,
+                    "retryDelay": "2m",
+                    "credentialHelper": "gcp"
+                }
+            ]
+        }
+    }
+}

--- a/pkg/extensions/sync/gcp_credential_helper.go
+++ b/pkg/extensions/sync/gcp_credential_helper.go
@@ -1,0 +1,190 @@
+//go:build sync
+
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+
+	syncconf "zotregistry.dev/zot/v2/pkg/extensions/config/sync"
+	"zotregistry.dev/zot/v2/pkg/log"
+)
+
+const (
+	// gcpTokenUser is the fixed username Google Artifact Registry expects when the password
+	// is an access token.
+	gcpTokenUser = "oauth2accesstoken"
+
+	// gcpScope is the scope a registry pull needs. Application Default Credentials applies
+	// it for the credential sources that are scope aware, such as gcloud user credentials.
+	gcpScope = "https://www.googleapis.com/auth/cloud-platform"
+)
+
+var (
+	errUnableToLoadGCPCredentials = errors.New("unable to load the Google application default credentials")
+	errUnableToGetGCPToken        = errors.New("unable to obtain a Google access token")
+)
+
+// GetGCPTokenSource returns the Application Default Credentials token source. It covers the
+// metadata server on GCE and GKE, GOOGLE_APPLICATION_CREDENTIALS, an external account file
+// for workload identity federation, and gcloud user credentials.
+func GetGCPTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
+	credentials, err := google.FindDefaultCredentials(ctx, gcpScope)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errUnableToLoadGCPCredentials, err)
+	}
+
+	return credentials.TokenSource, nil
+}
+
+type gcpCredential struct {
+	accessToken string
+	expiry      time.Time
+}
+
+type gcpCredentialsHelper struct {
+	mu             sync.RWMutex
+	credentials    map[string]gcpCredential
+	tokenSource    oauth2.TokenSource
+	newTokenSource func(context.Context) (oauth2.TokenSource, error)
+	log            log.Logger
+}
+
+func NewGCPCredentialHelper(
+	log log.Logger,
+	newTokenSource func(context.Context) (oauth2.TokenSource, error),
+) CredentialHelper {
+	return &gcpCredentialsHelper{
+		credentials:    make(map[string]gcpCredential),
+		newTokenSource: newTokenSource,
+		log:            log,
+	}
+}
+
+// source builds the token source on first use, so that credentials which are not reachable
+// yet when sync starts do not disable the helper for the lifetime of the process.
+func (credHelper *gcpCredentialsHelper) source(ctx context.Context) (oauth2.TokenSource, error) {
+	credHelper.mu.RLock()
+	source := credHelper.tokenSource
+	credHelper.mu.RUnlock()
+
+	if source != nil {
+		return source, nil
+	}
+
+	credHelper.mu.Lock()
+	defer credHelper.mu.Unlock()
+
+	// another caller may have won the race while the read lock was released
+	if credHelper.tokenSource != nil {
+		return credHelper.tokenSource, nil
+	}
+
+	source, err := credHelper.newTokenSource(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	credHelper.tokenSource = source
+
+	return source, nil
+}
+
+func (credHelper *gcpCredentialsHelper) token(ctx context.Context) (*oauth2.Token, error) {
+	source, err := credHelper.source(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	token, err := source.Token()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errUnableToGetGCPToken, err)
+	}
+
+	return token, nil
+}
+
+func (credHelper *gcpCredentialsHelper) store(remoteAddress string, token *oauth2.Token) {
+	credHelper.mu.Lock()
+	defer credHelper.mu.Unlock()
+
+	credHelper.credentials[remoteAddress] = gcpCredential{accessToken: token.AccessToken, expiry: token.Expiry}
+}
+
+// GetCredentials pairs the current access token with the username Artifact Registry expects.
+func (credHelper *gcpCredentialsHelper) GetCredentials(urls []string) (syncconf.CredentialsFile, error) {
+	token, err := credHelper.token(context.Background())
+	if err != nil {
+		return syncconf.CredentialsFile{}, err
+	}
+
+	gcpCredentials := make(syncconf.CredentialsFile)
+
+	for _, url := range urls {
+		remoteAddress := StripRegistryTransport(url)
+		gcpCredentials[remoteAddress] = syncconf.Credentials{Username: gcpTokenUser, Password: token.AccessToken}
+
+		credHelper.store(remoteAddress, token)
+	}
+
+	return gcpCredentials, nil
+}
+
+/*
+AreCredentialsValid reports whether the token held for a remote address is still the one the
+token source hands out.
+
+Unlike the ECR helper this does not compare a fixed window against an expiry. The token
+source keeps a cached token and mints a new one only once the old one is seconds from
+expiring, so a window of its own would mark the credentials expired while the source kept
+returning the same token, and the registry client would be rebuilt on every sync operation
+until the token finally rotated. Asking the source instead rebuilds it exactly once per
+rotation, and costs nothing while the cached token is still good.
+*/
+func (credHelper *gcpCredentialsHelper) AreCredentialsValid(remoteAddress string) bool {
+	credHelper.mu.RLock()
+	credential, ok := credHelper.credentials[remoteAddress]
+	credHelper.mu.RUnlock()
+
+	if !ok {
+		return false
+	}
+
+	token, err := credHelper.token(context.Background())
+	if err != nil {
+		credHelper.log.Error().Err(err).Str("url", remoteAddress).
+			Msg("failed to read the Google access token")
+
+		return false
+	}
+
+	if token.AccessToken != credential.accessToken {
+		credHelper.log.Info().Str("url", remoteAddress).Msg("the Google access token has been rotated")
+
+		return false
+	}
+
+	return true
+}
+
+// RefreshCredentials returns the current access token for the given remote address.
+func (credHelper *gcpCredentialsHelper) RefreshCredentials(
+	remoteAddress string,
+) (syncconf.Credentials, error) {
+	credHelper.log.Info().Str("url", remoteAddress).Msg("refreshing the Google access token")
+
+	token, err := credHelper.token(context.Background())
+	if err != nil {
+		return syncconf.Credentials{}, err
+	}
+
+	credHelper.store(remoteAddress, token)
+
+	return syncconf.Credentials{Username: gcpTokenUser, Password: token.AccessToken}, nil
+}

--- a/pkg/extensions/sync/gcp_credential_helper.go
+++ b/pkg/extensions/sync/gcp_credential_helper.go
@@ -67,8 +67,15 @@ func NewGCPCredentialHelper(
 	}
 }
 
-// source builds the token source on first use, so that credentials which are not reachable
-// yet when sync starts do not disable the helper for the lifetime of the process.
+/*
+source builds the token source on first use, so that credentials which are not reachable yet
+when sync starts do not disable the helper for the lifetime of the process.
+
+The result is wrapped in a reusing source. The TokenSource interface promises nothing about
+caching, and AreCredentialsValid below is built on the token only changing when it is really
+rotated, so the caching is made explicit here rather than assumed of whatever the credentials
+hand back.
+*/
 func (credHelper *gcpCredentialsHelper) source(ctx context.Context) (oauth2.TokenSource, error) {
 	credHelper.mu.RLock()
 	source := credHelper.tokenSource
@@ -91,9 +98,9 @@ func (credHelper *gcpCredentialsHelper) source(ctx context.Context) (oauth2.Toke
 		return nil, err
 	}
 
-	credHelper.tokenSource = source
+	credHelper.tokenSource = oauth2.ReuseTokenSource(nil, source)
 
-	return source, nil
+	return credHelper.tokenSource, nil
 }
 
 func (credHelper *gcpCredentialsHelper) token(ctx context.Context) (*oauth2.Token, error) {
@@ -119,12 +126,17 @@ func (credHelper *gcpCredentialsHelper) store(remoteAddress string, token *oauth
 
 // GetCredentials pairs the current access token with the username Artifact Registry expects.
 func (credHelper *gcpCredentialsHelper) GetCredentials(urls []string) (syncconf.CredentialsFile, error) {
+	gcpCredentials := make(syncconf.CredentialsFile)
+
+	// nothing to authenticate against, so do not go looking for credentials
+	if len(urls) == 0 {
+		return gcpCredentials, nil
+	}
+
 	token, err := credHelper.token(context.Background())
 	if err != nil {
 		return syncconf.CredentialsFile{}, err
 	}
-
-	gcpCredentials := make(syncconf.CredentialsFile)
 
 	for _, url := range urls {
 		remoteAddress := StripRegistryTransport(url)

--- a/pkg/extensions/sync/gcp_credential_helper.go
+++ b/pkg/extensions/sync/gcp_credential_helper.go
@@ -20,9 +20,13 @@ const (
 	// is an access token.
 	gcpTokenUser = "oauth2accesstoken"
 
-	// gcpScope is the scope a registry pull needs. Application Default Credentials applies
-	// it for the credential sources that are scope aware, such as gcloud user credentials.
-	gcpScope = "https://www.googleapis.com/auth/cloud-platform"
+	/* gcpScope is the narrowest scope Artifact Registry offers: it publishes only
+	cloud-platform and this read-only form, with nothing specific to a registry. Sync never
+	writes to the upstream, so a token that could is a liability rather than a capability.
+	The scope shapes the token for the credential sources that honour it, such as a service
+	account or an external account; the metadata server may hand back whatever the instance
+	was configured with instead. */
+	gcpScope = "https://www.googleapis.com/auth/cloud-platform.read-only"
 )
 
 var (

--- a/pkg/extensions/sync/gcp_credential_helper.go
+++ b/pkg/extensions/sync/gcp_credential_helper.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"time"
 
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -43,14 +42,9 @@ func GetGCPTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
 	return credentials.TokenSource, nil
 }
 
-type gcpCredential struct {
-	accessToken string
-	expiry      time.Time
-}
-
 type gcpCredentialsHelper struct {
 	mu             sync.RWMutex
-	credentials    map[string]gcpCredential
+	accessTokens   map[string]string
 	tokenSource    oauth2.TokenSource
 	newTokenSource func(context.Context) (oauth2.TokenSource, error)
 	log            log.Logger
@@ -61,14 +55,14 @@ func NewGCPCredentialHelper(
 	newTokenSource func(context.Context) (oauth2.TokenSource, error),
 ) CredentialHelper {
 	return &gcpCredentialsHelper{
-		credentials:    make(map[string]gcpCredential),
+		accessTokens:   make(map[string]string),
 		newTokenSource: newTokenSource,
 		log:            log,
 	}
 }
 
 /*
-source builds the token source on first use, so that credentials which are not reachable yet
+resolveTokenSource builds the token source on first use, so that credentials which are not reachable yet
 when sync starts do not disable the helper for the lifetime of the process.
 
 The result is wrapped in a reusing source. The TokenSource interface promises nothing about
@@ -76,7 +70,7 @@ caching, and AreCredentialsValid below is built on the token only changing when 
 rotated, so the caching is made explicit here rather than assumed of whatever the credentials
 hand back.
 */
-func (credHelper *gcpCredentialsHelper) source(ctx context.Context) (oauth2.TokenSource, error) {
+func (credHelper *gcpCredentialsHelper) resolveTokenSource(ctx context.Context) (oauth2.TokenSource, error) {
 	credHelper.mu.RLock()
 	source := credHelper.tokenSource
 	credHelper.mu.RUnlock()
@@ -103,8 +97,8 @@ func (credHelper *gcpCredentialsHelper) source(ctx context.Context) (oauth2.Toke
 	return credHelper.tokenSource, nil
 }
 
-func (credHelper *gcpCredentialsHelper) token(ctx context.Context) (*oauth2.Token, error) {
-	source, err := credHelper.source(ctx)
+func (credHelper *gcpCredentialsHelper) fetchToken(ctx context.Context) (*oauth2.Token, error) {
+	source, err := credHelper.resolveTokenSource(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -117,11 +111,11 @@ func (credHelper *gcpCredentialsHelper) token(ctx context.Context) (*oauth2.Toke
 	return token, nil
 }
 
-func (credHelper *gcpCredentialsHelper) store(remoteAddress string, token *oauth2.Token) {
+func (credHelper *gcpCredentialsHelper) rememberToken(remoteAddress string, token *oauth2.Token) {
 	credHelper.mu.Lock()
 	defer credHelper.mu.Unlock()
 
-	credHelper.credentials[remoteAddress] = gcpCredential{accessToken: token.AccessToken, expiry: token.Expiry}
+	credHelper.accessTokens[remoteAddress] = token.AccessToken
 }
 
 // GetCredentials pairs the current access token with the username Artifact Registry expects.
@@ -133,7 +127,7 @@ func (credHelper *gcpCredentialsHelper) GetCredentials(urls []string) (syncconf.
 		return gcpCredentials, nil
 	}
 
-	token, err := credHelper.token(context.Background())
+	token, err := credHelper.fetchToken(context.Background())
 	if err != nil {
 		return syncconf.CredentialsFile{}, err
 	}
@@ -142,7 +136,7 @@ func (credHelper *gcpCredentialsHelper) GetCredentials(urls []string) (syncconf.
 		remoteAddress := StripRegistryTransport(url)
 		gcpCredentials[remoteAddress] = syncconf.Credentials{Username: gcpTokenUser, Password: token.AccessToken}
 
-		credHelper.store(remoteAddress, token)
+		credHelper.rememberToken(remoteAddress, token)
 	}
 
 	return gcpCredentials, nil
@@ -161,14 +155,14 @@ rotation, and costs nothing while the cached token is still good.
 */
 func (credHelper *gcpCredentialsHelper) AreCredentialsValid(remoteAddress string) bool {
 	credHelper.mu.RLock()
-	credential, ok := credHelper.credentials[remoteAddress]
+	held, ok := credHelper.accessTokens[remoteAddress]
 	credHelper.mu.RUnlock()
 
 	if !ok {
 		return false
 	}
 
-	token, err := credHelper.token(context.Background())
+	token, err := credHelper.fetchToken(context.Background())
 	if err != nil {
 		credHelper.log.Error().Err(err).Str("url", remoteAddress).
 			Msg("failed to read the Google access token")
@@ -176,7 +170,7 @@ func (credHelper *gcpCredentialsHelper) AreCredentialsValid(remoteAddress string
 		return false
 	}
 
-	if token.AccessToken != credential.accessToken {
+	if token.AccessToken != held {
 		credHelper.log.Info().Str("url", remoteAddress).Msg("the Google access token has been rotated")
 
 		return false
@@ -191,12 +185,12 @@ func (credHelper *gcpCredentialsHelper) RefreshCredentials(
 ) (syncconf.Credentials, error) {
 	credHelper.log.Info().Str("url", remoteAddress).Msg("refreshing the Google access token")
 
-	token, err := credHelper.token(context.Background())
+	token, err := credHelper.fetchToken(context.Background())
 	if err != nil {
 		return syncconf.Credentials{}, err
 	}
 
-	credHelper.store(remoteAddress, token)
+	credHelper.rememberToken(remoteAddress, token)
 
 	return syncconf.Credentials{Username: gcpTokenUser, Password: token.AccessToken}, nil
 }

--- a/pkg/extensions/sync/gcp_credential_helper_test.go
+++ b/pkg/extensions/sync/gcp_credential_helper_test.go
@@ -1,0 +1,160 @@
+//go:build sync
+
+package sync_test
+
+import (
+	"context"
+	"errors"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"golang.org/x/oauth2"
+
+	"zotregistry.dev/zot/v2/pkg/extensions/sync"
+	"zotregistry.dev/zot/v2/pkg/log"
+)
+
+var (
+	errTokenSourceUnavailable = errors.New("metadata server unavailable")
+	errTokenMintFailed        = errors.New("no token for you")
+)
+
+// mintingTokenSource hands out a different access token on every call, so that a test can
+// tell whether the helper asked the source again or reused what it already had.
+type mintingTokenSource struct {
+	calls  atomic.Int64
+	expiry time.Time
+}
+
+func (source *mintingTokenSource) Token() (*oauth2.Token, error) {
+	count := source.calls.Add(1)
+
+	expiry := source.expiry
+	if expiry.IsZero() {
+		expiry = time.Now().Add(time.Hour)
+	}
+
+	return &oauth2.Token{
+		AccessToken: "access-token-" + strconv.FormatInt(count, 10),
+		TokenType:   "Bearer",
+		Expiry:      expiry,
+	}, nil
+}
+
+func newHelper(source oauth2.TokenSource) sync.CredentialHelper {
+	return sync.NewGCPCredentialHelper(log.NewTestLogger(),
+		func(_ context.Context) (oauth2.TokenSource, error) { return source, nil })
+}
+
+func TestGCPCredentialHelper(t *testing.T) {
+	const remoteAddress = "us-central1-docker.pkg.dev"
+
+	Convey("The access token is paired with the username Artifact Registry expects", t, func() {
+		source := &mintingTokenSource{}
+		helper := newHelper(source)
+
+		credentials, err := helper.GetCredentials([]string{"https://" + remoteAddress})
+		So(err, ShouldBeNil)
+		So(credentials[remoteAddress].Username, ShouldEqual, "oauth2accesstoken")
+		So(credentials[remoteAddress].Password, ShouldEqual, "access-token-1")
+	})
+
+	Convey("Every requested registry gets the same token", t, func() {
+		source := &mintingTokenSource{}
+		helper := newHelper(source)
+
+		credentials, err := helper.GetCredentials([]string{
+			"https://us-central1-docker.pkg.dev",
+			"https://europe-west1-docker.pkg.dev",
+		})
+		So(err, ShouldBeNil)
+		So(credentials["us-central1-docker.pkg.dev"].Password,
+			ShouldEqual, credentials["europe-west1-docker.pkg.dev"].Password)
+		So(source.calls.Load(), ShouldEqual, 1)
+	})
+
+	Convey("Credentials stay valid while the source returns the same token", t, func() {
+		token := &oauth2.Token{AccessToken: "stable", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour)}
+		helper := newHelper(oauth2.StaticTokenSource(token))
+
+		_, err := helper.GetCredentials([]string{"https://" + remoteAddress})
+		So(err, ShouldBeNil)
+		So(helper.AreCredentialsValid(remoteAddress), ShouldBeTrue)
+	})
+
+	/* A fixed expiry window would call the token invalid well before the source rotates it,
+	and rebuild the registry client on every sync operation in between. */
+	Convey("A token that is close to expiring is still valid until it is rotated", t, func() {
+		token := &oauth2.Token{AccessToken: "nearly-due", TokenType: "Bearer", Expiry: time.Now().Add(time.Second)}
+		helper := newHelper(oauth2.StaticTokenSource(token))
+
+		_, err := helper.GetCredentials([]string{"https://" + remoteAddress})
+		So(err, ShouldBeNil)
+		So(helper.AreCredentialsValid(remoteAddress), ShouldBeTrue)
+	})
+
+	Convey("Credentials become invalid once the source rotates the token", t, func() {
+		helper := newHelper(&mintingTokenSource{})
+
+		_, err := helper.GetCredentials([]string{"https://" + remoteAddress})
+		So(err, ShouldBeNil)
+		So(helper.AreCredentialsValid(remoteAddress), ShouldBeFalse)
+	})
+
+	Convey("An address that was never fetched is not valid", t, func() {
+		helper := newHelper(oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "stable"}))
+
+		So(helper.AreCredentialsValid(remoteAddress), ShouldBeFalse)
+	})
+
+	Convey("A refresh hands back the current token", t, func() {
+		source := &mintingTokenSource{}
+		helper := newHelper(source)
+
+		credentials, err := helper.RefreshCredentials(remoteAddress)
+		So(err, ShouldBeNil)
+		So(credentials.Username, ShouldEqual, "oauth2accesstoken")
+		So(credentials.Password, ShouldEqual, "access-token-1")
+		So(helper.AreCredentialsValid(remoteAddress), ShouldBeFalse) // the next call mints another one
+	})
+
+	Convey("A token source that cannot be built is reported, not cached", t, func() {
+		var attempts atomic.Int64
+
+		helper := sync.NewGCPCredentialHelper(log.NewTestLogger(),
+			func(_ context.Context) (oauth2.TokenSource, error) {
+				if attempts.Add(1) == 1 {
+					return nil, errTokenSourceUnavailable
+				}
+
+				return oauth2.StaticTokenSource(&oauth2.Token{AccessToken: "late"}), nil
+			})
+
+		_, err := helper.GetCredentials([]string{"https://" + remoteAddress})
+		So(err, ShouldNotBeNil)
+
+		// the failure must not disable the helper for good
+		credentials, err := helper.GetCredentials([]string{"https://" + remoteAddress})
+		So(err, ShouldBeNil)
+		So(credentials[remoteAddress].Password, ShouldEqual, "late")
+	})
+
+	Convey("A token source that fails to mint is reported", t, func() {
+		helper := newHelper(failingTokenSource{})
+
+		_, err := helper.GetCredentials([]string{"https://" + remoteAddress})
+		So(err, ShouldNotBeNil)
+
+		_, err = helper.RefreshCredentials(remoteAddress)
+		So(err, ShouldNotBeNil)
+	})
+}
+
+type failingTokenSource struct{}
+
+func (failingTokenSource) Token() (*oauth2.Token, error) {
+	return nil, errTokenMintFailed
+}

--- a/pkg/extensions/sync/gcp_credential_helper_test.go
+++ b/pkg/extensions/sync/gcp_credential_helper_test.go
@@ -64,6 +64,25 @@ func TestGCPCredentialHelper(t *testing.T) {
 		So(credentials[remoteAddress].Password, ShouldEqual, "access-token-1")
 	})
 
+	Convey("No token is fetched when there are no registries", t, func() {
+		source := &mintingTokenSource{}
+		helper := newHelper(source)
+
+		credentials, err := helper.GetCredentials(nil)
+		So(err, ShouldBeNil)
+		So(credentials, ShouldNotBeNil)
+		So(credentials, ShouldBeEmpty)
+		So(source.calls.Load(), ShouldEqual, 0)
+	})
+
+	Convey("A failed fetch still yields a usable map", t, func() {
+		helper := newHelper(failingTokenSource{})
+
+		credentials, err := helper.GetCredentials([]string{"https://" + remoteAddress})
+		So(err, ShouldNotBeNil)
+		So(credentials, ShouldNotBeNil) // the service writes into this map later
+	})
+
 	Convey("Every requested registry gets the same token", t, func() {
 		source := &mintingTokenSource{}
 		helper := newHelper(source)
@@ -99,7 +118,8 @@ func TestGCPCredentialHelper(t *testing.T) {
 	})
 
 	Convey("Credentials become invalid once the source rotates the token", t, func() {
-		helper := newHelper(&mintingTokenSource{})
+		// an expiry inside the reuse window makes the wrapped source mint a token every time
+		helper := newHelper(&mintingTokenSource{expiry: time.Now().Add(time.Second)})
 
 		_, err := helper.GetCredentials([]string{"https://" + remoteAddress})
 		So(err, ShouldBeNil)
@@ -113,7 +133,7 @@ func TestGCPCredentialHelper(t *testing.T) {
 	})
 
 	Convey("A refresh hands back the current token", t, func() {
-		source := &mintingTokenSource{}
+		source := &mintingTokenSource{expiry: time.Now().Add(time.Second)}
 		helper := newHelper(source)
 
 		credentials, err := helper.RefreshCredentials(remoteAddress)
@@ -174,7 +194,7 @@ func (source *flakyTokenSource) Token() (*oauth2.Token, error) {
 		return nil, errTokenMintFailed
 	}
 
-	return &oauth2.Token{AccessToken: "first", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour)}, nil
+	return &oauth2.Token{AccessToken: "first", TokenType: "Bearer", Expiry: time.Now().Add(time.Second)}, nil
 }
 
 type failingTokenSource struct{}

--- a/pkg/extensions/sync/gcp_credential_helper_test.go
+++ b/pkg/extensions/sync/gcp_credential_helper_test.go
@@ -5,6 +5,8 @@ package sync_test
 import (
 	"context"
 	"errors"
+	"os"
+	"path/filepath"
 	"strconv"
 	"sync/atomic"
 	"testing"
@@ -142,6 +144,14 @@ func TestGCPCredentialHelper(t *testing.T) {
 		So(credentials[remoteAddress].Password, ShouldEqual, "late")
 	})
 
+	Convey("Credentials are not valid when the token cannot be read", t, func() {
+		helper := newHelper(&flakyTokenSource{})
+
+		_, err := helper.GetCredentials([]string{"https://" + remoteAddress})
+		So(err, ShouldBeNil)
+		So(helper.AreCredentialsValid(remoteAddress), ShouldBeFalse)
+	})
+
 	Convey("A token source that fails to mint is reported", t, func() {
 		helper := newHelper(failingTokenSource{})
 
@@ -153,8 +163,55 @@ func TestGCPCredentialHelper(t *testing.T) {
 	})
 }
 
+// flakyTokenSource yields one token and fails afterwards, so that a test can reach the
+// branches that only run once credentials are already held.
+type flakyTokenSource struct {
+	calls atomic.Int64
+}
+
+func (source *flakyTokenSource) Token() (*oauth2.Token, error) {
+	if source.calls.Add(1) > 1 {
+		return nil, errTokenMintFailed
+	}
+
+	return &oauth2.Token{AccessToken: "first", TokenType: "Bearer", Expiry: time.Now().Add(time.Hour)}, nil
+}
+
 type failingTokenSource struct{}
 
 func (failingTokenSource) Token() (*oauth2.Token, error) {
 	return nil, errTokenMintFailed
+}
+
+func TestGetGCPTokenSource(t *testing.T) {
+	Convey("Application default credentials are read from the environment", t, func() {
+		directory := t.TempDir()
+		tokenFile := filepath.Join(directory, "token")
+		So(os.WriteFile(tokenFile, []byte("a.subject.token"), 0o600), ShouldBeNil)
+
+		/* an external account file is enough to build the token source offline: the exchange
+		itself only happens when a token is asked for */
+		credentialsFile := filepath.Join(directory, "credentials.json")
+		contents := `{
+			"type": "external_account",
+			"audience": "//iam.googleapis.com/projects/1/locations/global/workloadIdentityPools/p/providers/v",
+			"subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+			"token_url": "https://sts.googleapis.com/v1/token",
+			"credential_source": {"file": "` + tokenFile + `", "format": {"type": "text"}}
+		}`
+		So(os.WriteFile(credentialsFile, []byte(contents), 0o600), ShouldBeNil)
+
+		t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", credentialsFile)
+
+		source, err := sync.GetGCPTokenSource(context.Background())
+		So(err, ShouldBeNil)
+		So(source, ShouldNotBeNil)
+	})
+
+	Convey("A missing credentials file is reported", t, func() {
+		t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", filepath.Join(t.TempDir(), "absent.json"))
+
+		_, err := sync.GetGCPTokenSource(context.Background())
+		So(err, ShouldNotBeNil)
+	})
 }

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -104,6 +104,16 @@ func New(
 				log.Error().Err(err).Msg("failed to retrieve credentials using ECR credentials helper.")
 			}
 			service.credentials = creds
+		case "gcp":
+			// Logic to fetch an access token from the Google application default credentials.
+			log.Info().Msg("fetch the credentials using Google application default credentials.")
+			service.credentialHelper = NewGCPCredentialHelper(log, GetGCPTokenSource)
+
+			creds, err := service.credentialHelper.GetCredentials(service.config.URLs)
+			if err != nil {
+				log.Error().Err(err).Msg("failed to retrieve credentials using GCP credentials helper.")
+			}
+			service.credentials = creds
 		case "oauth2":
 			// Logic to fetch credentials by exchanging a JWT assertion for an access token.
 			log.Info().Msg("fetch the credentials using OAuth2 JWT assertion exchange.")

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -810,8 +810,13 @@ func TestServiceGCPCredentialHelper(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(service.credentialHelper, ShouldNotBeNil)
 
-		// the credentials could not be fetched, but that must not fail the service
+		/* the credentials could not be fetched, but the map must still be usable, because the
+		refresh path writes into it without checking */
+		So(service.credentials, ShouldNotBeNil)
 		So(service.credentials, ShouldBeEmpty)
+
+		// a refresh that cannot reach the credentials is swallowed rather than fatal
+		So(service.refreshRegistryTemporaryCredentials(), ShouldBeNil)
 	})
 }
 

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -795,6 +795,26 @@ func writeOAuth2SigningFile(t *testing.T) string {
 	return signingFile
 }
 
+func TestServiceGCPCredentialHelper(t *testing.T) {
+	Convey("New wires the gcp credential helper", t, func() {
+		/* point the application default credentials at a file that is not there, so that the
+		test neither depends on an ambient Google credential nor reaches the network */
+		t.Setenv("GOOGLE_APPLICATION_CREDENTIALS", path.Join(t.TempDir(), "absent.json"))
+
+		conf := syncconf.RegistryConfig{
+			URLs:             []string{"https://us-central1-docker.pkg.dev"},
+			CredentialHelper: "gcp",
+		}
+
+		service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		So(err, ShouldBeNil)
+		So(service.credentialHelper, ShouldNotBeNil)
+
+		// the credentials could not be fetched, but that must not fail the service
+		So(service.credentials, ShouldBeEmpty)
+	})
+}
+
 func TestServiceOAuth2CredentialHelper(t *testing.T) {
 	Convey("New wires the oauth2 credential helper", t, func() {
 		tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
Closes #4275

**What does this PR do / Why do we need it**:

`ecr` lets an AWS user mirror from ECR with `credentialHelper` alone. Reaching Google Artifact Registry meant spelling out the whole `oauth2` block instead, down to knowing it wants the fixed username `oauth2accesstoken`. This adds the equivalent:

```json
{ "urls": ["https://REGION-docker.pkg.dev"], "onDemand": true, "credentialHelper": "gcp" }
```

It is built on Application Default Credentials, so it covers the metadata server on GCE and GKE, `GOOGLE_APPLICATION_CREDENTIALS`, an external account file for workload identity federation, and gcloud user credentials. No new dependency: `golang.org/x/oauth2` is already one and `golang.org/x/oauth2/google` is in the same module, so `go.mod` and `go.sum` are unchanged.

`AreCredentialsValid` asks the token source instead of comparing a fixed window against the expiry, as `ecr` does. A Google access token lasts about an hour and `oauth2.ReuseTokenSource` hands back the cached one until 10 seconds before it expires, so a window of our own would report the credentials expired while the source kept returning the same token, rebuilding the registry client on every sync operation until it finally rotated.

**On the name**: the helper is `gcp` rather than `gar`. `ecr` is service-bound because it calls the ECR `GetAuthorizationToken` API; this one only asks Google for an access token, and one such token returns `200` on `/v2/` for `asia-northeast1-docker.pkg.dev` and for the `gcr.io` hostnames alike, so `gar` would suggest it applies to less than it does. Happy to make it `gar` if you disagree.

**Testing done on this change**:

`TestGCPCredentialHelper` covers the username pairing, one token shared across registries, validity while the source is stable, a token near expiry staying valid until it actually rotates, invalidation on rotation, refresh, and both failure paths. Passes under `-race`.

I also ran zot with the helper against a stand-in registry that logs what it receives, which is the part unit tests cannot show:

```
AUTH  /v2/some/repo/img/manifests/latest  user="oauth2accesstoken" passwordLen=256 passwordPrefix=ya29.a
```

One note for anyone reading such a log against a repository the principal cannot read: zot reports `unauthorized access. check credentials`, because regclient maps both 401 and 403 to `ErrHTTPUnauthorized`. The same request made directly returns `403` with the token and `401` without it, so the token is sent and accepted and only authorization fails.

I have not pulled an image all the way through from a real Artifact Registry repository, which needs a repository, an image and `roles/artifactregistry.reader`.

**Will this break upgrades or downgrades?**
No. `credentialHelper: "gcp"` is new; any other value behaves as before.

**Does this PR introduce any user-facing change?**:
Yes, the new `gcp` credential helper, with `examples/config-sync-gcp-credential-helper.json` alongside the ECR one.

**release-note**
Sync can now authenticate to Google Artifact Registry with `"credentialHelper": "gcp"`, which obtains a short-lived access token from Google application default credentials and refreshes it as it rotates.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
