### PR TITLE
fix(events): apply default HTTP sink timeout when unset

### DIFF
--- a/pkg/extensions/events/http_sink.go
+++ b/pkg/extensions/events/http_sink.go
@@ -30,6 +30,10 @@ func NewHTTPSink(config eventsconf.SinkConfig) (*HTTPSink, error) {
 		return nil, zerr.ErrEventSinkAddressEmpty
 	}
 
+	if config.Timeout <= 0 {
+		config.Timeout = DefaultHTTPTimeout
+	}
+
 	// Create the basic http client
 	httpClient, err := GetHTTPClientForConfig(config)
 	if err != nil {
@@ -123,7 +127,7 @@ func GetHTTPClientForConfig(config eventsconf.SinkConfig) (*http.Client, error) 
 	}
 
 	timeout := config.Timeout
-	if timeout == 0 {
+	if timeout <= 0 {
 		timeout = DefaultHTTPTimeout
 	}
 

--- a/pkg/extensions/events/http_sink_test.go
+++ b/pkg/extensions/events/http_sink_test.go
@@ -3,6 +3,9 @@
 package events_test
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -150,6 +153,33 @@ func TestHTTPSink(t *testing.T) {
 
 		err = sink.Emit(&event)
 		So(err, ShouldNotBeNil)
+	})
+
+	Convey("HTTPSink.Emit delivers when timeout is unset", t, func() {
+		var hits atomic.Int32
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits.Add(1)
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer server.Close()
+
+		event := cloudevents.NewEvent()
+		event.SetID("1234")
+		event.SetType("test.event")
+		event.SetSource("unit.test")
+
+		cfg := eventsconf.SinkConfig{
+			Type:    eventsconf.HTTP,
+			Address: server.URL,
+		}
+
+		sink, err := events.NewHTTPSink(cfg)
+		So(err, ShouldBeNil)
+
+		result := sink.Emit(&event)
+		So(cloudevents.IsACK(result), ShouldBeTrue)
+		So(hits.Load(), ShouldEqual, 1)
 	})
 
 	Convey("HTTPSink.Close completes successfully", t, func() {


### PR DESCRIPTION
(cherry picked from commit a8851b5234499aa747ca31f35d67b412582d7b45)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
