### PR TITLE
fix: dedupe digests before DynamoDB BatchGetItem

### DIFF
--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -2137,18 +2137,35 @@ const AwsS3BatchLimit = 100
 
 func (dwr *DynamoDB) fetchImageMetaAttributesByDigest(ctx context.Context, digests []string,
 ) ([]map[string]types.AttributeValue, error) {
-	// AWS S3 as a limit (=100) on number of keys that can retrieved in one
-	// request, so break it up
+	// BatchGetItem fails the whole request with a ValidationException if the same
+	// key is present twice, and callers do pass repeated digests legitimately (for
+	// example several tags, or several repos, referring to one manifest), so ask
+	// for each distinct digest only once. The caller's original order and
+	// repetitions are restored when building orderedResp below.
+	uniqueDigests := make([]string, 0, len(digests))
+	seenDigests := make(map[string]struct{}, len(digests))
+
+	for _, digest := range digests {
+		if _, seen := seenDigests[digest]; seen {
+			continue
+		}
+
+		seenDigests[digest] = struct{}{}
+		uniqueDigests = append(uniqueDigests, digest)
+	}
+
+	// BatchGetItem has a limit (=100) on the number of keys that can be retrieved
+	// in one request, so break it up
 	batchedResp := []map[string]types.AttributeValue{}
 
-	for start := 0; start < len(digests); {
-		size := min(len(digests)-start, AwsS3BatchLimit)
+	for start := 0; start < len(uniqueDigests); {
+		size := min(len(uniqueDigests)-start, AwsS3BatchLimit)
 		end := start + size
 
 		resp, err := dwr.Client.BatchGetItem(ctx, &dynamodb.BatchGetItemInput{
 			RequestItems: map[string]types.KeysAndAttributes{
 				dwr.ImageMetaTablename: {
-					Keys: getBatchImageKeys(digests[start:end]),
+					Keys: getBatchImageKeys(uniqueDigests[start:end]),
 				},
 			},
 		})

--- a/pkg/meta/dynamodb/dynamodb_test.go
+++ b/pkg/meta/dynamodb/dynamodb_test.go
@@ -241,8 +241,12 @@ func TestWrapperErrors(t *testing.T) {
 				err := dynamoWrapper.SetRepoReference(ctx, "repo", "tag", image.AsImageMeta())
 				So(err, ShouldBeNil)
 
-				_, err = dynamoWrapper.FilterImageMeta(ctx, []string{image.DigestStr(), image.DigestStr()})
-				So(err, ShouldNotBeNil)
+				// BatchGetItem rejects a request containing the same key twice, so the
+				// driver queries each distinct digest once. Repeated digests are valid
+				// input (boltdb accepts them) and must not fail here either.
+				imageMeta, err := dynamoWrapper.FilterImageMeta(ctx, []string{image.DigestStr(), image.DigestStr()})
+				So(err, ShouldBeNil)
+				So(imageMeta, ShouldContainKey, image.DigestStr())
 			})
 
 			Convey("manifest meta unmarshal error", func() {


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

Fixes #4279

**What does this PR do / Why do we need it**:

`fetchImageMetaAttributesByDigest` passes the caller's digest list straight to `BatchGetItem`, chunked by `AwsS3BatchLimit`, without deduplicating. DynamoDB rejects any request containing the same key twice:

```
api error ValidationException: Provided list of item keys contains duplicates
```

Repeated digests are legitimate input — several tags, or several repos, can refer to one manifest — and the **boltdb driver accepts them**: its `FilterImageMeta` iterates the list and overwrites the map entry. So today the same `MetaDB` call succeeds on boltdb and fails on dynamodb.

The user-visible effect is that the UI home/explore page hangs on *Loading* forever: `GlobalSearch` returns **HTTP 200** with the DynamoDB error inside the GraphQL body and `data: null`, and **nothing is written to the zot log**, so the registry looks healthy. Pulls, `/v2/_catalog`, `ExpandedRepoInfo` and `Image` are unaffected — they don't use this batched path.

Same class of bug as #2464 (fixed in the image-detail path only); #2629 later touched this function to add the 100-key chunking but did not dedupe.

This PR queries each distinct digest once. The response is expanded back to the caller's original order and repetitions when building `orderedResp`, so callers see no behaviour change — including `FilterImageMeta`'s `len(imageMetaAttributes) != len(digests)` check, which keeps working because the returned slice still has one entry per requested digest. As a side effect the 100-key chunking now operates on distinct digests, so fewer requests are issued.

**If an issue # is not available please add repro steps and logs showing the issue**:

See #4279.

**Testing done on this change**:

The existing `FilterImageMeta with duplicate digests` test asserted that duplicates return an error, which codified the driver quirk as expected behaviour. It now asserts the call succeeds and returns the requested digest, matching boltdb.

Verified against `amazon/dynamodb-local`, which enforces the same duplicate-key constraint as AWS.

Before the change:

```
DYNAMODBMOCK_ENDPOINT=http://localhost:8000 go test ./pkg/meta/dynamodb/ -run TestWrapperErrors
Line 248:
Actual: 'operation error DynamoDB: BatchGetItem, ... ValidationException: Provided list of item keys contains duplicates'
--- FAIL: TestWrapperErrors (2.71s)
```

After:

```
ok  	zotregistry.dev/zot/v2/pkg/meta/dynamodb	15.210s
ok  	zotregistry.dev/zot/v2/pkg/meta	4.780s
```

`go build` and `go vet` clean on the package.

**Automation added to e2e**:

No new case — an existing unit test covers the path; its assertion was inverted to the correct expectation.

**Will this break upgrades or downgrades?**

No. No storage, schema or API change; only the shape of the request sent to DynamoDB.

**Does this PR introduce any user-facing change?**:

```release-note
Fix the UI home/explore page hanging on "Loading" when using the DynamoDB metaDB: image metadata lookups no longer send duplicate keys to BatchGetItem.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.