### PR TITLE
test: migrate pkg/cli tests from GetFreePort to port "0"

### DIFF
--- a/pkg/cli/client/cve_cmd_test.go
+++ b/pkg/cli/client/cve_cmd_test.go
@@ -42,10 +42,8 @@ import (
 
 func TestNegativeServerResponse(t *testing.T) {
 	Convey("Test from real server without search endpoint", t, func() {
-		port := test.GetFreePort()
-		url := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		dir := t.TempDir()
 
@@ -80,7 +78,7 @@ func TestNegativeServerResponse(t *testing.T) {
 		ctlr.Log = log.NewLoggerWithWriter("info", writers)
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		url := cm.StartAndWait()
 		defer cm.StopServer()
 
 		_, err = test.ReadLogFileAndSearchString(logPath, "CVE config not provided, skipping CVE update", 90*time.Second)
@@ -105,10 +103,8 @@ func TestNegativeServerResponse(t *testing.T) {
 	})
 
 	Convey("Test non-existing manifest blob", t, func() {
-		port := test.GetFreePort()
-		url := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		dir := t.TempDir()
 
@@ -169,7 +165,9 @@ func TestNegativeServerResponse(t *testing.T) {
 
 		defer ctlr.Shutdown()
 
-		test.WaitTillServerReady(url)
+		cm := test.NewControllerManager(ctlr)
+		cm.WaitServerReady()
+		url := cm.BaseURL()
 
 		_, err = test.ReadLogFileAndSearchString(logPath, "cve-db update completed, next update scheduled after interval",
 			90*time.Second)
@@ -192,10 +190,8 @@ func TestNegativeServerResponse(t *testing.T) {
 }
 
 func TestCVEDiffList(t *testing.T) {
-	port := test.GetFreePort()
-	url := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 
 	dir := t.TempDir()
 
@@ -346,7 +342,9 @@ func TestCVEDiffList(t *testing.T) {
 
 	defer ctlr.Shutdown()
 
-	test.WaitTillServerReady(url)
+	cm := test.NewControllerManager(ctlr)
+	cm.WaitServerReady()
+	url := cm.BaseURL()
 
 	ctx := context.Background()
 	_, _ = ociutils.InitializeTestMetaDB(ctx, ctlr.MetaDB,
@@ -477,10 +475,8 @@ func TestCVEDiffList(t *testing.T) {
 
 //nolint:dupl
 func TestServerCVEResponse(t *testing.T) {
-	port := test.GetFreePort()
-	url := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 
 	dir := t.TempDir()
 
@@ -522,7 +518,9 @@ func TestServerCVEResponse(t *testing.T) {
 
 	defer ctlr.Shutdown()
 
-	test.WaitTillServerReady(url)
+	cm := test.NewControllerManager(ctlr)
+	cm.WaitServerReady()
+	url := cm.BaseURL()
 
 	image := CreateDefaultImage()
 
@@ -864,10 +862,8 @@ func TestServerCVEResponse(t *testing.T) {
 
 func TestCVESort(t *testing.T) {
 	rootDir := t.TempDir()
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
@@ -937,7 +933,9 @@ func TestCVESort(t *testing.T) {
 
 	defer ctlr.Shutdown()
 
-	test.WaitTillServerReady(baseURL)
+	cm := test.NewControllerManager(ctlr)
+	cm.WaitServerReady()
+	baseURL := cm.BaseURL()
 
 	space := regexp.MustCompile(`\s+`)
 

--- a/pkg/cli/client/image_cmd_test.go
+++ b/pkg/cli/client/image_cmd_test.go
@@ -49,10 +49,8 @@ func TestSignature(t *testing.T) {
 		err = os.Chdir(currentDir)
 		So(err, ShouldBeNil)
 
-		port := test.GetFreePort()
-		url := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
@@ -61,9 +59,11 @@ func TestSignature(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = currentDir
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		url := cm.StartAndWait()
 
 		defer cm.StopServer()
+
+		port := strconv.Itoa(cm.Port())
 
 		image := CreateDefaultImage()
 		err = UploadImage(image, url, repoName, "1.0")
@@ -126,10 +126,8 @@ func TestSignature(t *testing.T) {
 		err = os.Chdir(currentDir)
 		So(err, ShouldBeNil)
 
-		port := test.GetFreePort()
-		url := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
@@ -137,9 +135,11 @@ func TestSignature(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = currentDir
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		url := cm.StartAndWait()
 
 		defer cm.StopServer()
+
+		port := strconv.Itoa(cm.Port())
 
 		err = UploadImage(CreateDefaultImage(), url, repoName, "0.0.1")
 		So(err, ShouldBeNil)
@@ -181,10 +181,8 @@ func TestSignature(t *testing.T) {
 		err = os.Chdir(currentDir)
 		So(err, ShouldBeNil)
 
-		port := test.GetFreePort()
-		url := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
@@ -192,9 +190,11 @@ func TestSignature(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = currentDir
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		url := cm.StartAndWait()
 
 		defer cm.StopServer()
+
+		port := strconv.Itoa(cm.Port())
 
 		err = UploadImage(CreateDefaultImage(), url, repoName, "0.0.1")
 		So(err, ShouldBeNil)
@@ -229,10 +229,8 @@ func TestSignature(t *testing.T) {
 
 //nolint:dupl
 func TestDerivedImageList(t *testing.T) {
-	port := test.GetFreePort()
-	url := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
 		Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
@@ -242,7 +240,7 @@ func TestDerivedImageList(t *testing.T) {
 
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartAndWait(conf.HTTP.Port)
+	url := cm.StartAndWait()
 	defer cm.StopServer()
 
 	err := uploadManifestDerivedBase(url)
@@ -288,10 +286,8 @@ func TestDerivedImageList(t *testing.T) {
 
 //nolint:dupl
 func TestBaseImageList(t *testing.T) {
-	port := test.GetFreePort()
-	url := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
 		Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
@@ -300,7 +296,7 @@ func TestBaseImageList(t *testing.T) {
 	ctlr.Config.Storage.RootDirectory = t.TempDir()
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartAndWait(conf.HTTP.Port)
+	url := cm.StartAndWait()
 	defer cm.StopServer()
 
 	err := uploadManifestDerivedBase(url)
@@ -346,10 +342,8 @@ func TestBaseImageList(t *testing.T) {
 
 func TestOutputFormatGQL(t *testing.T) {
 	Convey("Test from real server", t, func() {
-		port := test.GetFreePort()
-		url := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
@@ -357,7 +351,7 @@ func TestOutputFormatGQL(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		url := cm.StartAndWait()
 
 		defer cm.StopServer()
 
@@ -545,10 +539,8 @@ func TestOutputFormatGQL(t *testing.T) {
 
 func TestServerResponseGQL(t *testing.T) {
 	Convey("Test from real server", t, func() {
-		port := test.GetFreePort()
-		url := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
 			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
@@ -556,7 +548,7 @@ func TestServerResponseGQL(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		url := cm.StartAndWait()
 
 		defer cm.StopServer()
 
@@ -780,10 +772,8 @@ func TestServerResponseGQL(t *testing.T) {
 }
 
 func TestServerResponse(t *testing.T) {
-	port := test.GetFreePort()
-	url := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
 		Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
@@ -792,7 +782,7 @@ func TestServerResponse(t *testing.T) {
 	ctlr.Config.Storage.RootDirectory = t.TempDir()
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartAndWait(conf.HTTP.Port)
+	url := cm.StartAndWait()
 	defer cm.StopServer()
 
 	err := uploadManifest(url)
@@ -891,9 +881,8 @@ func TestServerResponse(t *testing.T) {
 
 func TestServerResponseGQLWithoutPermissions(t *testing.T) {
 	Convey("Test accessing a blobs folder without having permissions fails fast", t, func() {
-		port := test.GetFreePort()
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		dir := t.TempDir()
 
@@ -1022,10 +1011,8 @@ func runDisplayIndexTests(baseURL string) {
 
 func TestImagesSortFlag(t *testing.T) {
 	rootDir := t.TempDir()
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
@@ -1056,7 +1043,7 @@ func TestImagesSortFlag(t *testing.T) {
 	}
 
 	cm := test.NewControllerManager(ctlr)
-	cm.StartAndWait(conf.HTTP.Port)
+	baseURL := cm.StartAndWait()
 
 	defer cm.StopServer()
 

--- a/pkg/cli/client/search_cmd_test.go
+++ b/pkg/cli/client/search_cmd_test.go
@@ -32,10 +32,8 @@ func TestReferrerCLI(t *testing.T) {
 	Convey("Test GQL", t, func() {
 		rootDir := t.TempDir()
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.GC = false
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -45,7 +43,7 @@ func TestReferrerCLI(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = rootDir
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
 
 		defer cm.StopServer()
 
@@ -127,10 +125,8 @@ func TestReferrerCLI(t *testing.T) {
 	Convey("Test REST", t, func() {
 		rootDir := t.TempDir()
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.GC = false
 		defaultVal := false
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -139,7 +135,7 @@ func TestReferrerCLI(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = rootDir
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
 
 		defer cm.StopServer()
 
@@ -220,10 +216,8 @@ func TestFormatsReferrersCLI(t *testing.T) {
 	Convey("Create server", t, func() {
 		rootDir := t.TempDir()
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.GC = false
 		defaultVal := false
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -232,7 +226,7 @@ func TestFormatsReferrersCLI(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = rootDir
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
 
 		defer cm.StopServer()
 
@@ -407,10 +401,8 @@ func TestSearchCLI(t *testing.T) {
 	Convey("Test GQL", t, func() {
 		rootDir := t.TempDir()
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.GC = false
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -419,7 +411,7 @@ func TestSearchCLI(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = rootDir
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
 
 		defer cm.StopServer()
 
@@ -518,10 +510,8 @@ func TestFormatsSearchCLI(t *testing.T) {
 	Convey("", t, func() {
 		rootDir := t.TempDir()
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.GC = false
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -530,7 +520,7 @@ func TestFormatsSearchCLI(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = rootDir
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
 
 		defer cm.StopServer()
 
@@ -689,10 +679,8 @@ func TestSearchCLIErrors(t *testing.T) {
 
 func TestSearchSort(t *testing.T) {
 	rootDir := t.TempDir()
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
@@ -725,7 +713,7 @@ func TestSearchSort(t *testing.T) {
 	}
 
 	cm := test.NewControllerManager(ctlr)
-	cm.StartAndWait(conf.HTTP.Port)
+	baseURL := cm.StartAndWait()
 
 	defer cm.StopServer()
 

--- a/pkg/cli/client/server_info_cmd_test.go
+++ b/pkg/cli/client/server_info_cmd_test.go
@@ -24,10 +24,8 @@ import (
 
 func TestServerStatusCommand(t *testing.T) {
 	Convey("ServerStatusCommand", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.GC = false
 		defaultVal := true
 		conf.Extensions = &extconf.ExtensionConfig{
@@ -38,7 +36,7 @@ func TestServerStatusCommand(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 		cm := test.NewControllerManager(ctlr)
 
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		_ = makeConfigFile(t, fmt.Sprintf(`{"configs":[{"_name":"status-test","url":"%s","showspinner":false}]}`,
@@ -129,18 +127,16 @@ func TestServerStatusCommandErrors(t *testing.T) {
 	})
 
 	Convey("HTTP errors", t, func() {
-		port := test.GetFreePort()
 		result := bytes.NewBuffer([]byte{})
 		searchConfig := SearchConfig{
 			SearchService: newMockService(),
-			ServURL:       fmt.Sprintf("http://127.0.0.1:%v", port),
 			User:          "",
 			OutputFormat:  "text",
 			ResultWriter:  result,
 		}
 
 		Convey("v2 is Unauthorised", func() {
-			server := StartTestHTTPServer(HTTPRoutes{
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{
 				RouteHandler{
 					Route: "/v2/",
 					HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -148,9 +144,10 @@ func TestServerStatusCommandErrors(t *testing.T) {
 					},
 					AllowedMethods: []string{http.MethodGet},
 				},
-			}, port)
+			})
 			defer server.Close()
 
+			searchConfig.ServURL = baseURL
 			err := GetServerStatus(searchConfig)
 			So(err, ShouldBeNil)
 			So(result.String(), ShouldContainSubstring, "unauthorised access, endpoint requires valid user credentials")
@@ -163,7 +160,7 @@ func TestServerStatusCommandErrors(t *testing.T) {
 		})
 
 		Convey("v2 bad http status code", func() {
-			server := StartTestHTTPServer(HTTPRoutes{
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{
 				RouteHandler{
 					Route: "/v2/",
 					HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -171,9 +168,10 @@ func TestServerStatusCommandErrors(t *testing.T) {
 					},
 					AllowedMethods: []string{http.MethodGet},
 				},
-			}, port)
+			})
 			defer server.Close()
 
+			searchConfig.ServURL = baseURL
 			err := GetServerStatus(searchConfig)
 			So(err, ShouldBeNil)
 			So(result.String(), ShouldContainSubstring, zerr.ErrAPINotSupported.Error())
@@ -181,7 +179,7 @@ func TestServerStatusCommandErrors(t *testing.T) {
 
 		Convey("MGMT errors", func() {
 			Convey("URL not found", func() {
-				server := StartTestHTTPServer(HTTPRoutes{
+				server, baseURL := StartTestHTTPServer(HTTPRoutes{
 					RouteHandler{
 						Route: "/v2/",
 						HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -189,16 +187,17 @@ func TestServerStatusCommandErrors(t *testing.T) {
 						},
 						AllowedMethods: []string{http.MethodGet},
 					},
-				}, port)
+				})
 				defer server.Close()
 
+				searchConfig.ServURL = baseURL
 				err := GetServerStatus(searchConfig)
 				So(err, ShouldBeNil)
 				So(result.String(), ShouldContainSubstring, "endpoint is not available")
 			})
 
 			Convey("Unauthorized Access", func() {
-				server := StartTestHTTPServer(HTTPRoutes{
+				server, baseURL := StartTestHTTPServer(HTTPRoutes{
 					RouteHandler{
 						Route: "/v2/",
 						HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -213,16 +212,17 @@ func TestServerStatusCommandErrors(t *testing.T) {
 						},
 						AllowedMethods: []string{http.MethodGet},
 					},
-				}, port)
+				})
 				defer server.Close()
 
+				searchConfig.ServURL = baseURL
 				err := GetServerStatus(searchConfig)
 				So(err, ShouldBeNil)
 				So(result.String(), ShouldContainSubstring, "unauthorised access")
 			})
 
 			Convey("Bad status code", func() {
-				server := StartTestHTTPServer(HTTPRoutes{
+				server, baseURL := StartTestHTTPServer(HTTPRoutes{
 					RouteHandler{
 						Route: "/v2/",
 						HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -237,9 +237,10 @@ func TestServerStatusCommandErrors(t *testing.T) {
 						},
 						AllowedMethods: []string{http.MethodGet},
 					},
-				}, port)
+				})
 				defer server.Close()
 
+				searchConfig.ServURL = baseURL
 				err := GetServerStatus(searchConfig)
 				So(err, ShouldBeNil)
 				So(result.String(), ShouldContainSubstring, zerr.ErrAPINotSupported.Error())

--- a/pkg/cli/client/utils_internal_test.go
+++ b/pkg/cli/client/utils_internal_test.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -47,8 +49,7 @@ type RouteHandler struct {
 // Routes is a map that associates HTTP paths to their corresponding HTTP handlers.
 type HTTPRoutes []RouteHandler
 
-func StartTestHTTPServer(routes HTTPRoutes, port string) *http.Server {
-	baseURL := test.GetBaseURL(port)
+func StartTestHTTPServer(routes HTTPRoutes) (*http.Server, string) {
 	mux := mux.NewRouter()
 
 	mux.HandleFunc("/test", func(w http.ResponseWriter, r *http.Request) {
@@ -62,30 +63,40 @@ func StartTestHTTPServer(routes HTTPRoutes, port string) *http.Server {
 		mux.HandleFunc(routeHandler.Route, routeHandler.HandlerFunc).Methods(routeHandler.AllowedMethods...)
 	}
 
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		panic(err)
+	}
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		panic(fmt.Sprintf("expected *net.TCPAddr, got %T", listener.Addr()))
+	}
+
+	baseURL := test.GetBaseURL(strconv.Itoa(tcpAddr.Port))
+
 	server := &http.Server{ //nolint:gosec
-		Addr:    ":" + port,
+		Addr:    listener.Addr().String(),
 		Handler: mux,
 	}
 
 	go func() {
-		if err := server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
-			return
+		if err := server.Serve(listener); !errors.Is(err, http.ErrServerClosed) {
+			panic(err)
 		}
 	}()
 
 	test.WaitTillServerReady(baseURL + "/test")
 
-	return server
+	return server, baseURL
 }
 
 func TestDoHTTPRequest(t *testing.T) {
 	Convey("doHTTPRequest nil result pointer", t, func() {
-		port := test.GetFreePort()
-
-		server := StartTestHTTPServer(nil, port)
+		server, baseURL := StartTestHTTPServer(nil)
 		defer server.Close()
 
-		url := fmt.Sprintf("http://127.0.0.1:%s/asd", port)
+		url := baseURL + "/asd"
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, nil)
 		So(err, ShouldBeNil)
 
@@ -94,8 +105,7 @@ func TestDoHTTPRequest(t *testing.T) {
 	})
 
 	Convey("doHTTPRequest bad return json", t, func() {
-		port := test.GetFreePort()
-		server := StartTestHTTPServer(HTTPRoutes{
+		server, baseURL := StartTestHTTPServer(HTTPRoutes{
 			{
 				Route: "/test",
 				HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -106,11 +116,11 @@ func TestDoHTTPRequest(t *testing.T) {
 				},
 				AllowedMethods: []string{http.MethodGet},
 			},
-		}, port)
+		})
 
 		defer server.Close()
 
-		url := fmt.Sprintf("http://127.0.0.1:%s/test", port)
+		url := baseURL + "/test"
 		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
 		So(err, ShouldBeNil)
 
@@ -137,14 +147,11 @@ func TestDoHTTPRequest(t *testing.T) {
 	})
 
 	Convey("fetchImageManifestStruct errors", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-		searchConf := getDefaultSearchConf(baseURL)
-
-		// 404 erorr will appear
-		server := StartTestHTTPServer(HTTPRoutes{}, port)
+		// 404 error will appear
+		server, baseURL := StartTestHTTPServer(HTTPRoutes{})
 		defer server.Close()
 
+		searchConf := getDefaultSearchConf(baseURL)
 		URL := baseURL + "/v2/repo/manifests/tag"
 
 		_, err := fetchImageManifestStruct(context.Background(), &httpJob{
@@ -160,14 +167,11 @@ func TestDoHTTPRequest(t *testing.T) {
 	})
 
 	Convey("fetchManifestStruct errors", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-		searchConf := getDefaultSearchConf(baseURL)
-
 		Convey("makeGETRequest manifest error, context is done", func() {
-			server := StartTestHTTPServer(HTTPRoutes{}, port)
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{})
 			defer server.Close()
 
+			searchConf := getDefaultSearchConf(baseURL)
 			ctx, cancel := context.WithCancel(context.Background())
 
 			cancel()
@@ -179,8 +183,10 @@ func TestDoHTTPRequest(t *testing.T) {
 		})
 
 		Convey("makeGETRequest manifest error, context is not done", func() {
-			server := StartTestHTTPServer(HTTPRoutes{}, port)
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{})
 			defer server.Close()
+
+			searchConf := getDefaultSearchConf(baseURL)
 
 			_, err := fetchManifestStruct(context.Background(), "repo", "tag", searchConf,
 				"", "")
@@ -189,7 +195,7 @@ func TestDoHTTPRequest(t *testing.T) {
 		})
 
 		Convey("makeGETRequest config error, context is not done", func() {
-			server := StartTestHTTPServer(HTTPRoutes{
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{
 				{
 					Route: "/v2/{name}/manifests/{reference}",
 					HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -200,8 +206,10 @@ func TestDoHTTPRequest(t *testing.T) {
 					},
 					AllowedMethods: []string{http.MethodGet},
 				},
-			}, port)
+			})
 			defer server.Close()
+
+			searchConf := getDefaultSearchConf(baseURL)
 
 			_, err := fetchManifestStruct(context.Background(), "repo", "tag", searchConf,
 				"", "")
@@ -210,7 +218,7 @@ func TestDoHTTPRequest(t *testing.T) {
 		})
 
 		Convey("Platforms on config", func() {
-			server := StartTestHTTPServer(HTTPRoutes{
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{
 				{
 					Route: "/v2/{name}/manifests/{reference}",
 					HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -249,8 +257,10 @@ func TestDoHTTPRequest(t *testing.T) {
 					},
 					AllowedMethods: []string{http.MethodGet},
 				},
-			}, port)
+			})
 			defer server.Close()
+
+			searchConf := getDefaultSearchConf(baseURL)
 
 			_, err := fetchManifestStruct(context.Background(), "repo", "tag", searchConf,
 				"", "")
@@ -259,13 +269,14 @@ func TestDoHTTPRequest(t *testing.T) {
 		})
 
 		Convey("isNotationSigned error", func() {
+			searchConf := getDefaultSearchConf("http://127.0.0.1:1")
 			isSigned := isNotationSigned(context.Background(), "repo", "digest", searchConf,
 				"", "")
 			So(isSigned, ShouldBeFalse)
 		})
 
 		Convey("fetchImageIndexStruct no errors", func() {
-			server := StartTestHTTPServer(HTTPRoutes{
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{
 				{
 					Route: "/v2/{name}/manifests/{reference}",
 					HandlerFunc: func(writer http.ResponseWriter, req *http.Request) {
@@ -316,9 +327,10 @@ func TestDoHTTPRequest(t *testing.T) {
 					},
 					AllowedMethods: []string{http.MethodGet},
 				},
-			}, port)
+			})
 			defer server.Close()
 
+			searchConf := getDefaultSearchConf(baseURL)
 			URL := baseURL + "/v2/repo/manifests/indexRef"
 
 			imageStruct, err := fetchImageIndexStruct(context.Background(), &httpJob{
@@ -334,9 +346,10 @@ func TestDoHTTPRequest(t *testing.T) {
 		})
 
 		Convey("fetchImageIndexStruct makeGETRequest errors context done", func() {
-			server := StartTestHTTPServer(HTTPRoutes{}, port)
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{})
 			defer server.Close()
 
+			searchConf := getDefaultSearchConf(baseURL)
 			ctx, cancel := context.WithCancel(context.Background())
 
 			cancel()
@@ -356,9 +369,10 @@ func TestDoHTTPRequest(t *testing.T) {
 		})
 
 		Convey("fetchImageIndexStruct makeGETRequest errors context not done", func() {
-			server := StartTestHTTPServer(HTTPRoutes{}, port)
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{})
 			defer server.Close()
 
+			searchConf := getDefaultSearchConf(baseURL)
 			URL := baseURL + "/v2/repo/manifests/indexRef"
 
 			imageStruct, err := fetchImageIndexStruct(context.Background(), &httpJob{
@@ -376,10 +390,6 @@ func TestDoHTTPRequest(t *testing.T) {
 }
 
 func TestDoJobErrors(t *testing.T) {
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
-	searchConf := getDefaultSearchConf(baseURL)
-
 	reqPool := &requestsPool{
 		jobs:     make(chan *httpJob),
 		done:     make(chan struct{}),
@@ -391,9 +401,10 @@ func TestDoJobErrors(t *testing.T) {
 		reqPool.wtgrp.Add(1)
 
 		Convey("Do Job makeHEADRequest error context done", func() {
-			server := StartTestHTTPServer(HTTPRoutes{}, port)
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{})
 			defer server.Close()
 
+			searchConf := getDefaultSearchConf(baseURL)
 			URL := baseURL + "/v2/repo/manifests/manifestRef"
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -411,9 +422,10 @@ func TestDoJobErrors(t *testing.T) {
 		})
 
 		Convey("Do Job makeHEADRequest error context not done", func() {
-			server := StartTestHTTPServer(HTTPRoutes{}, port)
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{})
 			defer server.Close()
 
+			searchConf := getDefaultSearchConf(baseURL)
 			URL := baseURL + "/v2/repo/manifests/manifestRef"
 
 			ctx := context.Background()
@@ -433,7 +445,7 @@ func TestDoJobErrors(t *testing.T) {
 		})
 
 		Convey("Do Job fetchManifestStruct errors context canceled", func() {
-			server := StartTestHTTPServer(HTTPRoutes{
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{
 				{
 					Route: "/v2/{name}/manifests/{reference}",
 					HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -445,9 +457,10 @@ func TestDoJobErrors(t *testing.T) {
 					},
 					AllowedMethods: []string{http.MethodHead},
 				},
-			}, port)
+			})
 			defer server.Close()
 
+			searchConf := getDefaultSearchConf(baseURL)
 			URL := baseURL + "/v2/repo/manifests/manifestRef"
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -466,7 +479,7 @@ func TestDoJobErrors(t *testing.T) {
 		})
 
 		Convey("Do Job fetchManifestStruct errors context not canceled", func() {
-			server := StartTestHTTPServer(HTTPRoutes{
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{
 				{
 					Route: "/v2/{name}/manifests/{reference}",
 					HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -478,9 +491,10 @@ func TestDoJobErrors(t *testing.T) {
 					},
 					AllowedMethods: []string{http.MethodHead},
 				},
-			}, port)
+			})
 			defer server.Close()
 
+			searchConf := getDefaultSearchConf(baseURL)
 			URL := baseURL + "/v2/repo/manifests/manifestRef"
 
 			ctx := context.Background()
@@ -500,7 +514,7 @@ func TestDoJobErrors(t *testing.T) {
 		})
 
 		Convey("Do Job fetchIndexStruct errors context canceled", func() {
-			server := StartTestHTTPServer(HTTPRoutes{
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{
 				{
 					Route: "/v2/{name}/manifests/{reference}",
 					HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -512,9 +526,10 @@ func TestDoJobErrors(t *testing.T) {
 					},
 					AllowedMethods: []string{http.MethodHead},
 				},
-			}, port)
+			})
 			defer server.Close()
 
+			searchConf := getDefaultSearchConf(baseURL)
 			URL := baseURL + "/v2/repo/manifests/indexRef"
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -533,7 +548,7 @@ func TestDoJobErrors(t *testing.T) {
 		})
 
 		Convey("Do Job fetchIndexStruct errors context not canceled", func() {
-			server := StartTestHTTPServer(HTTPRoutes{
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{
 				{
 					Route: "/v2/{name}/manifests/{reference}",
 					HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -545,9 +560,10 @@ func TestDoJobErrors(t *testing.T) {
 					},
 					AllowedMethods: []string{http.MethodHead},
 				},
-			}, port)
+			})
 			defer server.Close()
 
+			searchConf := getDefaultSearchConf(baseURL)
 			URL := baseURL + "/v2/repo/manifests/indexRef"
 
 			ctx := context.Background()
@@ -566,7 +582,7 @@ func TestDoJobErrors(t *testing.T) {
 			So(result.StrValue, ShouldResemble, "")
 		})
 		Convey("Do Job fetchIndexStruct not supported content type", func() {
-			server := StartTestHTTPServer(HTTPRoutes{
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{
 				{
 					Route: "/v2/{name}/manifests/{reference}",
 					HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -578,9 +594,10 @@ func TestDoJobErrors(t *testing.T) {
 					},
 					AllowedMethods: []string{http.MethodHead},
 				},
-			}, port)
+			})
 			defer server.Close()
 
+			searchConf := getDefaultSearchConf(baseURL)
 			URL := baseURL + "/v2/repo/manifests/indexRef"
 
 			ctx := context.Background()
@@ -596,7 +613,7 @@ func TestDoJobErrors(t *testing.T) {
 		})
 
 		Convey("Media type is MediaTypeImageIndex image.string erorrs", func() {
-			server := StartTestHTTPServer(HTTPRoutes{
+			server, baseURL := StartTestHTTPServer(HTTPRoutes{
 				{
 					Route: "/v2/{name}/manifests/{reference}",
 					HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
@@ -645,8 +662,10 @@ func TestDoJobErrors(t *testing.T) {
 					},
 					AllowedMethods: []string{http.MethodGet},
 				},
-			}, port)
+			})
 			defer server.Close()
+
+			searchConf := getDefaultSearchConf(baseURL)
 			URL := baseURL + "/v2/repo/manifests/indexRef"
 
 			go reqPool.doJob(context.Background(), &httpJob{

--- a/pkg/cli/server/config_reloader_test.go
+++ b/pkg/cli/server/config_reloader_test.go
@@ -21,9 +21,6 @@ func TestConfigReloader(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	Convey("reload access control config", t, func(conveyCtx C) {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		username := "alice"
@@ -38,7 +35,7 @@ func TestConfigReloader(t *testing.T) {
 			},
 			"http": {
 			  "address": "127.0.0.1",
-			  "port": "%s",
+			  "port": "0",
 			  "realm": "zot",
 			  "auth": {
 				"htpasswd": {
@@ -68,7 +65,7 @@ func TestConfigReloader(t *testing.T) {
 			  "level": "debug",
 			  "output": "%s"
 			}
-		  }`, t.TempDir(), port, htpasswdPath, logPath)
+		  }`, t.TempDir(), htpasswdPath, logPath)
 
 		cfgfile := test.MakeTempFile(t, "zot-test.json")
 		defer cfgfile.Close()
@@ -82,6 +79,7 @@ func TestConfigReloader(t *testing.T) {
 			conveyCtx.So(err, ShouldBeNil)
 		}()
 
+		baseURL := waitForKernelChosenPortBaseURL(logPath)
 		test.WaitTillServerReady(baseURL)
 
 		// verify initial startup authentication logs
@@ -106,7 +104,7 @@ func TestConfigReloader(t *testing.T) {
 			},
 			"http": {
 			  "address": "127.0.0.1",
-			  "port": "%s",
+			  "port": "0",
 			  "realm": "zot",
 			  "auth": {
 				"htpasswd": {
@@ -136,7 +134,7 @@ func TestConfigReloader(t *testing.T) {
 			  "level": "debug",
 			  "output": "%s"
 			}
-		}`, t.TempDir(), port, htpasswdPath, logPath)
+		}`, t.TempDir(), htpasswdPath, logPath)
 
 		err = cfgfile.Truncate(0)
 		So(err, ShouldBeNil)
@@ -174,9 +172,6 @@ func TestConfigReloader(t *testing.T) {
 	})
 
 	Convey("reload gc config", t, func(ctx C) {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		logFile := test.MakeTempFile(t, "zot-log.txt")
 		defer logFile.Close()
 
@@ -196,13 +191,13 @@ func TestConfigReloader(t *testing.T) {
 				},
 				"http": {
 					"address": "127.0.0.1",
-					"port": "%s"
+					"port": "0"
 				},
 				"log": {
 					"level": "debug",
 					"output": "%s"
 				}
-			}`, t.TempDir(), t.TempDir(), port, logFile.Name())
+			}`, t.TempDir(), t.TempDir(), logFile.Name())
 
 		cfgfile := test.MakeTempFile(t, "zot-test.json")
 		defer cfgfile.Close()
@@ -217,6 +212,7 @@ func TestConfigReloader(t *testing.T) {
 			ctx.So(err, ShouldBeNil)
 		}()
 
+		baseURL := waitForKernelChosenPortBaseURL(logFile.Name())
 		test.WaitTillServerReady(baseURL)
 
 		// verify initial startup authentication logs (no auth configured)
@@ -250,13 +246,13 @@ func TestConfigReloader(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
 				"output": "%s"
 			}
-		}`, t.TempDir(), t.TempDir(), port, logFile.Name())
+		}`, t.TempDir(), t.TempDir(), logFile.Name())
 
 		err = cfgfile.Truncate(0)
 		So(err, ShouldBeNil)
@@ -301,9 +297,6 @@ func TestConfigReloader(t *testing.T) {
 	})
 
 	Convey("reload sync config", t, func(ctx C) {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		content := fmt.Sprintf(`{
@@ -313,7 +306,7 @@ func TestConfigReloader(t *testing.T) {
 				},
 				"http": {
 					"address": "127.0.0.1",
-					"port": "%s"
+					"port": "0"
 				},
 				"log": {
 					"level": "debug",
@@ -340,7 +333,7 @@ func TestConfigReloader(t *testing.T) {
 						}]
 					}
 				}
-			}`, t.TempDir(), port, logPath)
+			}`, t.TempDir(), logPath)
 
 		cfgfile := test.MakeTempFile(t, "zot-test.json")
 		defer cfgfile.Close()
@@ -355,6 +348,7 @@ func TestConfigReloader(t *testing.T) {
 			ctx.So(err, ShouldBeNil)
 		}()
 
+		baseURL := waitForKernelChosenPortBaseURL(logPath)
 		test.WaitTillServerReady(baseURL)
 
 		// verify initial startup authentication logs (no auth configured)
@@ -379,7 +373,7 @@ func TestConfigReloader(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -406,7 +400,7 @@ func TestConfigReloader(t *testing.T) {
 					}]
 				}
 			}
-		}`, t.TempDir(), port, logPath)
+		}`, t.TempDir(), logPath)
 
 		err = cfgfile.Truncate(0)
 		So(err, ShouldBeNil)
@@ -451,9 +445,6 @@ func TestConfigReloader(t *testing.T) {
 	})
 
 	Convey("reload scrub and CVE config", t, func(ctx C) {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		content := fmt.Sprintf(`{
@@ -463,7 +454,7 @@ func TestConfigReloader(t *testing.T) {
 				},
 				"http": {
 					"address": "127.0.0.1",
-					"port": "%s"
+					"port": "0"
 				},
 				"log": {
 					"level": "debug",
@@ -483,7 +474,7 @@ func TestConfigReloader(t *testing.T) {
 						"interval": "24h"
 					}
 				}
-			}`, t.TempDir(), port, logPath)
+			}`, t.TempDir(), logPath)
 
 		cfgfile := test.MakeTempFile(t, "zot-test.json")
 		defer cfgfile.Close()
@@ -498,6 +489,7 @@ func TestConfigReloader(t *testing.T) {
 			ctx.So(err, ShouldBeNil)
 		}()
 
+		baseURL := waitForKernelChosenPortBaseURL(logPath)
 		test.WaitTillServerReady(baseURL)
 
 		// verify initial startup authentication logs (no auth configured)
@@ -522,7 +514,7 @@ func TestConfigReloader(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -538,7 +530,7 @@ func TestConfigReloader(t *testing.T) {
 					}
 				}
 			}
-		}`, t.TempDir(), port, logPath)
+		}`, t.TempDir(), logPath)
 
 		err = cfgfile.Truncate(0)
 		So(err, ShouldBeNil)
@@ -592,9 +584,6 @@ func TestConfigReloader(t *testing.T) {
 	})
 
 	Convey("reload bad config", t, func(conveyCtx C) {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		content := fmt.Sprintf(`{
@@ -604,7 +593,7 @@ func TestConfigReloader(t *testing.T) {
 				},
 				"http": {
 					"address": "127.0.0.1",
-					"port": "%s"
+					"port": "0"
 				},
 				"log": {
 					"level": "debug",
@@ -631,7 +620,7 @@ func TestConfigReloader(t *testing.T) {
 						}]
 					}
 				}
-			}`, t.TempDir(), port, logPath)
+			}`, t.TempDir(), logPath)
 
 		cfgfile := test.MakeTempFile(t, "zot-test.json")
 		defer cfgfile.Close()
@@ -646,6 +635,7 @@ func TestConfigReloader(t *testing.T) {
 			conveyCtx.So(err, ShouldBeNil)
 		}()
 
+		baseURL := waitForKernelChosenPortBaseURL(logPath)
 		test.WaitTillServerReady(baseURL)
 
 		content = "[]"

--- a/pkg/cli/server/extensions_test.go
+++ b/pkg/cli/server/extensions_test.go
@@ -18,7 +18,9 @@ import (
 	. "zotregistry.dev/zot/v2/pkg/test/common"
 )
 
-const readLogFileTimeout = 5 * time.Second
+const (
+	readLogFileTimeout = 5 * time.Second
+)
 
 func TestVerifyExtensionsConfig(t *testing.T) {
 	oldArgs := os.Args
@@ -315,8 +317,6 @@ func TestServeExtensions(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	Convey("config file with no extensions", t, func(c C) {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		logPath := MakeTempFilePath(t, "zot-log.txt")
 
 		tmpFile := t.TempDir()
@@ -327,13 +327,13 @@ func TestServeExtensions(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
 				"output": "%s"
 			}
-		}`, tmpFile, port, logPath)
+		}`, tmpFile, logPath)
 
 		cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
@@ -346,6 +346,7 @@ func TestServeExtensions(t *testing.T) {
 			})
 		}()
 
+		baseURL := waitForKernelChosenPortBaseURL(logPath)
 		WaitTillServerReady(baseURL)
 
 		data, err := os.ReadFile(logPath)
@@ -355,8 +356,6 @@ func TestServeExtensions(t *testing.T) {
 	})
 
 	Convey("config file with empty extensions", t, func(c C) {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		logPath := MakeTempFilePath(t, "zot-log.txt")
 
 		tmpFile := t.TempDir()
@@ -367,7 +366,7 @@ func TestServeExtensions(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -375,7 +374,7 @@ func TestServeExtensions(t *testing.T) {
 			},
 			"extensions": {
 			}
-		}`, tmpFile, port, logPath)
+		}`, tmpFile, logPath)
 
 		cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
@@ -388,6 +387,7 @@ func TestServeExtensions(t *testing.T) {
 			})
 		}()
 
+		baseURL := waitForKernelChosenPortBaseURL(logPath)
 		WaitTillServerReady(baseURL)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
@@ -398,11 +398,9 @@ func TestServeExtensions(t *testing.T) {
 
 func testWithMetricsEnabled(t *testing.T, rootDir string, cfgContentFormat string) {
 	t.Helper()
-	port := GetFreePort()
-	baseURL := GetBaseURL(port)
 	logPath := MakeTempFilePath(t, "zot-log.txt")
 
-	content := fmt.Sprintf(cfgContentFormat, rootDir, port, logPath)
+	content := fmt.Sprintf(cfgContentFormat, rootDir, logPath)
 	cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
 	os.Args = []string{"cli_test", "serve", cfgfile}
@@ -413,6 +411,8 @@ func testWithMetricsEnabled(t *testing.T, rootDir string, cfgContentFormat strin
 			So(err, ShouldBeNil)
 		})
 	}()
+
+	baseURL := waitForKernelChosenPortBaseURL(logPath)
 	WaitTillServerReady(baseURL)
 
 	resp, err := resty.R().Get(baseURL + "/metrics")
@@ -443,7 +443,7 @@ func TestServeMetricsExtension(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -466,7 +466,7 @@ func TestServeMetricsExtension(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -492,7 +492,7 @@ func TestServeMetricsExtension(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -508,8 +508,6 @@ func TestServeMetricsExtension(t *testing.T) {
 	})
 
 	Convey("with explicit disable", t, func(c C) {
-		port := GetFreePort()
-		baseURL := GetBaseURL(port)
 		logPath := MakeTempFilePath(t, "zot-log.txt")
 
 		tmpFile := t.TempDir()
@@ -520,7 +518,7 @@ func TestServeMetricsExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -531,7 +529,7 @@ func TestServeMetricsExtension(t *testing.T) {
 							"enable": false
 						}
 					}
-				}`, tmpFile, port, logPath)
+				}`, tmpFile, logPath)
 
 		cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
@@ -544,6 +542,7 @@ func TestServeMetricsExtension(t *testing.T) {
 			})
 		}()
 
+		baseURL := waitForKernelChosenPortBaseURL(logPath)
 		WaitTillServerReady(baseURL)
 
 		resp, err := resty.R().Get(baseURL + "/metrics")
@@ -570,7 +569,7 @@ func TestServeSyncExtension(t *testing.T) {
 				},
 				"http": {
 					"address": "127.0.0.1",
-					"port": "%s"
+					"port": "0"
 				},
 				"log": {
 					"level": "debug",
@@ -615,7 +614,7 @@ func TestServeSyncExtension(t *testing.T) {
 				},
 				"http": {
 					"address": "127.0.0.1",
-					"port": "%s"
+					"port": "0"
 				},
 				"log": {
 					"level": "debug",
@@ -661,7 +660,7 @@ func TestServeSyncExtension(t *testing.T) {
 				},
 				"http": {
 					"address": "127.0.0.1",
-					"port": "%s"
+					"port": "0"
 				},
 				"log": {
 					"level": "debug",
@@ -703,7 +702,7 @@ func TestServeScrubExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -734,7 +733,7 @@ func TestServeScrubExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -766,7 +765,7 @@ func TestServeScrubExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -798,7 +797,7 @@ func TestServeScrubExtension(t *testing.T) {
 				},
 				"http": {
 					"address": "127.0.0.1",
-					"port": "%s"
+					"port": "0"
 				},
 				"log": {
 					"level": "debug",
@@ -836,7 +835,7 @@ func TestServeLintExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -866,7 +865,7 @@ func TestServeLintExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -901,7 +900,7 @@ func TestServeSearchEnabled(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -944,7 +943,7 @@ func TestServeSearchEnabledDefaultCVEDB(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -1071,7 +1070,7 @@ func TestServeSearchEnabledNoCVE(t *testing.T) {
 				},
 				"http": {
 					"address": "127.0.0.1",
-					"port": "%s"
+					"port": "0"
 				},
 				"log": {
 					"level": "debug",
@@ -1113,7 +1112,7 @@ func TestServeSearchDisabled(t *testing.T) {
 				},
 				"http": {
 					"address": "127.0.0.1",
-					"port": "%s"
+					"port": "0"
 				},
 				"log": {
 					"level": "debug",
@@ -1155,7 +1154,7 @@ func TestServeMgmtExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -1190,7 +1189,7 @@ func TestServeMgmtExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -1223,7 +1222,7 @@ func TestServeMgmtExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -1260,7 +1259,7 @@ func TestServeImageTrustExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -1296,7 +1295,7 @@ func TestServeImageTrustExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -1332,7 +1331,7 @@ func TestServeImageTrustExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",
@@ -1407,7 +1406,7 @@ func TestOverlappingSyncRetentionConfig(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -1468,7 +1467,7 @@ func TestOverlappingSyncRetentionConfig(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -1528,7 +1527,7 @@ func TestOverlappingSyncRetentionConfig(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -1591,7 +1590,7 @@ func TestOverlappingSyncRetentionConfig(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -1651,7 +1650,7 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 			},
 			"http": {
 				"address": "0.0.0.0",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -1689,7 +1688,6 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 	})
 
 	Convey("Test verify sync with remote storage panics if sync.tmpdir is not provided", t, func(c C) {
-		port := GetFreePort()
 		logPath := MakeTempFilePath(t, "zot-log.txt")
 
 		content := fmt.Sprintf(`{
@@ -1710,7 +1708,7 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 			},
 			"http": {
 				"address": "0.0.0.0",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -1734,7 +1732,7 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 					]
 				}
 			}
-		}`, t.TempDir(), port, logPath)
+		}`, t.TempDir(), logPath)
 
 		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
@@ -1750,7 +1748,6 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 	})
 
 	Convey("Test verify sync with remote storage on subpath panics if sync.tmpdir is not provided", t, func(c C) {
-		port := GetFreePort()
 		logPath := MakeTempFilePath(t, "zot-log.txt")
 
 		content := fmt.Sprintf(`{
@@ -1775,7 +1772,7 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 			},
 			"http": {
 				"address": "0.0.0.0",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug",
@@ -1799,7 +1796,7 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 					]
 				}
 			}
-		}`, t.TempDir(), t.TempDir(), port, logPath)
+		}`, t.TempDir(), t.TempDir(), logPath)
 
 		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
@@ -1827,7 +1824,7 @@ func TestEventsExtension(t *testing.T) {
 				},
 				"http": {
 					"address": "127.0.0.1",
-					"port": "%s"
+					"port": "0"
 				},
 				"log": {
 					"level": "debug",
@@ -1863,7 +1860,7 @@ func TestEventsExtension(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					},
 					"log": {
 						"level": "debug",

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -21,6 +22,45 @@ import (
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
 	. "zotregistry.dev/zot/v2/pkg/test/common"
 )
+
+const (
+	// Must match the log message emitted in pkg/api/controller.go when Port is "0".
+	kernelChosenPortMsg   = "port is unspecified, listening on kernel chosen port"
+	kernelPortWaitTimeout = 30 * time.Second
+)
+
+// waitForKernelChosenPortBaseURL polls a zot log file for the kernel-assigned listen
+// port logged when conf.HTTP.Port is "0", then returns http://127.0.0.1:<port>.
+// Used for CLI serve tests that have no ControllerManager to query after bind.
+func waitForKernelChosenPortBaseURL(logPath string) string {
+	deadline := time.Now().Add(kernelPortWaitTimeout)
+
+	for time.Now().Before(deadline) {
+		content, err := os.ReadFile(logPath)
+		if err == nil {
+			for line := range strings.SplitSeq(string(content), "\n") {
+				if !strings.Contains(line, kernelChosenPortMsg) {
+					continue
+				}
+
+				var entry struct {
+					Port int `json:"port"`
+				}
+
+				if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.Port <= 0 {
+					continue
+				}
+
+				return GetBaseURL(strconv.Itoa(entry.Port))
+			}
+		}
+
+		time.Sleep(SleepTime)
+	}
+
+	panic(fmt.Sprintf("timed out after %s waiting for kernel chosen port in %s",
+		kernelPortWaitTimeout, logPath))
+}
 
 // checkAuthLogEntry checks if a log entry with the given message has the expected enabled value.
 func checkAuthLogEntry(logData []byte, message string, expectedEnabled bool) bool {
@@ -2820,7 +2860,7 @@ func TestServeAPIKey(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s",
+						"port": "0",
 						"auth": {
 							"apikey": true
 						}
@@ -2858,7 +2898,7 @@ func TestServeAPIKey(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s",
+						"port": "0",
 						"auth": {
 							"apikey": false
 						}
@@ -3187,16 +3227,19 @@ func TestScrub(t *testing.T) {
 		})
 
 		Convey("server is running", func(c C) {
-			port := GetFreePort()
 			config := config.New()
-			config.HTTP.Port = port
+			config.HTTP.Port = "0"
 			controller := api.NewController(config)
 
 			dir := t.TempDir()
 
 			controller.Config.Storage.RootDirectory = dir
 			ctrlManager := NewControllerManager(controller)
-			ctrlManager.StartAndWait(port)
+			ctrlManager.StartAndWait()
+
+			defer ctrlManager.StopServer()
+
+			port := strconv.Itoa(ctrlManager.Port())
 
 			content := fmt.Sprintf(`{
 				"storage": {
@@ -3215,25 +3258,21 @@ func TestScrub(t *testing.T) {
 			os.Args = []string{"cli_test", "scrub", tmpfile}
 			err := cli.NewServerRootCmd().Execute()
 			So(err, ShouldNotBeNil)
-
-			defer ctrlManager.StopServer()
 		})
 
 		Convey("no image store provided", func(c C) {
-			port := GetFreePort()
-
-			content := fmt.Sprintf(`{
+			content := `{
 				"storage": {
 					"rootDirectory": ""
 				},
 				"http": {
-					"port": %s
+					"port": "0"
 				},
 				"log": {
 					"level": "debug"
 				}
 			}
-			`, port)
+			`
 			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
 			os.Args = []string{"cli_test", "scrub", tmpfile}
@@ -3242,8 +3281,6 @@ func TestScrub(t *testing.T) {
 		})
 
 		Convey("bad index.json", func(c C) {
-			port := GetFreePort()
-
 			dir := t.TempDir()
 
 			repoName := "badindex"
@@ -3273,13 +3310,13 @@ func TestScrub(t *testing.T) {
 					"rootDirectory": "%s"
 				},
 				"http": {
-					"port": %s
+					"port": "0"
 				},
 				"log": {
 					"level": "debug"
 				}
 			}
-			`, dir, port)
+			`, dir)
 			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
 			os.Args = []string{"cli_test", "scrub", tmpfile}
@@ -3485,13 +3522,12 @@ func TestClusterConfig(t *testing.T) {
 //nolint:unparam // rootDir used by callers waiting for Trivy DB, build tags may not be available.
 func runCLIWithConfig(t *testing.T, config string) (string, string, error) {
 	t.Helper()
-	port := GetFreePort()
-	baseURL := GetBaseURL(port)
-
 	logPath := MakeTempFilePath(t, "zot-log.txt")
 
 	rootDir := t.TempDir()
-	config = fmt.Sprintf(config, rootDir, port, logPath)
+	// config must use fmt placeholders for rootDirectory and log output only;
+	// http.port must be hardcoded as "0" (kernel-assigned).
+	config = fmt.Sprintf(config, rootDir, logPath)
 
 	cfgfile := MakeTempFileWithContent(t, "zot-test.json", config)
 
@@ -3512,6 +3548,7 @@ func runCLIWithConfig(t *testing.T, config string) (string, string, error) {
 	case <-time.After(250 * time.Millisecond): // No startup error
 	}
 
+	baseURL := waitForKernelChosenPortBaseURL(logPath)
 	WaitTillServerReady(baseURL)
 
 	return logPath, rootDir, nil

--- a/pkg/cli/server/verify_retention_test.go
+++ b/pkg/cli/server/verify_retention_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -74,7 +75,6 @@ func TestRetentionCheckNegative(t *testing.T) {
 	Convey("config with GC disabled", t, func(c C) {
 		testDir := t.TempDir()
 		logFile := MakeTempFilePath(t, "retention-check.log")
-		port := GetFreePort()
 
 		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
@@ -84,9 +84,9 @@ func TestRetentionCheckNegative(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			}
-		}`, testDir, port)
+		}`, testDir)
 		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "30s", configFile}
@@ -106,9 +106,8 @@ func TestRetentionCheckNegative(t *testing.T) {
 	})
 
 	Convey("server is running", t, func(c C) {
-		port := GetFreePort()
 		config := config.New()
-		config.HTTP.Port = port
+		config.HTTP.Port = "0"
 		controller := api.NewController(config)
 
 		testDir := t.TempDir()
@@ -118,9 +117,11 @@ func TestRetentionCheckNegative(t *testing.T) {
 		controller.Config.Storage.RootDirectory = storageDir
 		controller.Config.Storage.GC = true
 		ctrlManager := NewControllerManager(controller)
-		ctrlManager.StartAndWait(port)
+		ctrlManager.StartAndWait()
 
 		defer ctrlManager.StopServer()
+
+		port := strconv.Itoa(ctrlManager.Port())
 
 		content := fmt.Sprintf(`{
 			"storage": {
@@ -169,7 +170,6 @@ func TestRetentionCheckNegative(t *testing.T) {
 	Convey("invalid address format", t, func(c C) {
 		testDir := t.TempDir()
 		logFile := MakeTempFilePath(t, "retention-check.log")
-		port := GetFreePort()
 
 		// Use an invalid IPv6 address format that will pass LoadConfiguration
 		// but fail net.ResolveTCPAddr immediately (syntax error, no DNS lookup)
@@ -181,12 +181,12 @@ func TestRetentionCheckNegative(t *testing.T) {
 			},
 			"http": {
 				"address": "[invalid:ipv6",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug"
 			}
-		}`, testDir, port)
+		}`, testDir)
 		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		os.Args = []string{"cli_test", "verify-feature", "retention", "-l", logFile, "-t", "30s", configFile}
@@ -216,7 +216,6 @@ func TestRetentionCheckNegative(t *testing.T) {
 		for _, testCase := range testCases {
 			Convey(testCase.name, func() {
 				testDir := t.TempDir()
-				port := GetFreePort()
 
 				content := fmt.Sprintf(`{
 					"distSpecVersion": "1.1.1",
@@ -226,9 +225,9 @@ func TestRetentionCheckNegative(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					}
-				}`, testDir, port)
+				}`, testDir)
 				configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 				os.Args = []string{"cli_test", "verify-feature", "retention", "-l", testCase.logFile, "-t", "30s", configFile}
@@ -254,7 +253,6 @@ func TestRetentionCheckNegative(t *testing.T) {
 			Convey(testCase.name, func() {
 				testDir := t.TempDir()
 				logFile := MakeTempFilePath(t, "retention-check.log")
-				port := GetFreePort()
 
 				content := fmt.Sprintf(`{
 					"distSpecVersion": "1.1.1",
@@ -264,9 +262,9 @@ func TestRetentionCheckNegative(t *testing.T) {
 					},
 					"http": {
 						"address": "127.0.0.1",
-						"port": "%s"
+						"port": "0"
 					}
-				}`, testDir, port)
+				}`, testDir)
 				configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 				args := []string{
@@ -297,11 +295,12 @@ func TestRetentionCheckWithRetentionEnabledAndRedisDriver(t *testing.T) {
 
 	Convey("server is running with Redis driver", t, func(c C) {
 		miniRedis := miniredis.RunT(t)
-		port := GetFreePort()
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
 		logFile := MakeTempFilePath(t, "retention-check.log")
 
+		// Port "0": verify-feature skips HTTP bind when remoteCache is enabled, so the
+		// live controller and CLI do not need a shared pre-declared port.
 		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
 			"storage": {
@@ -331,13 +330,13 @@ func TestRetentionCheckWithRetentionEnabledAndRedisDriver(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug"
 			}
 		}
-		`, storageDir, testGCDelay, miniRedis.Addr(), port)
+		`, storageDir, testGCDelay, miniRedis.Addr())
 		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		// Create complex image setup before running verify-feature retention
@@ -472,7 +471,7 @@ func TestRetentionCheckWithRetentionEnabledAndRedisDriver(t *testing.T) {
 		// Start a controller using the same config to test running verify-feature retention while server is running
 		controller := api.NewController(conf)
 		ctrlManager := NewControllerManager(controller)
-		ctrlManager.StartAndWait(port)
+		ctrlManager.StartAndWait()
 
 		defer ctrlManager.StopServer()
 
@@ -533,7 +532,6 @@ func TestRetentionCheckWithRetentionEnabled(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	Convey("valid config with retention enabled", t, func(c C) {
-		port := GetFreePort()
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
 		logFile := MakeTempFilePath(t, "retention-check.log")
@@ -562,13 +560,13 @@ func TestRetentionCheckWithRetentionEnabled(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug"
 			}
 		}
-		`, storageDir, testGCDelay, port)
+		`, storageDir, testGCDelay)
 		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		// Create complex image setup before running verify-feature retention
@@ -822,7 +820,6 @@ func TestRetentionCheckWithDeleteReferrers(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	Convey("valid config with deleteReferrers enabled", t, func(c C) {
-		port := GetFreePort()
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
 		logFile := MakeTempFilePath(t, "retention-check.log")
@@ -852,13 +849,13 @@ func TestRetentionCheckWithDeleteReferrers(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug"
 			}
 		}
-		`, storageDir, testGCDelay, port)
+		`, storageDir, testGCDelay)
 		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		// Create image setup before running verify-feature retention
@@ -1001,7 +998,6 @@ func TestRetentionCheckWithRetentionDisabled(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	Convey("valid config with retention disabled", t, func(c C) {
-		port := GetFreePort()
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
 		logFile := MakeTempFilePath(t, "retention-check.log")
@@ -1016,13 +1012,13 @@ func TestRetentionCheckWithRetentionDisabled(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug"
 			}
 		}
-		`, storageDir, testGCDelay, port)
+		`, storageDir, testGCDelay)
 		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		// Create image setup for GC testing (no retention, no MetaDB needed)
@@ -1155,7 +1151,6 @@ func TestRetentionCheckWithSubpaths(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	Convey("config with subpaths", t, func(c C) {
-		port := GetFreePort()
 		testDir := t.TempDir()
 		storageDir := path.Join(testDir, "storage")
 		subpathStoreDir := path.Join(testDir, "storage2")
@@ -1209,13 +1204,13 @@ func TestRetentionCheckWithSubpaths(t *testing.T) {
 		},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug"
 			}
 		}
-		`, storageDir, testGCDelay, subpathStoreDir, testGCDelay, port)
+		`, storageDir, testGCDelay, subpathStoreDir, testGCDelay)
 		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		// Create image setup before running verify-feature retention
@@ -1463,7 +1458,6 @@ func TestRetentionCheckWithGCIntervalOverride(t *testing.T) {
 		storageDir := path.Join(testDir, "storage")
 		subpathStoreDir := path.Join(testDir, "storage2")
 		logFile := MakeTempFilePath(t, "retention-check.log")
-		port := GetFreePort()
 
 		content := fmt.Sprintf(`{
 			"distSpecVersion": "1.1.1",
@@ -1483,13 +1477,13 @@ func TestRetentionCheckWithGCIntervalOverride(t *testing.T) {
 			},
 			"http": {
 				"address": "127.0.0.1",
-				"port": "%s"
+				"port": "0"
 			},
 			"log": {
 				"level": "debug"
 			}
 		}
-		`, storageDir, testGCDelay, subpathStoreDir, testGCDelay, port)
+		`, storageDir, testGCDelay, subpathStoreDir, testGCDelay)
 		configFile := MakeTempFileWithContent(t, "zot-config.json", content)
 
 		gcDelay, _ := time.ParseDuration(testGCDelay)


### PR DESCRIPTION
Avoid TOCTOU bind races by using kernel-assigned ports with StartAndWait()/Listen(":0"). CLI serve configs discover the bound port from the kernel-chosen-port log line.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
