### PR TITLE
fix(auth): make htpasswd hot-reload work for K8s secret mounts

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -214,6 +214,7 @@ var (
 	ErrOIDCAudienceMismatch             = errors.New("token audience does not match any of the expected audiences")
 	ErrCertificateNotLoaded             = errors.New("tls certificate not yet loaded")
 	ErrCertificateWatcherAlreadyRunning = errors.New("certificate watcher is already running")
+	ErrHTPasswdWatcherAlreadyRunning    = errors.New("htpasswd watcher is already running")
 	ErrInvalidEndSessionEndpoint        = errors.New("end_session_endpoint must be an absolute http(s) URL")
 	ErrPolicyConditionNotCompiled       = errors.New("policy condition not compiled")
 	ErrDisallowedMetricsPath            = errors.New("provided metrics path is disallowed")

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -555,7 +555,9 @@ func (c *Controller) StartBackgroundTasks() {
 
 	// Start HTPasswdWatcher goroutine
 	if c.HTPasswdWatcher != nil {
-		c.HTPasswdWatcher.Run()
+		if err := c.HTPasswdWatcher.Run(); err != nil {
+			c.Log.Warn().Err(err).Msg("failed to start htpasswd watcher")
+		}
 	}
 
 	// Run GC and retention tasks

--- a/pkg/api/htpasswd.go
+++ b/pkg/api/htpasswd.go
@@ -168,7 +168,6 @@ type HTPasswdWatcher struct {
 	// (it is cleared by the loop itself). While set, Run() refuses to start a
 	// second generation, so loops can never overlap even if Run() races Close().
 	stopped       chan struct{}
-	useInotify    bool
 	debounceTimer *time.Timer
 	// fileInfo is the stat fingerprint of the last successfully loaded file.
 	// Polling compares identity (os.SameFile), size and mtime against it, so
@@ -189,28 +188,27 @@ func NewHTPasswdWatcher(htp *HTPasswd, filePath string) (*HTPasswdWatcher, error
 
 // Run starts the watcher goroutine.
 // Returns ErrHTPasswdWatcherAlreadyRunning if the watcher is already running.
-// If inotify setup fails, the watcher still starts and falls back to stat-based polling.
+// Inotify only lowers reload latency; the loop always fingerprint-polls as a
+// backstop, so the watcher works (more slowly) even if inotify setup fails.
 func (s *HTPasswdWatcher) Run() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	// s.stopped stays non-nil until the previous loop goroutine has fully
 	// exited, so a Run() racing an in-progress Close() cannot start a second
-	// generation that would share the debounce timer and useInotify state.
+	// generation that would share the debounce timer with the dying one.
 	if s.done != nil || s.stopped != nil {
 		return zerr.ErrHTPasswdWatcherAlreadyRunning
 	}
 
 	// Create fresh fsnotify watcher for this run. On failure continue without it,
-	// the loop still runs and reloads via stat-based polling.
+	// the loop still reloads via the periodic fingerprint check.
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		s.log.Error().Err(err).Msg("failed to create fsnotify watcher, falling back to stat-based polling")
+		s.log.Error().Err(err).Msg("failed to create fsnotify watcher, relying on stat-based polling")
 
 		watcher = nil
 	}
-
-	useInotify := false
 
 	// Watch the file and its parent directory. Directory watches are required for
 	// Kubernetes Secret/ConfigMap mounts, where the file is a symlink and updates
@@ -218,9 +216,7 @@ func (s *HTPasswdWatcher) Run() error {
 	if watcher != nil && s.filePath != "" {
 		if err := s.addWatches(watcher, s.filePath); err != nil {
 			s.log.Error().Err(err).Str("htpasswd-file", s.filePath).
-				Msg("failed to add file to watcher, falling back to stat-based polling")
-		} else {
-			useInotify = true
+				Msg("failed to add file to watcher, relying on stat-based polling")
 		}
 	}
 
@@ -229,7 +225,6 @@ func (s *HTPasswdWatcher) Run() error {
 	s.done = done
 	s.stopped = stopped
 	s.watcher = watcher
-	s.useInotify = useInotify
 
 	go s.loop(done, stopped, watcher)
 
@@ -252,8 +247,6 @@ func (s *HTPasswdWatcher) loop(done chan struct{}, stopped chan struct{}, watche
 				s.watcher.Close() //nolint: errcheck
 				s.watcher = nil
 			}
-
-			s.useInotify = false
 		}
 		s.mu.Unlock()
 
@@ -301,15 +294,10 @@ func (s *HTPasswdWatcher) loop(done chan struct{}, stopped chan struct{}, watche
 
 			if event.Op&(fsnotify.Remove|fsnotify.Rename|fsnotify.Create) != 0 {
 				if !s.retryAddWatch(filePath, watcher, done) {
-					s.mu.Lock()
-					// Only fall back to polling when this path is still current;
-					// a concurrent ChangeFile may already own inotify for a new path.
-					if s.filePath == filePath {
-						s.log.Warn().Str("htpasswd-file", filePath).
-							Msg("failed to re-add watch after retries, switching to stat-based polling")
-						s.useInotify = false
-					}
-					s.mu.Unlock()
+					// Retries exhausted for the still-current path. Periodic
+					// fingerprint polling remains the backstop; log and continue.
+					s.log.Warn().Str("htpasswd-file", filePath).
+						Msg("failed to re-add watch after retries, relying on stat-based polling")
 				}
 			}
 
@@ -335,16 +323,10 @@ func (s *HTPasswdWatcher) loop(done chan struct{}, stopped chan struct{}, watche
 			s.reloadWatchedFile("debounced file change")
 
 		case <-statTicker.C:
-			// Always select the ticker so ChangeFile can flip useInotify off and
-			// have polling take effect on the next tick without needing a wake signal.
-			s.mu.Lock()
-			useInotify := s.useInotify
-			s.mu.Unlock()
-
-			if useInotify {
-				continue
-			}
-
+			// Always fingerprint-poll, even when inotify is healthy: that closes
+			// the gap when the file changes while the watcher is stopped (or
+			// between Reload and watch install in ChangeFile), when no event is
+			// emitted for the transition that already happened.
 			if s.checkFileChanged() {
 				s.reloadWatchedFile("stat-based polling")
 			}
@@ -361,13 +343,9 @@ func (s *HTPasswdWatcher) loop(done chan struct{}, stopped chan struct{}, watche
 				s.log.Error().Err(err).Str("htpasswd-file", s.getFilePath()).
 					Msg("failed to fsnotify, got error while watching file")
 
-				// Events may have been dropped (e.g. inotify queue overflow),
-				// so inotify can no longer be trusted for this run: fall back
-				// to stat-based polling and reload to resynchronize.
-				s.mu.Lock()
-				s.useInotify = false
-				s.mu.Unlock()
-
+				// Events may have been dropped (e.g. inotify queue overflow).
+				// Periodic fingerprint polling is the backstop; schedule an
+				// immediate reload to resynchronize sooner than the next tick.
 				s.scheduleReload()
 			}
 		}
@@ -418,8 +396,8 @@ func (s *HTPasswdWatcher) scheduleReload() {
 // The parent directory watch is required to detect Kubernetes Secret/ConfigMap
 // updates, which atomically retarget the ..data symlink instead of writing to
 // the watched inode. Either both watches are established or an error is
-// returned, so callers never treat partial coverage as working inotify and
-// keep the stat-based polling fallback active instead.
+// returned; callers treat a failure as "no inotify for this path" and rely on
+// the always-on fingerprint poller.
 func (s *HTPasswdWatcher) addWatches(watcher *fsnotify.Watcher, filePath string) error {
 	if err := watcher.Add(filePath); err != nil {
 		return err
@@ -468,12 +446,12 @@ func (s *HTPasswdWatcher) eventAffectsWatchedFile(eventName, filePath string) bo
 // It blocks the watcher loop for up to ~750ms total; that is acceptable since
 // fsnotify buffers events in the meantime and htpasswd changes are infrequent.
 // Returns false only when retries are exhausted for a path that is still current.
-// If ChangeFile switches the watched path mid-retry, returns true without touching
-// watches or useInotify, so it cannot clobber the new path's state.
+// If ChangeFile switches the watched path mid-retry, returns true without
+// touching watches, so it cannot clobber the new path's state.
 //
-// The path check, addWatches and useInotify update happen under s.mu as one unit
-// (mirroring ChangeFile): re-adding watches without the lock could race with a
-// concurrent ChangeFile to a sibling file and remove the shared parent-dir watch.
+// The path check and addWatches happen under s.mu as one unit (mirroring
+// ChangeFile): re-adding watches without the lock could race with a concurrent
+// ChangeFile to a sibling file and remove the shared parent-dir watch.
 func (s *HTPasswdWatcher) retryAddWatch(file string, watcher *fsnotify.Watcher, done <-chan struct{}) bool {
 	for attempt := range 5 {
 		select {
@@ -491,17 +469,15 @@ func (s *HTPasswdWatcher) retryAddWatch(file string, watcher *fsnotify.Watcher, 
 			return true
 		}
 
-		if err := s.addWatches(watcher, file); err == nil {
-			s.useInotify = true
-			s.mu.Unlock()
+		err := s.addWatches(watcher, file)
+		s.mu.Unlock()
 
+		if err == nil {
 			s.log.Debug().Str("htpasswd-file", file).Int("attempt", attempt+1).
 				Msg("re-added watch after file removal/rename")
 
 			return true
 		}
-
-		s.mu.Unlock()
 
 		s.log.Debug().Str("htpasswd-file", file).Int("attempt", attempt+1).
 			Msg("retrying watch add after failure")
@@ -544,8 +520,8 @@ func (s *HTPasswdWatcher) reloadWatchedFile(reason string) {
 // catches atomic-rename replacements even when the new file preserves the old
 // timestamp; size catches same-inode rewrites within one coarse-timestamp
 // granule; mtime catches plain in-place edits. An in-place rewrite with equal
-// size inside the same timestamp granule remains undetectable without hashing,
-// and is covered by inotify in all but the polling-only degraded mode.
+// size inside the same timestamp granule remains undetectable without hashing;
+// inotify covers that case when watches are healthy.
 func (s *HTPasswdWatcher) checkFileChanged() bool {
 	filePath := s.getFilePath()
 	if filePath == "" {
@@ -592,7 +568,6 @@ func (s *HTPasswdWatcher) ChangeFile(filePath string) error {
 
 		s.filePath = ""
 		s.fileInfo = nil
-		s.useInotify = false
 		s.htp.Clear()
 
 		return nil
@@ -608,20 +583,17 @@ func (s *HTPasswdWatcher) ChangeFile(filePath string) error {
 		return err
 	}
 
-	// Use s.done (not s.watcher) to detect a running watcher: in polling-only
-	// mode the loop is running but s.watcher is nil.
+	// Use s.done (not s.watcher) to detect a running watcher: when fsnotify
+	// setup failed the loop is running but s.watcher is nil.
 	if s.done != nil && s.watcher != nil {
 		if s.filePath != "" {
 			s.removeWatchesLocked(s.filePath)
 		}
 
 		if err := s.addWatches(s.watcher, filePath); err != nil {
-			// Degrade to stat-based polling rather than failing the change
+			// Periodic fingerprint polling remains the backstop.
 			s.log.Warn().Err(err).Str("htpasswd-file", filePath).
-				Msg("failed to watch htpasswd file, falling back to stat-based polling")
-			s.useInotify = false
-		} else {
-			s.useInotify = true
+				Msg("failed to watch htpasswd file, relying on stat-based polling")
 		}
 	}
 
@@ -687,7 +659,6 @@ func (s *HTPasswdWatcher) Close() error {
 	capturedStopped := s.stopped
 	s.done = nil
 	s.watcher = nil
-	s.useInotify = false
 	s.mu.Unlock()
 
 	// Close fsnotify watcher to terminate the goroutine promptly

--- a/pkg/api/htpasswd.go
+++ b/pkg/api/htpasswd.go
@@ -2,21 +2,31 @@ package api
 
 import (
 	"bufio"
-	"context"
 	"crypto/fips140"
 	"errors"
 	"os"
-	"os/signal"
+	"path/filepath"
 	"strings"
 	"sync"
-	"syscall"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 	cpass "github.com/nathanaelle/password"
 	"golang.org/x/crypto/bcrypt"
 
+	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/log"
 )
+
+const (
+	// htpasswdEventDebounceInterval coalesces multiple fsnotify events into one reload.
+	// Kubernetes Secret/ConfigMap updates often emit Remove/Create/Rename bursts.
+	htpasswdEventDebounceInterval = 150 * time.Millisecond
+	// htpasswdStatCheckInterval is the polling interval used when inotify watching is unavailable.
+	htpasswdStatCheckInterval = 1 * time.Second
+)
+
+var htpasswdFileStat = os.Stat //nolint:gochecknoglobals // test hook for os.Stat
 
 // HTPasswd user auth store
 //
@@ -138,15 +148,32 @@ func (s *HTPasswd) Authenticate(username, passphrase string) (ok, present bool) 
 
 // HTPasswdWatcher helper which triggers htpasswd reload on file change event.
 //
-// Can be restarted by calling Run() again after Close().
+// Can be restarted by calling Run() again after Close(); Close() waits for the
+// watcher goroutine to exit, so an immediate Run() after Close() is safe.
+// Mirrors TlsConfigWatcher behavior for Kubernetes Secret/ConfigMap mounts that
+// replace files via atomic rename/symlink swap (Remove/Create/Rename, not only Write).
 type HTPasswdWatcher struct {
-	htp      *HTPasswd
+	htp *HTPasswd
+	log log.Logger
+
+	// mu protects all fields below. No code path blocks while holding it:
+	// lock sections are short and never wait on channels, timers or the
+	// goroutine, so the single mutex cannot participate in a deadlock cycle.
+	mu       sync.Mutex
 	filePath string
 	watcher  *fsnotify.Watcher
-	ctx      context.Context //nolint:containedctx // Context is needed for watcher lifecycle management
-	cancel   context.CancelFunc
-	log      log.Logger
-	mu       sync.Mutex
+	// done is non-nil while the watcher is running and not yet signaled to stop.
+	done chan struct{}
+	// stopped is non-nil from Run() until the loop goroutine has fully exited
+	// (it is cleared by the loop itself). While set, Run() refuses to start a
+	// second generation, so loops can never overlap even if Run() races Close().
+	stopped       chan struct{}
+	useInotify    bool
+	debounceTimer *time.Timer
+	// fileInfo is the stat fingerprint of the last successfully loaded file.
+	// Polling compares identity (os.SameFile), size and mtime against it, so
+	// atomic replacements that preserve the timestamp are still detected.
+	fileInfo os.FileInfo
 }
 
 // NewHTPasswdWatcher creates a new watcher instance.
@@ -161,82 +188,395 @@ func NewHTPasswdWatcher(htp *HTPasswd, filePath string) (*HTPasswdWatcher, error
 }
 
 // Run starts the watcher goroutine.
-func (s *HTPasswdWatcher) Run() {
+// Returns ErrHTPasswdWatcherAlreadyRunning if the watcher is already running.
+// If inotify setup fails, the watcher still starts and falls back to stat-based polling.
+func (s *HTPasswdWatcher) Run() error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if s.ctx != nil {
-		return // Already running
+	// s.stopped stays non-nil until the previous loop goroutine has fully
+	// exited, so a Run() racing an in-progress Close() cannot start a second
+	// generation that would share the debounce timer and useInotify state.
+	if s.done != nil || s.stopped != nil {
+		return zerr.ErrHTPasswdWatcherAlreadyRunning
 	}
 
-	// Create fresh fsnotify watcher for this run
+	// Create fresh fsnotify watcher for this run. On failure continue without it,
+	// the loop still runs and reloads via stat-based polling.
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		s.log.Error().Err(err).Msg("failed to create fsnotify watcher")
+		s.log.Error().Err(err).Msg("failed to create fsnotify watcher, falling back to stat-based polling")
 
-		return
+		watcher = nil
 	}
 
-	// Only add file to watcher if we have a file to watch
-	if s.filePath != "" {
-		err = watcher.Add(s.filePath)
-		if err != nil {
-			s.log.Error().Err(err).Str("htpasswd-file", s.filePath).Msg("failed to add file to watcher")
-			watcher.Close() //nolint: errcheck
+	useInotify := false
 
-			return
+	// Watch the file and its parent directory. Directory watches are required for
+	// Kubernetes Secret/ConfigMap mounts, where the file is a symlink and updates
+	// atomically retarget ..data without rewriting the watched inode.
+	if watcher != nil && s.filePath != "" {
+		if err := s.addWatches(watcher, s.filePath); err != nil {
+			s.log.Error().Err(err).Str("htpasswd-file", s.filePath).
+				Msg("failed to add file to watcher, falling back to stat-based polling")
+		} else {
+			useInotify = true
 		}
 	}
 
-	// Create context and start goroutine
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	s.ctx = ctx
-	s.cancel = cancel
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	s.done = done
+	s.stopped = stopped
 	s.watcher = watcher
+	s.useInotify = useInotify
 
-	go func() {
-		defer func() {
-			s.mu.Lock()
-			defer s.mu.Unlock()
+	go s.loop(done, stopped, watcher)
 
-			// Clean up watcher
+	return nil
+}
+
+func (s *HTPasswdWatcher) loop(done chan struct{}, stopped chan struct{}, watcher *fsnotify.Watcher) {
+	defer close(stopped)
+
+	defer func() {
+		s.mu.Lock()
+		// Only clear state if it still belongs to this loop instance.
+		// s.stopped is the ownership marker: Close() never clears it, and a new
+		// Run() cannot replace it while it is set.
+		if s.stopped == stopped {
+			s.done = nil
+			s.stopped = nil
+
 			if s.watcher != nil {
 				s.watcher.Close() //nolint: errcheck
 				s.watcher = nil
 			}
 
-			// Clear context to indicate not running
-			s.ctx = nil
-			s.cancel = nil
-		}()
+			s.useInotify = false
+		}
+		s.mu.Unlock()
 
-		for {
-			select {
-			case <-ctx.Done():
-				s.log.Debug().Msg("htpasswd watcher terminating...")
+		// Logged on every exit path; tests rely on this message to detect termination.
+		s.log.Debug().Msg("htpasswd watcher terminating...")
+	}()
+
+	// Nil channels block forever in select, which makes the loop safe to run
+	// in polling-only mode when fsnotify is unavailable.
+	var eventsCh chan fsnotify.Event
+
+	var errorsCh chan error
+
+	if watcher != nil {
+		eventsCh = watcher.Events
+		errorsCh = watcher.Errors
+	}
+
+	statTicker := time.NewTicker(htpasswdStatCheckInterval)
+	defer statTicker.Stop()
+
+	for {
+		select {
+		case <-done:
+			return
+
+		case event, ok := <-eventsCh:
+			if !ok {
+				s.log.Debug().Msg("htpasswd watcher events channel closed")
 
 				return
+			}
 
-			case ev := <-watcher.Events:
-				if ev.Op != fsnotify.Write {
-					continue
-				}
+			if event.Op&(fsnotify.Write|fsnotify.Create|fsnotify.Remove|fsnotify.Rename|fsnotify.Chmod) == 0 {
+				continue
+			}
 
-				s.log.Info().Str("htpasswd-file", s.filePath).Msg("htpasswd file changed, trying to reload config")
+			filePath := s.getFilePath()
+			if filePath == "" || !s.eventAffectsWatchedFile(event.Name, filePath) {
+				continue
+			}
 
-				err := s.htp.Reload(s.filePath)
-				if err != nil {
-					s.log.Warn().Err(err).Str("htpasswd-file", s.filePath).Msg("failed to reload file")
-				}
+			s.log.Debug().Str("file", event.Name).Str("op", event.Op.String()).
+				Msg("htpasswd file change detected")
 
-			case err := <-watcher.Errors:
-				// Only log errors if we're actually watching a file
-				if s.filePath != "" {
-					s.log.Error().Err(err).Str("htpasswd-file", s.filePath).Msg("failed to fsnotfy, got error while watching file")
+			if event.Op&(fsnotify.Remove|fsnotify.Rename|fsnotify.Create) != 0 {
+				if !s.retryAddWatch(filePath, watcher, done) {
+					s.mu.Lock()
+					// Only fall back to polling when this path is still current;
+					// a concurrent ChangeFile may already own inotify for a new path.
+					if s.filePath == filePath {
+						s.log.Warn().Str("htpasswd-file", filePath).
+							Msg("failed to re-add watch after retries, switching to stat-based polling")
+						s.useInotify = false
+					}
+					s.mu.Unlock()
 				}
 			}
+
+			select {
+			case <-done:
+				return
+			default:
+			}
+
+			s.scheduleReload()
+
+		case <-s.getDebounceChannel():
+			s.mu.Lock()
+			s.debounceTimer = nil
+			s.mu.Unlock()
+
+			select {
+			case <-done:
+				return
+			default:
+			}
+
+			s.reloadWatchedFile("debounced file change")
+
+		case <-statTicker.C:
+			// Always select the ticker so ChangeFile can flip useInotify off and
+			// have polling take effect on the next tick without needing a wake signal.
+			s.mu.Lock()
+			useInotify := s.useInotify
+			s.mu.Unlock()
+
+			if useInotify {
+				continue
+			}
+
+			if s.checkFileChanged() {
+				s.reloadWatchedFile("stat-based polling")
+			}
+
+		case err, ok := <-errorsCh:
+			if !ok {
+				s.log.Debug().Msg("htpasswd watcher errors channel closed")
+
+				return
+			}
+
+			// Only react if we're actually watching a file
+			if s.getFilePath() != "" {
+				s.log.Error().Err(err).Str("htpasswd-file", s.getFilePath()).
+					Msg("failed to fsnotify, got error while watching file")
+
+				// Events may have been dropped (e.g. inotify queue overflow),
+				// so inotify can no longer be trusted for this run: fall back
+				// to stat-based polling and reload to resynchronize.
+				s.mu.Lock()
+				s.useInotify = false
+				s.mu.Unlock()
+
+				s.scheduleReload()
+			}
 		}
-	}()
+	}
+}
+
+func (s *HTPasswdWatcher) getFilePath() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.filePath
+}
+
+func (s *HTPasswdWatcher) getDebounceChannel() <-chan time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.debounceTimer == nil {
+		return nil
+	}
+
+	return s.debounceTimer.C
+}
+
+func (s *HTPasswdWatcher) scheduleReload() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.debounceTimer != nil {
+		if !s.debounceTimer.Stop() {
+			select {
+			case <-s.debounceTimer.C:
+			default:
+			}
+		}
+		s.debounceTimer.Reset(htpasswdEventDebounceInterval)
+		s.log.Debug().Msg("htpasswd debounce timer reset for additional file change event")
+
+		return
+	}
+
+	s.debounceTimer = time.NewTimer(htpasswdEventDebounceInterval)
+	s.log.Debug().Str("interval", htpasswdEventDebounceInterval.String()).
+		Msg("htpasswd debounce timer started for file change events")
+}
+
+// addWatches watches filePath and its parent directory as a unit.
+// The parent directory watch is required to detect Kubernetes Secret/ConfigMap
+// updates, which atomically retarget the ..data symlink instead of writing to
+// the watched inode. Either both watches are established or an error is
+// returned, so callers never treat partial coverage as working inotify and
+// keep the stat-based polling fallback active instead.
+func (s *HTPasswdWatcher) addWatches(watcher *fsnotify.Watcher, filePath string) error {
+	if err := watcher.Add(filePath); err != nil {
+		return err
+	}
+
+	dir := filepath.Dir(filePath)
+
+	if err := watcher.Add(dir); err != nil {
+		// Roll back the file watch so callers and retries start from a clean state
+		if rmErr := watcher.Remove(filePath); rmErr != nil && !errors.Is(rmErr, fsnotify.ErrNonExistentWatch) {
+			s.log.Debug().Err(rmErr).Str("htpasswd-file", filePath).
+				Msg("failed to remove htpasswd file watch during rollback")
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+// eventAffectsWatchedFile reports whether a fsnotify event is relevant for the
+// watched htpasswd file. Since the parent directory is watched too, events for
+// unrelated sibling files must be filtered out: only the exact file path and
+// Kubernetes ..data symlink swaps in the same directory trigger a reload.
+func (s *HTPasswdWatcher) eventAffectsWatchedFile(eventName, filePath string) bool {
+	if eventName == "" || filePath == "" {
+		return false
+	}
+
+	eventName = filepath.Clean(eventName)
+	filePath = filepath.Clean(filePath)
+
+	if eventName == filePath {
+		return true
+	}
+
+	// Kubernetes mounts swap the ..data (or ..data_tmp) symlink under the mount directory.
+	if strings.HasPrefix(filepath.Base(eventName), "..data") {
+		return filepath.Dir(eventName) == filepath.Dir(filePath)
+	}
+
+	return false
+}
+
+// retryAddWatch re-establishes watches after the file is removed/renamed.
+// It blocks the watcher loop for up to ~750ms total; that is acceptable since
+// fsnotify buffers events in the meantime and htpasswd changes are infrequent.
+// Returns false only when retries are exhausted for a path that is still current.
+// If ChangeFile switches the watched path mid-retry, returns true without touching
+// watches or useInotify, so it cannot clobber the new path's state.
+//
+// The path check, addWatches and useInotify update happen under s.mu as one unit
+// (mirroring ChangeFile): re-adding watches without the lock could race with a
+// concurrent ChangeFile to a sibling file and remove the shared parent-dir watch.
+func (s *HTPasswdWatcher) retryAddWatch(file string, watcher *fsnotify.Watcher, done <-chan struct{}) bool {
+	for attempt := range 5 {
+		select {
+		case <-done:
+			return false
+		case <-time.After(time.Duration(50*(attempt+1)) * time.Millisecond):
+		}
+
+		s.mu.Lock()
+
+		if s.filePath != file {
+			// Concurrent ChangeFile moved us to a different path; abandon this retry.
+			s.mu.Unlock()
+
+			return true
+		}
+
+		if err := s.addWatches(watcher, file); err == nil {
+			s.useInotify = true
+			s.mu.Unlock()
+
+			s.log.Debug().Str("htpasswd-file", file).Int("attempt", attempt+1).
+				Msg("re-added watch after file removal/rename")
+
+			return true
+		}
+
+		s.mu.Unlock()
+
+		s.log.Debug().Str("htpasswd-file", file).Int("attempt", attempt+1).
+			Msg("retrying watch add after failure")
+	}
+
+	return false
+}
+
+func (s *HTPasswdWatcher) reloadWatchedFile(reason string) {
+	// Hold s.mu for the entire reload so it serializes with ChangeFile:
+	// otherwise an in-flight reload of the previous path could overwrite the
+	// credentials and mod-time baseline a concurrent ChangeFile just installed,
+	// leaving stale users loaded indefinitely.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.filePath == "" {
+		return
+	}
+
+	s.log.Info().Str("htpasswd-file", s.filePath).Str("reason", reason).
+		Msg("htpasswd file changed, trying to reload config")
+
+	// Sample the fingerprint before reading the file: if a replacement lands
+	// mid-read, the stale baseline makes the next poll detect and reload it,
+	// instead of recording the new fingerprint against the old content.
+	info := s.statFile(s.filePath)
+
+	if err := s.htp.Reload(s.filePath); err != nil {
+		s.log.Warn().Err(err).Str("htpasswd-file", s.filePath).Msg("failed to reload file")
+
+		return
+	}
+
+	s.fileInfo = info
+}
+
+// checkFileChanged reports whether the watched file differs from the baseline
+// fingerprint recorded at the last successful reload. Identity (os.SameFile)
+// catches atomic-rename replacements even when the new file preserves the old
+// timestamp; size catches same-inode rewrites within one coarse-timestamp
+// granule; mtime catches plain in-place edits. An in-place rewrite with equal
+// size inside the same timestamp granule remains undetectable without hashing,
+// and is covered by inotify in all but the polling-only degraded mode.
+func (s *HTPasswdWatcher) checkFileChanged() bool {
+	filePath := s.getFilePath()
+	if filePath == "" {
+		return false
+	}
+
+	info, err := htpasswdFileStat(filePath)
+	if err != nil {
+		s.log.Debug().Err(err).Str("htpasswd-file", filePath).
+			Msg("failed to stat htpasswd file during polling")
+
+		return false
+	}
+
+	s.mu.Lock()
+	prev := s.fileInfo
+	s.mu.Unlock()
+
+	// No baseline yet: reload to establish one.
+	if prev == nil {
+		return true
+	}
+
+	if !os.SameFile(prev, info) || prev.Size() != info.Size() || !prev.ModTime().Equal(info.ModTime()) {
+		s.log.Debug().Str("htpasswd-file", filePath).
+			Msg("htpasswd file modification detected via stat")
+
+		return true
+	}
+
+	return false
 }
 
 // ChangeFile changes monitored file. Empty string clears store.
@@ -244,60 +584,127 @@ func (s *HTPasswdWatcher) ChangeFile(filePath string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	// If watcher is not running, just update the filePath for when Run() is called
-	if s.watcher == nil {
-		s.filePath = filePath
-		if filePath == "" {
-			s.htp.Clear()
-		} else {
-			return s.htp.Reload(filePath)
-		}
-
-		return nil
-	}
-
-	// Remove old file if it exists
-	if s.filePath != "" {
-		if err := s.watcher.Remove(s.filePath); err != nil && !errors.Is(err, fsnotify.ErrNonExistentWatch) {
-			// Ignore "can't remove non-existent watch" errors as they can happen
-			// due to race conditions or files being removed externally
-			return err
-		}
-	}
-
+	// Clearing the store works the same whether or not the watcher is running
 	if filePath == "" {
-		s.filePath = filePath
+		if s.watcher != nil && s.filePath != "" {
+			s.removeWatchesLocked(s.filePath)
+		}
+
+		s.filePath = ""
+		s.fileInfo = nil
+		s.useInotify = false
 		s.htp.Clear()
 
 		return nil
 	}
 
-	err := s.watcher.Add(filePath)
-	if err != nil {
+	// Sample the fingerprint before reading, so a replacement landing mid-read
+	// is caught by the next poll instead of being masked by a post-read baseline.
+	info := s.statFile(filePath)
+
+	// Validate and load the new file before touching any state, so a bad path
+	// leaves the previous configuration fully intact
+	if err := s.htp.Reload(filePath); err != nil {
 		return err
 	}
 
-	s.filePath = filePath
+	// Use s.done (not s.watcher) to detect a running watcher: in polling-only
+	// mode the loop is running but s.watcher is nil.
+	if s.done != nil && s.watcher != nil {
+		if s.filePath != "" {
+			s.removeWatchesLocked(s.filePath)
+		}
 
-	return s.htp.Reload(filePath)
+		if err := s.addWatches(s.watcher, filePath); err != nil {
+			// Degrade to stat-based polling rather than failing the change
+			s.log.Warn().Err(err).Str("htpasswd-file", filePath).
+				Msg("failed to watch htpasswd file, falling back to stat-based polling")
+			s.useInotify = false
+		} else {
+			s.useInotify = true
+		}
+	}
+
+	s.filePath = filePath
+	s.fileInfo = info
+
+	return nil
 }
 
+// removeWatchesLocked removes file and parent-dir watches; caller must hold s.mu.
+func (s *HTPasswdWatcher) removeWatchesLocked(filePath string) {
+	if s.watcher == nil || filePath == "" {
+		return
+	}
+
+	if err := s.watcher.Remove(filePath); err != nil && !errors.Is(err, fsnotify.ErrNonExistentWatch) {
+		s.log.Debug().Err(err).Str("htpasswd-file", filePath).Msg("failed to remove htpasswd file watch")
+	}
+
+	dir := filepath.Dir(filePath)
+	if dir == "" || dir == "." || dir == filePath {
+		return
+	}
+
+	if err := s.watcher.Remove(dir); err != nil && !errors.Is(err, fsnotify.ErrNonExistentWatch) {
+		s.log.Debug().Err(err).Str("dir", dir).Msg("failed to remove htpasswd directory watch")
+	}
+}
+
+// statFile returns the file's current stat fingerprint, or nil if stat fails.
+// A nil baseline is safe: the next poll tick treats it as changed and triggers
+// a redundant reload, which self-corrects the baseline.
+func (s *HTPasswdWatcher) statFile(filePath string) os.FileInfo {
+	info, err := htpasswdFileStat(filePath)
+	if err != nil {
+		s.log.Warn().Err(err).Str("htpasswd-file", filePath).
+			Msg("failed to stat htpasswd file")
+
+		return nil
+	}
+
+	return info
+}
+
+// Close stops the watcher goroutine and waits for it to finish, so Run() can be
+// called again immediately after Close() returns without overlapping reloads.
+// Safe to call multiple times and when the watcher is not running.
 func (s *HTPasswdWatcher) Close() error {
+	// Capture and reset watcher state in one critical section. Captures are nil
+	// when not running, which also makes concurrent and repeated Close() calls
+	// safe no-ops. s.stopped is intentionally NOT cleared here: the loop clears
+	// it on exit, and while it is set Run() refuses to start a new generation,
+	// so a Run() racing this Close() cannot overlap the draining loop.
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
-	if s.ctx == nil {
-		return nil // Already closed/not running
+	if s.debounceTimer != nil {
+		s.debounceTimer.Stop()
+		s.debounceTimer = nil
 	}
 
-	// Cancel context to signal goroutine to stop
-	if s.cancel != nil {
-		s.cancel()
+	capturedWatcher := s.watcher
+	capturedDone := s.done
+	capturedStopped := s.stopped
+	s.done = nil
+	s.watcher = nil
+	s.useInotify = false
+	s.mu.Unlock()
+
+	// Close fsnotify watcher to terminate the goroutine promptly
+	if capturedWatcher != nil {
+		_ = capturedWatcher.Close()
 	}
 
-	// The goroutine will clean up s.ctx, s.cancel, and s.watcher in its defer
-	// We just need to wait for it to finish by checking if s.ctx becomes nil
-	// This is safe because the goroutine sets s.ctx = nil in its defer
+	// Signal the goroutine to exit via the done channel
+	if capturedDone != nil {
+		close(capturedDone)
+	}
+
+	// Wait for the goroutine to finish (no locks held here) so in-flight
+	// reloads cannot overlap a new Run().
+	if capturedStopped != nil {
+		<-capturedStopped
+	}
 
 	return nil
 }

--- a/pkg/api/htpasswd_test.go
+++ b/pkg/api/htpasswd_test.go
@@ -2,16 +2,49 @@ package api_test
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 
+	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/api"
 	"zotregistry.dev/zot/v2/pkg/log"
 	test "zotregistry.dev/zot/v2/pkg/test/common"
 )
+
+const htpasswdReloadTimeout = 5 * time.Second
+
+func waitForHTPasswdAuth(htp *api.HTPasswd, username, password string) bool {
+	deadline := time.Now().Add(htpasswdReloadTimeout)
+
+	for time.Now().Before(deadline) {
+		ok, present := htp.Authenticate(username, password)
+		if ok && present {
+			return true
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	return false
+}
+
+func waitForHTPasswdUserGone(htp *api.HTPasswd, username string) bool {
+	deadline := time.Now().Add(htpasswdReloadTimeout)
+
+	for time.Now().Before(deadline) {
+		if _, present := htp.Get(username); !present {
+			return true
+		}
+
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	return false
+}
 
 func TestHTPasswdWatcherOriginal(t *testing.T) {
 	logger := log.NewLogger("DEBUG", "")
@@ -28,7 +61,7 @@ func TestHTPasswdWatcherOriginal(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// Start the watcher goroutine
-		htw.Run()
+		So(htw.Run(), ShouldBeNil)
 
 		defer htw.Close() //nolint: errcheck
 
@@ -51,8 +84,8 @@ func TestHTPasswdWatcherOriginal(t *testing.T) {
 		err = os.WriteFile(htpasswdPath, []byte(test.GetBcryptCredString(username, password2)), 0o600)
 		So(err, ShouldBeNil)
 
-		// 3. Give some time for the background task
-		time.Sleep(10 * time.Millisecond)
+		// 3. Wait for debounced reload
+		So(waitForHTPasswdAuth(htp, username, password2), ShouldBeTrue)
 
 		// 4. Check user present and now has password2
 		ok, present = htp.Authenticate(username, password1)
@@ -61,6 +94,146 @@ func TestHTPasswdWatcherOriginal(t *testing.T) {
 
 		ok, present = htp.Authenticate(username, password2)
 		So(ok, ShouldBeTrue)
+		So(present, ShouldBeTrue)
+	})
+}
+
+func TestHTPasswdWatcherAtomicReplace(t *testing.T) {
+	logger := log.NewLogger("DEBUG", "")
+
+	Convey("reload htpasswd after atomic rename (k8s-style)", t, func() {
+		username, _ := test.GenerateRandomString()
+		password1, _ := test.GenerateRandomString()
+		password2, _ := test.GenerateRandomString()
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password1))
+
+		htp := api.NewHTPasswd(logger)
+		htw, err := api.NewHTPasswdWatcher(htp, "")
+		So(err, ShouldBeNil)
+
+		So(htw.Run(), ShouldBeNil)
+		defer htw.Close() //nolint: errcheck
+
+		err = htw.ChangeFile(htpasswdPath)
+		So(err, ShouldBeNil)
+
+		ok, present := htp.Authenticate(username, password1)
+		So(ok, ShouldBeTrue)
+		So(present, ShouldBeTrue)
+
+		// Simulate kubelet Secret/ConfigMap update: write temp then rename over target.
+		tmpPath := htpasswdPath + ".tmp"
+		err = os.WriteFile(tmpPath, []byte(test.GetBcryptCredString(username, password2)), 0o600)
+		So(err, ShouldBeNil)
+		err = os.Rename(tmpPath, htpasswdPath)
+		So(err, ShouldBeNil)
+
+		So(waitForHTPasswdAuth(htp, username, password2), ShouldBeTrue)
+
+		ok, present = htp.Authenticate(username, password1)
+		So(ok, ShouldBeFalse)
+		So(present, ShouldBeTrue)
+	})
+
+	Convey("reload htpasswd after symlink retarget (k8s ..data style)", t, func() {
+		username, _ := test.GenerateRandomString()
+		password1, _ := test.GenerateRandomString()
+		password2, _ := test.GenerateRandomString()
+
+		dir := t.TempDir()
+		data1 := dir + "/data1"
+		data2 := dir + "/data2"
+		So(os.Mkdir(data1, 0o755), ShouldBeNil)
+		So(os.Mkdir(data2, 0o755), ShouldBeNil)
+
+		So(os.WriteFile(data1+"/htpasswd", []byte(test.GetBcryptCredString(username, password1)), 0o600),
+			ShouldBeNil)
+		So(os.WriteFile(data2+"/htpasswd", []byte(test.GetBcryptCredString(username, password2)), 0o600),
+			ShouldBeNil)
+
+		dataLink := dir + "/..data"
+		htpasswdPath := dir + "/htpasswd"
+		So(os.Symlink("data1", dataLink), ShouldBeNil)
+		So(os.Symlink("..data/htpasswd", htpasswdPath), ShouldBeNil)
+
+		htp := api.NewHTPasswd(logger)
+		htw, err := api.NewHTPasswdWatcher(htp, "")
+		So(err, ShouldBeNil)
+
+		So(htw.Run(), ShouldBeNil)
+		defer htw.Close() //nolint: errcheck
+
+		err = htw.ChangeFile(htpasswdPath)
+		So(err, ShouldBeNil)
+
+		ok, present := htp.Authenticate(username, password1)
+		So(ok, ShouldBeTrue)
+		So(present, ShouldBeTrue)
+
+		// Atomic symlink swap of ..data, as kubelet does for Secret/ConfigMap mounts.
+		tmpLink := dir + "/..data_tmp"
+		So(os.Symlink("data2", tmpLink), ShouldBeNil)
+		So(os.Rename(tmpLink, dataLink), ShouldBeNil)
+
+		So(waitForHTPasswdAuth(htp, username, password2), ShouldBeTrue)
+
+		ok, present = htp.Authenticate(username, password1)
+		So(ok, ShouldBeFalse)
+		So(present, ShouldBeTrue)
+	})
+
+	Convey("reload htpasswd via stat-based polling when inotify cannot watch path", t, func() {
+		username, _ := test.GenerateRandomString()
+		password1, _ := test.GenerateRandomString()
+		password2, _ := test.GenerateRandomString()
+
+		// Start watching a path that does not exist yet so addWatches fails and
+		// the loop stays in polling mode.
+		htpasswdPath := filepath.Join(t.TempDir(), "missing-subdir", "htpasswd")
+
+		htp := api.NewHTPasswd(logger)
+		htw, err := api.NewHTPasswdWatcher(htp, htpasswdPath)
+		So(err, ShouldBeNil)
+
+		So(htw.Run(), ShouldBeNil)
+		defer htw.Close() //nolint: errcheck
+
+		So(os.MkdirAll(filepath.Dir(htpasswdPath), 0o755), ShouldBeNil)
+		So(os.WriteFile(htpasswdPath, []byte(test.GetBcryptCredString(username, password1)), 0o600),
+			ShouldBeNil)
+
+		So(waitForHTPasswdAuth(htp, username, password1), ShouldBeTrue)
+
+		So(os.WriteFile(htpasswdPath, []byte(test.GetBcryptCredString(username, password2)), 0o600),
+			ShouldBeNil)
+
+		// Set the mtime explicitly so it differs from the baseline even on
+		// filesystems with coarse (e.g. one-second) timestamp resolution.
+		newModTime := time.Now().Add(2 * time.Second)
+		So(os.Chtimes(htpasswdPath, newModTime, newModTime), ShouldBeNil)
+
+		So(waitForHTPasswdAuth(htp, username, password2), ShouldBeTrue)
+
+		ok, present := htp.Authenticate(username, password1)
+		So(ok, ShouldBeFalse)
+		So(present, ShouldBeTrue)
+
+		// Atomic replacement that preserves the previous mtime exactly: only
+		// the inode differs, so this exercises the os.SameFile identity check.
+		password3, _ := test.GenerateRandomString()
+		prevInfo, err := os.Stat(htpasswdPath)
+		So(err, ShouldBeNil)
+
+		tmpPath := htpasswdPath + ".tmp"
+		So(os.WriteFile(tmpPath, []byte(test.GetBcryptCredString(username, password3)), 0o600),
+			ShouldBeNil)
+		So(os.Chtimes(tmpPath, prevInfo.ModTime(), prevInfo.ModTime()), ShouldBeNil)
+		So(os.Rename(tmpPath, htpasswdPath), ShouldBeNil)
+
+		So(waitForHTPasswdAuth(htp, username, password3), ShouldBeTrue)
+
+		ok, present = htp.Authenticate(username, password2)
+		So(ok, ShouldBeFalse)
 		So(present, ShouldBeTrue)
 	})
 }
@@ -79,9 +252,9 @@ func TestHTPasswdWatcher(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// Test Run() and Close() operations
-			So(func() { htw.Run() }, ShouldNotPanic)
+			So(htw.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
-			So(func() { htw.Run() }, ShouldNotPanic) // Idempotent
+			So(htw.Run(), ShouldEqual, zerr.ErrHTPasswdWatcherAlreadyRunning) // Already running
 			time.Sleep(10 * time.Millisecond)
 			So(func() { htw.Close() }, ShouldNotPanic)
 			time.Sleep(10 * time.Millisecond)
@@ -112,7 +285,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			So(present, ShouldBeTrue)
 
 			// Start watcher and test ChangeFile() when running
-			htw.Run()
+			So(htw.Run(), ShouldBeNil)
 			defer htw.Close()
 			time.Sleep(10 * time.Millisecond)
 
@@ -148,35 +321,29 @@ func TestHTPasswdWatcher(t *testing.T) {
 			// Change file content and verify automatic reload
 			err = os.WriteFile(htpasswdPath1, []byte(test.GetBcryptCredString(username1, password2)), 0o600)
 			So(err, ShouldBeNil)
-			time.Sleep(100 * time.Millisecond)
-			ok, present = htp.Authenticate(username1, password2)
-			So(ok, ShouldBeTrue)
-			So(present, ShouldBeTrue)
+			So(waitForHTPasswdAuth(htp, username1, password2), ShouldBeTrue)
 
 			// Test multiple users
 			multiUserContent := test.GetBcryptCredString(username1, password1) +
 				"\n" + test.GetBcryptCredString(username2, password2)
 			err = os.WriteFile(htpasswdPath1, []byte(multiUserContent), 0o600)
 			So(err, ShouldBeNil)
-			time.Sleep(100 * time.Millisecond)
-			ok, present = htp.Authenticate(username1, password1)
-			So(ok, ShouldBeTrue)
-			So(present, ShouldBeTrue)
-			ok, present = htp.Authenticate(username2, password2)
-			So(ok, ShouldBeTrue)
-			So(present, ShouldBeTrue)
+			So(waitForHTPasswdAuth(htp, username1, password1), ShouldBeTrue)
+			So(waitForHTPasswdAuth(htp, username2, password2), ShouldBeTrue)
 
 			// Test invalid content (clears store)
 			err = os.WriteFile(htpasswdPath1, []byte("invalid-content"), 0o600)
 			So(err, ShouldBeNil)
-			time.Sleep(100 * time.Millisecond)
+			So(waitForHTPasswdUserGone(htp, username1), ShouldBeTrue)
+
 			_, present = htp.Authenticate(username1, password1)
 			So(present, ShouldBeFalse)
 
 			// Test empty file (clears store)
 			err = os.WriteFile(htpasswdPath1, []byte(""), 0o600)
 			So(err, ShouldBeNil)
-			time.Sleep(100 * time.Millisecond)
+			So(waitForHTPasswdUserGone(htp, username2), ShouldBeTrue)
+
 			_, present = htp.Authenticate(username2, password2)
 			So(present, ShouldBeFalse)
 		})
@@ -199,7 +366,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// Test restart capability
-			htw.Run()
+			So(htw.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
 			err = htw.ChangeFile(htpasswdPath1)
 			So(err, ShouldBeNil)
@@ -211,7 +378,8 @@ func TestHTPasswdWatcher(t *testing.T) {
 			// Close and restart
 			So(htw.Close(), ShouldBeNil)
 			So(test.WaitForLogMessages(logBuffer, "htpasswd watcher terminating...", 1, 5*time.Second), ShouldBeTrue)
-			htw.Run()
+			// Close() waits for the goroutine to exit, so restart is safe immediately
+			So(htw.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
 
 			// Change file after restart
@@ -229,7 +397,8 @@ func TestHTPasswdWatcher(t *testing.T) {
 			So(ok, ShouldBeTrue) // User should still be present
 			So(present, ShouldBeTrue)
 
-			// Test file rename (should not trigger reload)
+			// Test file rename away from watched path: reload is attempted but fails,
+			// so previously loaded credentials remain available.
 			htpasswdPath3 := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username1, password1))
 			err = htw.ChangeFile(htpasswdPath3)
 			So(err, ShouldBeNil)
@@ -243,23 +412,24 @@ func TestHTPasswdWatcher(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			defer os.Remove(newPath)
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 			ok, _ = htp.Authenticate(username1, password1)
 			So(ok, ShouldBeTrue) // User should still be present
 
-			// Test file permission change (should not trigger reload)
+			// Chmod on the renamed (unwatched) path should not clear credentials
 			err = os.Chmod(newPath, 0o000)
 			So(err, ShouldBeNil)
 
 			defer func() { _ = os.Chmod(newPath, 0o644) }()
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(500 * time.Millisecond)
 			ok, _ = htp.Authenticate(username1, password1)
 			So(ok, ShouldBeTrue) // User should still be present
 
 			// Test with non-existent directory
 			htw2, err := api.NewHTPasswdWatcher(htp, "/non/existent/dir/htpasswd")
 			So(err, ShouldBeNil)
-			So(func() { htw2.Run() }, ShouldNotPanic)
+			// Inotify setup fails but the watcher starts in polling mode
+			So(htw2.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
 			So(htw2.Close(), ShouldBeNil)
 			// 1 termination message
@@ -276,7 +446,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			longPath := longPathBuilder.String()
 			htw3, err := api.NewHTPasswdWatcher(htp, longPath)
 			So(err, ShouldBeNil)
-			So(func() { htw3.Run() }, ShouldNotPanic)
+			So(htw3.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
 			So(htw3.Close(), ShouldBeNil)
 			// 1 termination message
@@ -308,7 +478,8 @@ func TestHTPasswdWatcher(t *testing.T) {
 			// Test concurrent Run() and Close()
 			go func() {
 				for range 5 {
-					htw.Run()
+					_ = htw.Run()
+
 					time.Sleep(1 * time.Millisecond)
 				}
 			}()
@@ -326,7 +497,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			time.Sleep(100 * time.Millisecond) // let watcher goroutine finish cleanup before restart
 
 			// Test concurrent ChangeFile() operations
-			htw.Run()
+			So(htw.Run(), ShouldBeNil)
 			defer htw.Close()
 			time.Sleep(10 * time.Millisecond)
 
@@ -370,7 +541,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// Start watcher
-			htw2.Run()
+			So(htw2.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
 
 			// Close watcher
@@ -381,7 +552,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			So(test.WaitForLogMessages(logBuffer, "htpasswd watcher terminating...", 1, 5*time.Second), ShouldBeTrue)
 
 			// Verify we can restart the watcher (indicates proper cleanup)
-			htw2.Run()
+			So(htw2.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
 			So(htw2.Close(), ShouldBeNil)
 			// 1 termination message
@@ -389,7 +560,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 
 			// Test multiple Run/Close cycles
 			for range 3 {
-				htw2.Run()
+				So(htw2.Run(), ShouldBeNil)
 				time.Sleep(10 * time.Millisecond)
 				So(htw2.Close(), ShouldBeNil)
 				time.Sleep(50 * time.Millisecond) // Give time for termination
@@ -406,7 +577,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			htw1, err := api.NewHTPasswdWatcher(htp1, "")
 			So(err, ShouldBeNil)
 
-			htw1.Run()
+			So(htw1.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
 			So(htw1.Close(), ShouldBeNil)
 			So(test.WaitForLogMessages(logBuffer, "htpasswd watcher terminating...", 1, 5*time.Second), ShouldBeTrue)
@@ -421,7 +592,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			// Start watcher with file
-			htw2.Run()
+			So(htw2.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
 
 			// Load file to ensure watcher is active
@@ -436,7 +607,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 
 			// Test 3: Multiple termination cycles with file watching
 			for range 3 {
-				htw2.Run()
+				So(htw2.Run(), ShouldBeNil)
 				time.Sleep(10 * time.Millisecond)
 				So(htw2.Close(), ShouldBeNil)
 				time.Sleep(50 * time.Millisecond) // Give time for termination
@@ -447,7 +618,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 
 			// Test 4: Stress test with rapid cycles
 			for range 5 {
-				htw2.Run()
+				So(htw2.Run(), ShouldBeNil)
 				time.Sleep(5 * time.Millisecond)
 				So(htw2.Close(), ShouldBeNil)
 				time.Sleep(20 * time.Millisecond) // Give time for termination
@@ -457,7 +628,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			So(test.WaitForLogMessages(logBuffer, "htpasswd watcher terminating...", 8, 5*time.Second), ShouldBeTrue)
 
 			// Final verification: watcher should still work after all cycles
-			htw2.Run()
+			So(htw2.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
 			So(htw2.Close(), ShouldBeNil)
 
@@ -479,7 +650,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			colonPath := test.MakeHtpasswdFileFromString(t, ":::")
 			htw1, err := api.NewHTPasswdWatcher(htp, colonPath)
 			So(err, ShouldBeNil)
-			htw1.Run()
+			So(htw1.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
 			_ = htw1.ChangeFile(colonPath)
 
@@ -497,7 +668,7 @@ func TestHTPasswdWatcher(t *testing.T) {
 			commentedPath := test.MakeHtpasswdFileFromString(t, content)
 			htw2, err := api.NewHTPasswdWatcher(htp, commentedPath)
 			So(err, ShouldBeNil)
-			htw2.Run()
+			So(htw2.Run(), ShouldBeNil)
 			time.Sleep(10 * time.Millisecond)
 			_ = htw2.ChangeFile(commentedPath)
 

--- a/pkg/api/htpasswd_test.go
+++ b/pkg/api/htpasswd_test.go
@@ -236,6 +236,39 @@ func TestHTPasswdWatcherAtomicReplace(t *testing.T) {
 		So(ok, ShouldBeFalse)
 		So(present, ShouldBeTrue)
 	})
+
+	Convey("reload htpasswd after Close when file changed while stopped", t, func() {
+		username, _ := test.GenerateRandomString()
+		password1, _ := test.GenerateRandomString()
+		password2, _ := test.GenerateRandomString()
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password1))
+
+		htp := api.NewHTPasswd(logger)
+		htw, err := api.NewHTPasswdWatcher(htp, htpasswdPath)
+		So(err, ShouldBeNil)
+
+		So(htw.Run(), ShouldBeNil)
+		So(waitForHTPasswdAuth(htp, username, password1), ShouldBeTrue)
+
+		// Stop watching, rotate credentials, then restart. Inotify will not emit
+		// an event for the change that already happened; the always-on fingerprint
+		// poller must pick it up.
+		So(htw.Close(), ShouldBeNil)
+
+		So(os.WriteFile(htpasswdPath, []byte(test.GetBcryptCredString(username, password2)), 0o600),
+			ShouldBeNil)
+		newModTime := time.Now().Add(2 * time.Second)
+		So(os.Chtimes(htpasswdPath, newModTime, newModTime), ShouldBeNil)
+
+		So(htw.Run(), ShouldBeNil)
+		defer htw.Close() //nolint: errcheck
+
+		So(waitForHTPasswdAuth(htp, username, password2), ShouldBeTrue)
+
+		ok, present := htp.Authenticate(username, password1)
+		So(ok, ShouldBeFalse)
+		So(present, ShouldBeTrue)
+	})
 }
 
 func TestHTPasswdWatcher(t *testing.T) {


### PR DESCRIPTION
Align HTPasswdWatcher with TLS cert reload: handle rename/create/remove, watch the parent dir for ..data symlink swaps, debounce reloads, and fall back to mtime polling. Also harden lifecycle with a done channel, synchronous Close(), and Run() error reporting.

Fixes #4284

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
