### PR TITLE
fix(meta): don't 500 a manifest delete once metaDB signature cleanup …

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -109,6 +109,7 @@ var (
 	ErrBadRange                         = errors.New("bad range for streaming blob")
 	ErrBadLayerCount                    = errors.New("manifest layers count doesn't correspond to config history")
 	ErrManifestConflict                 = errors.New("multiple manifests found")
+	ErrManifestRestoreAttempted         = errors.New("manifest restore to image store attempted after a metadb failure")
 	ErrImageMetaNotFound                = errors.New("image meta not found")
 	ErrUnexpectedMediaType              = errors.New("unexpected media type")
 	ErrRepoMetaNotFound                 = errors.New("repo metadata not found for given repo name")

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1007,9 +1007,15 @@ func (rh *RouteHandler) DeleteManifest(response http.ResponseWriter, request *ht
 		err := meta.OnDeleteManifest(name, reference, mediaType, manifestDigest, manifestBlob,
 			rh.c.StoreController, rh.c.MetaDB, rh.c.Log)
 		if err != nil {
-			response.WriteHeader(http.StatusInternalServerError)
+			// The image store manifest may have been restored (or restore may itself have
+			// failed), so this must not report success either way.
+			if errors.Is(err, zerr.ErrManifestRestoreAttempted) {
+				rh.c.Log.Error().Err(err).Str("repository", name).Str("reference", reference).
+					Msg("failed to remove manifest from metadb; attempted to restore it in the image store")
+				response.WriteHeader(http.StatusInternalServerError)
 
-			return
+				return
+			}
 		}
 	}
 

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -34,9 +34,13 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
 	apiErr "zotregistry.dev/zot/v2/pkg/api/errors"
+	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
 	"zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/meta/boltdb"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	reqCtx "zotregistry.dev/zot/v2/pkg/requestcontext"
+	"zotregistry.dev/zot/v2/pkg/storage/local"
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 	test "zotregistry.dev/zot/v2/pkg/test/common"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
@@ -3538,4 +3542,193 @@ func TestGetBlobMultipartReaderCloseError(t *testing.T) {
 	body := drainResponseBody(t, resp)
 	assert.Less(t, int64(len(body)), advertisedLen,
 		"a Close() error on the second range must truncate the body")
+}
+
+// TestDeleteManifestSucceedsDespiteMetaDBHookFailure verifies that an OnDeleteManifest failure
+// after a successful image-store delete does not surface as a client-facing error.
+func TestDeleteManifestSucceedsDespiteMetaDBHookFailure(t *testing.T) {
+	Convey("Deleting a signature referrer whose metaDB cleanup fails still returns 202", t, func() {
+		subjectDigest := godigest.FromString("subject-manifest")
+
+		manifest := ispec.Manifest{
+			Versioned:    specs.Versioned{SchemaVersion: 2},
+			MediaType:    ispec.MediaTypeImageManifest,
+			ArtifactType: zcommon.ArtifactTypeCosignBundle,
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.empty.v1+json",
+				Digest:    godigest.FromString("empty-config"),
+				Size:      2,
+			},
+			Subject: &ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    subjectDigest,
+				Size:      10,
+			},
+		}
+
+		manifestJSON, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+
+		referrerDigest := godigest.FromBytes(manifestJSON)
+
+		store := mocks.MockedImageStore{
+			GetImageManifestFn: func(repo, reference string) ([]byte, godigest.Digest, string, error) {
+				return manifestJSON, referrerDigest, ispec.MediaTypeImageManifest, nil
+			},
+			DeleteImageManifestFn: func(ctx context.Context, repo, reference string, detectCollision bool) error {
+				return nil
+			},
+		}
+
+		ctlr := api.NewController(config.New())
+		ctlr.Router = mux.NewRouter()
+		ctlr.StoreController.DefaultStore = store
+		ctlr.MetaDB = mocks.MetaDBMock{
+			DeleteSignatureFn: func(repo string, signedManifestDigest godigest.Digest,
+				sigMeta mTypes.SignatureMetadata,
+			) error {
+				// Simulates a concurrent writer already removing this entry.
+				return zerr.ErrImageMetaNotFound
+			},
+		}
+
+		handler := api.NewRouteHandler(ctlr)
+
+		req := httptest.NewRequestWithContext(
+			context.Background(),
+			http.MethodDelete,
+			"http://example.com/v2/test/manifests/"+referrerDigest.String(),
+			http.NoBody,
+		)
+		req = mux.SetURLVars(req, map[string]string{
+			"name":      "test",
+			"reference": referrerDigest.String(),
+		})
+
+		rec := httptest.NewRecorder()
+		handler.DeleteManifest(rec, req)
+
+		resp := rec.Result()
+		defer resp.Body.Close()
+
+		So(resp.StatusCode, ShouldEqual, http.StatusAccepted)
+	})
+}
+
+// TestDeleteManifestSucceedsAfterSignatureSubjectOrphaned runs the same scenario end to end
+// against real components (no mocked metaDB).
+func TestDeleteManifestSucceedsAfterSignatureSubjectOrphaned(t *testing.T) {
+	Convey("Deleting a signature referrer whose subject was already untagged", t, func() {
+		rootDir := t.TempDir()
+		testLog := log.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, testLog)
+		defer metrics.Stop()
+
+		imgStore := local.NewImageStore(rootDir, true, true, testLog, metrics, nil, nil, nil, nil)
+
+		boltDriver, err := boltdb.GetBoltDriver(boltdb.DBParameters{RootDir: rootDir})
+		So(err, ShouldBeNil)
+
+		metaDB, err := boltdb.New(boltDriver, testLog)
+		So(err, ShouldBeNil)
+
+		ctx := context.Background()
+
+		ctlr := api.NewController(config.New())
+		ctlr.Router = mux.NewRouter()
+		ctlr.StoreController.DefaultStore = imgStore
+		ctlr.MetaDB = metaDB
+		handler := api.NewRouteHandler(ctlr)
+
+		putReq := func(reference string, body []byte) int {
+			req := httptest.NewRequestWithContext(ctx, http.MethodPut,
+				"http://example.com/v2/repo/manifests/"+reference, bytes.NewReader(body))
+			req.Header.Set("Content-Type", ispec.MediaTypeImageManifest)
+			req = mux.SetURLVars(req, map[string]string{"name": "repo", "reference": reference})
+
+			rec := httptest.NewRecorder()
+			handler.UpdateManifest(rec, req)
+			rec.Result().Body.Close()
+
+			return rec.Result().StatusCode
+		}
+
+		deleteReq := func(reference string) int {
+			req := httptest.NewRequestWithContext(ctx, http.MethodDelete,
+				"http://example.com/v2/repo/manifests/"+reference, http.NoBody)
+			req = mux.SetURLVars(req, map[string]string{"name": "repo", "reference": reference})
+
+			rec := httptest.NewRecorder()
+			handler.DeleteManifest(rec, req)
+			rec.Result().Body.Close()
+
+			return rec.Result().StatusCode
+		}
+
+		// Push and tag the subject image through the real hook path.
+		subjectManifest := ispec.Manifest{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			MediaType: ispec.MediaTypeImageManifest,
+			Config: ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageConfig,
+				Digest:    godigest.FromString("{}"),
+				Size:      2,
+			},
+			Layers: []ispec.Descriptor{},
+		}
+		subjectBody, err := json.Marshal(subjectManifest)
+		So(err, ShouldBeNil)
+		subjectDigest := godigest.FromBytes(subjectBody)
+
+		_, _, err = imgStore.FullBlobUpload(ctx, "repo", bytes.NewReader([]byte("{}")), godigest.FromString("{}"))
+		So(err, ShouldBeNil)
+
+		statusCode := putReq("latest", subjectBody)
+		So(statusCode, ShouldEqual, http.StatusCreated)
+
+		// Sign it: push a sigstore-bundle referrer whose Subject is the subject image.
+		emptyConfig := []byte("{}")
+		emptyConfigDigest := godigest.FromBytes(emptyConfig)
+		_, _, err = imgStore.FullBlobUpload(ctx, "repo", bytes.NewReader(emptyConfig), emptyConfigDigest)
+		So(err, ShouldBeNil)
+
+		referrer := ispec.Manifest{
+			Versioned:    specs.Versioned{SchemaVersion: 2},
+			MediaType:    ispec.MediaTypeImageManifest,
+			ArtifactType: zcommon.ArtifactTypeCosignBundle,
+			Config: ispec.Descriptor{
+				MediaType: "application/vnd.oci.empty.v1+json",
+				Digest:    emptyConfigDigest,
+				Size:      int64(len(emptyConfig)),
+			},
+			Layers: []ispec.Descriptor{},
+			Subject: &ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    subjectDigest,
+				Size:      int64(len(subjectBody)),
+			},
+		}
+		referrerBody, err := json.Marshal(referrer)
+		So(err, ShouldBeNil)
+		referrerDigest := godigest.FromBytes(referrerBody)
+
+		statusCode = putReq(referrerDigest.String(), referrerBody)
+		So(statusCode, ShouldEqual, http.StatusCreated)
+
+		repoMeta, err := metaDB.GetRepoMeta(ctx, "repo")
+		So(err, ShouldBeNil)
+		So(repoMeta.Signatures, ShouldContainKey, subjectDigest.String())
+
+		// Delete the subject's only tag: its digest is now untagged.
+		statusCode = deleteReq("latest")
+		So(statusCode, ShouldEqual, http.StatusAccepted)
+
+		repoMeta, err = metaDB.GetRepoMeta(ctx, "repo")
+		So(err, ShouldBeNil)
+		So(repoMeta.Signatures, ShouldNotContainKey, subjectDigest.String())
+
+		// Deleting the now-orphaned referrer must still return 202.
+		statusCode = deleteReq(referrerDigest.String())
+		So(statusCode, ShouldEqual, http.StatusAccepted)
+	})
 }

--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -6583,7 +6583,9 @@ func TestMetaDBWhenDeletingImages(t *testing.T) {
 				resp, err = resty.R().Delete(baseURL + "/v2/" + "repo1" + "/manifests/" + "signatureReference")
 				So(resp, ShouldNotBeNil)
 				So(err, ShouldBeNil)
-				So(resp.StatusCode(), ShouldEqual, http.StatusInternalServerError)
+				// the image is already gone from the image store at this point, so a metadb
+				// bookkeeping failure here is not exposed to the client.
+				So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
 			})
 
 			Convey("image is a signature, DeleteSignature fails", func() {
@@ -6614,10 +6616,12 @@ func TestMetaDBWhenDeletingImages(t *testing.T) {
 					"sha256-343ebab94a7674da181c6ea3da013aee4f8cbe357870f8dcaf6268d5343c3474.sig")
 				So(resp, ShouldNotBeNil)
 				So(err, ShouldBeNil)
-				So(resp.StatusCode(), ShouldEqual, http.StatusInternalServerError)
+				// the image is already gone from the image store at this point, so a metadb
+				// bookkeeping failure here is not exposed to the client.
+				So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
 			})
 
-			Convey("image is a signature, PutImageManifest fails", func() {
+			Convey("non-signature delete, RemoveRepoReference and restore PutImageManifest both fail", func() {
 				ctlr.StoreController.DefaultStore = mocks.MockedImageStore{
 					NewBlobUploadFn: ctlr.StoreController.DefaultStore.NewBlobUpload,
 					PutBlobChunkFn:  ctlr.StoreController.DefaultStore.PutBlobChunk,
@@ -6652,6 +6656,7 @@ func TestMetaDBWhenDeletingImages(t *testing.T) {
 					"343ebab94a7674da181c6ea3da013aee4f8cbe357870f8dcaf6268d5343c3474.sig")
 				So(resp, ShouldNotBeNil)
 				So(err, ShouldBeNil)
+				// A restore may have rolled back the delete, so this must be a 500.
 				So(resp.StatusCode(), ShouldEqual, http.StatusInternalServerError)
 			})
 		})

--- a/pkg/meta/hooks.go
+++ b/pkg/meta/hooks.go
@@ -3,6 +3,7 @@ package meta
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 
 	godigest "github.com/opencontainers/go-digest"
@@ -240,8 +241,15 @@ func OnDeleteManifest(repo, reference, mediaType string, digest godigest.Digest,
 			SignatureType:   signatureType,
 		})
 		if err != nil {
-			log.Error().Err(err).Str("component", "metadb").
-				Msg("failed to check if image is a signature or not")
+			if errors.Is(err, zerr.ErrImageMetaNotFound) {
+				// Expected: RemoveRepoReference already deleted Signatures[signedManifestDigest]
+				// when the last reference to the signed manifest was removed.
+				log.Debug().Err(err).Str("component", "metadb").
+					Msg("signature meta already removed")
+			} else {
+				log.Error().Err(err).Str("component", "metadb").
+					Msg("failed to delete signature meta")
+			}
 
 			manageRepoMetaSuccessfully = false
 		}
@@ -264,6 +272,10 @@ func OnDeleteManifest(repo, reference, mediaType string, digest godigest.Digest,
 	if !manageRepoMetaSuccessfully {
 		log.Info().Str("tag", reference).Str("repository", repo).Str("component", "metadb").
 			Msg("failed to delete image meta was unsuccessful for tag in repo")
+
+		if !isSignature {
+			return fmt.Errorf("%w: %w", zerr.ErrManifestRestoreAttempted, err)
+		}
 
 		return err
 	}

--- a/pkg/meta/hooks_test.go
+++ b/pkg/meta/hooks_test.go
@@ -1,7 +1,9 @@
 package meta_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 
@@ -10,6 +12,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	zerr "zotregistry.dev/zot/v2/errors"
+	zcommon "zotregistry.dev/zot/v2/pkg/common"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
 	"zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/meta"
@@ -467,4 +470,91 @@ func TestUpdateErrors(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 	})
+}
+
+// TestOnDeleteManifest_OrphanedSignatureReferrerDeletionSucceeds verifies that
+// OnDeleteManifest returns ErrImageMetaNotFound when deleting a signature referrer
+// whose subject manifest was already untagged.
+func TestOnDeleteManifest_OrphanedSignatureReferrerDeletionSucceeds(t *testing.T) {
+	Convey("Deleting a signature referrer after its subject's last tag is gone fails with ErrImageMetaNotFound",
+		t, func() {
+			rootDir := t.TempDir()
+			storeController := storage.StoreController{}
+			log := log.NewTestLogger()
+			metrics := monitoring.NewMetricsServer(false, log)
+
+			defer metrics.Stop()
+			storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
+
+			params := boltdb.DBParameters{RootDir: rootDir}
+			boltDriver, err := boltdb.GetBoltDriver(params)
+			So(err, ShouldBeNil)
+
+			metaDB, err := boltdb.New(boltDriver, log)
+			So(err, ShouldBeNil)
+
+			imgStore := storeController.GetImageStore("repo")
+			ctx := context.Background()
+
+			// Push and register the subject image.
+			image := CreateDefaultImage()
+			subjectDigest := image.Digest()
+			subjectBody := image.ManifestDescriptor.Data
+
+			So(WriteImageToFileSystem(image, "repo", "latest", storeController), ShouldBeNil)
+			So(meta.OnUpdateManifest(ctx, "repo", "latest", ispec.MediaTypeImageManifest, subjectDigest, subjectBody,
+				storeController, metaDB, log), ShouldBeNil)
+
+			// Push and register a sigstore-bundle referrer signing it.
+			emptyConfig := []byte("{}")
+			emptyConfigDigest := godigest.FromBytes(emptyConfig)
+			_, _, err = imgStore.FullBlobUpload(ctx, "repo", bytes.NewReader(emptyConfig), emptyConfigDigest)
+			So(err, ShouldBeNil)
+
+			referrer := ispec.Manifest{
+				MediaType:    ispec.MediaTypeImageManifest,
+				ArtifactType: zcommon.ArtifactTypeCosignBundle,
+				Config: ispec.Descriptor{
+					MediaType: "application/vnd.oci.empty.v1+json",
+					Digest:    emptyConfigDigest,
+					Size:      int64(len(emptyConfig)),
+				},
+				Layers: []ispec.Descriptor{},
+				Subject: &ispec.Descriptor{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    subjectDigest,
+					Size:      int64(len(subjectBody)),
+				},
+			}
+			referrer.SchemaVersion = 2
+
+			referrerBody, err := json.Marshal(referrer)
+			So(err, ShouldBeNil)
+			referrerDigest := godigest.FromBytes(referrerBody)
+
+			_, _, err = imgStore.PutImageManifest(ctx, "repo", referrerDigest.String(), ispec.MediaTypeImageManifest,
+				referrerBody, nil)
+			So(err, ShouldBeNil)
+			So(meta.OnUpdateManifest(ctx, "repo", referrerDigest.String(), ispec.MediaTypeImageManifest, referrerDigest,
+				referrerBody, storeController, metaDB, log), ShouldBeNil)
+
+			repoMeta, err := metaDB.GetRepoMeta(ctx, "repo")
+			So(err, ShouldBeNil)
+			So(repoMeta.Signatures, ShouldContainKey, subjectDigest.String())
+
+			// Delete the subject's only tag.
+			So(imgStore.DeleteImageManifest(ctx, "repo", "latest", false), ShouldBeNil)
+			So(meta.OnDeleteManifest("repo", "latest", ispec.MediaTypeImageManifest, subjectDigest, subjectBody,
+				storeController, metaDB, log), ShouldBeNil)
+
+			repoMeta, err = metaDB.GetRepoMeta(ctx, "repo")
+			So(err, ShouldBeNil)
+			So(repoMeta.Signatures, ShouldNotContainKey, subjectDigest.String())
+
+			// The referrer is still present in the image store; deleting it now fails.
+			So(imgStore.DeleteImageManifest(ctx, "repo", referrerDigest.String(), false), ShouldBeNil)
+			err = meta.OnDeleteManifest("repo", referrerDigest.String(), ispec.MediaTypeImageManifest, referrerDigest,
+				referrerBody, storeController, metaDB, log)
+			So(errors.Is(err, zerr.ErrImageMetaNotFound), ShouldBeTrue)
+		})
 }

--- a/pkg/meta/parse.go
+++ b/pkg/meta/parse.go
@@ -399,10 +399,13 @@ func getCosignSignatureLayersInfo(
 			return layers, err
 		}
 
+		// The legacy cosign annotation is absent on sigstore-bundle referrers (and any other
+		// non-legacy cosign format) by design. SignatureKey is simply left
+		// empty below in that case.
 		layerSigKey, ok := layer.Annotations[zcommon.CosignSigKey]
 		if !ok {
-			log.Error().Err(err).Str("repository", repo).Str("reference", tag).Str("layerDigest", layer.Digest.String()).Msg(
-				"failed to get specific annotation of cosign signature")
+			log.Debug().Str("repository", repo).Str("reference", tag).Str("layerDigest", layer.Digest.String()).Msg(
+				"cosign signature layer has no legacy signature-key annotation")
 		}
 
 		layers = append(layers, mTypes.LayerInfo{

--- a/test/blackbox/annotations.bats
+++ b/test/blackbox/annotations.bats
@@ -189,6 +189,58 @@ function teardown_file() {
     [[ "$sigName" == *"${digest}"* ]]
 }
 
+@test "delete cosign sigstore-bundle referrer returns 202 without error-level logs" {
+    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
+
+    # Dedicated image content so this digest starts with zero referrers.
+    cat > ${BATS_FILE_TMPDIR}/Dockerfile.delete-referrer-test<<EOF
+FROM public.ecr.aws/t0x7q1g8/centos:7
+CMD ["/bin/sh", "-c", "echo 'delete cosign referrer test'"]
+EOF
+    run podman build -f ${BATS_FILE_TMPDIR}/Dockerfile.delete-referrer-test -t 127.0.0.1:${zot_port}/annotations:delete-referrer-test . --format oci
+    [ "$status" -eq 0 ]
+    run podman push 127.0.0.1:${zot_port}/annotations:delete-referrer-test --tls-verify=false --format=oci
+    [ "$status" -eq 0 ]
+
+    run curl -s -I -H "Accept: application/vnd.oci.image.manifest.v1+json" http://localhost:${zot_port}/v2/annotations/manifests/delete-referrer-test
+    [ "$status" -eq 0 ]
+    local digest=$(echo "${output}" | grep -i docker-content-digest | tr -d '\r' | awk '{print $2}')
+    [ -n "$digest" ]
+
+    run cosign initialize
+    [ "$status" -eq 0 ]
+    run cosign generate-key-pair --output-key-prefix "${BATS_FILE_TMPDIR}/cosign-sign-test-delete"
+    [ "$status" -eq 0 ]
+    run env COSIGN_EXPERIMENTAL=1 cosign sign --new-bundle-format=true --registry-referrers-mode=oci-1-1 --key ${BATS_FILE_TMPDIR}/cosign-sign-test-delete.key --allow-insecure-registry localhost:${zot_port}/annotations@${digest} --yes
+    [ "$status" -eq 0 ]
+
+    run curl -s http://localhost:${zot_port}/v2/annotations/referrers/${digest}
+    [ "$status" -eq 0 ]
+    local referrerDigest=$(echo "${output}" | jq -r '.manifests[0].digest')
+    [ -n "$referrerDigest" ]
+    [ "$referrerDigest" != "null" ]
+
+    # A well-formed sigstore-bundle referrer must never log the missing legacy
+    # annotation at error level.
+    run bash -c "grep -c '\"level\":\"error\".*legacy signature-key annotation' ${BATS_FILE_TMPDIR}/zot.log || true"
+    [ "$status" -eq 0 ]
+    [ "${output}" -eq 0 ]
+
+    # Delete the subject's only tag; the referrer above is left untouched, undeleted.
+    run curl -s -o /dev/null -w "%{http_code}" -X DELETE "http://localhost:${zot_port}/v2/annotations/manifests/delete-referrer-test"
+    [ "$status" -eq 0 ]
+    [ "${lines[-1]}" -eq 202 ]
+
+    # Deleting the now-orphaned referrer must still return 202, not 500.
+    run curl -s -o /dev/null -w "%{http_code}" -X DELETE "http://localhost:${zot_port}/v2/annotations/manifests/${referrerDigest}"
+    [ "$status" -eq 0 ]
+    [ "${lines[-1]}" -eq 202 ]
+
+    run curl -s http://localhost:${zot_port}/v2/annotations/referrers/${digest}
+    [ "$status" -eq 0 ]
+    [ $(echo "${output}" | jq --arg d "${referrerDigest}" '[.manifests[] | select(.digest == $d)] | length') -eq 0 ]
+}
+
 @test "zot reports IsSigned true for cosign referrer signatures" {
     zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
     run curl -X POST -H "Content-Type: application/json" --data '{ "query": "{ ImageList(repo: \"annotations\") { Results { RepoName Tag Manifests {Digest ConfigDigest Size Layers { Size Digest }} Vendor Licenses }}}"}' http://localhost:${zot_port}/v2/_zot/ext/search


### PR DESCRIPTION
…fails

Fixes #4286.

Two issues with cosign v3 sigstore-bundle referrers:

- getCosignSignatureLayersInfo logged at error level whenever a layer lacked the legacy cosign signature-key annotation. Sigstore-bundle referrers never carry that annotation by design, so every push of one produced spurious error-level noise. Downgraded to debug.

- DELETE on a signature referrer could return 500 even though the manifest was already gone from the image store. Root cause: BoltDB's RemoveRepoReference clears a digest's Signatures entry as soon as its last tag is removed (see the "foundTag" check), even if a referrer manifest pointing at that digest via Subject still exists, undeleted, in the store. Deleting that referrer afterward then finds nothing to update and fails with ErrImageMetaNotFound. This is deterministic, not a race - delete/replace the subject's tag, then delete its signature referrer, and it reproduces every time (also hit internally by retention's own GC pass, which removes untagged manifests before re-checking orphaned referrers). Since the actual deletion already succeeded by the time this metaDB bookkeeping runs, a failure there is now logged but no longer turns the response into a 500.

Also fixed a copy-pasted log message in OnDeleteManifest's DeleteSignature error branch that mislabeled this exact failure as "failed to check if image is a signature or not", which obscured the real cause while triaging this issue.

Tests: pkg/meta/hooks_test.go documents the metaDB-level mechanism directly; pkg/api/routes_test.go reproduces it end to end through the real HTTP handler (no mocked metaDB) and confirms the fix; a new blackbox test in annotations.bats signs a real image with cosign v3, deletes its tag, then deletes the referrer and asserts 202.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
