### PR TITLE
fix(sync): surface the rejected media type in manifest sync failures

### DIFF
--- a/pkg/extensions/sync/destination.go
+++ b/pkg/extensions/sync/destination.go
@@ -244,7 +244,7 @@ func (registry *DestinationRegistry) copyManifest(repo string, desc ispec.Descri
 		digest, _, err := imageStore.PutImageManifest(context.Background(), repo, reference,
 			desc.MediaType, manifestContent, nil)
 		if err != nil {
-			registry.log.Error().Str("errorType", common.TypeOf(err)).
+			registry.log.Error().Str("errorType", common.TypeOf(err)).Str("mediaType", desc.MediaType).
 				Err(err).Msg("couldn't upload manifest")
 
 			return err
@@ -332,7 +332,7 @@ func (registry *DestinationRegistry) copyManifest(repo string, desc ispec.Descri
 		_, _, err := imageStore.PutImageManifest(context.Background(), repo, reference, desc.MediaType, manifestContent, nil)
 		if err != nil {
 			registry.log.Error().Str("errorType", common.TypeOf(err)).Str("repo", repo).Str("reference", reference).
-				Err(err).Msg("failed to upload manifest")
+				Str("mediaType", desc.MediaType).Err(err).Msg("failed to upload manifest")
 
 			return err
 		}

--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -73,10 +73,10 @@ func ValidateManifest(imgStore storageTypes.ImageStore, repo, reference, mediaTy
 ) error {
 	// validate the manifest
 	if !IsSupportedMediaType(compats, mediaType) {
-		log.Debug().Interface("actual", mediaType).
+		log.Warn().Str("mediaType", mediaType).
 			Msg("bad manifest media type")
 
-		return zerr.ErrBadManifest
+		return zerr.NewError(zerr.ErrBadManifest).AddDetail("mediaType", mediaType)
 	}
 
 	if len(body) == 0 {

--- a/pkg/storage/common/common_test.go
+++ b/pkg/storage/common/common_test.go
@@ -66,14 +66,19 @@ func TestValidateManifest(t *testing.T) {
 
 			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0", ispec.MediaTypeImageConfig, body, nil)
 			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, zerr.ErrBadManifest)
+			So(errors.Is(err, zerr.ErrBadManifest), ShouldBeTrue)
+
+			var internalErr *zerr.Error
+
+			So(errors.As(err, &internalErr), ShouldBeTrue)
+			So(internalErr.GetDetails()["mediaType"], ShouldEqual, ispec.MediaTypeImageConfig)
 		})
 
 		Convey("empty manifest with bad media type", func() {
 			_, _, err = imgStore.PutImageManifest(context.Background(), "test", "1.0",
 				ispec.MediaTypeImageConfig, []byte(""), nil)
 			So(err, ShouldNotBeNil)
-			So(err, ShouldEqual, zerr.ErrBadManifest)
+			So(errors.Is(err, zerr.ErrBadManifest), ShouldBeTrue)
 		})
 
 		Convey("empty manifest with correct media type", func() {


### PR DESCRIPTION
Fixes #4290. Sync failures for an unsupported manifest media type (e.g. a Docker schema2 child manifest with http.compat missing docker2s2) only logged "invalid manifest content" at error level, with the actual media type buried in a debug-only log line - unlike the push path, which reports it directly in the response. Promote that log to warn with the media type as a field, attach it as a detail on the returned error, and add it to sync's own upload-failure log lines so operators can diagnose a config gap without enabling debug logging.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
