### PR TITLE
feat(ci): also use floci for CI tests

### DIFF
--- a/.github/actions/setup-floci/action.yaml
+++ b/.github/actions/setup-floci/action.yaml
@@ -29,8 +29,7 @@ runs:
         docker pull "$IMAGE_NAME"
         docker run -d \
           --name floci \
-          -p '4566:4566' \
-          -e 'FLOCI_STORAGE_MODE=persistent' "$IMAGE_NAME"
+          -p '4566:4566' "$IMAGE_NAME"
 
         # Wait for floci to be healthy
         attempt=1
@@ -65,6 +64,6 @@ runs:
       env:
         AWS_ACCESS_KEY_ID: fake
         AWS_SECRET_ACCESS_KEY: fake
-        IMAGE_NAME: ghcr.io/project-zot/floci/floci:1.5.34
+        IMAGE_NAME: ghcr.io/project-zot/ci-images/floci:1.5.34
         MAX_ATTEMPTS: 30
         WAIT_PERIOD_SECONDS: 1

--- a/.github/actions/setup-floci/action.yaml
+++ b/.github/actions/setup-floci/action.yaml
@@ -1,0 +1,70 @@
+name: 'Setup floci service'
+description: 'Download & run floci container (does not create S3 buckets; tests or workflows should create resources they need)'
+inputs:
+  # inputs for https://github.com/docker/login-action
+  username:
+    description: 'Username used to log against the github registry'
+    required: false
+    default: ${{ github.actor }}
+  password:
+    description: 'Password or personal access token used to log against the github registry'
+    required: false
+    default: ${{ github.token }}
+runs:
+  using: "composite"
+  steps:
+    - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.11'
+    - shell: bash
+      run: |
+        pip install --upgrade pyopenssl
+        pip install 'awscli-local[ver1]'
+
+        docker pull "$IMAGE_NAME"
+        docker run -d \
+          --name floci \
+          -p '4566:4566' \
+          -e 'FLOCI_STORAGE_MODE=persistent' "$IMAGE_NAME"
+
+        # Wait for floci to be healthy
+        attempt=1
+        ready=0
+        while [[ $ready -eq 0 && $attempt -le $MAX_ATTEMPTS ]]; do
+          echo "Attempt: $attempt"
+          response=$(curl -s -w "\n%{http_code}" "http://localhost:4566/health" || echo "000")
+          http_code=$(echo "$response" | tail -n 1)
+          json_body=$(echo "$response" | sed '$d')
+
+          if [[ "$http_code" -eq 200 ]]; then
+            s3_status=$(echo "$json_body" | jq -r '.services.s3 // empty' 2>/dev/null || true)
+            dynamodb_status=$(echo "$json_body" | jq -r '.services.dynamodb // empty' 2>/dev/null || true)
+            if [[ "$s3_status" == "running" && "$dynamodb_status" == "running" ]]; then
+              echo "S3 and DynamoDB are ready."
+              ready=1
+            else
+              echo "S3: $s3_status DynamoDB: $dynamodb_status. Continue waiting."
+            fi
+          else
+            echo "Status was $http_code. Continue waiting."
+          fi
+
+          sleep $WAIT_PERIOD_SECONDS
+          attempt=$((attempt + 1))
+        done
+        if [[ $ready -eq 0 ]]; then
+          echo "Floci failed to be ready in time."
+          docker logs floci || true
+          exit 1
+        fi
+      env:
+        AWS_ACCESS_KEY_ID: fake
+        AWS_SECRET_ACCESS_KEY: fake
+        IMAGE_NAME: ghcr.io/project-zot/floci/floci:1.5.34
+        MAX_ATTEMPTS: 30
+        WAIT_PERIOD_SECONDS: 1

--- a/.github/actions/setup-floci/action.yaml
+++ b/.github/actions/setup-floci/action.yaml
@@ -1,0 +1,54 @@
+name: 'Setup floci service'
+description: 'Download & run floci container (does not create S3 buckets; tests or workflows should create resources they need)'
+inputs:
+  # inputs for https://github.com/docker/login-action
+  username:
+    description: 'Username used to log against the github registry'
+    required: false
+    default: ${{ github.actor }}
+  password:
+    description: 'Password or personal access token used to log against the github registry'
+    required: false
+    default: ${{ github.token }}
+  persistent_mode:
+    description: 'Whether to use persistent storage mode for floci ("0" for no, "1" for yes)'
+    required: false
+    default: "0"
+runs:
+  using: "composite"
+  steps:
+    - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.username }}
+        password: ${{ inputs.password }}
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: '3.11'
+    - shell: bash
+      run: |
+        pip install --upgrade pyopenssl
+        pip install 'awscli-local[ver1]'
+
+        # install floci-cli to manage floci
+        curl -fsSL "https://github.com/floci-io/floci-cli/raw/refs/tags/${FLOCI_INSTALLER_VERSION_TAG}/installer/install.sh" | sh
+        floci version
+
+        if [[ "1" == "${{ inputs.persistent_mode }}" ]]; then
+          mkdir -p ./floci-data
+          floci start --image "${IMAGE_NAME}" --services "${SERVICES_TO_START}" --persist ./floci-data
+        else
+          floci start --image "${IMAGE_NAME}" --services "${SERVICES_TO_START}"
+        fi
+        for svc in ${SERVICES_TO_START//,/ }; do
+          echo "Waiting for ${svc}"
+          # Default timeout is 30 seconds
+          floci wait --service "${svc}"
+        done
+      env:
+        AWS_ACCESS_KEY_ID: fake
+        AWS_SECRET_ACCESS_KEY: fake
+        IMAGE_NAME: ghcr.io/project-zot/ci-images/floci:1.5.34
+        FLOCI_INSTALLER_VERSION_TAG: 0.2.0
+        FLOCI_CLI_VERSION: 0.2.0
+        SERVICES_TO_START: 's3,dynamodb,secretsmanager'

--- a/.github/actions/teardown-floci/action.yaml
+++ b/.github/actions/teardown-floci/action.yaml
@@ -1,0 +1,8 @@
+name: 'Stop floci'
+description: 'Stop floci'
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        floci stop --remove || true

--- a/.github/actions/teardown-floci/action.yaml
+++ b/.github/actions/teardown-floci/action.yaml
@@ -1,0 +1,10 @@
+name: 'Stop floci'
+description: 'Stop floci container'
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      if: always()
+      run: |
+        docker stop floci || true
+        docker rm -f floci || true

--- a/.github/workflows/ecosystem-tools-with-floci.yaml
+++ b/.github/workflows/ecosystem-tools-with-floci.yaml
@@ -1,0 +1,167 @@
+name: "Ecosystem client tools with floci"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [main]
+  release:
+    types:
+      - published
+
+permissions: read-all
+
+jobs:
+  floci-client-tools:
+    name: floci - Check client tools
+    runs-on: cncf-ubuntu-32-128-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          go install github.com/swaggo/swag/cmd/swag@v1.16.2
+          go mod download
+          sudo apt-get update
+          sudo apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev \
+            libdevmapper-dev pkg-config rpm uidmap haproxy jq valkey-tools whois \
+            npm
+          # install skopeo
+          git clone -b v1.12.0 https://github.com/containers/skopeo.git
+          cd skopeo
+          make bin/skopeo
+          sudo cp bin/skopeo /usr/bin
+          skopeo -v
+          # install cri-o (for crictl)
+          OS=xUbuntu_22.04
+          CRIO_VERSION=1.26
+          curl -fsSL https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/prerelease:/main:/build/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/prerelease:/main:/build/deb/ /" | sudo tee /etc/apt/sources.list.d/cri-o.list
+          sudo apt update
+          sudo apt install -y cri-o runc
+          sudo systemctl enable crio.service
+          sudo systemctl start crio.service
+          sudo chmod 0777 /var/run/crio/crio.sock
+          # install docker
+          # Add Docker's official GPG key:
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+           $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          docker version
+          # install nodejs deps (for oidc claim mapping support)
+          sudo npm install -g oidc-provider express
+          # install dex
+          git clone https://github.com/dexidp/dex.git
+          cd dex/
+          git checkout v2.39.1
+          make bin/dex
+          ./bin/dex serve $GITHUB_WORKSPACE/test/dex/config-dev.yaml &
+          # Prepare for stacker run on Ubuntu 24
+          cd $GITHUB_WORKSPACE
+          sudo ./scripts/enable_userns.sh
+      - name: Run CI tests
+        run: |
+          make run-blackbox-ci
+      - uses: ./.github/actions/setup-floci
+      - name: Run cloud-only tests
+        run: |
+          make run-blackbox-cloud-ci
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+
+      # DynamoDB scale-out tests
+      - name: Run cloud scale-out DynamoDB tests
+        id: dynamodb_scale
+        run: |
+          make run-cloud-scale-out-tests
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+      - name: Print service logs for DynamoDB scale-out
+        run: |
+          find /tmp/zot-ft-logs -name '*.log' -print0 | xargs -0 cat
+      - name: Upload DynamoDB zot logs as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zot-scale-out-dynamodb-logs-floci
+          path: /tmp/zot-ft-logs
+          if-no-files-found: ignore
+      - name: DynamoDB multi-hop detection
+        id: dynamodb_multihop
+        run: |
+          if find /tmp/zot-ft-logs -name '*.log' -print0 | xargs -0 cat | grep 'cannot proxy an already proxied request'; then
+            echo "detected multi-hop in DynamoDB tests"
+            exit 1
+          else
+            exit 0
+          fi
+        continue-on-error: true
+      - name: Clean up DynamoDB scale-out logs
+        run: |
+          rm -r /tmp/zot-ft-logs
+      - name: Fail job if DynamoDB error
+        if: ${{ steps.dynamodb_scale.outcome != 'success' || steps.dynamodb_multihop.outcome != 'success' }}
+        run: |
+          echo "DynamoDB scale-out tests failed"
+          exit 1
+
+      # Redis scale-out tests
+      - name: Run cloud scale-out Redis tests
+        id: redis_scale
+        run: |
+          make run-cloud-scale-out-redis-tests
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+      - name: Print service logs for Redis scale-out
+        run: |
+          find /tmp/zot-ft-logs/redis -name '*.log' -print0 | xargs -0 cat
+      - name: Upload Redis zot logs as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zot-scale-out-redis-logs-floci
+          path: /tmp/zot-ft-logs
+          if-no-files-found: ignore
+      - name: Redis multi-hop detection
+        id: redis_multihop
+        run: |
+          if find /tmp/zot-ft-logs/redis -name '*.log' -print0 | xargs -0 cat | grep 'cannot proxy an already proxied request'; then
+            echo "detected multi-hop in Redis tests"
+            exit 1
+          else
+            exit 0
+          fi
+        continue-on-error: true
+      - name: Clean up Redis scale-out logs
+        run: |
+          rm -rf /tmp/zot-ft-logs/redis
+      - name: Fail job if Redis error
+        if: ${{ steps.redis_scale.outcome != 'success' || steps.redis_multihop.outcome != 'success' }}
+        run: |
+          echo "Redis scale-out tests failed"
+          exit 1
+      - name: Upload zb test results zip as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zb-cloud-scale-out-functional-results-floci-${{ github.sha }}
+          path: ./zb-results/
+      - uses: ./.github/actions/teardown-floci
+        if: always()

--- a/.github/workflows/ecosystem-tools-with-floci.yaml
+++ b/.github/workflows/ecosystem-tools-with-floci.yaml
@@ -1,0 +1,160 @@
+name: "Ecosystem client tools with floci"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [main]
+  release:
+    types:
+      - published
+
+permissions: read-all
+
+jobs:
+  client-tools:
+    name: Check client tools
+    runs-on: cncf-ubuntu-32-128-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          go install github.com/swaggo/swag/cmd/swag@v1.16.2
+          go mod download
+          sudo apt-get update
+          sudo apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev \
+            libdevmapper-dev pkg-config rpm uidmap haproxy jq valkey-tools whois \
+            npm
+          # install skopeo
+          git clone -b v1.12.0 https://github.com/containers/skopeo.git
+          cd skopeo
+          make bin/skopeo
+          sudo cp bin/skopeo /usr/bin
+          skopeo -v
+          # install cri-o (for crictl)
+          OS=xUbuntu_22.04
+          CRIO_VERSION=1.26
+          curl -fsSL https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/prerelease:/main:/build/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
+          echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/prerelease:/main:/build/deb/ /" | sudo tee /etc/apt/sources.list.d/cri-o.list
+          sudo apt update
+          sudo apt install -y cri-o runc
+          sudo systemctl enable crio.service
+          sudo systemctl start crio.service
+          sudo chmod 0777 /var/run/crio/crio.sock
+          # install docker
+          # Add Docker's official GPG key:
+          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+          sudo chmod a+r /etc/apt/keyrings/docker.asc
+          echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+           $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          sudo apt update
+          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+          docker version
+          # install nodejs deps (for oidc claim mapping support)
+          sudo npm install -g oidc-provider express
+          # install dex
+          git clone https://github.com/dexidp/dex.git
+          cd dex/
+          git checkout v2.39.1
+          make bin/dex
+          ./bin/dex serve $GITHUB_WORKSPACE/test/dex/config-dev.yaml &
+          # Prepare for stacker run on Ubuntu 24
+          cd $GITHUB_WORKSPACE
+          sudo ./scripts/enable_userns.sh
+      - name: Run CI tests
+        run: |
+          make run-blackbox-ci
+      - uses: ./.github/actions/setup-floci
+      - name: Run cloud-only tests
+        run: |
+          make run-blackbox-cloud-ci
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+
+      # DynamoDB scale-out tests
+      - name: Run cloud scale-out DynamoDB tests
+        id: dynamodb_scale
+        run: |
+          make run-cloud-scale-out-tests
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+      - name: Print service logs for DynamoDB scale-out
+        run: |
+          find /tmp/zot-ft-logs -name '*.log' -print0 | xargs -0 cat
+      - name: Upload DynamoDB zot logs as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zot-scale-out-dynamodb-logs-floci
+          path: /tmp/zot-ft-logs
+          if-no-files-found: ignore
+      - name: DynamoDB multi-hop detection
+        id: dynamodb_multihop
+        run: |
+          if find /tmp/zot-ft-logs -name '*.log' -print0 | xargs -0 cat | grep 'cannot proxy an already proxied request'; then
+            echo "detected multi-hop in DynamoDB tests"
+            exit 1
+          else
+            exit 0
+          fi
+        continue-on-error: true
+      - name: Clean up DynamoDB scale-out logs
+        run: |
+          rm -r /tmp/zot-ft-logs
+      - name: Fail job if DynamoDB error
+        if: ${{ steps.dynamodb_scale.outcome != 'success' || steps.dynamodb_multihop.outcome != 'success' }}
+        run: |
+          echo "DynamoDB scale-out tests failed"
+          exit 1
+
+      # Redis scale-out tests
+      - name: Run cloud scale-out Redis tests
+        id: redis_scale
+        run: |
+          make run-cloud-scale-out-redis-tests
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+      - name: Print service logs for Redis scale-out
+        run: |
+          find /tmp/zot-ft-logs/redis -name '*.log' -print0 | xargs -0 cat
+      - name: Upload Redis zot logs as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zot-scale-out-redis-logs-floci
+          path: /tmp/zot-ft-logs
+          if-no-files-found: ignore
+      - name: Redis multi-hop detection
+        id: redis_multihop
+        run: |
+          if find /tmp/zot-ft-logs/redis -name '*.log' -print0 | xargs -0 cat | grep 'cannot proxy an already proxied request'; then
+            echo "detected multi-hop in Redis tests"
+            exit 1
+          else
+            exit 0
+          fi
+        continue-on-error: true
+      - name: Clean up Redis scale-out logs
+        run: |
+          rm -rf /tmp/zot-ft-logs/redis
+      - name: Fail job if Redis error
+        if: ${{ steps.redis_scale.outcome != 'success' || steps.redis_multihop.outcome != 'success' }}
+        run: |
+          echo "Redis scale-out tests failed"
+          exit 1
+      - uses: ./.github/actions/teardown-floci

--- a/.github/workflows/gc-stress-test-with-floci.yaml
+++ b/.github/workflows/gc-stress-test-with-floci.yaml
@@ -1,0 +1,271 @@
+name: "GC stress test with floci"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [main]
+  release:
+    types:
+      - published
+
+permissions: read-all
+
+jobs:
+  gc-referrers-stress-local:
+    name: GC(with referrers) on filesystem with short interval
+    runs-on: cncf-ubuntu-8-32-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+
+      - name: Run zb
+        id: bench
+        run: |
+            make binary
+            make bench
+            ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-local.json &
+            sleep 10
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+
+            killall --wait -r zot-*
+
+            # clean zot storage
+            sudo rm -rf /tmp/zot
+        continue-on-error: true
+
+      - name: Upload zot logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: gc-referrers-bench-local-floci
+          path: /tmp/gc-referrers-bench-local.log
+          if-no-files-found: error
+
+      - name: Check on failures
+        if: steps.bench.outcome != 'success'
+        run: |
+          cat /tmp/gc-referrers-bench-local.log
+          exit 1
+
+  gc-stress-local:
+    name: GC(without referrers) on filesystem with short interval
+    runs-on: cncf-ubuntu-8-32-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+
+      - name: Run zb
+        id: bench
+        run: |
+            make binary
+            make bench
+            ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-local.json &
+            sleep 10
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+
+            killall --wait -r zot-*
+
+            # clean zot storage
+            sudo rm -rf /tmp/zot
+        continue-on-error: true
+
+      - name: Upload zot logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: gc-bench-local-floci
+          path: /tmp/gc-bench-local.log
+          if-no-files-found: error
+
+      - name: Check on failures
+        if: steps.bench.outcome != 'success'
+        run: |
+          cat /tmp/gc-bench-local.log
+          exit 1
+
+  gc-referrers-stress-s3:
+    name: GC(with referrers) on S3(minio) with short interval
+    runs-on: cncf-ubuntu-8-32-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-floci
+      - name: Setup minio service
+        run: |
+            docker run -d -p 9000:9000 --name minio \
+                -e "MINIO_ACCESS_KEY=minioadmin" \
+                -e "MINIO_SECRET_KEY=minioadmin" \
+                -v /tmp/data:/data \
+                -v /tmp/config:/root/.minio \
+                --health-cmd "curl http://localhost:9000/minio/health/live" \
+                ghcr.io/project-zot/ci-images/minio:RELEASE.2024-07-16T23-46-41Z server /data
+      - name: Install py minio
+        run: pip3 install minio==7.2.18
+
+      - name: Wait for minio to come up
+        run: |
+          sleep 10
+          curl --connect-timeout 5 \
+            --max-time 120 \
+            --retry 12 \
+            --retry-max-time 120 \
+            'http://localhost:9000/minio/health/live'
+
+      - name: Create minio bucket
+        run: |
+            python3 - <<'EOF'
+            from minio import Minio
+
+            try:
+                minio = Minio(
+                    'localhost:9000',
+                    access_key='minioadmin',
+                    secret_key='minioadmin',
+                    secure=False
+                )
+            except Exception as ex:
+                raise
+
+            minio.make_bucket('zot-storage')
+            print(f'{minio.list_buckets()}')
+            EOF
+
+      - name: Run zb
+        id: bench
+        run: |
+            make binary
+            make bench
+            ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-s3-minio.json &
+            sleep 10
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+
+            killall --wait -r zot-*
+
+            # clean zot storage
+            sudo rm -rf /tmp/zot
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+
+      - name: Upload zot logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: gc-referrers-bench-s3-floci
+          path: /tmp/gc-referrers-bench-s3.log
+          if-no-files-found: error
+
+      - name: Check on failures
+        if: steps.bench.outcome != 'success'
+        run: |
+          cat /tmp/gc-referrers-bench-s3.log
+          exit 1
+
+      - uses: ./.github/actions/teardown-floci
+
+  gc-stress-s3:
+    name: GC(without referrers) on S3(minio) with short interval
+    runs-on: cncf-ubuntu-8-32-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-floci
+      - name: Setup minio service
+        run: |
+            docker run -d -p 9000:9000 --name minio \
+                -e "MINIO_ACCESS_KEY=minioadmin" \
+                -e "MINIO_SECRET_KEY=minioadmin" \
+                -v /tmp/data:/data \
+                -v /tmp/config:/root/.minio \
+                --health-cmd "curl http://localhost:9000/minio/health/live" \
+                ghcr.io/project-zot/ci-images/minio:RELEASE.2024-07-16T23-46-41Z server /data
+      - name: Install py minio
+        run: pip3 install minio==7.2.18
+
+      - name: Wait for minio to come up
+        run: |
+          sleep 10
+          curl --connect-timeout 5 \
+            --max-time 120 \
+            --retry 12 \
+            --retry-max-time 120 \
+            'http://localhost:9000/minio/health/live'
+
+      - name: Create minio bucket
+        run: |
+            python3 - <<'EOF'
+            from minio import Minio
+
+            try:
+                minio = Minio(
+                    'localhost:9000',
+                    access_key='minioadmin',
+                    secret_key='minioadmin',
+                    secure=False
+                )
+            except Exception as ex:
+                raise
+
+            minio.make_bucket('zot-storage')
+            print(f'{minio.list_buckets()}')
+            EOF
+
+      - name: Run zb
+        id: bench
+        run: |
+            make binary
+            make bench
+            ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-s3-minio.json &
+            sleep 10
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+
+            killall --wait -r zot-*
+
+            # clean zot storage
+            sudo rm -rf /tmp/zot
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+
+      - name: Upload zot logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: gc-bench-s3-floci
+          path: /tmp/gc-bench-s3.log
+          if-no-files-found: error
+
+      - name: Check on failures
+        if: steps.bench.outcome != 'success'
+        run: |
+          cat /tmp/gc-bench-s3.log
+          exit 1
+
+      - uses: ./.github/actions/teardown-floci

--- a/.github/workflows/gc-stress-test-with-floci.yaml
+++ b/.github/workflows/gc-stress-test-with-floci.yaml
@@ -1,0 +1,189 @@
+name: "GC stress test with floci"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [main]
+  release:
+    types:
+      - published
+
+permissions: read-all
+
+jobs:
+  floci-gc-referrers-stress-s3:
+    name: floci GC(with referrers) on S3(minio) with short interval
+    runs-on: cncf-ubuntu-8-32-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-floci
+      - name: Setup minio service
+        run: |
+            docker run -d -p 9000:9000 --name minio \
+                -e "MINIO_ACCESS_KEY=minioadmin" \
+                -e "MINIO_SECRET_KEY=minioadmin" \
+                -v /tmp/data:/data \
+                -v /tmp/config:/root/.minio \
+                --health-cmd "curl http://localhost:9000/minio/health/live" \
+                ghcr.io/project-zot/ci-images/minio:RELEASE.2024-07-16T23-46-41Z server /data
+      - name: Install py minio
+        run: pip3 install minio==7.2.18
+
+      - name: Wait for minio to come up
+        run: |
+          sleep 10
+          curl --connect-timeout 5 \
+            --max-time 120 \
+            --retry 12 \
+            --retry-max-time 120 \
+            'http://localhost:9000/minio/health/live'
+
+      - name: Create minio bucket
+        run: |
+            python3 - <<'EOF'
+            from minio import Minio
+
+            try:
+                minio = Minio(
+                    'localhost:9000',
+                    access_key='minioadmin',
+                    secret_key='minioadmin',
+                    secure=False
+                )
+            except Exception as ex:
+                raise
+
+            minio.make_bucket('zot-storage')
+            print(f'{minio.list_buckets()}')
+            EOF
+
+      - name: Run zb
+        id: bench
+        run: |
+            make binary
+            make bench
+            ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-s3-minio.json &
+            sleep 10
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+
+            killall --wait -r zot-*
+
+            # clean zot storage
+            sudo rm -rf /tmp/zot
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+
+      - name: Upload zot logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: gc-referrers-bench-s3-floci
+          path: /tmp/gc-referrers-bench-s3.log
+          if-no-files-found: error
+
+      - uses: ./.github/actions/teardown-floci
+        if: always()
+
+      - name: Check on failures
+        if: steps.bench.outcome != 'success'
+        run: |
+          cat /tmp/gc-referrers-bench-s3.log
+          exit 1
+
+  floci-gc-stress-s3:
+    name: floci GC(without referrers) on S3(minio) with short interval
+    runs-on: cncf-ubuntu-8-32-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-floci
+      - name: Setup minio service
+        run: |
+            docker run -d -p 9000:9000 --name minio \
+                -e "MINIO_ACCESS_KEY=minioadmin" \
+                -e "MINIO_SECRET_KEY=minioadmin" \
+                -v /tmp/data:/data \
+                -v /tmp/config:/root/.minio \
+                --health-cmd "curl http://localhost:9000/minio/health/live" \
+                ghcr.io/project-zot/ci-images/minio:RELEASE.2024-07-16T23-46-41Z server /data
+      - name: Install py minio
+        run: pip3 install minio==7.2.18
+
+      - name: Wait for minio to come up
+        run: |
+          sleep 10
+          curl --connect-timeout 5 \
+            --max-time 120 \
+            --retry 12 \
+            --retry-max-time 120 \
+            'http://localhost:9000/minio/health/live'
+
+      - name: Create minio bucket
+        run: |
+            python3 - <<'EOF'
+            from minio import Minio
+
+            try:
+                minio = Minio(
+                    'localhost:9000',
+                    access_key='minioadmin',
+                    secret_key='minioadmin',
+                    secure=False
+                )
+            except Exception as ex:
+                raise
+
+            minio.make_bucket('zot-storage')
+            print(f'{minio.list_buckets()}')
+            EOF
+
+      - name: Run zb
+        id: bench
+        run: |
+            make binary
+            make bench
+            ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-s3-minio.json &
+            sleep 10
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+
+            killall --wait -r zot-*
+
+            # clean zot storage
+            sudo rm -rf /tmp/zot
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+
+      - name: Upload zot logs
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: gc-bench-s3-floci
+          path: /tmp/gc-bench-s3.log
+          if-no-files-found: error
+
+      - uses: ./.github/actions/teardown-floci
+        if: always()
+
+      - name: Check on failures
+        if: steps.bench.outcome != 'success'
+        run: |
+          cat /tmp/gc-bench-s3.log
+          exit 1

--- a/.github/workflows/nightly-with-floci.yaml
+++ b/.github/workflows/nightly-with-floci.yaml
@@ -1,0 +1,428 @@
+name: 'Nightly jobs with floci'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+
+permissions: read-all
+
+#  The following tests are run:
+#  1. run zot with local storage and dedupe disabled, push images, restart zot with dedupe enabled
+#  task scheduler will start a dedupe all blobs process at zot startup and it shouldn't interfere with clients.
+#  2. run zot with s3 storage and dynamodb and dedupe enabled, push images, restart zot with dedupe false and no cache
+#  task scheduler will start a restore all blobs process at zot startup, after it finishes all blobs should be restored to their original state (have content)
+#  3. run many, many, many instances of zot with shared storage and metadata front-ended by HAProxy. start a long-running zb run with high concurrency and number of requests
+#  to achieve a long-running sustained load on the system. The system is expected to perform well without errors and return performance data after the test.
+jobs:
+  dedupe:
+    name: Dedupe/restore blobs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          go install github.com/swaggo/swag/cmd/swag@v1.16.2
+          go mod download
+          sudo apt-get update
+          sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap
+          # install skopeo
+          git clone -b v1.12.0 https://github.com/containers/skopeo.git
+          cd skopeo
+          make bin/skopeo
+          sudo cp bin/skopeo /usr/bin
+          skopeo -v
+      - uses: ./.github/actions/setup-floci
+      - name: Run blackbox nightly dedupe tests
+        run: |
+            # test restoring s3 blobs after cache is deleted
+            # test deduping filesystem blobs after switching dedupe to enable
+            make run-blackbox-dedupe-nightly
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+      - uses: ./.github/actions/teardown-floci
+
+  sync:
+    name: Sync harness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          go install github.com/swaggo/swag/cmd/swag@v1.16.2
+          go mod download
+      - name: Run sync harness
+        run: |
+            make run-blackbox-sync-nightly
+
+  gc-referrers-stress-s3:
+    name: GC(with referrers) on S3(floci) with short interval
+    runs-on: cncf-ubuntu-16-64-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-floci
+      - name: Create zot-storage bucket on floci
+        run: |
+          awslocal s3api create-bucket --bucket zot-storage --region us-east-2 \
+            --create-bucket-configuration='{"LocationConstraint": "us-east-2"}'
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+      - name: Run zb
+        timeout-minutes: 240
+        id: bench
+        run: |
+            make binary
+            make bench
+            ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-s3-localstack.json &
+            sleep 10
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080 --skip-cleanup
+
+            killall --wait -r zot-*
+
+            # clean zot storage
+            sudo rm -rf /tmp/zot
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+
+      - name: Check on failures
+        if: steps.bench.outcome != 'success'
+        run: |
+          cat /tmp/gc-referrers-bench-s3.log
+          exit 1
+      - uses: ./.github/actions/teardown-floci
+
+  gc-stress-s3:
+    name: GC(without referrers) on S3(floci) with short interval
+    runs-on: cncf-ubuntu-16-64-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-floci
+      - name: Create zot-storage bucket on floci
+        run: |
+          awslocal s3api create-bucket --bucket zot-storage --region us-east-2 \
+            --create-bucket-configuration='{"LocationConstraint": "us-east-2"}'
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+      - name: Run zb
+        timeout-minutes: 240
+        id: bench
+        run: |
+            make binary
+            make bench
+            ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-s3-localstack.json &
+            sleep 10
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080 --skip-cleanup
+
+            killall --wait -r zot-*
+
+            # clean zot storage
+            sudo rm -rf /tmp/zot
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+
+      - name: Check on failures
+        if: steps.bench.outcome != 'success'
+        run: |
+          cat /tmp/gc-bench-s3.log
+          exit 1
+      - uses: ./.github/actions/teardown-floci
+
+  docker-image:
+    name: Build docker image (for users still using Docker environments)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/clean-runner
+      - name: Build image
+        run: |
+          make docker-image
+
+  kind-setup:
+    name: Prometheus setup
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          make check-blackbox-prerequisites
+          go mod download
+          sudo apt-get update
+          sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap
+          # install skopeo
+          git clone -b v1.12.0 https://github.com/containers/skopeo.git
+          cd skopeo
+          make bin/skopeo
+          sudo cp bin/skopeo /usr/bin
+          skopeo -v
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+      - name: Run tests
+        run: |
+            sudo ./scripts/enable_userns.sh
+            ./examples/kind/kind-ci.sh
+
+  kind-sync-ondemand:
+    name: On-demand sync mirror regression (issue 4184)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          make check-blackbox-prerequisites
+          go mod download
+          sudo apt-get update
+          sudo apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap jq
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+      - name: Build zot binary
+        run: make binary
+      - name: Run on-demand sync mirror regression test
+        run: |
+          sudo ./scripts/enable_userns.sh
+          ./examples/kind/kind-sync-ondemand.sh
+
+  oidc-workload-identity:
+    name: OIDC Workload Identity E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          make check-blackbox-prerequisites
+          go mod download
+          sudo apt-get update
+          sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap jq
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+      - name: Run OIDC workload identity tests
+        run: |
+            sudo ./scripts/enable_userns.sh
+            ./examples/kind/kind-oidc-workload-identity.sh
+
+  aws-secrets-manager-bearer:
+    name: AWS Secrets Manager Bearer Auth E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install crane
+        run: |
+          go install github.com/google/go-containerregistry/cmd/crane@latest
+      - name: Run AWS Secrets Manager bearer auth tests
+        run: |
+          ./examples/aws-secrets-manager-bearer-auth.sh
+
+  cloud-scale-out:
+    name: s3+dynamodb scale-out
+    runs-on: cncf-ubuntu-16-64-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          go install github.com/swaggo/swag/cmd/swag@v1.16.2
+          go mod download
+          sudo apt-get update
+          sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap haproxy jq
+          # install skopeo
+          git clone -b v1.12.0 https://github.com/containers/skopeo.git
+          cd skopeo
+          make bin/skopeo
+          sudo cp bin/skopeo /usr/bin
+          skopeo -v
+          cd $GITHUB_WORKSPACE
+      - uses: ./.github/actions/setup-floci
+      - name: Run cloud scale-out high scale performance tests
+        id: scale
+        run: |
+          make run-cloud-scale-out-high-scale-tests
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+      - name: Upload zot logs as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zot-scale-out-dynamodb-logs
+          path: /tmp/zot-ft-logs
+          if-no-files-found: error
+      - name: print service logs
+        run: |
+          sudo dmesg
+          cat /tmp/zot-ft-logs/dynamo-scale/*.log
+      - name: multi-hop detection
+        id: multihop
+        run: |
+          if cat /tmp/zot-ft-logs/dynamo-scale/*.log | grep 'cannot proxy an already proxied request'; then
+            echo "detected multi-hop"
+            exit 1
+          else
+            exit 0
+          fi
+        continue-on-error: true
+      - name: clean up logs
+        run: |
+          rm -r /tmp/zot-ft-logs/dynamo-scale
+      - name: fail job if error
+        if: ${{ steps.scale.outcome != 'success' || steps.multihop.outcome != 'success' }}
+        run: |
+          exit 1
+      - name: Upload zb test results zip as build artifact
+        if: steps.scale.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zb-cloud-scale-out-perf-results-${{ github.sha }}
+          path: ./zb-results/
+      - uses: ./.github/actions/teardown-floci
+
+  cloud-scale-out-redis:
+    name: s3+redis scale-out
+    runs-on: cncf-ubuntu-16-64-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          go install github.com/swaggo/swag/cmd/swag@v1.16.2
+          go mod download
+          sudo apt-get update
+          sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap haproxy jq
+          # install skopeo
+          git clone -b v1.12.0 https://github.com/containers/skopeo.git
+          cd skopeo
+          make bin/skopeo
+          sudo cp bin/skopeo /usr/bin
+          skopeo -v
+          cd $GITHUB_WORKSPACE
+      - uses: ./.github/actions/setup-floci
+      - name: Run cloud scale-out Redis tests
+        id: scale
+        run: |
+          make run-cloud-scale-out-redis-high-scale-tests
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+      - name: Upload zot logs as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zot-scale-out-redis-logs
+          path: /tmp/zot-ft-logs/redis-scale
+          if-no-files-found: error
+      - name: print service logs
+        run: |
+          sudo dmesg
+          cat /tmp/zot-ft-logs/redis-scale/*.log
+      - name: multi-hop detection
+        id: multihop
+        run: |
+          if cat /tmp/zot-ft-logs/redis-scale/*.log | grep 'cannot proxy an already proxied request'; then
+            echo "detected multi-hop"
+            exit 1
+          else
+            exit 0
+          fi
+        continue-on-error: true
+      - name: clean up logs
+        run: |
+          rm -r /tmp/zot-ft-logs/redis-scale
+      - name: fail job if error
+        if: ${{ steps.scale.outcome != 'success' || steps.multihop.outcome != 'success' }}
+        run: |
+          exit 1
+      - name: Upload zb test results zip as build artifact
+        if: steps.scale.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zb-cloud-scale-out-redis-results-${{ github.sha }}
+          path: ./zb-results/
+      - uses: ./.github/actions/teardown-floci

--- a/.github/workflows/nightly-with-floci.yaml
+++ b/.github/workflows/nightly-with-floci.yaml
@@ -1,0 +1,340 @@
+name: 'Nightly jobs with floci'
+
+# Runs every 12 hours or on workflow dispatch
+on:
+  schedule:
+    - cron: '0 */12 * * *'
+  workflow_dispatch:
+
+permissions: read-all
+
+#  The following tests are run:
+#  1. run zot with local storage and dedupe disabled, push images, restart zot with dedupe enabled
+#  task scheduler will start a dedupe all blobs process at zot startup and it shouldn't interfere with clients.
+#  2. run zot with s3 storage and dynamodb and dedupe enabled, push images, restart zot with dedupe false and no cache
+#  task scheduler will start a restore all blobs process at zot startup, after it finishes all blobs should be restored to their original state (have content)
+#  3. run many, many, many instances of zot with shared storage and metadata front-ended by HAProxy. start a long-running zb run with high concurrency and number of requests
+#  to achieve a long-running sustained load on the system. The system is expected to perform well without errors and return performance data after the test.
+jobs:
+  floci-dedupe:
+    name: floci Dedupe/restore blobs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          go install github.com/swaggo/swag/cmd/swag@v1.16.2
+          go mod download
+          sudo apt-get update
+          sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap
+          # install skopeo
+          git clone -b v1.12.0 https://github.com/containers/skopeo.git
+          cd skopeo
+          make bin/skopeo
+          sudo cp bin/skopeo /usr/bin
+          skopeo -v
+      - uses: ./.github/actions/setup-floci
+      - name: Run blackbox nightly dedupe tests
+        run: |
+            # test restoring s3 blobs after cache is deleted
+            # test deduping filesystem blobs after switching dedupe to enable
+            make run-blackbox-dedupe-nightly
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+      - uses: ./.github/actions/teardown-floci
+        if: always()
+
+  floci-sync:
+    name: floci Sync harness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          go install github.com/swaggo/swag/cmd/swag@v1.16.2
+          go mod download
+      - name: Run sync harness
+        run: |
+            make run-blackbox-sync-nightly
+
+  floci-gc-referrers-stress-s3:
+    name: floci GC(with referrers) on S3(floci) with short interval
+    runs-on: cncf-ubuntu-16-64-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-floci
+        with:
+          persistent_mode: "1"
+      - name: Create zot-storage bucket on floci
+        run: |
+          awslocal s3api create-bucket --bucket zot-storage --region us-east-2 \
+            --create-bucket-configuration='{"LocationConstraint": "us-east-2"}'
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+      - name: Run zb
+        timeout-minutes: 240
+        id: bench
+        run: |
+            make binary
+            make bench
+            ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-s3-localstack.json &
+            sleep 10
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080 --skip-cleanup
+
+            killall --wait -r zot-*
+
+            # clean zot storage
+            sudo rm -rf /tmp/zot
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+      - uses: ./.github/actions/teardown-floci
+        if: always()
+      - name: Check on failures
+        if: steps.bench.outcome != 'success'
+        run: |
+          cat /tmp/gc-referrers-bench-s3.log
+          exit 1
+
+
+  floci-gc-stress-s3:
+    name: floci GC(without referrers) on S3(floci) with short interval
+    runs-on: cncf-ubuntu-16-64-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-floci
+        with:
+          persistent_mode: "1"
+      - name: Create zot-storage bucket on floci
+        run: |
+          awslocal s3api create-bucket --bucket zot-storage --region us-east-2 \
+            --create-bucket-configuration='{"LocationConstraint": "us-east-2"}'
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+      - name: Run zb
+        timeout-minutes: 240
+        id: bench
+        run: |
+            make binary
+            make bench
+            ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-s3-localstack.json &
+            sleep 10
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080 --skip-cleanup
+
+            killall --wait -r zot-*
+
+            # clean zot storage
+            sudo rm -rf /tmp/zot
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+      - uses: ./.github/actions/teardown-floci
+        if: always()
+      - name: Check on failures
+        if: steps.bench.outcome != 'success'
+        run: |
+          cat /tmp/gc-bench-s3.log
+          exit 1
+
+  floci-aws-secrets-manager-bearer:
+    name: floci AWS Secrets Manager Bearer Auth E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-floci
+      - name: Install crane
+        run: |
+          go install github.com/google/go-containerregistry/cmd/crane@latest
+      - name: Run AWS Secrets Manager bearer auth tests
+        run: |
+          ./examples/aws-secrets-manager-bearer-auth-floci.sh
+      - uses: ./.github/actions/teardown-floci
+        if: always()
+
+  floci-cloud-scale-out:
+    name: floci s3+dynamodb scale-out
+    runs-on: cncf-ubuntu-16-64-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          go install github.com/swaggo/swag/cmd/swag@v1.16.2
+          go mod download
+          sudo apt-get update
+          sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap haproxy jq
+          # install skopeo
+          git clone -b v1.12.0 https://github.com/containers/skopeo.git
+          cd skopeo
+          make bin/skopeo
+          sudo cp bin/skopeo /usr/bin
+          skopeo -v
+          cd $GITHUB_WORKSPACE
+      - uses: ./.github/actions/setup-floci
+        with:
+          persistent_mode: "1"
+      - name: Run cloud scale-out high scale performance tests
+        id: scale
+        run: |
+          make run-cloud-scale-out-high-scale-tests
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+      - name: Upload zot logs as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zot-scale-out-dynamodb-logs-floci
+          path: /tmp/zot-ft-logs
+          if-no-files-found: error
+      - name: print service logs
+        run: |
+          sudo dmesg
+          cat /tmp/zot-ft-logs/dynamo-scale/*.log
+      - name: multi-hop detection
+        id: multihop
+        run: |
+          if cat /tmp/zot-ft-logs/dynamo-scale/*.log | grep 'cannot proxy an already proxied request'; then
+            echo "detected multi-hop"
+            exit 1
+          else
+            exit 0
+          fi
+        continue-on-error: true
+      - uses: ./.github/actions/teardown-floci
+        if: always()
+      - name: clean up logs
+        run: |
+          rm -r /tmp/zot-ft-logs/dynamo-scale
+      - name: fail job if error
+        if: ${{ steps.scale.outcome != 'success' || steps.multihop.outcome != 'success' }}
+        run: |
+          exit 1
+      - name: Upload zb test results zip as build artifact
+        if: steps.scale.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zb-cloud-scale-out-perf-results-floci-${{ github.sha }}
+          path: ./zb-results/
+
+  floci-cloud-scale-out-redis:
+    name: floci s3+redis scale-out
+    runs-on: cncf-ubuntu-16-64-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE
+          go install github.com/swaggo/swag/cmd/swag@v1.16.2
+          go mod download
+          sudo apt-get update
+          sudo apt-get install libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap haproxy jq
+          # install skopeo
+          git clone -b v1.12.0 https://github.com/containers/skopeo.git
+          cd skopeo
+          make bin/skopeo
+          sudo cp bin/skopeo /usr/bin
+          skopeo -v
+          cd $GITHUB_WORKSPACE
+      - uses: ./.github/actions/setup-floci
+        with:
+          persistent_mode: "1"
+      - name: Run cloud scale-out Redis tests
+        id: scale
+        run: |
+          make run-cloud-scale-out-redis-high-scale-tests
+        env:
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+        continue-on-error: true
+      - name: Upload zot logs as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zot-scale-out-redis-logs-floci
+          path: /tmp/zot-ft-logs/redis-scale
+          if-no-files-found: error
+      - name: print service logs
+        run: |
+          sudo dmesg
+          cat /tmp/zot-ft-logs/redis-scale/*.log
+      - name: multi-hop detection
+        id: multihop
+        run: |
+          if cat /tmp/zot-ft-logs/redis-scale/*.log | grep 'cannot proxy an already proxied request'; then
+            echo "detected multi-hop"
+            exit 1
+          else
+            exit 0
+          fi
+        continue-on-error: true
+      - name: clean up logs
+        run: |
+          rm -r /tmp/zot-ft-logs/redis-scale
+      - uses: ./.github/actions/teardown-floci
+        if: always()
+      - name: fail job if error
+        if: ${{ steps.scale.outcome != 'success' || steps.multihop.outcome != 'success' }}
+        run: |
+          exit 1
+      - name: Upload zb test results zip as build artifact
+        if: steps.scale.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: zb-cloud-scale-out-redis-results-floci-${{ github.sha }}
+          path: ./zb-results/

--- a/.github/workflows/nightly-with-floci.yaml
+++ b/.github/workflows/nightly-with-floci.yaml
@@ -1,8 +1,7 @@
 name: 'Nightly jobs with floci'
 on:
-  schedule:
-    - cron: '30 1 * * *'
-  workflow_dispatch:
+  pull_request:
+    branches: [main]
 
 permissions: read-all
 

--- a/.github/workflows/sync-3rdparty-images.yaml
+++ b/.github/workflows/sync-3rdparty-images.yaml
@@ -80,3 +80,25 @@ jobs:
           docker pull localstack/localstack:${{ matrix.localstack_version }}
           docker tag localstack/localstack:${{ matrix.localstack_version }} ghcr.io/${{ github.repository_owner }}/ci-images/localstack:${{ matrix.localstack_version }}
           docker push ghcr.io/${{ github.repository_owner }}/ci-images/localstack:${{ matrix.localstack_version }}
+  sync-floci:
+    name: 'floci'
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        floci_version:
+          - "1.5.34"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tag and push floci to ghcr
+        run: |
+          docker pull floci/floci:${{ matrix.floci_version }}
+          docker tag floci/floci:${{ matrix.floci_version }} ghcr.io/${{ github.repository_owner }}/ci-images/floci:${{ matrix.floci_version }}
+          docker push ghcr.io/${{ github.repository_owner }}/ci-images/floci:${{ matrix.floci_version }}

--- a/.github/workflows/sync-3rdparty-images.yaml
+++ b/.github/workflows/sync-3rdparty-images.yaml
@@ -80,3 +80,25 @@ jobs:
           docker pull localstack/localstack:${{ matrix.localstack_version }}
           docker tag localstack/localstack:${{ matrix.localstack_version }} ghcr.io/${{ github.repository_owner }}/ci-images/localstack:${{ matrix.localstack_version }}
           docker push ghcr.io/${{ github.repository_owner }}/ci-images/localstack:${{ matrix.localstack_version }}
+  sync-floci:
+    name: 'floci'
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      matrix:
+        floci_version:
+          - "1.5.34"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to GitHub Docker Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Tag and push floci to ghcr
+        run: |
+          docker pull floci/floci:${{ matrix.floci_version }}
+          docker tag floci/floci:${{ matrix.floci_version }} ghcr.io/${{ github.repository_owner }}/ci-images/floci:${{ matrix.floci_version }}
+          docker push ghcr.io/${{ github.repository_owner }}/ci-images/floci:${{ matrix.floci_version }}

--- a/.github/workflows/test-with-floci.yaml
+++ b/.github/workflows/test-with-floci.yaml
@@ -1,0 +1,181 @@
+name: "Running tests with floci"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [main]
+  release:
+    types:
+      - published
+
+permissions: read-all
+
+jobs:
+  test-run-minimal:
+    name: Running zot without extensions tests
+    runs-on: cncf-ubuntu-8-32-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Cache go dependencies
+        id: cache-go-dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Install go dependencies
+        if: steps.cache-go-dependencies.outputs.cache-hit != 'true'
+        run: |
+          cd $GITHUB_WORKSPACE
+          go mod download
+      - uses: ./.github/actions/setup-floci
+      - uses: ./.github/actions/setup-azurite
+      - name: run zot minimal tests
+        run: |
+          cd $GITHUB_WORKSPACE
+          make test-minimal
+        env:
+          S3MOCK_ENDPOINT: localhost:4566
+          DYNAMODBMOCK_ENDPOINT: http://localhost:4566
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+          AZURITEMOCK_ENDPOINT: http://127.0.0.1:10000/devstoreaccount1
+      - name: upload coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-minimal
+          path: coverage-minimal.txt
+      - uses: ./.github/actions/teardown-floci
+      - uses: ./.github/actions/teardown-azurite
+  test-run-extensions:
+    name: Run zot with extensions tests
+    runs-on: cncf-ubuntu-16-64-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Cache go dependencies
+        id: cache-go-dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Install go dependencies
+        if: steps.cache-go-dependencies.outputs.cache-hit != 'true'
+        run: |
+          cd $GITHUB_WORKSPACE
+          go mod download
+      - uses: ./.github/actions/setup-floci
+      - uses: ./.github/actions/setup-azurite
+      - name: run zot extended tests
+        run: |
+          cd $GITHUB_WORKSPACE
+          make test-extended
+        env:
+          S3MOCK_ENDPOINT: localhost:4566
+          DYNAMODBMOCK_ENDPOINT: http://localhost:4566
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+          AZURITEMOCK_ENDPOINT: http://127.0.0.1:10000/devstoreaccount1
+      - name: upload coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-extended
+          path: coverage-extended.txt
+      - uses: ./.github/actions/teardown-floci
+      - uses: ./.github/actions/teardown-azurite
+  test-run-devmode:
+    name: Running development-mode tests on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Cache go dependencies
+        id: cache-go-dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Install go dependencies
+        if: steps.cache-go-dependencies.outputs.cache-hit != 'true'
+        run: |
+            cd $GITHUB_WORKSPACE
+            go mod download
+      - name: run zot development-mode unit tests (possibly using failure injection)
+        run: make test-devmode
+      - name: upload coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-devmode
+          path: coverage-dev-*.txt
+  test-run-privileged:
+    name: Running privileged tests on Linux
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Cache go dependencies
+        id: cache-go-dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Install go dependencies
+        if: steps.cache-go-dependencies.outputs.cache-hit != 'true'
+        run: |
+            cd $GITHUB_WORKSPACE
+            go mod download
+      - uses: ./.github/actions/setup-gcs-storage-testbench
+      - name: run zot privileged tests
+        run: >
+          sudo env
+          "PATH=$PATH"
+          "GCSMOCK_ENDPOINT=$GCSMOCK_ENDPOINT"
+          "STORAGE_EMULATOR_HOST=$STORAGE_EMULATOR_HOST"
+          make privileged-test
+        env:
+          GCSMOCK_ENDPOINT: http://localhost:9000/
+          STORAGE_EMULATOR_HOST: localhost:9000
+      - name: upload coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-needprivileges
+          path: coverage-needprivileges-*.txt
+      - uses: ./.github/actions/teardown-gcs-storage-testbench

--- a/.github/workflows/test-with-floci.yaml
+++ b/.github/workflows/test-with-floci.yaml
@@ -1,0 +1,109 @@
+name: "Running tests with floci"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches: [main]
+  release:
+    types:
+      - published
+
+permissions: read-all
+
+jobs:
+  floci-test-run-minimal:
+    name: floci Running zot without extensions tests
+    runs-on: cncf-ubuntu-8-32-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Cache go dependencies
+        id: cache-go-dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Install go dependencies
+        if: steps.cache-go-dependencies.outputs.cache-hit != 'true'
+        run: |
+          cd $GITHUB_WORKSPACE
+          go mod download
+      - uses: ./.github/actions/setup-floci
+      - uses: ./.github/actions/setup-azurite
+      - name: run zot minimal tests
+        run: |
+          cd $GITHUB_WORKSPACE
+          make test-minimal
+        env:
+          S3MOCK_ENDPOINT: localhost:4566
+          DYNAMODBMOCK_ENDPOINT: http://localhost:4566
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+          AZURITEMOCK_ENDPOINT: http://127.0.0.1:10000/devstoreaccount1
+      - name: upload coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-minimal-floci
+          path: coverage-minimal.txt
+      - uses: ./.github/actions/teardown-floci
+        if: always()
+      - uses: ./.github/actions/teardown-azurite
+        if: always()
+  floci-test-run-extensions:
+    name: floci Run zot with extensions tests
+    runs-on: cncf-ubuntu-16-64-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - name: Cache go dependencies
+        id: cache-go-dependencies
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-mod-
+      - name: Install go dependencies
+        if: steps.cache-go-dependencies.outputs.cache-hit != 'true'
+        run: |
+          cd $GITHUB_WORKSPACE
+          go mod download
+      - uses: ./.github/actions/setup-floci
+      - uses: ./.github/actions/setup-azurite
+      - name: run zot extended tests
+        run: |
+          cd $GITHUB_WORKSPACE
+          make test-extended
+        env:
+          S3MOCK_ENDPOINT: localhost:4566
+          DYNAMODBMOCK_ENDPOINT: http://localhost:4566
+          AWS_ACCESS_KEY_ID: fake
+          AWS_SECRET_ACCESS_KEY: fake
+          AZURITEMOCK_ENDPOINT: http://127.0.0.1:10000/devstoreaccount1
+      - name: upload coverage
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-extended-floci
+          path: coverage-extended.txt
+      - uses: ./.github/actions/teardown-floci
+        if: always()
+      - uses: ./.github/actions/teardown-azurite
+        if: always()

--- a/examples/aws-secrets-manager-bearer-auth-floci.sh
+++ b/examples/aws-secrets-manager-bearer-auth-floci.sh
@@ -1,0 +1,505 @@
+#!/bin/bash
+# AWS Secrets Manager Bearer Authentication E2E Test
+#
+# This script tests bearer authentication with JWT verification keys
+# stored in AWS Secrets Manager. It uses hardcoded Ed25519 JWKS keys
+# to sign JWTs and verifies that Zot correctly authenticates requests
+# using keys retrieved from AWS Secrets Manager.
+#
+# The test:
+# 1. Creates a secret with Ed25519 public keys
+# 2. Builds and starts Zot with AWS Secrets Manager bearer auth
+# 3. Tests push/pull operations with crane using pre-signed JWTs
+# 4. Verifies authentication fails without a valid token
+#
+# By default, the script expects a local AWS emulator
+# so no real AWS credentials are needed. Use --use-real-aws to test against
+# a real AWS account with credentials from ~/.aws/credentials.
+#
+# Usage:
+#   ./aws-secrets-manager-bearer-auth-floci.sh [OPTIONS]
+#
+# Options:
+#   --use-real-aws    Use real AWS Secrets Manager (requires ~/.aws/credentials)
+#   --skip-build      Skip building zot (reuse existing binary)
+#   --keep-resources  Don't clean up resources on exit
+#   --region REGION   AWS region (default: us-east-1)
+#   --help            Show this help message
+#
+# Prerequisites:
+#   go, crane, jq, curl, aws CLI
+#   For floci mode (default): floci must be running on port 4566 before this script is used.
+#   For real AWS mode: aws CLI with configured credentials
+
+set -o errexit
+set -o pipefail
+
+# Parse command line arguments
+USE_REAL_AWS=false
+SKIP_BUILD=false
+KEEP_RESOURCES=false
+AWS_REGION="us-east-1"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --use-real-aws)
+            USE_REAL_AWS=true
+            shift
+            ;;
+        --skip-build)
+            SKIP_BUILD=true
+            shift
+            ;;
+        --keep-resources)
+            KEEP_RESOURCES=true
+            shift
+            ;;
+        --region)
+            AWS_REGION="$2"
+            shift 2
+            ;;
+        --help)
+            sed -n '2,/^$/p' "$0" | grep -E "^#" | sed 's/^# *//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+log_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+log_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Check prerequisites
+check_prerequisites() {
+    local missing=""
+    for cmd in go crane jq curl; do
+        if ! command -v "$cmd" &> /dev/null; then
+            missing="$missing $cmd"
+        fi
+    done
+
+    if [ "$USE_REAL_AWS" = true ]; then
+        if ! command -v aws &> /dev/null; then
+            missing="$missing aws"
+        fi
+    else
+        # Need aws CLI to talk to floci
+        if ! command -v aws &> /dev/null; then
+            missing="$missing aws"
+        fi
+    fi
+
+    if [ -n "$missing" ]; then
+        log_error "Missing required tools:$missing"
+        exit 1
+    fi
+
+    if [ "$USE_REAL_AWS" = true ]; then
+        # Verify AWS credentials are configured
+        if ! aws sts get-caller-identity --region "${AWS_REGION}" &>/dev/null; then
+            log_error "AWS credentials not configured or invalid. Check ~/.aws/credentials"
+            exit 1
+        fi
+        log_info "AWS credentials verified (real AWS mode)"
+    else
+        log_info "Using local mode (no real AWS credentials needed)"
+    fi
+}
+
+check_prerequisites
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+cd "${ROOT_DIR}"
+
+# Configuration
+ZOT_PORT="5000"
+ZOT_BINARY="/tmp/zot-asm-test"
+ZOT_CONFIG="/tmp/zot-asm-config.json"
+ZOT_STORAGE="/tmp/zot-asm-storage"
+ZOT_PID_FILE="/tmp/zot-asm-test.pid"
+SECRET_NAME="zot/e2e-test-jwt-keys-$(date +%s)"
+LOCAL_PORT="4566"
+BUSYBOX_IMAGE="gcr.io/google-containers/busybox:1.27"
+
+# AWS CLI flags: when using a local simulator, point the AWS CLI at the local endpoint
+# and set dummy credentials.
+if [ "$USE_REAL_AWS" = true ]; then
+    AWS_CMD_FLAGS="--region ${AWS_REGION}"
+else
+    AWS_CMD_FLAGS="--region ${AWS_REGION} --endpoint-url http://127.0.0.1:${LOCAL_PORT}"
+    export AWS_ACCESS_KEY_ID="test"
+    export AWS_SECRET_ACCESS_KEY="test"
+fi
+
+# Ed25519 public JWKS key stored in AWS Secrets Manager for JWT verification.
+PUBLIC_JWKS='{"keys":[{"use":"sig","kty":"OKP","kid":"01f0ff96-0286-62c9-9fe0-68c6ac4f48e0","crv":"Ed25519","alg":"EdDSA","x":"3pL95mHbZYNG6-YT_MqXKibGQrXF7WziWk25EcgEJGs"}]}'
+KID="01f0ff96-0286-62c9-9fe0-68c6ac4f48e0"
+
+# Pre-signed long-lived JWTs (exp ~2126) for test use only. Signed with the Ed25519
+# private key corresponding to the public key above (private key not stored in repo).
+# JWT with push+pull access to "test-repo"
+TOKEN_PUSH_PULL="eyJhbGciOiJFZERTQSIsImtpZCI6IjAxZjBmZjk2LTAyODYtNjJjOS05ZmUwLTY4YzZhYzRmNDhlMCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzZXJ2aWNlLWFjY291bnQtMSIsImV4cCI6NDkyMzY0NzIxMCwiaWF0IjoxNzcwMDQ3MjEwLCJhY2Nlc3MiOlt7InR5cGUiOiJyZXBvc2l0b3J5IiwibmFtZSI6InRlc3QtcmVwbyIsImFjdGlvbnMiOlsicHVsbCIsInB1c2giXX1dfQ.D8CN1Yt5gUV9ZEJHOkJWmEa54Ame5oHyERjH0-_TDkLBa2hjHRq6StJOUCl8wejZ2O_oFGspdlz2X_MVwWXMCQ"
+# JWT with pull-only access to "test-repo"
+TOKEN_PULL_ONLY="eyJhbGciOiJFZERTQSIsImtpZCI6IjAxZjBmZjk2LTAyODYtNjJjOS05ZmUwLTY4YzZhYzRmNDhlMCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzZXJ2aWNlLWFjY291bnQtMSIsImV4cCI6NDkyMzY0NzIxMiwiaWF0IjoxNzcwMDQ3MjEyLCJhY2Nlc3MiOlt7InR5cGUiOiJyZXBvc2l0b3J5IiwibmFtZSI6InRlc3QtcmVwbyIsImFjdGlvbnMiOlsicHVsbCJdfV19.QqVzME9mO61QBhw1gQhBFleBv76Aju3hUVxv-KWZdyYKwHiXINX6vMW8aKWG81DMam26Y19GeMK7QRz5Sg6rAw"
+# JWT with no access claims (authentication only)
+TOKEN_NO_ACCESS="eyJhbGciOiJFZERTQSIsImtpZCI6IjAxZjBmZjk2LTAyODYtNjJjOS05ZmUwLTY4YzZhYzRmNDhlMCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzZXJ2aWNlLWFjY291bnQtMSIsImV4cCI6NDkyMzY0NzIxMiwiaWF0IjoxNzcwMDQ3MjEyfQ.t-1eng92zu7W4tfskVMHkynlvojSEnwHlWOCIc2MN234rMeqyPZrD9tFmkKsEWlznJpKIo-wMXY70JQkOCQ8Bg"
+# JWT with wrong kid (for rejection test)
+TOKEN_WRONG_KID="eyJhbGciOiJFZERTQSIsImtpZCI6Indyb25nLWtpZC1kb2VzLW5vdC1leGlzdCIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJzZXJ2aWNlLWFjY291bnQtMSIsImV4cCI6NDkyMzY0NzIxMiwiaWF0IjoxNzcwMDQ3MjEyLCJhY2Nlc3MiOlt7InR5cGUiOiJyZXBvc2l0b3J5IiwibmFtZSI6InRlc3QtcmVwbyIsImFjdGlvbnMiOlsicHVsbCJdfV19.4WKgZIQwAxTG3xJsn83_qpq1w_b1WvQR977Hj-1LlTKred8bfrcbJt9Fy7_gzP5ee6UgFs-IitldL6hy6emYAA"
+
+cleanup() {
+    if [ "$KEEP_RESOURCES" = true ]; then
+        log_info "Keeping resources (--keep-resources specified)"
+        log_info "To clean up manually:"
+        if [ "$USE_REAL_AWS" = true ]; then
+            log_info "  aws secretsmanager delete-secret --secret-id '${SECRET_NAME}' --force-delete-without-recovery --region '${AWS_REGION}'"
+        fi
+        log_info "  kill \$(cat ${ZOT_PID_FILE}) 2>/dev/null"
+        log_info "  rm -rf ${ZOT_STORAGE} ${ZOT_CONFIG}"
+        return
+    fi
+
+    log_info "Cleaning up..."
+
+    # Stop zot
+    if [ -f "${ZOT_PID_FILE}" ]; then
+        kill "$(cat "${ZOT_PID_FILE}")" 2>/dev/null || true
+        rm -f "${ZOT_PID_FILE}"
+    fi
+
+    if [ "$USE_REAL_AWS" = true ]; then
+        # Delete the secret from AWS Secrets Manager
+        aws secretsmanager delete-secret \
+            --secret-id "${SECRET_NAME}" \
+            --force-delete-without-recovery \
+            --region "${AWS_REGION}" 2>/dev/null || true
+    else
+        aws secretsmanager delete-secret \
+            --secret-id "${SECRET_NAME}" \
+            --force-delete-without-recovery \
+            ${AWS_CMD_FLAGS} 2>/dev/null || true
+    fi
+
+    # Clean up local files
+    rm -rf "${ZOT_STORAGE}" "${ZOT_CONFIG}" /tmp/zot-asm-docker 2>/dev/null || true
+}
+
+trap cleanup EXIT
+
+# =============================================================================
+# SETUP
+# =============================================================================
+
+# Step 1: Create the secret in AWS Secrets Manager
+log_info "Creating secret '${SECRET_NAME}' in Secrets Manager (${AWS_REGION})..."
+
+# The secret format is a JSON object: {"kid": "JWKS-or-PEM-string"}
+# We store the public key in JWKS format.
+SECRET_VALUE=$(jq -n --arg kid "$KID" --arg key "$PUBLIC_JWKS" '{($kid): $key}')
+
+# shellcheck disable=SC2086
+aws secretsmanager create-secret \
+    --name "${SECRET_NAME}" \
+    --secret-string "${SECRET_VALUE}" \
+    ${AWS_CMD_FLAGS} \
+    --output json | jq .
+
+log_info "Secret created successfully"
+
+# Verify the secret can be retrieved
+log_info "Verifying secret retrieval..."
+# shellcheck disable=SC2086
+RETRIEVED=$(aws secretsmanager get-secret-value \
+    --secret-id "${SECRET_NAME}" \
+    ${AWS_CMD_FLAGS} \
+    --query 'SecretString' \
+    --output text)
+
+if [ "$(echo "$RETRIEVED" | jq -r ".[\"$KID\"]")" = "$PUBLIC_JWKS" ]; then
+    log_info "Secret verification passed"
+else
+    log_error "Secret verification failed"
+    log_error "Expected: $PUBLIC_JWKS"
+    log_error "Got: $(echo "$RETRIEVED" | jq -r ".[\"$KID\"]")"
+    exit 1
+fi
+
+# Step 2: Build zot
+if [ "$SKIP_BUILD" = true ] && [ -f "${ZOT_BINARY}" ]; then
+    log_info "Skipping build (--skip-build specified, using existing binary)"
+else
+    log_info "Building zot..."
+    go build -o "${ZOT_BINARY}" ./cmd/zot
+    log_info "Zot built: ${ZOT_BINARY}"
+fi
+
+# Step 3: Create zot configuration
+log_info "Creating zot configuration..."
+rm -rf "${ZOT_STORAGE}"
+mkdir -p "${ZOT_STORAGE}"
+
+cat > "${ZOT_CONFIG}" <<EOF
+{
+  "distSpecVersion": "1.1.1",
+  "storage": {
+    "rootDirectory": "${ZOT_STORAGE}"
+  },
+  "http": {
+    "address": "127.0.0.1",
+    "port": "${ZOT_PORT}",
+    "compat": ["docker2s2"],
+    "auth": {
+      "bearer": {
+        "realm": "http://zot",
+        "service": "zot-service",
+        "awsSecretsManager": {
+          "region": "${AWS_REGION}",
+          "secretName": "${SECRET_NAME}",
+          "refreshInterval": "30s"
+        }
+      }
+    }
+  },
+  "log": {
+    "level": "debug"
+  }
+}
+EOF
+
+log_info "Zot configuration:"
+jq . "${ZOT_CONFIG}"
+
+# Step 4: Start zot
+# When using a local emulator, set AWS_ENDPOINT_URL so the AWS SDK in zot talks to the local endpoint.
+# Also set dummy credentials.
+log_info "Starting zot..."
+if [ "$USE_REAL_AWS" = true ]; then
+    "${ZOT_BINARY}" serve "${ZOT_CONFIG}" &
+else
+    AWS_ENDPOINT_URL="http://127.0.0.1:${LOCAL_PORT}" \
+    AWS_ACCESS_KEY_ID="test" \
+    AWS_SECRET_ACCESS_KEY="test" \
+    "${ZOT_BINARY}" serve "${ZOT_CONFIG}" &
+fi
+ZOT_PID=$!
+echo "${ZOT_PID}" > "${ZOT_PID_FILE}"
+log_info "Zot started with PID ${ZOT_PID}"
+
+# Wait for zot to be ready
+log_info "Waiting for zot to be ready..."
+for i in {1..30}; do
+    HTTP_RESPONSE=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:${ZOT_PORT}/v2/" 2>/dev/null || echo "000")
+    if [ "$HTTP_RESPONSE" = "401" ] || [ "$HTTP_RESPONSE" = "200" ]; then
+        log_info "Zot is responding (HTTP $HTTP_RESPONSE)"
+        break
+    fi
+    if [ "$i" -eq 30 ]; then
+        log_error "Zot failed to start (last HTTP response: $HTTP_RESPONSE)"
+        exit 1
+    fi
+    sleep 1
+done
+
+# Helper: configure crane docker config with a given token
+setup_crane_docker_config() {
+    local token="$1"
+    mkdir -p /tmp/zot-asm-docker
+    cat > /tmp/zot-asm-docker/config.json <<EOFCONFIG
+{
+  "auths": {
+    "127.0.0.1:${ZOT_PORT}": {
+      "registryToken": "${token}"
+    }
+  }
+}
+EOFCONFIG
+}
+
+remove_crane_auth() {
+    rm -f /tmp/zot-asm-docker/config.json
+}
+
+REGISTRY="127.0.0.1:${ZOT_PORT}"
+
+# =============================================================================
+# TESTS
+# =============================================================================
+
+# TEST 1: Basic authentication check (GET /v2/ with valid token)
+log_info "TEST 1: Verifying basic authentication with valid token..."
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${TOKEN_NO_ACCESS}" \
+    "http://${REGISTRY}/v2/")
+
+if [ "$HTTP_CODE" = "200" ]; then
+    log_info "TEST 1 PASSED: Authentication succeeded (HTTP $HTTP_CODE)"
+else
+    log_error "TEST 1 FAILED: Expected 200, got HTTP $HTTP_CODE"
+    exit 1
+fi
+
+# TEST 2: Authentication fails without token
+log_info "TEST 2: Verifying authentication fails without token..."
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    "http://${REGISTRY}/v2/")
+
+if [ "$HTTP_CODE" = "401" ]; then
+    log_info "TEST 2 PASSED: No token correctly rejected (HTTP $HTTP_CODE)"
+else
+    log_error "TEST 2 FAILED: Expected 401, got HTTP $HTTP_CODE"
+    exit 1
+fi
+
+# TEST 3: Authentication fails with invalid token
+log_info "TEST 3: Verifying authentication fails with invalid token..."
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer invalid.token.here" \
+    "http://${REGISTRY}/v2/")
+
+if [ "$HTTP_CODE" = "401" ]; then
+    log_info "TEST 3 PASSED: Invalid token correctly rejected (HTTP $HTTP_CODE)"
+else
+    log_error "TEST 3 FAILED: Expected 401, got HTTP $HTTP_CODE"
+    exit 1
+fi
+
+# TEST 4: Push OCI image using crane WITH push+pull token
+log_info "TEST 4: Pushing OCI image using crane with push+pull token..."
+setup_crane_docker_config "$TOKEN_PUSH_PULL"
+
+PUSH_OUTPUT=$(DOCKER_CONFIG=/tmp/zot-asm-docker crane copy --insecure --platform linux/amd64 \
+    "${BUSYBOX_IMAGE}" "${REGISTRY}/test-repo:v1" 2>&1) || true
+
+if echo "$PUSH_OUTPUT" | grep -qiE "error|UNAUTHORIZED|unauthorized|401|403"; then
+    log_error "TEST 4 FAILED: crane copy failed"
+    log_error "Output: $PUSH_OUTPUT"
+    exit 1
+else
+    log_info "TEST 4 PASSED: crane copy succeeded with push+pull token"
+    log_info "Output: $(echo "$PUSH_OUTPUT" | tail -3)"
+fi
+
+# TEST 5: List tags using crane WITH pull token
+log_info "TEST 5: Listing tags using crane with pull-only token..."
+setup_crane_docker_config "$TOKEN_PULL_ONLY"
+
+TAGS_OUTPUT=$(DOCKER_CONFIG=/tmp/zot-asm-docker crane ls --insecure \
+    "${REGISTRY}/test-repo" 2>&1) || true
+
+if echo "$TAGS_OUTPUT" | grep -q "v1"; then
+    log_info "TEST 5 PASSED: crane ls succeeded and found tag 'v1'"
+    log_info "Tags: $TAGS_OUTPUT"
+else
+    log_error "TEST 5 FAILED: Expected to find tag 'v1'"
+    log_error "Output: $TAGS_OUTPUT"
+    exit 1
+fi
+
+# TEST 6: Pull manifest using crane WITH pull token
+log_info "TEST 6: Pulling manifest using crane with pull-only token..."
+setup_crane_docker_config "$TOKEN_PULL_ONLY"
+
+MANIFEST_OUTPUT=$(DOCKER_CONFIG=/tmp/zot-asm-docker crane manifest --insecure \
+    "${REGISTRY}/test-repo:v1" 2>&1) || true
+
+if echo "$MANIFEST_OUTPUT" | grep -qiE "schemaVersion|mediaType|manifests"; then
+    log_info "TEST 6 PASSED: crane manifest succeeded with pull token"
+    log_info "Manifest preview: $(echo "$MANIFEST_OUTPUT" | head -5)"
+else
+    log_error "TEST 6 FAILED: crane manifest failed with valid pull token"
+    log_error "Output: $MANIFEST_OUTPUT"
+    exit 1
+fi
+
+# TEST 7: Push fails with pull-only token
+log_info "TEST 7: Verifying push fails with pull-only token..."
+setup_crane_docker_config "$TOKEN_PULL_ONLY"
+
+PUSH_FAIL_OUTPUT=$(DOCKER_CONFIG=/tmp/zot-asm-docker crane copy --insecure --platform linux/amd64 \
+    "${BUSYBOX_IMAGE}" "${REGISTRY}/test-repo:v2" 2>&1 || true)
+
+if echo "$PUSH_FAIL_OUTPUT" | grep -qiE "401|unauthorized|UNAUTHORIZED"; then
+    log_info "TEST 7 PASSED: Push correctly rejected with pull-only token"
+    log_info "Output: $(echo "$PUSH_FAIL_OUTPUT" | tail -2)"
+else
+    log_error "TEST 7 FAILED: Expected 401 for push with pull-only token"
+    log_error "Output: $PUSH_FAIL_OUTPUT"
+    exit 1
+fi
+
+# TEST 8: crane operations fail WITHOUT any token
+log_info "TEST 8: Verifying crane operations fail without token..."
+remove_crane_auth
+
+NOTOK_OUTPUT=$(DOCKER_CONFIG=/tmp/zot-asm-docker crane ls --insecure \
+    "${REGISTRY}/test-repo" 2>&1 || true)
+
+if echo "$NOTOK_OUTPUT" | grep -qiE "401|unauthorized|UNAUTHORIZED|error|Error"; then
+    log_info "TEST 8 PASSED: crane ls failed without token"
+    log_info "Output: $(echo "$NOTOK_OUTPUT" | tail -2)"
+else
+    log_error "TEST 8 FAILED: Expected error for unauthenticated request"
+    log_error "Output: $NOTOK_OUTPUT"
+    exit 1
+fi
+
+# TEST 9: Token with wrong kid is rejected
+log_info "TEST 9: Verifying token with wrong kid is rejected..."
+
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${TOKEN_WRONG_KID}" \
+    "http://${REGISTRY}/v2/")
+
+if [ "$HTTP_CODE" = "401" ]; then
+    log_info "TEST 9 PASSED: Wrong kid correctly rejected (HTTP $HTTP_CODE)"
+else
+    log_error "TEST 9 FAILED: Expected 401 for wrong kid, got HTTP $HTTP_CODE"
+    exit 1
+fi
+
+# TEST 10: Token accessing unauthorized repository is rejected
+log_info "TEST 10: Verifying access to unauthorized repository fails..."
+
+# The push+pull token only grants access to "test-repo"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
+    -H "Authorization: Bearer ${TOKEN_PUSH_PULL}" \
+    "http://${REGISTRY}/v2/other-repo/tags/list")
+
+if [ "$HTTP_CODE" = "401" ]; then
+    log_info "TEST 10 PASSED: Access to unauthorized repo correctly rejected (HTTP $HTTP_CODE)"
+else
+    log_error "TEST 10 FAILED: Expected 401 for unauthorized repo, got HTTP $HTTP_CODE"
+    exit 1
+fi
+
+# =============================================================================
+# SUMMARY
+# =============================================================================
+
+log_info "=========================================="
+log_info "All AWS Secrets Manager Bearer Auth tests PASSED!"
+log_info "=========================================="
+log_info ""
+log_info "Options:"
+log_info "  --use-real-aws    Use real AWS (default: local)"
+log_info "  --skip-build      Skip building zot"
+log_info "  --keep-resources  Keep resources after exit"
+log_info "  --region REGION   AWS region (default: us-east-1)"


### PR DESCRIPTION
**What type of PR is this?**
CI feature

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
- Adds duplicates of the current workflows where localstack is used, but uses floci instead.
- floci is MIT licensed and a very popular alternative to localstack.
- The aim is to run these in parallel for some time and then switchover completely by deleting these temporary workflows and modifying the main ones.

**Testing done on this change**:
CI tests should pass

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
