### PR TITLE
fix(ci): pin zot release ver to v2.1.18

### DIFF
--- a/test/blackbox/helpers_zot.bash
+++ b/test/blackbox/helpers_zot.bash
@@ -6,6 +6,7 @@ ZLI_PATH=${ROOT_DIR}/bin/zli-${OS}-${ARCH}
 ZOT_MINIMAL_PATH=${ROOT_DIR}/bin/zot-${OS}-${ARCH}-minimal
 ZB_PATH=${ROOT_DIR}/bin/zb-${OS}-${ARCH}
 TEST_DATA_DIR=${BATS_FILE_TMPDIR}/test/data
+ZOT_RELEASE_VERSION="v2.1.18"
 AUTH_USER=poweruser
 AUTH_PASS=sup*rSecr9T
 # additional creds for sha256/sha512 based password hashes
@@ -28,17 +29,28 @@ function zot_serve() {
     echo -n "$! " >> ${BATS_FILE_TMPDIR}/zot.pid
 }
 
+function zot_download_base_url() {
+    local base="https://github.com/project-zot/zot/releases"
+    local url_version_path="${ZOT_RELEASE_VERSION}/download"
+    if [[ "${ZOT_RELEASE_VERSION}" != "latest" ]]; then
+        url_version_path="download/${ZOT_RELEASE_VERSION}"
+    fi
+
+    echo "${base}/${url_version_path}"
+}
+
 function zot_rel_serve() {
     local config_file=${1}
     local zot_path=${BATS_FILE_TMPDIR}/zot-rel-${OS}-${ARCH}
+    local base_url=$(zot_download_base_url)
 
     if [ ! -f "${zot_path}" ]; then
-        if ! curl -f -L -o "${zot_path}" https://github.com/project-zot/zot/releases/latest/download/zot-${OS}-${ARCH}; then 
+        if ! curl -f -L -o "${zot_path}" "${base_url}/zot-${OS}-${ARCH}"; then
             echo "ERROR: Failed to download zot binary from GitHub." >&2
             return 1
         fi
         # Download checksum file and verify integrity
-        checksum_url="https://github.com/project-zot/zot/releases/latest/download/checksums.sha256.txt"
+        checksum_url="${base_url}/checksums.sha256.txt"
         checksum_file="${BATS_FILE_TMPDIR}/zot-sha256sums.txt"
         curl -L -o "${checksum_file}" "${checksum_url}"
         expected_sum=$(grep "zot-${OS}-${ARCH}$" "${checksum_file}" | awk '{print $1}')
@@ -62,14 +74,15 @@ function zot_rel_serve() {
 function zot_rel_min_serve() {
     local config_file=${1}
     local zot_path=${BATS_FILE_TMPDIR}/zot-rel-${OS}-${ARCH}-minimal
+    local base_url=$(zot_download_base_url)
 
     if [ ! -f "${zot_path}" ]; then
-        if ! curl -f -L -o "${zot_path}" https://github.com/project-zot/zot/releases/latest/download/zot-${OS}-${ARCH}-minimal; then
+        if ! curl -f -L -o "${zot_path}" "${base_url}/zot-${OS}-${ARCH}-minimal"; then
             echo "ERROR: Failed to download zot binary from GitHub." >&2
             return 1
         fi
         # Download checksum file and verify integrity
-        checksum_url="https://github.com/project-zot/zot/releases/latest/download/checksums.sha256.txt"
+        checksum_url="${base_url}/checksums.sha256.txt"
         checksum_file="${BATS_FILE_TMPDIR}/zot-sha256sums.txt"
         curl -L -o "${checksum_file}" "${checksum_url}"
         expected_sum=$(grep "zot-${OS}-${ARCH}-minimal$" "${checksum_file}" | awk '{print $1}')


### PR DESCRIPTION
**What type of PR is this?**
fix

**Which issue does this PR fix**:
Untracked

**What does this PR do / Why do we need it**:
- v2.1.19's release couldn't be updated with binaries. This is causing upgrade BATS to fail. This PR pins the release version of zot to v2.1.18 so tests can pass until the next release.

**If an issue # is not available please add repro steps and logs showing the issue**:
CI failures.

**Testing done on this change**:
N/A

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
