### PR TITLE
fix(ci): use latest zot for upgrade tests

### DIFF
--- a/test/blackbox/helpers_zot.bash
+++ b/test/blackbox/helpers_zot.bash
@@ -6,7 +6,7 @@ ZLI_PATH=${ROOT_DIR}/bin/zli-${OS}-${ARCH}
 ZOT_MINIMAL_PATH=${ROOT_DIR}/bin/zot-${OS}-${ARCH}-minimal
 ZB_PATH=${ROOT_DIR}/bin/zb-${OS}-${ARCH}
 TEST_DATA_DIR=${BATS_FILE_TMPDIR}/test/data
-ZOT_RELEASE_VERSION="v2.1.18"
+ZOT_RELEASE_VERSION="latest"
 AUTH_USER=poweruser
 AUTH_PASS=sup*rSecr9T
 # additional creds for sha256/sha512 based password hashes


### PR DESCRIPTION
**What type of PR is this?**
fix

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
- Goes back to using "latest" for upgrade tests.

**If an issue # is not available please add repro steps and logs showing the issue**:
N/A

**Testing done on this change**:
CI Passes

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
