### PR TITLE
fix(ci): fix noisy codecov project failure

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,9 @@ ignore:
     - "./swagger/*.go"
     - "./pkg/test/test_http_server.go"
     - "./pkg/meta/proto/gen/*.go"
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.1

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,3 +7,9 @@ ignore:
     - "./swagger/*.go"
     - "./pkg/test/test_http_server.go"
     - "./pkg/meta/proto/gen/*.go"
+
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.5


### PR DESCRIPTION
**What type of PR is this?**
CI fix

**Which issue does this PR fix**:
N/A

**What does this PR do / Why do we need it**:
- codecov/project keeps failing every now and then with the message "codecov/project - 91.83% (-0.02%) compared to 3b5796d". This even happens on PRs where there is no code change.
- This PR sets codecov to tolerate up to a 0.1% drop in the coverage to reduce noisy codecov CI status.

Codecov doc reference: https://docs.codecov.com/docs/commit-status#threshold

**If an issue # is not available please add repro steps and logs showing the issue**:
CI status checks for codecov fail with a small percentage drop.

**Testing done on this change**:
None - we'll see it once CI runs.

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades?**
No - CI

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
