### PR TITLE
fix(imagetrust): add recognization of sigstore v3 bundles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,8 +66,10 @@ require (
 	github.com/regclient/regclient v0.11.5
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3
+	github.com/secure-systems-lab/go-securesystemslib v0.11.0
 	github.com/sigstore/cosign/v3 v3.1.2
 	github.com/sigstore/sigstore v1.10.8
+	github.com/sigstore/sigstore-go v1.2.1
 	github.com/smartystreets/goconvey v1.8.1
 	github.com/spf13/cast v1.10.0
 	github.com/spf13/cobra v1.10.2
@@ -442,7 +444,6 @@ require (
 	github.com/samber/oops v1.18.1 // indirect
 	github.com/sassoftware/go-rpmutils v0.4.0 // indirect
 	github.com/sassoftware/relic v7.2.1+incompatible // indirect
-	github.com/secure-systems-lab/go-securesystemslib v0.11.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/shibumi/go-pathspec v1.3.0 // indirect
@@ -451,7 +452,6 @@ require (
 	github.com/sigstore/protobuf-specs v0.5.1 // indirect
 	github.com/sigstore/rekor v1.5.3 // indirect
 	github.com/sigstore/rekor-tiles/v2 v2.3.0 // indirect
-	github.com/sigstore/sigstore-go v1.2.1 // indirect
 	github.com/sigstore/timestamp-authority/v2 v2.1.2 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skeema/knownhosts v1.3.2 // indirect

--- a/pkg/extensions/imagetrust/cosign.go
+++ b/pkg/extensions/imagetrust/cosign.go
@@ -150,7 +150,7 @@ func VerifyCosignSignature(
 // image digest.
 func verifyCosignBundleSignature(
 	cosignStorage publicKeyStorage, publicKeys []string, digest godigest.Digest, layerContent []byte,
-) (string, bool, error) {
+) (string, bool, error) { //nolint:unparam // error kept to match VerifyCosignSignature's return signature
 	var sigBundle bundle.Bundle
 	if err := sigBundle.UnmarshalJSON(layerContent); err != nil {
 		return "", false, nil //nolint: nilerr // not a bundle, nothing to verify
@@ -189,12 +189,16 @@ func verifyCosignBundleSignature(
 				continue
 			}
 
-			if pkcs11Key, ok := pubKeyVerifier.(*pkcs11key.Key); ok {
-				defer pkcs11Key.Close()
-			}
+			pkcs11Key, isPKCS11Key := pubKeyVerifier.(*pkcs11key.Key)
 
 			err = pubKeyVerifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(signedContent),
 				options.WithContext(context.Background()))
+
+			// close explicitly right after this attempt, instead of deferring inside the loop
+			if isPKCS11Key {
+				pkcs11Key.Close()
+			}
+
 			if err == nil {
 				return string(pubKeyContent), true, nil
 			}

--- a/pkg/extensions/imagetrust/cosign.go
+++ b/pkg/extensions/imagetrust/cosign.go
@@ -16,8 +16,10 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
 	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
 	godigest "github.com/opencontainers/go-digest"
+	"github.com/secure-systems-lab/go-securesystemslib/dsse"
 	"github.com/sigstore/cosign/v3/pkg/cosign/pkcs11key"
 	sigs "github.com/sigstore/cosign/v3/pkg/signature"
+	"github.com/sigstore/sigstore-go/pkg/bundle"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
 	sigstoreSigs "github.com/sigstore/sigstore/pkg/signature"
 	"github.com/sigstore/sigstore/pkg/signature/options"
@@ -88,6 +90,12 @@ func VerifyCosignSignature(
 		return "", false, err
 	}
 
+	// cosign >= v3 signs using the new sigstore bundle format by default, in which case the
+	// signature is inside the bundle itself and there is no legacy signature-key annotation.
+	if signatureKey == "" {
+		return verifyCosignBundleSignature(cosignStorage, publicKeys, digest, layerContent)
+	}
+
 	for _, publicKey := range publicKeys {
 		// cosign verify the image
 		pubKeyVerifier, pubKeyContent, err := cosignStorage.GetPublicKeyVerifier(publicKey)
@@ -134,6 +142,83 @@ func VerifyCosignSignature(
 	}
 
 	return "", false, nil
+}
+
+// verifyCosignBundleSignature verifies a signature stored using the sigstore bundle format
+// (application/vnd.dev.sigstore.bundle.v0.3+json), which is what cosign v3 produces by default.
+// The bundle embeds a DSSE envelope wrapping an in-toto statement whose subject is the signed
+// image digest.
+func verifyCosignBundleSignature(
+	cosignStorage publicKeyStorage, publicKeys []string, digest godigest.Digest, layerContent []byte,
+) (string, bool, error) {
+	var sigBundle bundle.Bundle
+	if err := sigBundle.UnmarshalJSON(layerContent); err != nil {
+		return "", false, nil //nolint: nilerr // not a bundle, nothing to verify
+	}
+
+	envelope, err := sigBundle.Envelope()
+	if err != nil {
+		return "", false, nil //nolint: nilerr // only DSSE envelopes are supported
+	}
+
+	if len(envelope.Signatures) == 0 {
+		return "", false, nil
+	}
+
+	payload, err := envelope.DecodeB64Payload()
+	if err != nil {
+		return "", false, nil //nolint: nilerr
+	}
+
+	signature, err := base64.StdEncoding.DecodeString(envelope.Signatures[0].Sig)
+	if err != nil {
+		return "", false, nil //nolint: nilerr
+	}
+
+	// the DSSE signature is computed over the pre-authentication encoding of the payload
+	signedContent := dsse.PAE(envelope.PayloadType, payload)
+
+	if !bundleSubjectMatchesDigest(envelope, digest) {
+		return "", false, nil
+	}
+
+	for _, publicKey := range publicKeys {
+		pubKeyVerifier, pubKeyContent, err := cosignStorage.GetPublicKeyVerifier(publicKey)
+		if err != nil {
+			continue
+		}
+
+		if pkcs11Key, ok := pubKeyVerifier.(*pkcs11key.Key); ok {
+			defer pkcs11Key.Close()
+		}
+
+		err = pubKeyVerifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(signedContent),
+			options.WithContext(context.Background()))
+		if err == nil {
+			return string(pubKeyContent), true, nil
+		}
+	}
+
+	return "", false, nil
+}
+
+// bundleSubjectMatchesDigest checks that the in-toto statement carried by the DSSE envelope
+// refers to the image digest being verified.
+func bundleSubjectMatchesDigest(envelope *bundle.Envelope, digest godigest.Digest) bool {
+	statement, err := envelope.Statement()
+	if err != nil {
+		return false
+	}
+
+	for _, subject := range statement.GetSubject() {
+		for algorithm, encoded := range subject.GetDigest() {
+			if godigest.NewDigestFromEncoded(godigest.Algorithm(algorithm), encoded) == digest {
+				return true
+			}
+		}
+	}
+
+	return false
 }
 
 func (local *PublicKeyLocalStorage) GetPublicKeyVerifier(fileName string) (sigstoreSigs.Verifier, []byte, error) {

--- a/pkg/extensions/imagetrust/cosign.go
+++ b/pkg/extensions/imagetrust/cosign.go
@@ -170,11 +170,6 @@ func verifyCosignBundleSignature(
 		return "", false, nil //nolint: nilerr
 	}
 
-	signature, err := base64.StdEncoding.DecodeString(envelope.Signatures[0].Sig)
-	if err != nil {
-		return "", false, nil //nolint: nilerr
-	}
-
 	// the DSSE signature is computed over the pre-authentication encoding of the payload
 	signedContent := dsse.PAE(envelope.PayloadType, payload)
 
@@ -182,20 +177,27 @@ func verifyCosignBundleSignature(
 		return "", false, nil
 	}
 
-	for _, publicKey := range publicKeys {
-		pubKeyVerifier, pubKeyContent, err := cosignStorage.GetPublicKeyVerifier(publicKey)
+	for _, envelopeSignature := range envelope.Signatures {
+		signature, err := base64.StdEncoding.DecodeString(envelopeSignature.Sig)
 		if err != nil {
 			continue
 		}
 
-		if pkcs11Key, ok := pubKeyVerifier.(*pkcs11key.Key); ok {
-			defer pkcs11Key.Close()
-		}
+		for _, publicKey := range publicKeys {
+			pubKeyVerifier, pubKeyContent, err := cosignStorage.GetPublicKeyVerifier(publicKey)
+			if err != nil {
+				continue
+			}
 
-		err = pubKeyVerifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(signedContent),
-			options.WithContext(context.Background()))
-		if err == nil {
-			return string(pubKeyContent), true, nil
+			if pkcs11Key, ok := pubKeyVerifier.(*pkcs11key.Key); ok {
+				defer pkcs11Key.Close()
+			}
+
+			err = pubKeyVerifier.VerifySignature(bytes.NewReader(signature), bytes.NewReader(signedContent),
+				options.WithContext(context.Background()))
+			if err == nil {
+				return string(pubKeyContent), true, nil
+			}
 		}
 	}
 

--- a/pkg/extensions/imagetrust/image_trust_test.go
+++ b/pkg/extensions/imagetrust/image_trust_test.go
@@ -42,6 +42,7 @@ import (
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
 	"zotregistry.dev/zot/v2/pkg/extensions/imagetrust"
 	"zotregistry.dev/zot/v2/pkg/log"
+	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	test "zotregistry.dev/zot/v2/pkg/test/common"
 	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
@@ -654,6 +655,90 @@ func TestCosignSignatureDigestBinding(t *testing.T) {
 	})
 }
 
+func TestCosignBundleSignatureEndToEnd(t *testing.T) {
+	Convey("cosign sigstore bundle signature is verified through the live ingestion path", t, func() {
+		repo := "repo"
+		tag := "test"
+
+		image := CreateRandomImage()
+
+		rootDir := t.TempDir()
+
+		defaultValue := true
+
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		conf.Storage.GC = false
+		conf.Extensions = &extconf.ExtensionConfig{}
+		conf.Extensions.Trust = &extconf.ImageTrustConfig{}
+		conf.Extensions.Trust.Enable = &defaultValue
+		conf.Extensions.Trust.Cosign = defaultValue
+
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = rootDir
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+		port := strconv.Itoa(cm.Port())
+		defer cm.StopServer()
+
+		err := UploadImage(image, baseURL, repo, tag)
+		So(err, ShouldBeNil)
+
+		keyDir := t.TempDir()
+
+		cwd, err := os.Getwd()
+		So(err, ShouldBeNil)
+
+		func() {
+			So(os.Chdir(keyDir), ShouldBeNil)
+			defer func() {
+				So(os.Chdir(cwd), ShouldBeNil)
+			}()
+
+			t.Setenv("COSIGN_PASSWORD", "")
+			err = generate.GenerateKeyPairCmd(context.TODO(), "", "cosign", nil)
+			So(err, ShouldBeNil)
+		}()
+
+		publicKeyContent, err := os.ReadFile(path.Join(keyDir, "cosign.pub"))
+		So(err, ShouldBeNil)
+
+		// upload the public key before signing, so the running server can verify at push time
+		client := resty.New()
+		resp, err := client.R().SetHeader("Content-type", "application/octet-stream").
+			SetBody(publicKeyContent).Post(baseURL + constants.FullCosign)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		err = sign.SignCmd(context.TODO(),
+			&options.RootOptions{Verbose: true, Timeout: 1 * time.Minute},
+			options.KeyOpts{KeyRef: path.Join(keyDir, "cosign.key"), PassFunc: generate.GetPass},
+			options.SignOptions{
+				Registry:        options.RegistryOptions{AllowInsecure: true},
+				Upload:          true,
+				NewBundleFormat: true,
+				TlogUpload:      false,
+			},
+			[]string{fmt.Sprintf("localhost:%s/%s@%s", port, repo, image.DigestStr())})
+		So(err, ShouldBeNil)
+
+		repoMeta, err := ctlr.MetaDB.GetRepoMeta(context.Background(), repo)
+		So(err, ShouldBeNil)
+
+		var layerInfo mTypes.LayerInfo
+
+		for _, sigInfo := range repoMeta.Signatures[image.DigestStr()][zcommon.CosignSignature] {
+			if len(sigInfo.LayersInfo) > 0 {
+				layerInfo = sigInfo.LayersInfo[0]
+			}
+		}
+
+		So(layerInfo.SignatureKey, ShouldBeEmpty)
+		So(layerInfo.Signer, ShouldNotBeEmpty)
+	})
+}
+
 func TestCosignBundleSignature(t *testing.T) {
 	Convey("cosign sigstore bundle signature is verified", t, func() {
 		repo := "repo"
@@ -686,13 +771,16 @@ func TestCosignBundleSignature(t *testing.T) {
 		cwd, err := os.Getwd()
 		So(err, ShouldBeNil)
 
-		So(os.Chdir(cosignDir), ShouldBeNil)
+		func() {
+			So(os.Chdir(cosignDir), ShouldBeNil)
+			defer func() {
+				So(os.Chdir(cwd), ShouldBeNil)
+			}()
 
-		t.Setenv("COSIGN_PASSWORD", "")
-		err = generate.GenerateKeyPairCmd(context.TODO(), "", "cosign", nil)
-		So(err, ShouldBeNil)
-
-		So(os.Chdir(cwd), ShouldBeNil)
+			t.Setenv("COSIGN_PASSWORD", "")
+			err = generate.GenerateKeyPairCmd(context.TODO(), "", "cosign", nil)
+			So(err, ShouldBeNil)
+		}()
 
 		err = sign.SignCmd(context.TODO(),
 			&options.RootOptions{Verbose: true, Timeout: 1 * time.Minute},

--- a/pkg/extensions/imagetrust/image_trust_test.go
+++ b/pkg/extensions/imagetrust/image_trust_test.go
@@ -654,6 +654,126 @@ func TestCosignSignatureDigestBinding(t *testing.T) {
 	})
 }
 
+func TestCosignBundleSignature(t *testing.T) {
+	Convey("cosign sigstore bundle signature is verified", t, func() {
+		repo := "repo"
+		tag := "test"
+
+		image := CreateRandomImage()
+
+		rootDir := t.TempDir()
+
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		conf.Storage.GC = false
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = rootDir
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+		port := strconv.Itoa(cm.Port())
+		defer cm.StopServer()
+
+		err := UploadImage(image, baseURL, repo, tag)
+		So(err, ShouldBeNil)
+
+		pubKeyStorage, err := imagetrust.NewPublicKeyLocalStorage(rootDir)
+		So(err, ShouldBeNil)
+
+		cosignDir, err := pubKeyStorage.GetCosignDirPath()
+		So(err, ShouldBeNil)
+
+		cwd, err := os.Getwd()
+		So(err, ShouldBeNil)
+
+		So(os.Chdir(cosignDir), ShouldBeNil)
+
+		t.Setenv("COSIGN_PASSWORD", "")
+		err = generate.GenerateKeyPairCmd(context.TODO(), "", "cosign", nil)
+		So(err, ShouldBeNil)
+
+		So(os.Chdir(cwd), ShouldBeNil)
+
+		err = sign.SignCmd(context.TODO(),
+			&options.RootOptions{Verbose: true, Timeout: 1 * time.Minute},
+			options.KeyOpts{KeyRef: path.Join(cosignDir, "cosign.key"), PassFunc: generate.GetPass},
+			options.SignOptions{
+				Registry:        options.RegistryOptions{AllowInsecure: true},
+				Upload:          true,
+				NewBundleFormat: true,
+				TlogUpload:      false,
+			},
+			[]string{fmt.Sprintf("localhost:%s/%s@%s", port, repo, image.DigestStr())})
+		So(err, ShouldBeNil)
+
+		err = os.Remove(path.Join(cosignDir, "cosign.key"))
+		So(err, ShouldBeNil)
+
+		indexContent, err := ctlr.StoreController.DefaultStore.GetIndexContent(repo)
+		So(err, ShouldBeNil)
+
+		var index ispec.Index
+
+		err = json.Unmarshal(indexContent, &index)
+		So(err, ShouldBeNil)
+
+		var rawSignature []byte
+
+		for _, manifest := range index.Manifests {
+			if manifest.Digest == image.Digest() {
+				continue
+			}
+
+			blobContent, err := ctlr.StoreController.DefaultStore.GetBlobContent(repo, manifest.Digest)
+			So(err, ShouldBeNil)
+
+			var cosignSig ispec.Manifest
+
+			err = json.Unmarshal(blobContent, &cosignSig)
+			So(err, ShouldBeNil)
+
+			if cosignSig.ArtifactType != zcommon.ArtifactTypeCosignBundle {
+				continue
+			}
+
+			// the sigstore bundle format has no legacy signature-key annotation
+			So(cosignSig.Layers[0].Annotations[zcommon.CosignSigKey], ShouldBeEmpty)
+
+			rawSignature, err = ctlr.StoreController.DefaultStore.GetBlobContent(repo, cosignSig.Layers[0].Digest)
+			So(err, ShouldBeNil)
+		}
+
+		So(rawSignature, ShouldNotBeEmpty)
+
+		Convey("bundle signature verifies against the manifest it signed", func() {
+			author, isTrusted, err := imagetrust.VerifyCosignSignature(pubKeyStorage, repo, image.Digest(), "",
+				rawSignature)
+			So(err, ShouldBeNil)
+			So(isTrusted, ShouldBeTrue)
+			So(author, ShouldNotBeEmpty)
+		})
+
+		Convey("bundle signature transplanted onto a different manifest is not trusted", func() {
+			otherImage := CreateRandomImage()
+			So(otherImage.Digest(), ShouldNotEqual, image.Digest())
+
+			author, isTrusted, err := imagetrust.VerifyCosignSignature(pubKeyStorage, repo, otherImage.Digest(), "",
+				rawSignature)
+			So(err, ShouldBeNil)
+			So(isTrusted, ShouldBeFalse)
+			So(author, ShouldBeEmpty)
+		})
+
+		Convey("garbage content is not trusted", func() {
+			author, isTrusted, err := imagetrust.VerifyCosignSignature(pubKeyStorage, repo, image.Digest(), "",
+				[]byte("not a bundle"))
+			So(err, ShouldBeNil)
+			So(isTrusted, ShouldBeFalse)
+			So(author, ShouldBeEmpty)
+		})
+	})
+}
+
 func TestCheckExpiryErr(t *testing.T) {
 	Convey("no expiry err", t, func() {
 		isExpiryErr := imagetrust.CheckExpiryErr([]*notation.ValidationResult{{Error: nil, Type: "wrongtype"}}, time.Now(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

Bug.

**Which issue does this PR fix**:

fixes #4299 

**What does this PR do / Why do we need it**:

Cosign v3 signs using a new bundle format, where the signature lives inside a DSSE envelope with no dev.cosignproject.cosign/signature annotation, so zot could not verify the signatures. This PR adds verification for the new bundle format by parsing the bundle, checking that the in-toto statement subject matches the manifest digest, and validating the DSSE payload against the trusted public keys.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

- Added TestCosignBundleSignature: signs an image with the new bundle format and verifies it returns a trusted result
- Added TestCosignBundleSignatureEndToEnd: tests the full path against a live server and confirms a trusted uploaded key results in a trusted image.
- Verified the fix commit builds and lints cleanly
- Manually verified with a local Zot instance with the trust extension, by uploading a public key and signing multiple images, some with other signatures already. 

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

None. Unit/integration testing added to ```pkg/extensions/imagetrust/image_trust_test.go```

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes.
```release-note
Fix cosign v3 sigstore-bundle signature verification. Previously, images signed with the latest versions of cosign were never marked as trusted. 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
