### PR TITLE
fix(storage): dedupe walk must visit nested-namespace repositories

### DIFF
--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -2187,15 +2187,27 @@ func (is *ImageStore) GetNextDigestWithBlobPaths(repos []string, lastDigests []g
 		}
 
 		if fileInfo.IsDir() {
-			// skip repositories not found in repos
-			baseName := path.Base(fileInfo.Path())
-			if slices.Contains(repos, baseName) || baseName == ispec.ImageBlobsDir {
-				return nil
+			// Descend into this directory only if it lies on the path to some
+			// repo's blobs: it is the repo itself, an ancestor of a repo
+			// (e.g. "org" for "org/team"), or inside a repo (blobs/algorithm dir).
+			rel, relErr := filepath.Rel(is.rootDir, fileInfo.Path())
+			if relErr != nil {
+				return nil //nolint:nilerr // ignore paths that are not under root dir
 			}
 
-			candidateAlgorithm := godigest.Algorithm(baseName)
+			rel = filepath.ToSlash(rel)
 
-			if !candidateAlgorithm.Available() {
+			descend := false
+
+			for _, r := range repos {
+				if rel == r || strings.HasPrefix(r, rel+"/") || strings.HasPrefix(rel, r+"/") {
+					descend = true
+
+					break
+				}
+			}
+
+			if !descend {
 				return driver.ErrSkipDir
 			}
 

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -3660,6 +3660,62 @@ func TestGetNextDigestWithBlobPathsPathNotFound(t *testing.T) {
 	})
 }
 
+func TestGetNextDigestWithBlobPathsNestedRepo(t *testing.T) {
+	Convey("GetNextDigestWithBlobPaths must visit nested-namespace repositories", t, func() {
+		dir := t.TempDir()
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewMetricsServer(false, log)
+		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
+			RootDir:     dir,
+			Name:        "cache",
+			UseRelPaths: true,
+		}, log)
+
+		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
+
+		blobContent := []byte("shared-blob-content")
+		dgst := godigest.FromBytes(blobContent)
+		algo := dgst.Algorithm().String()
+		enc := dgst.Encoded()
+
+		// Two valid OCI repos sharing one blob: one single-level, one nested.
+		for _, repo := range []string{"repo1", "org/team"} {
+			repoDir := path.Join(dir, repo)
+			So(os.MkdirAll(path.Join(repoDir, ispec.ImageBlobsDir), storageConstants.DefaultDirPerms), ShouldBeNil)
+
+			ilBuf, err := json.Marshal(ispec.ImageLayout{Version: ispec.ImageLayoutVersion})
+			So(err, ShouldBeNil)
+			So(os.WriteFile(path.Join(repoDir, ispec.ImageLayoutFile), ilBuf, storageConstants.DefaultFilePerms), ShouldBeNil)
+
+			idxBuf, err := json.Marshal(ispec.Index{Versioned: imeta.Versioned{SchemaVersion: 2}})
+			So(err, ShouldBeNil)
+			So(os.WriteFile(path.Join(repoDir, ispec.ImageIndexFile), idxBuf, storageConstants.DefaultFilePerms), ShouldBeNil)
+
+			blobPath := path.Join(repoDir, ispec.ImageBlobsDir, algo, enc)
+			So(os.MkdirAll(path.Dir(blobPath), storageConstants.DefaultDirPerms), ShouldBeNil)
+			So(os.WriteFile(blobPath, blobContent, storageConstants.DefaultFilePerms), ShouldBeNil)
+		}
+
+		// A directory that matches no repo must be pruned via ErrSkipDir,
+		// not descend (and contain no blobs when walked).
+		So(os.MkdirAll(path.Join(dir, "unrelated-dir"), storageConstants.DefaultDirPerms), ShouldBeNil)
+
+		// GetRepositories returns full relative paths including the nested one.
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldContain, "repo1")
+		So(repos, ShouldContain, "org/team")
+
+		// The dedupe walk must discover BOTH copies of the shared blob.
+		// Before the fix, "$root/org" was pruned via ErrSkipDir (path.Base("org")
+		// matched nothing in repos), so the nested copy was never collected.
+		gotDigest, duplicateBlobs, err := imgStore.GetNextDigestWithBlobPaths(repos, []godigest.Digest{})
+		So(err, ShouldBeNil)
+		So(gotDigest, ShouldEqual, dgst)
+		So(len(duplicateBlobs), ShouldEqual, 2)
+	})
+}
+
 func newRandomBlobForFuzz(data []byte) (godigest.Digest, []byte, error) { //nolint:unparam
 	return godigest.FromBytes(data), data, nil
 }


### PR DESCRIPTION
## Problem

`GetNextDigestWithBlobPaths` pruned directories by comparing `path.Base()` against the **full** repo paths returned by `GetRepositories()`. For a nested-namespace repo such as `org/team`, the walk hit `$root/org`, found nothing matching the single component `"org"` in `repos` (which holds full paths like `"org/team"`), and returned `ErrSkipDir` — so the **entire nested repo subtree was invisible** to the dedupe rebuild/restore walk.

The dedupe walk is the only consumer of this function (`DedupeTaskGenerator.Next` → `common.go:1029`), and it runs at startup (`controller.go:567` / `:591`) for both the `dedupe=true` rebuild and the `dedupe=false` restore scans.

## Impact

- **`storage.dedupe=true`**: duplicate blobs already sitting in nested repos before dedupe was enabled were never hardlinked (local) / placeholder-linked (S3). The startup scan logs `"dedupe finished successfully"` while doing zero work for nested repos — silent partial failure of the dedupe feature.
- **`storage.dedupe` toggled off**: the restore scan skipped nested repos' zero-size S3 placeholders, yet `OnRunComplete` still wrote the `DedupeRestoreCompleteMarker`. Subsequent startups read the marker and skip the restore scan entirely — the skip becomes permanent. With the cache record gone (cache.db removed/rebuilt, redis flushed, dedupe=false so no cache driver), pulls of those nested-repo blobs return empty content.

Single-level repos (`repo1`) are unaffected: `path.Base("$root/repo1") == "repo1"` matched the repo entry, so they continued descending. This is also why every existing test passed.

## Root cause

Directory decision used a single path component against full repo paths:

```go
baseName := path.Base(fileInfo.Path())
if slices.Contains(repos, baseName) || baseName == ispec.ImageBlobsDir {
    return nil
}
candidateAlgorithm := godigest.Algorithm(baseName)
if !candidateAlgorithm.Available() {
    return driver.ErrSkipDir   // ← prunes nested repos at the first prefix segment
}
```

## Fix

Decide whether to descend using the **full relative path** of the directory: descend iff it is a repo itself, an ancestor of a repo, or inside a repo:

```go
rel, relErr := filepath.Rel(is.rootDir, fileInfo.Path())
// ...
for _, r := range repos {
    if rel == r || strings.HasPrefix(r, rel+"/") || strings.HasPrefix(rel, r+"/") {
        descend = true
        break
    }
}
if !descend {
    return driver.ErrSkipDir
}
```

The file-level structural check (`parent == algorithm dir, grandparent == blobs`, lines 2230+) is unchanged — directory pruning is only an optimization, and that check already correctly filters non-blob files. No behavior change for single-level repos (`rel == repo1` hits the first branch).

## Verification

- The local driver `Walk` (pkg/storage/local/driver.go:190-230) honors `ErrSkipDir` only by not recursing into the directory, so the fix directly applies.
- Distribution's `s3-aws` driver `doWalk` presents inferred intermediate directories to the callback and skips their subtree on `ErrSkipDir` via `prevSkipDir`; behavior is identical after the fix.
- Added a local-storage regression test (`TestGetNextDigestWithBlobPathsNestedRepo`) that creates one single-level repo and one nested repo (`org/team`) sharing the same blob, then asserts `GetNextDigestWithBlobPaths` discovers **both** copies.

### Test run (Go 1.26, real local driver)

- **With this fix applied** — `TestGetNextDigestWithBlobPathsNestedRepo`: **PASS** (20/20 assertions), `len(duplicateBlobs) == 2`.
- **With the buggy code restored** (only the `imagestore.go` change reverted, the new test kept) — same test: **FAIL**, `Expected: 2, Actual: 1`. The nested copy at `org/team/blobs/sha256/<d>` was never visited because `$root/org` returned `ErrSkipDir` — exactly the bug.
- Existing dedupe paths: `TestDedupe`, `TestGetNextDigestWithBlobPathsPathNotFound`, and the full `pkg/storage/imagestore` + `pkg/storage/common` test packages: **PASS**, no regression from this change.
- `TestGarbageCollectForImageStore` fails in this sandbox on **both** this branch and `main` — cause is a missing test-data asset (`test/data/alpine/blobs/sha256/f56be85...`, not tracked by git) unrelated to this change.

Existing dedupe tests cover the feature with mock `WalkFn` (s3_test.go, e.g. calling with `[]string{"path/to"}` — note the authors intended nested names to work) or with single-level repo names (controller_test.go, local_test.go end-to-end), which is why this regression was not caught.