### PR TITLE
test: prefer Port "0" and TLS-aware StartAndWait to cut bind flakes

### DIFF
--- a/pkg/api/authn_test.go
+++ b/pkg/api/authn_test.go
@@ -2516,9 +2516,8 @@ func TestCookieSecureFlag(t *testing.T) {
 			ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait()
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
-			baseURL := test.GetSecureBaseURL(port)
 
 			// Load CA certificate for proper TLS verification
 			caCert, err := os.ReadFile(caCertPath)

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -140,6 +140,13 @@ func (c *Controller) GetPort() int {
 	return int(c.chosenPort.Load())
 }
 
+// TLSEnabled reports whether the controller is configured to serve HTTPS (ServeTLS).
+func (c *Controller) TLSEnabled() bool {
+	tlsConfig := c.Config.CopyTLSConfig()
+
+	return tlsConfig != nil && tlsConfig.Key != "" && tlsConfig.Cert != ""
+}
+
 func (c *Controller) Run() error {
 	if err := c.initCookieStore(); err != nil {
 		return err

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -553,16 +553,19 @@ func TestCreateMetaDBDriver(t *testing.T) {
 
 func TestRunAlreadyRunningServer(t *testing.T) {
 	Convey("Run server on unavailable port", t, func() {
-		port := test.GetFreePort()
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		ctlr := makeController(conf, t.TempDir())
-		cm := test.NewControllerManager(ctlr)
+		ctlrManager := test.NewControllerManager(ctlr)
 
-		cm.StartAndWait(port)
+		ctlrManager.StartAndWait()
 
-		defer cm.StopServer()
+		defer ctlrManager.StopServer()
+
+		// Config stays "0" after bind; pin it so a second Run() hits EADDRINUSE
+		// instead of another ephemeral listen that would block in Serve.
+		conf.HTTP.Port = strconv.Itoa(ctlrManager.Port())
 
 		err := ctlr.Init()
 		So(err, ShouldNotBeNil)
@@ -1224,7 +1227,7 @@ func TestScaleOutRequestProxy(t *testing.T) {
 
 		ctrlr := makeController(conf, t.TempDir())
 		cm := test.NewControllerManager(ctrlr)
-		cm.StartAndWait(port)
+		cm.StartAndWait()
 
 		defer cm.StopServer()
 
@@ -1281,7 +1284,7 @@ func TestScaleOutRequestProxy(t *testing.T) {
 		ctrlr := makeController(conf, t.TempDir())
 
 		cm := test.NewControllerManager(ctrlr)
-		cm.StartAndWait(port)
+		cm.StartAndWait()
 
 		defer cm.StopServer()
 
@@ -1331,7 +1334,7 @@ func TestScaleOutRequestProxy(t *testing.T) {
 
 			ctrlr := makeController(conf, t.TempDir())
 			cm := test.NewControllerManager(ctrlr)
-			cm.StartAndWait(port)
+			cm.StartAndWait()
 
 			defer func(cm test.ControllerManager) {
 				cm.StopServer()
@@ -1427,7 +1430,7 @@ func TestScaleOutRequestProxy(t *testing.T) {
 
 			ctrlr := makeController(conf, t.TempDir())
 			cm := test.NewControllerManager(ctrlr)
-			cm.StartAndWait(port)
+			cm.StartAndWait()
 
 			defer func(cm test.ControllerManager) {
 				cm.StopServer()
@@ -1508,7 +1511,7 @@ func TestScaleOutRequestProxy(t *testing.T) {
 
 			ctrlr := makeController(conf, t.TempDir())
 			cm := test.NewControllerManager(ctrlr)
-			cm.StartAndWait(port)
+			cm.StartAndWait()
 
 			defer func(cm test.ControllerManager) {
 				cm.StopServer()
@@ -1574,7 +1577,7 @@ func TestScaleOutRequestProxy(t *testing.T) {
 			ctrlr := makeController(conf, t.TempDir())
 
 			cm := test.NewControllerManager(ctrlr)
-			cm.StartAndWait(port)
+			cm.StartAndWait()
 
 			defer func(cm test.ControllerManager) {
 				cm.StopServer()
@@ -1640,7 +1643,7 @@ func TestScaleOutRequestProxy(t *testing.T) {
 			ctrlr := makeController(conf, t.TempDir())
 
 			cm := test.NewControllerManager(ctrlr)
-			cm.StartAndWait(port)
+			cm.StartAndWait()
 
 			defer func(cm test.ControllerManager) {
 				cm.StopServer()
@@ -2118,8 +2121,8 @@ func TestTLSWithBasicAuth(t *testing.T) {
 		ctlr.Log.Info().Int64("seedUser", seedUser).Int64("seedPass", seedPass).Msg("random seed for username & password")
 
 		cm := test.NewControllerManager(ctlr)
-		baseURL := cm.StartAndWait()
-		secureBaseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
+		secureBaseURL := cm.StartAndWait()
+		baseURL := test.GetBaseURL(strconv.Itoa(cm.Port()))
 
 		defer cm.StopServer()
 
@@ -2192,8 +2195,8 @@ func TestTLSWithBasicAuthAllowReadAccess(t *testing.T) {
 		ctlr.Log.Info().Int64("seedUser", seedUser).Int64("seedPass", seedPass).Msg("random seed for username & password")
 
 		cm := test.NewControllerManager(ctlr)
-		baseURL := cm.StartAndWait()
-		secureBaseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
+		secureBaseURL := cm.StartAndWait()
+		baseURL := test.GetBaseURL(strconv.Itoa(cm.Port()))
 
 		defer cm.StopServer()
 
@@ -2425,23 +2428,42 @@ func newTestLDAPServer() *testLDAPServer {
 	return ldaps
 }
 
-func (l *testLDAPServer) Start(port int) {
+func (l *testLDAPServer) Start() int {
+	lc := net.ListenConfig{}
+
+	listener, err := lc.Listen(context.Background(), "tcp", net.JoinHostPort(LDAPAddress, "0"))
+	if err != nil {
+		panic(err)
+	}
+
+	tcpAddr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		_ = listener.Close()
+
+		panic("ldap test server: unexpected listener addr type")
+	}
+
+	port := tcpAddr.Port
 	addr := net.JoinHostPort(LDAPAddress, strconv.Itoa(port))
 
 	go func() {
-		if err := l.server.ListenAndServe(addr); err != nil {
+		if err := l.server.Serve(listener); err != nil {
 			panic(err)
 		}
 	}()
 
 	for {
-		_, err := net.Dial("tcp", addr) //nolint: noctx
+		conn, err := net.Dial("tcp", addr) //nolint: noctx
 		if err == nil {
+			_ = conn.Close()
+
 			break
 		}
 
 		time.Sleep(10 * time.Millisecond)
 	}
+
+	return port
 }
 
 func (l *testLDAPServer) Stop() {
@@ -2518,9 +2540,7 @@ func (l *testLDAPServer) Search(boundDN string, req vldap.SearchRequest,
 func TestBasicAuthWithLDAP(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		ldapServer := newTestLDAPServer()
-		ldapPort, err := strconv.Atoi(test.GetFreePort())
-		So(err, ShouldBeNil)
-		ldapServer.Start(ldapPort)
+		ldapPort := ldapServer.Start()
 
 		defer ldapServer.Stop()
 
@@ -2572,9 +2592,7 @@ func TestBasicAuthWithLDAP(t *testing.T) {
 func TestBasicAuthWithReloadedCredentials(t *testing.T) {
 	Convey("Start server with bad credentials", t, func() {
 		l := newTestLDAPServer()
-		ldapPort, err := strconv.Atoi(test.GetFreePort())
-		So(err, ShouldBeNil)
-		l.Start(ldapPort)
+		ldapPort := l.Start()
 
 		defer l.Stop()
 
@@ -2582,7 +2600,7 @@ func TestBasicAuthWithReloadedCredentials(t *testing.T) {
 		ldapConfigContent := fmt.Sprintf(`{"BindDN": "%s", "BindPassword": "%s"}`, LDAPBindDN, LDAPBindPassword)
 		ldapConfigPath := filepath.Join(tempDir, "ldap.json")
 
-		err = os.WriteFile(ldapConfigPath, []byte(ldapConfigContent), 0o600)
+		err := os.WriteFile(ldapConfigPath, []byte(ldapConfigContent), 0o600)
 		So(err, ShouldBeNil)
 
 		configTemplate := `
@@ -2750,9 +2768,7 @@ func TestBasicAuthWithReloadedCredentials(t *testing.T) {
 func TestLDAPWithoutCreds(t *testing.T) {
 	Convey("Make a new LDAP server", t, func() {
 		ldapServer := newTestLDAPServer()
-		ldapPort, err := strconv.Atoi(test.GetFreePort())
-		So(err, ShouldBeNil)
-		ldapServer.Start(ldapPort)
+		ldapPort := ldapServer.Start()
 
 		defer ldapServer.Stop()
 
@@ -2828,15 +2844,12 @@ func TestLDAPWithoutCreds(t *testing.T) {
 func TestBasicAuthWithLDAPFromFile(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		ldapServer := newTestLDAPServer()
-		ldapPort, err := strconv.Atoi(test.GetFreePort())
-		So(err, ShouldBeNil)
-		ldapServer.Start(ldapPort)
+		ldapPort := ldapServer.Start()
 
 		defer ldapServer.Stop()
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		tempDir := t.TempDir()
+		logPath := test.MakeTempFilePath(t, "zot-ldap-from-file-log.txt")
 
 		ldapConfigContent := fmt.Sprintf(`
 		{
@@ -2846,7 +2859,7 @@ func TestBasicAuthWithLDAPFromFile(t *testing.T) {
 
 		ldapConfigPath := filepath.Join(tempDir, "ldap.json")
 
-		err = os.WriteFile(ldapConfigPath, []byte(ldapConfigContent), 0o600)
+		err := os.WriteFile(ldapConfigPath, []byte(ldapConfigContent), 0o600)
 		So(err, ShouldBeNil)
 
 		configStr := fmt.Sprintf(`
@@ -2856,7 +2869,7 @@ func TestBasicAuthWithLDAPFromFile(t *testing.T) {
 			},
 			"HTTP": {
 				"Address": "%s",
-				"Port": "%s",
+				"Port": "0",
 				"Auth": {
 					"LDAP": {
 						"CredentialsFile":     "%s",
@@ -2868,8 +2881,12 @@ func TestBasicAuthWithLDAPFromFile(t *testing.T) {
 						"Port":               %v
 					}
 				}
+			},
+			"Log": {
+				"Level": "debug",
+				"Output": "%s"
 			}
-		}`, tempDir, "127.0.0.1", port, ldapConfigPath, LDAPBaseDN, LDAPAddress, ldapPort)
+		}`, tempDir, "127.0.0.1", ldapConfigPath, LDAPBaseDN, LDAPAddress, ldapPort, logPath)
 
 		configPath := filepath.Join(tempDir, "config.json")
 
@@ -2886,6 +2903,7 @@ func TestBasicAuthWithLDAPFromFile(t *testing.T) {
 			}
 		}()
 
+		baseURL := test.WaitForKernelChosenPortBaseURL(logPath)
 		test.WaitTillServerReady(baseURL)
 
 		// without creds, should get access error
@@ -3038,9 +3056,7 @@ func TestLDAPConfigErrors(t *testing.T) {
 func TestGroupsPermissionsForLDAP(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		ldapServer := newTestLDAPServer()
-		ldapPort, err := strconv.Atoi(test.GetFreePort())
-		So(err, ShouldBeNil)
-		ldapServer.Start(ldapPort)
+		ldapPort := ldapServer.Start()
 
 		defer ldapServer.Stop()
 
@@ -3093,7 +3109,7 @@ func TestGroupsPermissionsForLDAP(t *testing.T) {
 
 		img := CreateDefaultImage()
 
-		err = UploadImageWithBasicAuth(
+		err := UploadImageWithBasicAuth(
 			img, baseURL, repoName, img.DigestStr(),
 			username, password)
 		So(err, ShouldBeNil)
@@ -3103,15 +3119,12 @@ func TestGroupsPermissionsForLDAP(t *testing.T) {
 func TestLDAPConfigFromFile(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		ldapServer := newTestLDAPServer()
-		ldapPort, err := strconv.Atoi(test.GetFreePort())
-		So(err, ShouldBeNil)
-		ldapServer.Start(ldapPort)
+		ldapPort := ldapServer.Start()
 
 		defer ldapServer.Stop()
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		tempDir := t.TempDir()
+		logPath := test.MakeTempFilePath(t, "zot-ldap-config-from-file-log.txt")
 
 		ldapConfigContent := fmt.Sprintf(`
 		{
@@ -3121,7 +3134,7 @@ func TestLDAPConfigFromFile(t *testing.T) {
 
 		ldapConfigPath := filepath.Join(tempDir, "ldap.json")
 
-		err = os.WriteFile(ldapConfigPath, []byte(ldapConfigContent), 0o600)
+		err := os.WriteFile(ldapConfigPath, []byte(ldapConfigContent), 0o600)
 		So(err, ShouldBeNil)
 
 		configStr := fmt.Sprintf(`
@@ -3131,7 +3144,7 @@ func TestLDAPConfigFromFile(t *testing.T) {
 			},
 			"HTTP": {
 				"Address": "%s",
-				"Port": "%s",
+				"Port": "0",
 				"Auth": {
 					"LDAP": {
 						"CredentialsFile": "%s",
@@ -3168,8 +3181,12 @@ func TestLDAPConfigFromFile(t *testing.T) {
 						}
 					}
 				}
+			},
+			"Log": {
+				"Level": "debug",
+				"Output": "%s"
 			}
-		}`, tempDir, "127.0.0.1", port, ldapConfigPath, LDAPBaseDN, LDAPAddress, ldapPort)
+		}`, tempDir, "127.0.0.1", ldapConfigPath, LDAPBaseDN, LDAPAddress, ldapPort, logPath)
 
 		configPath := filepath.Join(tempDir, "config.json")
 
@@ -3186,6 +3203,7 @@ func TestLDAPConfigFromFile(t *testing.T) {
 			}
 		}()
 
+		baseURL := test.WaitForKernelChosenPortBaseURL(logPath)
 		test.WaitTillServerReady(baseURL)
 
 		repo := "test-ldap"
@@ -3199,9 +3217,7 @@ func TestLDAPConfigFromFile(t *testing.T) {
 func TestLDAPFailures(t *testing.T) {
 	Convey("Make a LDAP conn", t, func() {
 		ldapServer := newTestLDAPServer()
-		ldapPort, err := strconv.Atoi(test.GetFreePort())
-		So(err, ShouldBeNil)
-		ldapServer.Start(ldapPort)
+		ldapPort := ldapServer.Start()
 
 		defer ldapServer.Stop()
 
@@ -3237,9 +3253,7 @@ func TestLDAPFailures(t *testing.T) {
 func TestLDAPClient(t *testing.T) {
 	Convey("LDAP Client", t, func() {
 		ldapServer := newTestLDAPServer()
-		ldapPort, err := strconv.Atoi(test.GetFreePort())
-		So(err, ShouldBeNil)
-		ldapServer.Start(ldapPort)
+		ldapPort := ldapServer.Start()
 
 		defer ldapServer.Stop()
 
@@ -3253,7 +3267,7 @@ func TestLDAPClient(t *testing.T) {
 			Log:          log.NewTestLogger(),
 		}
 
-		_, _, _, err = lClient.Authenticate("bad-user", "bad-pass")
+		_, _, _, err := lClient.Authenticate("bad-user", "bad-pass")
 		So(err, ShouldNotBeNil)
 
 		// bad credentials with anonymous authentication
@@ -3943,14 +3957,7 @@ func TestOpenIDMiddleware(t *testing.T) {
 	htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
 
 	ldapServer := newTestLDAPServer()
-	port = test.GetFreePort()
-
-	ldapPort, err := strconv.Atoi(port)
-	if err != nil {
-		panic(err)
-	}
-
-	ldapServer.Start(ldapPort)
+	ldapPort := ldapServer.Start()
 	defer ldapServer.Stop()
 
 	mockOIDCServer, err := authutils.MockOIDCRun()
@@ -4030,10 +4037,9 @@ func TestOpenIDMiddleware(t *testing.T) {
 				ctlr.Config.HTTP.Address = testcase.address
 				cm := test.NewControllerManager(ctlr)
 
-				cm.StartServer()
+				cm.StartAndWait()
 
 				defer cm.StopServer()
-				test.WaitTillServerReady(baseURL)
 
 				Convey("browser client requests", func() {
 					Convey("login with no provider supplied", func() {
@@ -4401,14 +4407,7 @@ func TestOpenIDMiddlewareWithRedisSessionDriver(t *testing.T) {
 	htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
 
 	ldapServer := newTestLDAPServer()
-	port = test.GetFreePort()
-
-	ldapPort, err := strconv.Atoi(port)
-	if err != nil {
-		panic(err)
-	}
-
-	ldapServer.Start(ldapPort)
+	ldapPort := ldapServer.Start()
 	defer ldapServer.Stop()
 
 	mockOIDCServer, err := authutils.MockOIDCRun()
@@ -4493,10 +4492,9 @@ func TestOpenIDMiddlewareWithRedisSessionDriver(t *testing.T) {
 
 				cm := test.NewControllerManager(ctlr)
 
-				cm.StartServer()
+				cm.StartAndWait()
 
 				defer cm.StopServer()
-				test.WaitTillServerReady(baseURL)
 
 				Convey("browser client requests", func() {
 					Convey("login with no provider supplied", func() {
@@ -4820,11 +4818,8 @@ func TestOpenIDMiddlewareWithRedisSessionDriver(t *testing.T) {
 
 func TestIsOpenIDEnabled(t *testing.T) {
 	Convey("make oidc server", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
-
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		mockOIDCServer, err := authutils.MockOIDCRun()
 		if err != nil {
@@ -4862,10 +4857,8 @@ func TestIsOpenIDEnabled(t *testing.T) {
 
 			cm := test.NewControllerManager(ctlr)
 
-			cm.StartServer()
-
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
-			test.WaitTillServerReady(baseURL)
 
 			resp, err := resty.R().
 				Get(baseURL + "/v2/")
@@ -4896,10 +4889,8 @@ func TestIsOpenIDEnabled(t *testing.T) {
 
 			cm := test.NewControllerManager(ctlr)
 
-			cm.StartServer()
-
+			baseURL := cm.StartAndWait()
 			defer cm.StopServer()
-			test.WaitTillServerReady(baseURL)
 
 			// it will work because we have an invalid provider, and no other authn enabled, so no authn enabled
 			// normally an invalid provider will exit with error in cli validations
@@ -4929,12 +4920,7 @@ func TestAuthnSessionErrors(t *testing.T) {
 		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(htpasswdUsername, htpasswdPassword))
 
 		ldapServer := newTestLDAPServer()
-		ldapPort, err := strconv.Atoi(test.GetFreePort())
-		if err != nil {
-			panic(err)
-		}
-
-		ldapServer.Start(ldapPort)
+		ldapPort := ldapServer.Start()
 		defer ldapServer.Stop()
 
 		mockOIDCServer, err := authutils.MockOIDCRun()
@@ -4996,10 +4982,9 @@ func TestAuthnSessionErrors(t *testing.T) {
 
 		cm := test.NewControllerManager(ctlr)
 
-		cm.StartServer()
+		cm.StartAndWait()
 
 		defer cm.StopServer()
-		test.WaitTillServerReady(baseURL)
 
 		Convey("trigger basic authn middle(htpasswd) error", func() {
 			client := resty.New()

--- a/pkg/api/mtls_test.go
+++ b/pkg/api/mtls_test.go
@@ -176,9 +176,8 @@ func runMTLSTest(t *testing.T, testCase mTLSTestCase) {
 	ctlr := api.NewController(conf)
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartAndWait()
+	baseURL := cm.StartAndWait()
 	defer cm.StopServer()
-	baseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
 
 	// Set up client
 	caCertPEM, err := os.ReadFile(caCertPath)
@@ -655,9 +654,8 @@ func TestMTLSAuthentication(t *testing.T) {
 		ctlr := api.NewController(conf)
 		cm := test.NewControllerManager(ctlr)
 
-		cm.StartAndWait()
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
-		baseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
 
 		// Test without client certificate - should fail
 		caCertPEM, err := os.ReadFile(caCertPath)
@@ -759,9 +757,8 @@ func TestMTLSAuthentication(t *testing.T) {
 		ctlr := api.NewController(conf)
 		cm := test.NewControllerManager(ctlr)
 
-		cm.StartAndWait()
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
-		baseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
 
 		// Load server CA certificate
 		caCertPEM, err := os.ReadFile(caCertPath)
@@ -911,9 +908,8 @@ func TestMTLSAuthenticationWithCertificateChain(t *testing.T) {
 		ctlr := api.NewController(conf)
 		cm := test.NewControllerManager(ctlr)
 
-		cm.StartAndWait()
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
-		baseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
 
 		caCertPool := x509.NewCertPool()
 		caCertPool.AppendCertsFromPEM(rootCACert)
@@ -1039,9 +1035,8 @@ func TestMTLSAuthenticationWithExpiredCertificate(t *testing.T) {
 		ctlr := api.NewController(conf)
 		cm := test.NewControllerManager(ctlr)
 
-		cm.StartAndWait()
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
-		baseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
 
 		// Set up client with expired certificate
 		caCertPEM, err := os.ReadFile(caCertPath)
@@ -1131,9 +1126,8 @@ func TestMTLSAuthenticationWithUnknownCA(t *testing.T) {
 		ctlr := api.NewController(conf)
 		cm := test.NewControllerManager(ctlr)
 
-		cm.StartAndWait()
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
-		baseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
 
 		// Set up client with certificate signed by unknown CA
 		serverCACertPEM, err := os.ReadFile(serverCACertPath)
@@ -1225,9 +1219,8 @@ func TestMTLSAuthenticationWithMetaDBError(t *testing.T) {
 		ctlr := api.NewController(conf)
 		cm := test.NewControllerManager(ctlr)
 
-		cm.StartAndWait()
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
-		baseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
 
 		// Set up client with valid certificate
 		caCertPEM, err := os.ReadFile(caCertPath)
@@ -1297,8 +1290,8 @@ func TestMutualTLSAuthWithUserPermissions(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		cm := test.NewControllerManager(ctlr)
-		baseURL := cm.StartAndWait()
-		secureBaseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
+		secureBaseURL := cm.StartAndWait()
+		baseURL := test.GetBaseURL(strconv.Itoa(cm.Port()))
 
 		defer cm.StopServer()
 
@@ -1375,8 +1368,8 @@ func TestTLSMutualAuth(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		cm := test.NewControllerManager(ctlr)
-		baseURL := cm.StartAndWait()
-		secureBaseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
+		secureBaseURL := cm.StartAndWait()
+		baseURL := test.GetBaseURL(strconv.Itoa(cm.Port()))
 
 		defer cm.StopServer()
 
@@ -1488,8 +1481,8 @@ func TestTLSMutualAuthAllowReadAccess(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		cm := test.NewControllerManager(ctlr)
-		baseURL := cm.StartAndWait()
-		secureBaseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
+		secureBaseURL := cm.StartAndWait()
+		baseURL := test.GetBaseURL(strconv.Itoa(cm.Port()))
 
 		defer cm.StopServer()
 
@@ -1588,8 +1581,8 @@ func TestTLSMutualAndBasicAuth(t *testing.T) {
 		ctlr.Log.Info().Int64("seedUser", seedUser).Int64("seedPass", seedPass).Msg("random seed for username & password")
 
 		cm := test.NewControllerManager(ctlr)
-		baseURL := cm.StartAndWait()
-		secureBaseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
+		secureBaseURL := cm.StartAndWait()
+		baseURL := test.GetBaseURL(strconv.Itoa(cm.Port()))
 
 		defer cm.StopServer()
 
@@ -1681,8 +1674,8 @@ func TestTLSMutualAndBasicAuthAllowReadAccess(t *testing.T) {
 		ctlr.Log.Info().Int64("seedUser", seedUser).Int64("seedPass", seedPass).Msg("random seed for username & password")
 
 		cm := test.NewControllerManager(ctlr)
-		baseURL := cm.StartAndWait()
-		secureBaseURL := test.GetSecureBaseURL(strconv.Itoa(cm.Port()))
+		secureBaseURL := cm.StartAndWait()
+		baseURL := test.GetBaseURL(strconv.Itoa(cm.Port()))
 
 		defer cm.StopServer()
 

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -97,10 +97,9 @@ func TestRoutes(t *testing.T) {
 		ctlr.Config.Storage.Commit = true
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
-		baseURL := test.GetBaseURL(strconv.Itoa(ctlr.GetPort()))
 		rthdlr := api.NewRouteHandler(ctlr)
 
 		// NOTE: the url or method itself doesn't matter below since we are calling the handlers directly,

--- a/pkg/cli/client/client_test.go
+++ b/pkg/cli/client/client_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -25,16 +26,32 @@ import (
 	tlsutils "zotregistry.dev/zot/v2/pkg/test/tls"
 )
 
-const (
-	BaseSecureURL1 = "https://127.0.0.1:8088"
-	HOST1          = "127.0.0.1:8088"
-	SecurePort1    = "8088"
-	BaseSecureURL2 = "https://127.0.0.1:8089"
-	SecurePort2    = "8089"
-	BaseSecureURL3 = "https://127.0.0.1:8090"
-	SecurePort3    = "8090"
-	certsDir1      = ".config/containers/certs.d/127.0.0.1:8088"
-)
+func homeCertsDir(hostPort string) string {
+	return filepath.Join(".config", "containers", "certs.d", hostPort)
+}
+
+func writeHomeClientCerts(t *testing.T, home, hostPort string, caCertPEM, caKeyPEM []byte) {
+	t.Helper()
+
+	destCertsDir := filepath.Join(home, homeCertsDir(hostPort))
+	//nolint:gosec // test path is tempdir-scoped via HOME override
+	err := os.MkdirAll(destCertsDir, 0o755)
+	So(err, ShouldBeNil)
+
+	//nolint:gosec // test path is tempdir-scoped via HOME override
+	err = os.WriteFile(filepath.Join(destCertsDir, "ca.crt"), caCertPEM, 0o600)
+	So(err, ShouldBeNil)
+
+	clientCertPath := filepath.Join(destCertsDir, "client.cert")
+	clientKeyPath := filepath.Join(destCertsDir, "client.key")
+	clientOpts := &tlsutils.CertificateOptions{
+		CommonName:         "testclient",
+		OrganizationalUnit: "TestClient",
+		NotAfter:           time.Now().AddDate(10, 0, 0),
+	}
+	err = tlsutils.GenerateClientCertToFile(caCertPEM, caKeyPEM, clientCertPath, clientKeyPath, clientOpts)
+	So(err, ShouldBeNil)
+}
 
 func TestTLSWithAuth(t *testing.T) {
 	Convey("Make a new controller", t, func() {
@@ -73,7 +90,7 @@ func TestTLSWithAuth(t *testing.T) {
 		defer func() { resty.SetTLSClientConfig(nil) }()
 
 		conf := config.New()
-		conf.HTTP.Port = SecurePort1
+		conf.HTTP.Port = "0"
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 
@@ -101,38 +118,17 @@ func TestTLSWithAuth(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
+		hostPort := "127.0.0.1:" + strconv.Itoa(cm.Port())
+
 		Convey("Test with htpassw auth", func() {
-			t.Setenv("HOME", t.TempDir())
-
 			// Client certs are resolved under $HOME; isolate from the real home directory.
-			home := os.Getenv("HOME")
-			destCertsDir := filepath.Join(home, certsDir1)
-			//nolint:gosec // test path is tempdir-scoped via HOME override
-			err := os.MkdirAll(destCertsDir, 0o755)
-			So(err, ShouldBeNil)
+			t.Setenv("HOME", t.TempDir())
+			writeHomeClientCerts(t, os.Getenv("HOME"), hostPort, caCertPEM, caKeyPEM)
 
-			// Write CA certificate to client certs directory (needed for server verification)
-			//nolint:gosec // test path is tempdir-scoped via HOME override
-			err = os.WriteFile(filepath.Join(destCertsDir, "ca.crt"), caCertPEM, 0o600)
-			So(err, ShouldBeNil)
-
-			// Generate and write client certificate and key (needed for mTLS client authentication)
-			clientCertPath := filepath.Join(destCertsDir, "client.cert")
-			clientKeyPath := filepath.Join(destCertsDir, "client.key")
-			clientOpts := &tlsutils.CertificateOptions{
-				CommonName:         "testclient",
-				OrganizationalUnit: "TestClient",
-				NotAfter:           time.Now().AddDate(10, 0, 0),
-			}
-			err = tlsutils.GenerateClientCertToFile(caCertPEM, caKeyPEM, clientCertPath, clientKeyPath, clientOpts)
-			So(err, ShouldBeNil)
-
-			defer os.RemoveAll(destCertsDir)
-
-			args := []string{"name", "dummyImageName", "--url", HOST1}
+			args := []string{"name", "dummyImageName", "--url", hostPort}
 			imageCmd := client.NewImageCommand(client.NewSearchService())
 			imageBuff := bytes.NewBufferString("")
 			imageCmd.SetOut(imageBuff)
@@ -147,28 +143,10 @@ func TestTLSWithAuth(t *testing.T) {
 
 			_ = makeConfigFile(t,
 				fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s%s%s","showspinner":false}]}`,
-					BaseSecureURL1, constants.RoutePrefix, constants.ExtCatalogPrefix))
+					baseURL, constants.RoutePrefix, constants.ExtCatalogPrefix))
 
 			// Ensure certificates are in the HOME directory that makeConfigFile set
-			home = os.Getenv("HOME")
-			destCertsDir = filepath.Join(home, certsDir1)
-			//nolint:gosec // test path is tempdir-scoped via HOME override
-			err = os.MkdirAll(destCertsDir, 0o755)
-			So(err, ShouldBeNil)
-
-			// Write CA certificate to client certs directory (needed for server verification)
-			//nolint:gosec // test path is tempdir-scoped via HOME override
-			err = os.WriteFile(filepath.Join(destCertsDir, "ca.crt"), caCertPEM, 0o600)
-			So(err, ShouldBeNil)
-
-			// Generate and write client certificate and key (needed for mTLS client authentication)
-			clientCertPath = filepath.Join(destCertsDir, "client.cert")
-			clientKeyPath = filepath.Join(destCertsDir, "client.key")
-			clientOpts = &tlsutils.CertificateOptions{
-				CommonName: "testclient",
-			}
-			err = tlsutils.GenerateClientCertToFile(caCertPEM, caKeyPEM, clientCertPath, clientKeyPath, clientOpts)
-			So(err, ShouldBeNil)
+			writeHomeClientCerts(t, os.Getenv("HOME"), hostPort, caCertPEM, caKeyPEM)
 
 			imageCmd = client.NewImageCommand(client.NewSearchService())
 			imageBuff = bytes.NewBufferString("")
@@ -184,7 +162,9 @@ func TestTLSWithAuth(t *testing.T) {
 
 			_ = makeConfigFile(t,
 				fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s%s%s","showspinner":false}]}`,
-					BaseSecureURL1, constants.RoutePrefix, constants.ExtCatalogPrefix))
+					baseURL, constants.RoutePrefix, constants.ExtCatalogPrefix))
+
+			writeHomeClientCerts(t, os.Getenv("HOME"), hostPort, caCertPEM, caKeyPEM)
 
 			imageCmd = client.NewImageCommand(client.NewSearchService())
 			imageBuff = bytes.NewBufferString("")
@@ -234,7 +214,7 @@ func TestTLSWithoutAuth(t *testing.T) {
 		defer func() { resty.SetTLSClientConfig(nil) }()
 
 		conf := config.New()
-		conf.HTTP.Port = SecurePort1
+		conf.HTTP.Port = "0"
 		conf.HTTP.TLS = &config.TLSConfig{
 			Cert:   serverCertPath,
 			Key:    serverKeyPath,
@@ -250,38 +230,17 @@ func TestTLSWithoutAuth(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
+
+		hostPort := "127.0.0.1:" + strconv.Itoa(cm.Port())
 
 		Convey("Certs in user's home", func() {
 			_ = makeConfigFile(t,
 				fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s%s%s","showspinner":false}]}`,
-					BaseSecureURL1, constants.RoutePrefix, constants.ExtCatalogPrefix))
+					baseURL, constants.RoutePrefix, constants.ExtCatalogPrefix))
 
-			home := os.Getenv("HOME")
-			destCertsDir := filepath.Join(home, certsDir1)
-
-			//nolint:gosec // test path is tempdir-scoped via HOME override
-			err := os.MkdirAll(destCertsDir, 0o755)
-			So(err, ShouldBeNil)
-
-			// Write CA certificate to client certs directory (needed for server verification)
-			//nolint:gosec // test path is tempdir-scoped via HOME override
-			err = os.WriteFile(filepath.Join(destCertsDir, "ca.crt"), caCertPEM, 0o600)
-			So(err, ShouldBeNil)
-
-			// Generate and write client certificate and key (needed for mTLS client authentication)
-			clientCertPath := filepath.Join(destCertsDir, "client.cert")
-			clientKeyPath := filepath.Join(destCertsDir, "client.key")
-			clientOpts := &tlsutils.CertificateOptions{
-				CommonName:         "testclient",
-				OrganizationalUnit: "TestClient",
-				NotAfter:           time.Now().AddDate(10, 0, 0),
-			}
-			err = tlsutils.GenerateClientCertToFile(caCertPEM, caKeyPEM, clientCertPath, clientKeyPath, clientOpts)
-			So(err, ShouldBeNil)
-
-			defer os.RemoveAll(destCertsDir)
+			writeHomeClientCerts(t, os.Getenv("HOME"), hostPort, caCertPEM, caKeyPEM)
 
 			args := []string{"list", "--config", "imagetest"}
 			imageCmd := client.NewImageCommand(client.NewSearchService())
@@ -339,7 +298,7 @@ func TestTLSBadCerts(t *testing.T) {
 		defer func() { resty.SetTLSClientConfig(nil) }()
 
 		conf := config.New()
-		conf.HTTP.Port = SecurePort3
+		conf.HTTP.Port = "0"
 		conf.HTTP.TLS = &config.TLSConfig{
 			Cert:   serverCertPath,
 			Key:    serverKeyPath,
@@ -350,13 +309,13 @@ func TestTLSBadCerts(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 
 		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		Convey("Test with system certs", func() {
 			_ = makeConfigFile(t,
 				fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s%s%s","showspinner":false}]}`,
-					BaseSecureURL3, constants.RoutePrefix, constants.ExtCatalogPrefix))
+					baseURL, constants.RoutePrefix, constants.ExtCatalogPrefix))
 
 			args := []string{"list", "--config", "imagetest"}
 			imageCmd := client.NewImageCommand(client.NewSearchService())

--- a/pkg/cli/client/cve_cmd_internal_test.go
+++ b/pkg/cli/client/cve_cmd_internal_test.go
@@ -23,10 +23,8 @@ import (
 )
 
 func TestSearchCVECmd(t *testing.T) {
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	rootDir := t.TempDir()
 	conf.Storage.RootDirectory = rootDir
 
@@ -40,7 +38,7 @@ func TestSearchCVECmd(t *testing.T) {
 	ctlr := api.NewController(conf)
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartAndWait(port)
+	baseURL := cm.StartAndWait()
 	defer cm.StopServer()
 
 	Convey("Test CVE help", t, func() {
@@ -479,10 +477,8 @@ func TestSearchCVECmd(t *testing.T) {
 }
 
 func TestCVECommandGQL(t *testing.T) {
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
@@ -495,7 +491,7 @@ func TestCVECommandGQL(t *testing.T) {
 	ctlr.Config.Storage.RootDirectory = t.TempDir()
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartAndWait(conf.HTTP.Port)
+	baseURL := cm.StartAndWait()
 	defer cm.StopServer()
 
 	Convey("commands without gql", t, func() {
@@ -654,10 +650,8 @@ func TestCVECommandGQL(t *testing.T) {
 }
 
 func TestCVECommandErrors(t *testing.T) {
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 
 	conf.Extensions = &extconf.ExtensionConfig{
 		Search: &extconf.SearchConfig{
@@ -669,7 +663,7 @@ func TestCVECommandErrors(t *testing.T) {
 	ctlr.Config.Storage.RootDirectory = t.TempDir()
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartAndWait(conf.HTTP.Port)
+	baseURL := cm.StartAndWait()
 	defer cm.StopServer()
 
 	Convey("commands without gql", t, func() {

--- a/pkg/cli/client/elevated_test.go
+++ b/pkg/cli/client/elevated_test.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -23,10 +24,6 @@ import (
 	"zotregistry.dev/zot/v2/pkg/cli/client"
 	test "zotregistry.dev/zot/v2/pkg/test/common"
 	tlsutils "zotregistry.dev/zot/v2/pkg/test/tls"
-)
-
-const (
-	privilegedCertsDir = "/etc/containers/certs.d/127.0.0.1:8089"
 )
 
 func TestElevatedPrivilegesTLSNewControllerPrivilegedCert(t *testing.T) {
@@ -69,6 +66,31 @@ func TestElevatedPrivilegesTLSNewControllerPrivilegedCert(t *testing.T) {
 		err = tlsutils.GenerateClientCertToFile(caCertPEM, caKeyPEM, clientCertPath, clientKeyPath, clientOpts)
 		So(err, ShouldBeNil)
 
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCertPEM)
+
+		resty.SetTLSClientConfig(&tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12})
+
+		defer func() { resty.SetTLSClientConfig(nil) }()
+
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		conf.HTTP.TLS = &config.TLSConfig{
+			Cert:   serverCertPath,
+			Key:    serverKeyPath,
+			CACert: caCertPath,
+		}
+
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+
+		defer cm.StopServer()
+
+		privilegedCertsDir := filepath.Join("/etc/containers/certs.d", "127.0.0.1:"+strconv.Itoa(cm.Port()))
+
 		//nolint: noctx // old code, no context available
 		cmd := exec.Command("mkdir", "-p", privilegedCertsDir+"/") //nolint: gosec
 
@@ -78,7 +100,9 @@ func TestElevatedPrivilegesTLSNewControllerPrivilegedCert(t *testing.T) {
 		}
 
 		//nolint: noctx // old code, no context available
-		defer exec.Command("rm", "-rf", privilegedCertsDir+"/")
+		defer func() {
+			_ = exec.Command("rm", "-rf", privilegedCertsDir+"/").Run() //nolint: gosec
+		}()
 
 		// Copy generated certificates to privileged location
 		//nolint: noctx // old code, no context available
@@ -121,33 +145,10 @@ func TestElevatedPrivilegesTLSNewControllerPrivilegedCert(t *testing.T) {
 			}
 		}
 
-		caCertPool := x509.NewCertPool()
-		caCertPool.AppendCertsFromPEM(caCertPEM)
-
-		resty.SetTLSClientConfig(&tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12})
-
-		defer func() { resty.SetTLSClientConfig(nil) }()
-
-		conf := config.New()
-		conf.HTTP.Port = SecurePort2
-		conf.HTTP.TLS = &config.TLSConfig{
-			Cert:   serverCertPath,
-			Key:    serverKeyPath,
-			CACert: caCertPath,
-		}
-
-		ctlr := api.NewController(conf)
-		ctlr.Config.Storage.RootDirectory = t.TempDir()
-
-		cm := test.NewControllerManager(ctlr)
-		cm.StartAndWait(conf.HTTP.Port)
-
-		defer cm.StopServer()
-
 		Convey("Certs in privileged path", func() {
 			_ = makeConfigFile(t,
 				fmt.Sprintf(`{"configs":[{"_name":"imagetest","url":"%s%s%s","showspinner":false}]}`,
-					BaseSecureURL2, constants.RoutePrefix, constants.ExtCatalogPrefix))
+					baseURL, constants.RoutePrefix, constants.ExtCatalogPrefix))
 
 			args := []string{"list", "--config", "imagetest"}
 			imageCmd := client.NewImageCommand(client.NewSearchService())

--- a/pkg/cli/client/gql_queries_test.go
+++ b/pkg/cli/client/gql_queries_test.go
@@ -16,10 +16,8 @@ import (
 )
 
 func TestGQLQueries(t *testing.T) {
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	dir := t.TempDir()
 	conf.Storage.RootDirectory = dir
 	defaultVal := true
@@ -32,7 +30,7 @@ func TestGQLQueries(t *testing.T) {
 	ctlr := api.NewController(conf)
 
 	cm := test.NewControllerManager(ctlr)
-	cm.StartAndWait(conf.HTTP.Port)
+	baseURL := cm.StartAndWait()
 
 	defer cm.StopServer()
 

--- a/pkg/cli/client/image_cmd_internal_test.go
+++ b/pkg/cli/client/image_cmd_internal_test.go
@@ -482,10 +482,8 @@ func TestOutputFormat(t *testing.T) {
 }
 
 func TestImagesCommandGQL(t *testing.T) {
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
@@ -497,7 +495,7 @@ func TestImagesCommandGQL(t *testing.T) {
 	ctlr.Config.Storage.RootDirectory = t.TempDir()
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartAndWait(conf.HTTP.Port)
+	baseURL := cm.StartAndWait()
 	defer cm.StopServer()
 
 	Convey("commands with gql", t, func() {
@@ -884,16 +882,14 @@ func TestImagesCommandGQL(t *testing.T) {
 }
 
 func TestImageCommandREST(t *testing.T) {
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 
 	ctlr := api.NewController(conf)
 	ctlr.Config.Storage.RootDirectory = t.TempDir()
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartAndWait(conf.HTTP.Port)
+	baseURL := cm.StartAndWait()
 	defer cm.StopServer()
 
 	Convey("commands without gql", t, func() {

--- a/pkg/cli/client/repo_test.go
+++ b/pkg/cli/client/repo_test.go
@@ -20,16 +20,14 @@ import (
 
 func TestReposCommand(t *testing.T) {
 	Convey("repos", t, func() {
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		ctlr := api.NewController(conf)
 		ctlr.Config.Storage.RootDirectory = t.TempDir()
 		cm := test.NewControllerManager(ctlr)
 
-		cm.StartAndWait(conf.HTTP.Port)
+		baseURL := cm.StartAndWait()
 		defer cm.StopServer()
 
 		err := UploadImage(CreateRandomImage(), baseURL, "repo1", "tag1")

--- a/pkg/cli/client/search_cmd_internal_test.go
+++ b/pkg/cli/client/search_cmd_internal_test.go
@@ -19,10 +19,8 @@ import (
 )
 
 func TestSearchCommandGQL(t *testing.T) {
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 
 	defaultVal := true
 	conf.Extensions = &extconf.ExtensionConfig{
@@ -35,7 +33,7 @@ func TestSearchCommandGQL(t *testing.T) {
 	ctlr.Config.Storage.RootDirectory = t.TempDir()
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartAndWait(conf.HTTP.Port)
+	baseURL := cm.StartAndWait()
 	defer cm.StopServer()
 
 	Convey("commands without gql", t, func() {
@@ -105,16 +103,14 @@ func TestSearchCommandGQL(t *testing.T) {
 }
 
 func TestSearchCommandREST(t *testing.T) {
-	port := test.GetFreePort()
-	baseURL := test.GetBaseURL(port)
 	conf := config.New()
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 
 	ctlr := api.NewController(conf)
 	ctlr.Config.Storage.RootDirectory = t.TempDir()
 	cm := test.NewControllerManager(ctlr)
 
-	cm.StartAndWait(conf.HTTP.Port)
+	baseURL := cm.StartAndWait()
 	defer cm.StopServer()
 
 	Convey("commands without gql", t, func() {

--- a/pkg/cli/server/config_reloader_test.go
+++ b/pkg/cli/server/config_reloader_test.go
@@ -79,7 +79,7 @@ func TestConfigReloader(t *testing.T) {
 			conveyCtx.So(err, ShouldBeNil)
 		}()
 
-		baseURL := waitForKernelChosenPortBaseURL(logPath)
+		baseURL := test.WaitForKernelChosenPortBaseURL(logPath)
 		test.WaitTillServerReady(baseURL)
 
 		// verify initial startup authentication logs
@@ -212,7 +212,7 @@ func TestConfigReloader(t *testing.T) {
 			ctx.So(err, ShouldBeNil)
 		}()
 
-		baseURL := waitForKernelChosenPortBaseURL(logFile.Name())
+		baseURL := test.WaitForKernelChosenPortBaseURL(logFile.Name())
 		test.WaitTillServerReady(baseURL)
 
 		// verify initial startup authentication logs (no auth configured)
@@ -348,7 +348,7 @@ func TestConfigReloader(t *testing.T) {
 			ctx.So(err, ShouldBeNil)
 		}()
 
-		baseURL := waitForKernelChosenPortBaseURL(logPath)
+		baseURL := test.WaitForKernelChosenPortBaseURL(logPath)
 		test.WaitTillServerReady(baseURL)
 
 		// verify initial startup authentication logs (no auth configured)
@@ -489,7 +489,7 @@ func TestConfigReloader(t *testing.T) {
 			ctx.So(err, ShouldBeNil)
 		}()
 
-		baseURL := waitForKernelChosenPortBaseURL(logPath)
+		baseURL := test.WaitForKernelChosenPortBaseURL(logPath)
 		test.WaitTillServerReady(baseURL)
 
 		// verify initial startup authentication logs (no auth configured)
@@ -635,7 +635,7 @@ func TestConfigReloader(t *testing.T) {
 			conveyCtx.So(err, ShouldBeNil)
 		}()
 
-		baseURL := waitForKernelChosenPortBaseURL(logPath)
+		baseURL := test.WaitForKernelChosenPortBaseURL(logPath)
 		test.WaitTillServerReady(baseURL)
 
 		content = "[]"

--- a/pkg/cli/server/extensions_test.go
+++ b/pkg/cli/server/extensions_test.go
@@ -346,7 +346,7 @@ func TestServeExtensions(t *testing.T) {
 			})
 		}()
 
-		baseURL := waitForKernelChosenPortBaseURL(logPath)
+		baseURL := WaitForKernelChosenPortBaseURL(logPath)
 		WaitTillServerReady(baseURL)
 
 		data, err := os.ReadFile(logPath)
@@ -387,7 +387,7 @@ func TestServeExtensions(t *testing.T) {
 			})
 		}()
 
-		baseURL := waitForKernelChosenPortBaseURL(logPath)
+		baseURL := WaitForKernelChosenPortBaseURL(logPath)
 		WaitTillServerReady(baseURL)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
@@ -412,7 +412,7 @@ func testWithMetricsEnabled(t *testing.T, rootDir string, cfgContentFormat strin
 		})
 	}()
 
-	baseURL := waitForKernelChosenPortBaseURL(logPath)
+	baseURL := WaitForKernelChosenPortBaseURL(logPath)
 	WaitTillServerReady(baseURL)
 
 	resp, err := resty.R().Get(baseURL + "/metrics")
@@ -542,7 +542,7 @@ func TestServeMetricsExtension(t *testing.T) {
 			})
 		}()
 
-		baseURL := waitForKernelChosenPortBaseURL(logPath)
+		baseURL := WaitForKernelChosenPortBaseURL(logPath)
 		WaitTillServerReady(baseURL)
 
 		resp, err := resty.R().Get(baseURL + "/metrics")

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -23,45 +23,6 @@ import (
 	. "zotregistry.dev/zot/v2/pkg/test/common"
 )
 
-const (
-	// Must match the log message emitted in pkg/api/controller.go when Port is "0".
-	kernelChosenPortMsg   = "port is unspecified, listening on kernel chosen port"
-	kernelPortWaitTimeout = 30 * time.Second
-)
-
-// waitForKernelChosenPortBaseURL polls a zot log file for the kernel-assigned listen
-// port logged when conf.HTTP.Port is "0", then returns http://127.0.0.1:<port>.
-// Used for CLI serve tests that have no ControllerManager to query after bind.
-func waitForKernelChosenPortBaseURL(logPath string) string {
-	deadline := time.Now().Add(kernelPortWaitTimeout)
-
-	for time.Now().Before(deadline) {
-		content, err := os.ReadFile(logPath)
-		if err == nil {
-			for line := range strings.SplitSeq(string(content), "\n") {
-				if !strings.Contains(line, kernelChosenPortMsg) {
-					continue
-				}
-
-				var entry struct {
-					Port int `json:"port"`
-				}
-
-				if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.Port <= 0 {
-					continue
-				}
-
-				return GetBaseURL(strconv.Itoa(entry.Port))
-			}
-		}
-
-		time.Sleep(SleepTime)
-	}
-
-	panic(fmt.Sprintf("timed out after %s waiting for kernel chosen port in %s",
-		kernelPortWaitTimeout, logPath))
-}
-
 // checkAuthLogEntry checks if a log entry with the given message has the expected enabled value.
 func checkAuthLogEntry(logData []byte, message string, expectedEnabled bool) bool {
 	//nolint:modernize // strings.Split is compatible with older Go versions
@@ -3548,7 +3509,7 @@ func runCLIWithConfig(t *testing.T, config string) (string, string, error) {
 	case <-time.After(250 * time.Millisecond): // No startup error
 	}
 
-	baseURL := waitForKernelChosenPortBaseURL(logPath)
+	baseURL := WaitForKernelChosenPortBaseURL(logPath)
 	WaitTillServerReady(baseURL)
 
 	return logPath, rootDir, nil

--- a/pkg/cli/server/stress_test.go
+++ b/pkg/cli/server/stress_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"syscall"
 	"testing"
@@ -38,9 +39,8 @@ func TestStressTooManyOpenFiles(t *testing.T) {
 		initialLimit, err := setMaxOpenFilesLimit(MaxFileDescriptors)
 		So(err, ShouldBeNil)
 
-		port := test.GetFreePort()
 		conf := config.New()
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.Dedupe = false
 		conf.Storage.GC = true
 
@@ -76,7 +76,8 @@ func TestStressTooManyOpenFiles(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = dir
 
 		ctrlManager := test.NewControllerManager(ctlr)
-		ctrlManager.StartAndWait(port)
+		ctrlManager.StartAndWait()
+		port := strconv.Itoa(ctrlManager.Port())
 
 		content := fmt.Sprintf(`{
 				"storage": {

--- a/pkg/compliance/v1_0_0/check_test.go
+++ b/pkg/compliance/v1_0_0/check_test.go
@@ -2,12 +2,9 @@ package v1_0_0_test
 
 import (
 	"context"
-	"net/http"
 	"os"
+	"strconv"
 	"testing"
-	"time"
-
-	"gopkg.in/resty.v1"
 
 	"zotregistry.dev/zot/v2/pkg/api"
 	"zotregistry.dev/zot/v2/pkg/api/config"
@@ -51,15 +48,13 @@ func TestWorkflowsOutputJSON(t *testing.T) {
 	})
 }
 
-// start local server on random open port.
+// start local server on a kernel-chosen port.
 func startServer(t *testing.T) (*api.Controller, string) {
 	t.Helper()
 
-	port := GetFreePort()
-	baseURL := GetBaseURL(port)
 	conf := config.New()
 	conf.HTTP.Address = listenAddress
-	conf.HTTP.Port = port
+	conf.HTTP.Port = "0"
 	ctrl := api.NewController(conf)
 
 	dir := t.TempDir()
@@ -80,26 +75,10 @@ func startServer(t *testing.T) (*api.Controller, string) {
 
 	ctrl.Config.Storage.SubPaths = subPaths
 
-	go func() {
-		if err := ctrl.Init(); err != nil {
-			return
-		}
+	cm := NewControllerManager(ctrl)
+	_ = cm.StartAndWait()
 
-		// this blocks
-		if err := ctrl.Run(); err != nil {
-			return
-		}
-	}()
-
-	for {
-		// poll until ready
-		resp, _ := resty.R().Get(baseURL)
-		if resp.StatusCode() == http.StatusNotFound {
-			break
-		}
-
-		time.Sleep(100 * time.Millisecond)
-	}
+	port := strconv.Itoa(cm.Port())
 
 	return ctrl, port
 }

--- a/pkg/exporter/api/controller_test.go
+++ b/pkg/exporter/api/controller_test.go
@@ -3,13 +3,10 @@
 package api_test
 
 import (
-	"context"
 	"crypto/rand"
-	"errors"
-	"fmt"
 	"math/big"
-	"net/http"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -94,15 +91,14 @@ func TestNewExporter(t *testing.T) {
 		exporterConfig := api.DefaultConfig()
 		So(exporterConfig, ShouldNotBeNil)
 
-		ports := GetFreePorts(2)
-		exporterPort := ports[0]
-		serverPort := ports[1]
-		exporterConfig.Exporter.Port = exporterPort
+		exporterConfig.Exporter.Port = "0"
 		exporterConfig.Exporter.Metrics.Path = strings.TrimPrefix(t.TempDir(), "/tmp/")
-		exporterConfig.Server.Port = serverPort
-		exporterController := api.NewController(exporterConfig)
 
-		Convey("Start the zot exporter", func() {
+		Convey("When zot server not running", func() {
+			// Unreachable target — no zot listen; avoid GetFreePort TOCTOU.
+			exporterConfig.Server.Port = "1"
+			exporterController := api.NewController(exporterConfig)
+
 			go func() {
 				// this blocks
 				exporterController.Run()
@@ -113,449 +109,443 @@ func TestNewExporter(t *testing.T) {
 			collector := api.GetCollector(exporterController)
 			chMetric := make(chan prometheus.Metric)
 
-			Convey("When zot server not running", func() {
+			go func() {
+				// this blocks
+				collector.Collect(chMetric)
+			}()
+			// Read from the channel expected values
+			pm := <-chMetric
+			So(pm.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_up"].String())
+
+			var metric dto.Metric
+			err := pm.Write(&metric)
+			So(err, ShouldBeNil)
+			So(*metric.Gauge.Value, ShouldEqual, 0) // "zot_up=0" means zot server is not running
+
+			// Check that no more data was written to the channel
+			So(isChannelDrained(chMetric), ShouldEqual, true)
+		})
+		Convey("When zot server is running", func() {
+			servercConfig := zotcfg.New()
+			So(servercConfig, ShouldNotBeNil)
+
+			servercConfig.HTTP.Port = "0"
+			servercConfig.BinaryType = "minimal"
+			servercConfig.Storage.Dedupe = false
+			servercConfig.Storage.GC = false
+			serverController := zotapi.NewController(servercConfig)
+			So(serverController, ShouldNotBeNil)
+
+			dir := t.TempDir()
+
+			serverController.Config.Storage.RootDirectory = dir
+
+			scm := NewControllerManager(serverController)
+			baseURL := scm.StartAndWait()
+
+			defer scm.StopServer()
+
+			serverPort := strconv.Itoa(scm.Port())
+
+			exporterConfig.Server.Port = serverPort
+			exporterController := api.NewController(exporterConfig)
+
+			go func() {
+				// this blocks
+				exporterController.Run()
+				So(nil, ShouldNotBeNil) // Fail the test in case zot exporter unexpectedly exits
+			}()
+			time.Sleep(SleepTime)
+
+			collector := api.GetCollector(exporterController)
+			chMetric := make(chan prometheus.Metric)
+
+			// Side effect of calling this endpoint is that it will enable metrics
+			resp, err := resty.R().Get(baseURL + "/metrics")
+			So(resp, ShouldNotBeNil)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, 200)
+
+			Convey("Collecting data: default metrics", func() {
 				go func() {
 					// this blocks
 					collector.Collect(chMetric)
 				}()
-				// Read from the channel expected values
-				pm := <-chMetric
-				So(pm.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_up"].String())
-
-				var metric dto.Metric
-				err := pm.Write(&metric)
-				So(err, ShouldBeNil)
-				So(*metric.Gauge.Value, ShouldEqual, 0) // "zot_up=0" means zot server is not running
-
-				// Check that no more data was written to the channel
+				readDefaultMetrics(collector, chMetric)
 				So(isChannelDrained(chMetric), ShouldEqual, true)
 			})
-			Convey("When zot server is running", func() {
-				servercConfig := zotcfg.New()
-				So(servercConfig, ShouldNotBeNil)
 
-				baseURL := fmt.Sprintf(BaseURL, serverPort)
-				servercConfig.HTTP.Port = serverPort
-				servercConfig.BinaryType = "minimal"
-				servercConfig.Storage.Dedupe = false
-				servercConfig.Storage.GC = false
-				serverController := zotapi.NewController(servercConfig)
-				So(serverController, ShouldNotBeNil)
+			Convey("Collecting data: Test init value & that increment works on Counters", func() {
+				// Testing initial value of the counter to be 1 after first incrementation call
+				monitoring.IncUploadCounter(serverController.Metrics, "testrepo")
+				time.Sleep(SleepTime)
 
-				dir := t.TempDir()
-
-				serverController.Config.Storage.RootDirectory = dir
-				go func(ctrl *zotapi.Controller) {
-					if err := ctrl.Init(); err != nil {
-						panic(err)
-					}
-
+				go func() {
 					// this blocks
-					if err := ctrl.Run(); !errors.Is(err, http.ErrServerClosed) {
-						panic(err)
-					}
-				}(serverController)
+					collector.Collect(chMetric)
+				}()
+				readDefaultMetrics(collector, chMetric)
 
-				defer func(ctrl *zotapi.Controller) {
-					_ = ctrl.Server.Shutdown(context.TODO())
-				}(serverController)
-				// wait till ready
-				for {
-					_, err := resty.R().Get(baseURL)
-					if err == nil {
-						break
-					}
+				pmMetric := <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_repo_uploads_total"].String())
 
-					time.Sleep(SleepTime)
+				var metric dto.Metric
+				err := pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, 1)
+
+				So(isChannelDrained(chMetric), ShouldEqual, true)
+
+				// Testing that counter is incremented by 1
+				monitoring.IncUploadCounter(serverController.Metrics, "testrepo")
+				time.Sleep(SleepTime)
+
+				go func() {
+					// this blocks
+					collector.Collect(chMetric)
+				}()
+				readDefaultMetrics(collector, chMetric)
+
+				pmMetric = <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_repo_uploads_total"].String())
+
+				err = pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, 2)
+
+				So(isChannelDrained(chMetric), ShouldEqual, true)
+			})
+			Convey("Collecting data: Test that concurent Counter increment requests works properly", func() {
+				nBig, err := rand.Int(rand.Reader, big.NewInt(1000))
+				if err != nil {
+					panic(err)
 				}
 
-				// Side effect of calling this endpoint is that it will enable metrics
-				resp, err := resty.R().Get(baseURL + "/metrics")
-				So(resp, ShouldNotBeNil)
+				reqsSize := int(nBig.Int64()) + 1
+				for range reqsSize {
+					monitoring.IncDownloadCounter(serverController.Metrics, "dummyrepo")
+				}
+
+				time.Sleep(SleepTime)
+
+				go func() {
+					// this blocks
+					collector.Collect(chMetric)
+				}()
+				readDefaultMetrics(collector, chMetric)
+				pm := <-chMetric
+				So(pm.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_repo_downloads_total"].String())
+
+				var metric dto.Metric
+				err = pm.Write(&metric)
 				So(err, ShouldBeNil)
-				So(resp.StatusCode(), ShouldEqual, 200)
+				So(*metric.Counter.Value, ShouldEqual, reqsSize)
 
-				Convey("Collecting data: default metrics", func() {
-					go func() {
-						// this blocks
-						collector.Collect(chMetric)
-					}()
-					readDefaultMetrics(collector, chMetric)
-					So(isChannelDrained(chMetric), ShouldEqual, true)
-				})
+				So(isChannelDrained(chMetric), ShouldEqual, true)
+			})
+			Convey("Collecting data: Test init value & that observe works on Summaries", func() {
+				// Testing initial value of the summary counter to be 1 after first observation call
+				var latency1, latency2 time.Duration
+				latency1 = getRandomLatency()
+				monitoring.ObserveHTTPRepoLatency(serverController.Metrics, "/v2/testrepo/blogs/dummydigest", latency1)
+				time.Sleep(SleepTime)
 
-				Convey("Collecting data: Test init value & that increment works on Counters", func() {
-					// Testing initial value of the counter to be 1 after first incrementation call
-					monitoring.IncUploadCounter(serverController.Metrics, "testrepo")
-					time.Sleep(SleepTime)
+				go func() {
+					// this blocks
+					collector.Collect(chMetric)
+				}()
+				readDefaultMetrics(collector, chMetric)
 
-					go func() {
-						// this blocks
-						collector.Collect(chMetric)
-					}()
-					readDefaultMetrics(collector, chMetric)
+				pmMetric := <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_count"].String())
 
-					pmMetric := <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_repo_uploads_total"].String())
+				var metric dto.Metric
+				err := pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, 1)
 
-					var metric dto.Metric
-					err := pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, 1)
+				pmMetric = <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_sum"].String())
 
-					So(isChannelDrained(chMetric), ShouldEqual, true)
+				err = pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, latency1.Seconds())
 
-					// Testing that counter is incremented by 1
-					monitoring.IncUploadCounter(serverController.Metrics, "testrepo")
-					time.Sleep(SleepTime)
+				So(isChannelDrained(chMetric), ShouldEqual, true)
 
-					go func() {
-						// this blocks
-						collector.Collect(chMetric)
-					}()
-					readDefaultMetrics(collector, chMetric)
+				// Testing that summary counter is incremented by 1 and summary sum is  properly updated
+				latency2 = getRandomLatency()
+				monitoring.ObserveHTTPRepoLatency(serverController.Metrics, "/v2/testrepo/blogs/dummydigest", latency2)
+				time.Sleep(SleepTime)
 
-					pmMetric = <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_repo_uploads_total"].String())
+				go func() {
+					// this blocks
+					collector.Collect(chMetric)
+				}()
+				readDefaultMetrics(collector, chMetric)
 
-					err = pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, 2)
+				pmMetric = <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_count"].String())
 
-					So(isChannelDrained(chMetric), ShouldEqual, true)
-				})
-				Convey("Collecting data: Test that concurent Counter increment requests works properly", func() {
-					nBig, err := rand.Int(rand.Reader, big.NewInt(1000))
-					if err != nil {
-						panic(err)
-					}
+				err = pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, 2)
 
-					reqsSize := int(nBig.Int64()) + 1
-					for range reqsSize {
-						monitoring.IncDownloadCounter(serverController.Metrics, "dummyrepo")
-					}
+				pmMetric = <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_sum"].String())
 
-					time.Sleep(SleepTime)
+				err = pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, (latency1.Seconds())+(latency2.Seconds()))
 
-					go func() {
-						// this blocks
-						collector.Collect(chMetric)
-					}()
-					readDefaultMetrics(collector, chMetric)
-					pm := <-chMetric
-					So(pm.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_repo_downloads_total"].String())
+				So(isChannelDrained(chMetric), ShouldEqual, true)
+			})
+			Convey("Collecting data: Test that concurent Summary observation requests works properly", func() {
+				var latencySum float64
 
-					var metric dto.Metric
-					err = pm.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, reqsSize)
+				nBig, err := rand.Int(rand.Reader, big.NewInt(1000))
+				if err != nil {
+					panic(err)
+				}
 
-					So(isChannelDrained(chMetric), ShouldEqual, true)
-				})
-				Convey("Collecting data: Test init value & that observe works on Summaries", func() {
-					// Testing initial value of the summary counter to be 1 after first observation call
-					var latency1, latency2 time.Duration
-					latency1 = getRandomLatency()
-					monitoring.ObserveHTTPRepoLatency(serverController.Metrics, "/v2/testrepo/blogs/dummydigest", latency1)
-					time.Sleep(SleepTime)
-
-					go func() {
-						// this blocks
-						collector.Collect(chMetric)
-					}()
-					readDefaultMetrics(collector, chMetric)
-
-					pmMetric := <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_count"].String())
-
-					var metric dto.Metric
-					err := pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, 1)
-
-					pmMetric = <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_sum"].String())
-
-					err = pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, latency1.Seconds())
-
-					So(isChannelDrained(chMetric), ShouldEqual, true)
-
-					// Testing that summary counter is incremented by 1 and summary sum is  properly updated
-					latency2 = getRandomLatency()
-					monitoring.ObserveHTTPRepoLatency(serverController.Metrics, "/v2/testrepo/blogs/dummydigest", latency2)
-					time.Sleep(SleepTime)
-
-					go func() {
-						// this blocks
-						collector.Collect(chMetric)
-					}()
-					readDefaultMetrics(collector, chMetric)
-
-					pmMetric = <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_count"].String())
-
-					err = pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, 2)
-
-					pmMetric = <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_sum"].String())
-
-					err = pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, (latency1.Seconds())+(latency2.Seconds()))
-
-					So(isChannelDrained(chMetric), ShouldEqual, true)
-				})
-				Convey("Collecting data: Test that concurent Summary observation requests works properly", func() {
-					var latencySum float64
-
-					nBig, err := rand.Int(rand.Reader, big.NewInt(1000))
-					if err != nil {
-						panic(err)
-					}
-
-					reqsSize := int(nBig.Int64()) + 1
-					for range reqsSize {
-						latency := getRandomLatency()
-						latencySum += latency.Seconds()
-						monitoring.ObserveHTTPRepoLatency(serverController.Metrics, "/v2/dummyrepo/manifests/testreference", latency)
-					}
-
-					time.Sleep(SleepTime)
-
-					go func() {
-						// this blocks
-						collector.Collect(chMetric)
-					}()
-					readDefaultMetrics(collector, chMetric)
-
-					pmMetric := <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_count"].String())
-
-					var metric dto.Metric
-					err = pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, reqsSize)
-
-					pmMetric = <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_sum"].String())
-
-					err = pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, latencySum)
-
-					So(isChannelDrained(chMetric), ShouldEqual, true)
-				})
-				Convey("Collecting data: Test init value & that observe works on Histogram buckets", func() {
-					// Testing initial value of the histogram counter to be 1 after first observation call
+				reqsSize := int(nBig.Int64()) + 1
+				for range reqsSize {
 					latency := getRandomLatency()
-					monitoring.ObserveHTTPMethodLatency(serverController.Metrics, "GET", latency)
-					time.Sleep(SleepTime)
+					latencySum += latency.Seconds()
+					monitoring.ObserveHTTPRepoLatency(serverController.Metrics, "/v2/dummyrepo/manifests/testreference", latency)
+				}
 
-					go func() {
-						// this blocks
-						collector.Collect(chMetric)
-					}()
-					readDefaultMetrics(collector, chMetric)
+				time.Sleep(SleepTime)
 
-					pmMetric := <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_method_latency_seconds_count"].String())
+				go func() {
+					// this blocks
+					collector.Collect(chMetric)
+				}()
+				readDefaultMetrics(collector, chMetric)
 
-					var metric dto.Metric
-					err := pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, 1)
+				pmMetric := <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_count"].String())
 
-					pmMetric = <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_method_latency_seconds_sum"].String())
+				var metric dto.Metric
+				err = pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, reqsSize)
 
-					err = pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, latency.Seconds())
+				pmMetric = <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_repo_latency_seconds_sum"].String())
 
-					for _, fvalue := range monitoring.GetDefaultBuckets() {
-						pmMetric = <-chMetric
-						So(pmMetric.Desc().String(), ShouldEqual,
-							collector.MetricsDesc["zot_http_method_latency_seconds_bucket"].String())
+				err = pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, latencySum)
 
-						err = pmMetric.Write(&metric)
-						So(err, ShouldBeNil)
+				So(isChannelDrained(chMetric), ShouldEqual, true)
+			})
+			Convey("Collecting data: Test init value & that observe works on Histogram buckets", func() {
+				// Testing initial value of the histogram counter to be 1 after first observation call
+				latency := getRandomLatency()
+				monitoring.ObserveHTTPMethodLatency(serverController.Metrics, "GET", latency)
+				time.Sleep(SleepTime)
 
-						if latency.Seconds() < fvalue {
-							So(*metric.Counter.Value, ShouldEqual, 1)
-						} else {
-							So(*metric.Counter.Value, ShouldEqual, 0)
-						}
-					}
+				go func() {
+					// this blocks
+					collector.Collect(chMetric)
+				}()
+				readDefaultMetrics(collector, chMetric)
 
-					So(isChannelDrained(chMetric), ShouldEqual, true)
-				})
-				Convey("Collecting data: Test init value & that observe works on Histogram buckets (lock latency)", func() {
-					// Testing initial value of the histogram counter to be 1 after first observation call
-					latency := getRandomLatency()
-					monitoring.ObserveStorageLockLatency(serverController.Metrics, latency, "/tmp/zot", "RWLock")
-					time.Sleep(SleepTime)
+				pmMetric := <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_method_latency_seconds_count"].String())
 
-					go func() {
-						// this blocks
-						collector.Collect(chMetric)
-					}()
-					readDefaultMetrics(collector, chMetric)
+				var metric dto.Metric
+				err := pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, 1)
 
-					pmMetric := <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_storage_lock_latency_seconds_count"].String())
+				pmMetric = <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_method_latency_seconds_sum"].String())
 
-					var metric dto.Metric
-					err := pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, 1)
+				err = pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, latency.Seconds())
 
-					pmMetric = <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_storage_lock_latency_seconds_sum"].String())
-
-					err = pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, latency.Seconds())
-
-					for _, fvalue := range monitoring.GetBuckets("zot.storage.lock.latency.seconds") {
-						pmMetric = <-chMetric
-						So(pmMetric.Desc().String(), ShouldEqual,
-							collector.MetricsDesc["zot_storage_lock_latency_seconds_bucket"].String())
-
-						err = pmMetric.Write(&metric)
-						So(err, ShouldBeNil)
-
-						if latency.Seconds() < fvalue {
-							So(*metric.Counter.Value, ShouldEqual, 1)
-						} else {
-							So(*metric.Counter.Value, ShouldEqual, 0)
-						}
-					}
-
-					So(isChannelDrained(chMetric), ShouldEqual, true)
-				})
-				Convey("Collecting data: Test init Histogram buckets \n", func() {
-					// Generate a random  latency within each bucket and finally test
-					// that "higher" rank bucket counter is incremented by 1
-					var latencySum float64
-
-					dBuckets := monitoring.GetDefaultBuckets()
-					for index, fvalue := range dBuckets {
-						var latency time.Duration
-						if index == 0 {
-							// first bucket value
-							latency = getRandomLatencyN(int64(fvalue * float64(time.Second)))
-						} else {
-							pvalue := dBuckets[index-1] // previous bucket value
-							latency = time.Duration(pvalue*float64(time.Second)) +
-								getRandomLatencyN(int64(dBuckets[0]*float64(time.Second)))
-						}
-
-						latencySum += latency.Seconds()
-						monitoring.ObserveHTTPMethodLatency(serverController.Metrics, "GET", latency)
-					}
-
-					time.Sleep(SleepTime)
-
-					go func() {
-						// this blocks
-						collector.Collect(chMetric)
-					}()
-					readDefaultMetrics(collector, chMetric)
-
-					pmMetric := <-chMetric
-					So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_method_latency_seconds_count"].String())
-
-					var metric dto.Metric
-					err := pmMetric.Write(&metric)
-					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, len(dBuckets))
-
+				for _, fvalue := range monitoring.GetDefaultBuckets() {
 					pmMetric = <-chMetric
 					So(pmMetric.Desc().String(), ShouldEqual,
-						collector.MetricsDesc["zot_http_method_latency_seconds_sum"].String())
+						collector.MetricsDesc["zot_http_method_latency_seconds_bucket"].String())
 
 					err = pmMetric.Write(&metric)
 					So(err, ShouldBeNil)
-					So(*metric.Counter.Value, ShouldEqual, latencySum)
 
-					for index := range dBuckets {
-						pmMetric = <-chMetric
-						So(pmMetric.Desc().String(), ShouldEqual,
-							collector.MetricsDesc["zot_http_method_latency_seconds_bucket"].String())
+					if latency.Seconds() < fvalue {
+						So(*metric.Counter.Value, ShouldEqual, 1)
+					} else {
+						So(*metric.Counter.Value, ShouldEqual, 0)
+					}
+				}
 
-						err = pmMetric.Write(&metric)
-						So(err, ShouldBeNil)
-						So(*metric.Counter.Value, ShouldEqual, index+1)
+				So(isChannelDrained(chMetric), ShouldEqual, true)
+			})
+			Convey("Collecting data: Test init value & that observe works on Histogram buckets (lock latency)", func() {
+				// Testing initial value of the histogram counter to be 1 after first observation call
+				latency := getRandomLatency()
+				monitoring.ObserveStorageLockLatency(serverController.Metrics, latency, "/tmp/zot", "RWLock")
+				time.Sleep(SleepTime)
+
+				go func() {
+					// this blocks
+					collector.Collect(chMetric)
+				}()
+				readDefaultMetrics(collector, chMetric)
+
+				pmMetric := <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_storage_lock_latency_seconds_count"].String())
+
+				var metric dto.Metric
+				err := pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, 1)
+
+				pmMetric = <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_storage_lock_latency_seconds_sum"].String())
+
+				err = pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, latency.Seconds())
+
+				for _, fvalue := range monitoring.GetBuckets("zot.storage.lock.latency.seconds") {
+					pmMetric = <-chMetric
+					So(pmMetric.Desc().String(), ShouldEqual,
+						collector.MetricsDesc["zot_storage_lock_latency_seconds_bucket"].String())
+
+					err = pmMetric.Write(&metric)
+					So(err, ShouldBeNil)
+
+					if latency.Seconds() < fvalue {
+						So(*metric.Counter.Value, ShouldEqual, 1)
+					} else {
+						So(*metric.Counter.Value, ShouldEqual, 0)
+					}
+				}
+
+				So(isChannelDrained(chMetric), ShouldEqual, true)
+			})
+			Convey("Collecting data: Test init Histogram buckets \n", func() {
+				// Generate a random  latency within each bucket and finally test
+				// that "higher" rank bucket counter is incremented by 1
+				var latencySum float64
+
+				dBuckets := monitoring.GetDefaultBuckets()
+				for index, fvalue := range dBuckets {
+					var latency time.Duration
+					if index == 0 {
+						// first bucket value
+						latency = getRandomLatencyN(int64(fvalue * float64(time.Second)))
+					} else {
+						pvalue := dBuckets[index-1] // previous bucket value
+						latency = time.Duration(pvalue*float64(time.Second)) +
+							getRandomLatencyN(int64(dBuckets[0]*float64(time.Second)))
 					}
 
-					So(isChannelDrained(chMetric), ShouldEqual, true)
-				})
-				Convey("Negative testing: Send unknown metric type to MetricServer", func() {
-					serverController.Metrics.SendMetric(getRandomLatency())
-				})
-				Convey("Concurrent metrics scrape", func() {
-					var wg sync.WaitGroup
+					latencySum += latency.Seconds()
+					monitoring.ObserveHTTPMethodLatency(serverController.Metrics, "GET", latency)
+				}
 
-					nBig, err := rand.Int(rand.Reader, big.NewInt(100))
-					if err != nil {
-						panic(err)
-					}
+				time.Sleep(SleepTime)
 
-					workersSize := int(nBig.Int64())
-					for range workersSize {
-						wg.Go(func() {
-							m := serverController.Metrics.ReceiveMetrics()
-							json := jsoniter.ConfigCompatibleWithStandardLibrary
+				go func() {
+					// this blocks
+					collector.Collect(chMetric)
+				}()
+				readDefaultMetrics(collector, chMetric)
 
-							_, err := json.Marshal(m)
-							if err != nil {
-								exporterController.Log.Error().Err(err).Msg("Concurrent metrics scrape fail")
-							}
-						})
-					}
+				pmMetric := <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual, collector.MetricsDesc["zot_http_method_latency_seconds_count"].String())
 
-					wg.Wait()
-				})
-				Convey("Negative testing: Increment a counter that does not exist", func() {
-					cv := monitoring.CounterValue{Name: "dummyName"}
-					serverController.Metrics.SendMetric(cv)
-				})
-				Convey("Negative testing: Set a gauge for a metric with len(labelNames)!=len(knownLabelNames)", func() {
-					gv := monitoring.GaugeValue{
-						Name:       "zot.info",
-						Value:      1,
-						LabelNames: []string{"commit", "binaryType", "version"},
-					}
-					serverController.Metrics.SendMetric(gv)
-				})
-				Convey("Negative testing: Summary observe for a metric with labelNames!=knownLabelNames", func() {
-					sv := monitoring.SummaryValue{
-						Name:        "zot.repo.latency.seconds",
-						LabelNames:  []string{"dummyRepoLabelName"},
-						LabelValues: []string{"dummyrepo"},
-					}
-					serverController.Metrics.SendMetric(sv)
-				})
-				Convey("Negative testing: Histogram observe for a metric with len(labelNames)!=len(LabelValues)", func() {
-					hv := monitoring.HistogramValue{
-						Name:        "zot.method.latency.seconds",
-						LabelNames:  []string{"method"},
-						LabelValues: []string{"GET", "POST", "DELETE"},
-					}
-					serverController.Metrics.SendMetric(hv)
-				})
-				Convey("Negative testing: error in getting the size for a repo directory", func() {
-					monitoring.SetStorageUsage(serverController.Metrics, "/tmp/zot", "dummyrepo")
-				})
-				Convey("Disabling metrics after idle timeout", func() {
-					So(serverController.Metrics.IsEnabled(), ShouldEqual, true)
-					time.Sleep(monitoring.GetMaxIdleScrapeInterval())
-					So(serverController.Metrics.IsEnabled(), ShouldEqual, false)
-				})
+				var metric dto.Metric
+				err := pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, len(dBuckets))
+
+				pmMetric = <-chMetric
+				So(pmMetric.Desc().String(), ShouldEqual,
+					collector.MetricsDesc["zot_http_method_latency_seconds_sum"].String())
+
+				err = pmMetric.Write(&metric)
+				So(err, ShouldBeNil)
+				So(*metric.Counter.Value, ShouldEqual, latencySum)
+
+				for index := range dBuckets {
+					pmMetric = <-chMetric
+					So(pmMetric.Desc().String(), ShouldEqual,
+						collector.MetricsDesc["zot_http_method_latency_seconds_bucket"].String())
+
+					err = pmMetric.Write(&metric)
+					So(err, ShouldBeNil)
+					So(*metric.Counter.Value, ShouldEqual, index+1)
+				}
+
+				So(isChannelDrained(chMetric), ShouldEqual, true)
+			})
+			Convey("Negative testing: Send unknown metric type to MetricServer", func() {
+				serverController.Metrics.SendMetric(getRandomLatency())
+			})
+			Convey("Concurrent metrics scrape", func() {
+				var wg sync.WaitGroup
+
+				nBig, err := rand.Int(rand.Reader, big.NewInt(100))
+				if err != nil {
+					panic(err)
+				}
+
+				workersSize := int(nBig.Int64())
+				for range workersSize {
+					wg.Go(func() {
+						m := serverController.Metrics.ReceiveMetrics()
+						json := jsoniter.ConfigCompatibleWithStandardLibrary
+
+						_, err := json.Marshal(m)
+						if err != nil {
+							exporterController.Log.Error().Err(err).Msg("Concurrent metrics scrape fail")
+						}
+					})
+				}
+
+				wg.Wait()
+			})
+			Convey("Negative testing: Increment a counter that does not exist", func() {
+				cv := monitoring.CounterValue{Name: "dummyName"}
+				serverController.Metrics.SendMetric(cv)
+			})
+			Convey("Negative testing: Set a gauge for a metric with len(labelNames)!=len(knownLabelNames)", func() {
+				gv := monitoring.GaugeValue{
+					Name:       "zot.info",
+					Value:      1,
+					LabelNames: []string{"commit", "binaryType", "version"},
+				}
+				serverController.Metrics.SendMetric(gv)
+			})
+			Convey("Negative testing: Summary observe for a metric with labelNames!=knownLabelNames", func() {
+				sv := monitoring.SummaryValue{
+					Name:        "zot.repo.latency.seconds",
+					LabelNames:  []string{"dummyRepoLabelName"},
+					LabelValues: []string{"dummyrepo"},
+				}
+				serverController.Metrics.SendMetric(sv)
+			})
+			Convey("Negative testing: Histogram observe for a metric with len(labelNames)!=len(LabelValues)", func() {
+				hv := monitoring.HistogramValue{
+					Name:        "zot.method.latency.seconds",
+					LabelNames:  []string{"method"},
+					LabelValues: []string{"GET", "POST", "DELETE"},
+				}
+				serverController.Metrics.SendMetric(hv)
+			})
+			Convey("Negative testing: error in getting the size for a repo directory", func() {
+				monitoring.SetStorageUsage(serverController.Metrics, "/tmp/zot", "dummyrepo")
+			})
+			Convey("Disabling metrics after idle timeout", func() {
+				So(serverController.Metrics.IsEnabled(), ShouldEqual, true)
+				time.Sleep(monitoring.GetMaxIdleScrapeInterval())
+				So(serverController.Metrics.IsEnabled(), ShouldEqual, false)
 			})
 		})
 	})

--- a/pkg/extensions/sync/sync_disabled_test.go
+++ b/pkg/extensions/sync/sync_disabled_test.go
@@ -19,15 +19,13 @@ import (
 func TestSyncExtension(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		conf := config.New()
-		port := test.GetFreePort()
 
-		baseURL := test.GetBaseURL(port)
 		globalDir := t.TempDir()
 		defaultValue := true
 
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 		conf.Storage.RootDirectory = globalDir
 		conf.Storage.Commit = true
 		conf.Extensions = &extconf.ExtensionConfig{}
@@ -40,7 +38,7 @@ func TestSyncExtension(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlrManager := test.NewControllerManager(ctlr)
 
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		Convey("verify sync is skipped when binary doesn't include it", func() {

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -145,19 +145,16 @@ func setupTestCertsForSync(t *testing.T, tempDir string) (
 }
 
 // makeUpstreamServerWithCerts creates an upstream server using shared certificates.
+// Callers must obtain the base URL after bind via scm.StartAndWait() (scheme follows TLS config).
 func makeUpstreamServerWithCerts(
 	t *testing.T, secure, basicAuth bool, certDir string, caCertPEM []byte,
-) (*api.Controller, string, string, *resty.Client) {
+) (*api.Controller, string, *resty.Client) {
 	t.Helper()
 
-	srcPort := test.GetFreePort()
 	srcConfig := config.New()
 	client := resty.New()
 
-	var srcBaseURL string
 	if secure {
-		srcBaseURL = test.GetSecureBaseURL(srcPort)
-
 		// Use shared certificates
 		caCertPath := path.Join(certDir, "ca.crt")
 		serverCertPath := path.Join(certDir, "server.cert")
@@ -182,8 +179,6 @@ func makeUpstreamServerWithCerts(
 		}
 
 		client.SetCertificates(cert)
-	} else {
-		srcBaseURL = test.GetBaseURL(srcPort)
 	}
 
 	var htpasswdPath string
@@ -196,7 +191,7 @@ func makeUpstreamServerWithCerts(
 		}
 	}
 
-	srcConfig.HTTP.Port = srcPort
+	srcConfig.HTTP.Port = "0"
 	srcConfig.Storage.GC = false
 
 	srcDir := t.TempDir()
@@ -222,12 +217,12 @@ func makeUpstreamServerWithCerts(
 
 	sctlr := api.NewController(srcConfig)
 
-	return sctlr, srcBaseURL, srcDir, client
+	return sctlr, srcDir, client
 }
 
 func makeUpstreamServer(
 	t *testing.T, secure, basicAuth bool,
-) (*api.Controller, string, string, *resty.Client) {
+) (*api.Controller, string, *resty.Client) {
 	t.Helper()
 
 	// Generate certificates and delegate to makeUpstreamServerWithCerts
@@ -242,19 +237,16 @@ func makeUpstreamServer(
 }
 
 // makeDownstreamServerWithCerts creates a downstream server using shared certificates.
+// Callers must obtain the base URL after bind via dcm.StartAndWait() (scheme follows TLS config).
 func makeDownstreamServerWithCerts(
 	t *testing.T, secure bool, syncConfig *syncconf.Config, certDir string, caCertPEM []byte,
-) (*api.Controller, string, string, *resty.Client) {
+) (*api.Controller, string, *resty.Client) {
 	t.Helper()
 
-	destPort := test.GetFreePort()
 	destConfig := config.New()
 	client := resty.New()
 
-	var destBaseURL string
 	if secure {
-		destBaseURL = test.GetSecureBaseURL(destPort)
-
 		// Use shared certificates (same CA as upstream)
 		caCertPath := path.Join(certDir, "ca.crt")
 		serverCertPath := path.Join(certDir, "server.cert")
@@ -279,11 +271,9 @@ func makeDownstreamServerWithCerts(
 		}
 
 		client.SetCertificates(cert)
-	} else {
-		destBaseURL = test.GetBaseURL(destPort)
 	}
 
-	destConfig.HTTP.Port = destPort
+	destConfig.HTTP.Port = "0"
 
 	destDir := t.TempDir()
 
@@ -302,12 +292,12 @@ func makeDownstreamServerWithCerts(
 
 	dctlr := api.NewController(destConfig)
 
-	return dctlr, destBaseURL, destDir, client
+	return dctlr, destDir, client
 }
 
 func makeDownstreamServer(
 	t *testing.T, secure bool, syncConfig *syncconf.Config,
-) (*api.Controller, string, string, *resty.Client) {
+) (*api.Controller, string, *resty.Client) {
 	t.Helper()
 
 	// Generate certificates and delegate to makeDownstreamServerWithCerts
@@ -358,9 +348,9 @@ func makeInsecureDownstreamServerFixedPort(
 
 func TestOnDemand(t *testing.T) {
 	Convey("Verify sync on demand feature", t, func() {
-		sctlr, srcBaseURL, _, srcClient := makeUpstreamServer(t, false, false)
+		sctlr, _, srcClient := makeUpstreamServer(t, false, false)
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -393,10 +383,10 @@ func TestOnDemand(t *testing.T) {
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
 
-			dctlr, destBaseURL, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
+			dctlr, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			var (
@@ -503,9 +493,9 @@ func TestOnDemand(t *testing.T) {
 		})
 		Convey("Verify sync on demand feature with multiple registryConfig", func() {
 			// make a new upstream server
-			sctlr, newSrcBaseURL, srcDir, srcClient := makeUpstreamServer(t, false, false)
+			sctlr, srcDir, srcClient := makeUpstreamServer(t, false, false)
 			scm := test.NewControllerManager(sctlr)
-			scm.StartAndWait(sctlr.Config.HTTP.Port)
+			newSrcBaseURL := scm.StartAndWait()
 
 			defer scm.StopServer()
 
@@ -522,10 +512,10 @@ func TestOnDemand(t *testing.T) {
 				Registries: []syncconf.RegistryConfig{newRegistryConfig, syncRegistryConfig},
 			}
 
-			dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			var (
@@ -571,17 +561,16 @@ func TestOnDemand(t *testing.T) {
 		Convey("Signature copier errors", func() {
 			// start upstream server
 			rootDir := t.TempDir()
-			port := test.GetFreePort()
-			srcBaseURL := test.GetBaseURL(port)
 			conf := config.New()
-			conf.HTTP.Port = port
+			conf.HTTP.Port = "0"
 			conf.Storage.GC = false
 			ctlr := api.NewController(conf)
 			ctlr.Config.Storage.RootDirectory = rootDir
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(conf.HTTP.Port)
+			srcBaseURL := cm.StartAndWait()
 			defer cm.StopServer()
+			port := strconv.Itoa(cm.Port())
 
 			image := CreateRandomImage()
 			manifestBlob := image.ManifestDescriptor.Data
@@ -642,6 +631,7 @@ func TestOnDemand(t *testing.T) {
 			regex := ".*"
 			semver := true
 
+			// Keep GetFreePort: destPort is embedded in sync RegistryConfig.URLs before bind.
 			destPort := test.GetFreePort()
 			destConfig := config.New()
 
@@ -718,7 +708,7 @@ func TestOnDemand(t *testing.T) {
 			}
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(destPort)
+			dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			resp, err = resty.R().Get(destBaseURL + "/v2/remote-repo/manifests/test")
@@ -729,16 +719,14 @@ func TestOnDemand(t *testing.T) {
 		Convey("Sync referrers tag errors", func() {
 			// start upstream server
 			rootDir := t.TempDir()
-			port := test.GetFreePort()
-			srcBaseURL := test.GetBaseURL(port)
 			conf := config.New()
-			conf.HTTP.Port = port
+			conf.HTTP.Port = "0"
 			conf.Storage.GC = false
 			ctlr := api.NewController(conf)
 			ctlr.Config.Storage.RootDirectory = rootDir
 
 			cm := test.NewControllerManager(ctlr)
-			cm.StartAndWait(conf.HTTP.Port)
+			srcBaseURL := cm.StartAndWait()
 			defer cm.StopServer()
 
 			image := CreateRandomImage()
@@ -794,6 +782,7 @@ func TestOnDemand(t *testing.T) {
 			regex := ".*"
 			semver := true
 
+			// Keep GetFreePort: destPort is embedded in sync RegistryConfig.URLs before bind.
 			destPort := test.GetFreePort()
 			destConfig := config.New()
 
@@ -854,7 +843,7 @@ func TestOnDemand(t *testing.T) {
 			}
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(destPort)
+			dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			resp, err = resty.R().Get(destBaseURL + "/v2/remote-repo/manifests/test")
@@ -870,10 +859,10 @@ func TestOnDemand(t *testing.T) {
 
 func TestOnDemandWithScaleOutCluster(t *testing.T) {
 	Convey("Given 2 downstream zots and one upstream, test that the cluster can sync images", t, func() {
-		sctlr, srcBaseURL, _, srcClient := makeUpstreamServer(t, false, false)
+		sctlr, _, srcClient := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -901,6 +890,7 @@ func TestOnDemandWithScaleOutCluster(t *testing.T) {
 		}
 
 		// Get dynamic ports for cluster members
+		// Keep GetFreePorts: cluster member ports must be known before bind.
 		clusterPorts := test.GetFreePorts(2)
 
 		// cluster config for member 1.
@@ -923,10 +913,10 @@ func TestOnDemandWithScaleOutCluster(t *testing.T) {
 			t, clusterPorts[1], syncConfig, &clusterCfgDownstream2)
 		dctrl2Scm := test.NewControllerManager(dctrl2)
 
-		dctrl1Scm.StartAndWait(dctrl1.Config.HTTP.Port)
+		dctrl1Scm.StartAndWait()
 		defer dctrl1Scm.StopServer()
 
-		dctrl2Scm.StartAndWait(dctrl2.Config.HTTP.Port)
+		dctrl2Scm.StartAndWait()
 		defer dctrl2Scm.StopServer()
 
 		// verify that all servers are up.
@@ -1045,9 +1035,9 @@ func TestOnDemandWithScaleOutCluster(t *testing.T) {
 
 func TestOnDemandWithScaleOutClusterWithReposNotAddedForSync(t *testing.T) {
 	Convey("When repos are not added for sync, cluster should not sync images", t, func() {
-		sctlr, srcBaseURL, _, srcClient := makeUpstreamServer(t, false, false)
+		sctlr, _, srcClient := makeUpstreamServer(t, false, false)
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -1073,6 +1063,7 @@ func TestOnDemandWithScaleOutClusterWithReposNotAddedForSync(t *testing.T) {
 		}
 
 		// Get dynamic ports for cluster members
+		// Keep GetFreePorts: cluster member ports must be known before bind.
 		clusterPorts := test.GetFreePorts(2)
 
 		// cluster config for member 1.
@@ -1095,10 +1086,10 @@ func TestOnDemandWithScaleOutClusterWithReposNotAddedForSync(t *testing.T) {
 			t, clusterPorts[1], syncConfig, &clusterCfgDownstream2)
 		dctrl2Scm := test.NewControllerManager(dctrl2)
 
-		dctrl1Scm.StartAndWait(dctrl1.Config.HTTP.Port)
+		dctrl1Scm.StartAndWait()
 		defer dctrl1Scm.StopServer()
 
-		dctrl2Scm.StartAndWait(dctrl2.Config.HTTP.Port)
+		dctrl2Scm.StartAndWait()
 		defer dctrl2Scm.StopServer()
 
 		// verify that all servers are up.
@@ -1180,10 +1171,10 @@ func TestOnDemandWithScaleOutClusterWithReposNotAddedForSync(t *testing.T) {
 
 func TestSyncReferenceInLoop(t *testing.T) {
 	Convey("Verify sync doesn't end up in an infinite loop when syncing image references", t, func() {
-		sctlr, srcBaseURL, srcDir, _ := makeUpstreamServer(t, false, false)
+		sctlr, srcDir, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -1211,10 +1202,10 @@ func TestSyncReferenceInLoop(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -1228,7 +1219,7 @@ func TestSyncReferenceInLoop(t *testing.T) {
 		imageDigest := godigest.FromBytes(resp.Body())
 
 		// attach sbom
-		attachSBOM(srcDir, sctlr.Config.HTTP.Port, testImage, imageDigest)
+		attachSBOM(srcDir, strconv.Itoa(scm.Port()), testImage, imageDigest)
 
 		// sbom tag
 		sbomTag := strings.Replace(imageDigest.String(), ":", "-", 1) + "." + remote.SBOMTagSuffix
@@ -1326,10 +1317,10 @@ func TestSyncReferenceInLoop(t *testing.T) {
 
 func TestSyncWithNonDistributableBlob(t *testing.T) {
 	Convey("Verify sync doesn't copy non distributable blobs", t, func() {
-		sctlr, srcBaseURL, srcDir, _ := makeUpstreamServer(t, false, false)
+		sctlr, srcDir, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -1359,7 +1350,7 @@ func TestSyncWithNonDistributableBlob(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
 
@@ -1381,7 +1372,7 @@ func TestSyncWithNonDistributableBlob(t *testing.T) {
 			nonDistributableLayerData, 0o600)
 		So(err, ShouldBeNil)
 
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -1434,10 +1425,10 @@ func TestDockerImagesAreSkipped(t *testing.T) {
 		Convey("Verify docker images are skipped when they are already synced, preserveDigest: "+testCase.name, t, func() {
 			updateDuration, _ := time.ParseDuration("30m")
 
-			sctlr, srcBaseURL, srcDir, _ := makeUpstreamServer(t, false, false)
+			sctlr, srcDir, _ := makeUpstreamServer(t, false, false)
 
 			scm := test.NewControllerManager(sctlr)
-			scm.StartAndWait(sctlr.Config.HTTP.Port)
+			srcBaseURL := scm.StartAndWait()
 
 			defer scm.StopServer()
 
@@ -1473,7 +1464,7 @@ func TestDockerImagesAreSkipped(t *testing.T) {
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
 
-			dctlr, destBaseURL, destDir, _ := makeDownstreamServer(t, false, syncConfig)
+			dctlr, destDir, _ := makeDownstreamServer(t, false, syncConfig)
 
 			if testCase.preserveDigest {
 				dctlr.Config.HTTP.Compat = append(dctlr.Config.HTTP.Compat, "docker2s2")
@@ -1532,7 +1523,7 @@ func TestDockerImagesAreSkipped(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				dcm := test.NewControllerManager(dctlr)
-				dcm.StartAndWait(dctlr.Config.HTTP.Port)
+				destBaseURL := dcm.StartAndWait()
 				defer dcm.StopServer()
 
 				resp, err := resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
@@ -1695,7 +1686,7 @@ func TestDockerImagesAreSkipped(t *testing.T) {
 				So(err, ShouldBeNil)
 
 				dcm := test.NewControllerManager(dctlr)
-				dcm.StartAndWait(dctlr.Config.HTTP.Port)
+				destBaseURL := dcm.StartAndWait()
 				defer dcm.StopServer()
 
 				// sync
@@ -1759,10 +1750,10 @@ func TestPeriodically(t *testing.T) {
 	Convey("Verify sync feature", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, _, srcClient := makeUpstreamServer(t, false, false)
+		sctlr, _, srcClient := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -1798,10 +1789,10 @@ func TestPeriodically(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -1876,10 +1867,10 @@ func TestPeriodically(t *testing.T) {
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
 
-			dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			var (
@@ -1944,10 +1935,10 @@ func TestPeriodicallyWithScaleOutCluster(t *testing.T) {
 
 		const zotAlpineTestImageName = "zot-alpine-test"
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -1996,6 +1987,7 @@ func TestPeriodicallyWithScaleOutCluster(t *testing.T) {
 		// zot-alpine-test is managed by member index 1.
 
 		// Get dynamic ports for cluster members
+		// Keep GetFreePorts: cluster member ports must be known before bind.
 		clusterPorts := test.GetFreePorts(2)
 
 		clusterCfg := config.ClusterConfig{
@@ -2010,7 +2002,7 @@ func TestPeriodicallyWithScaleOutCluster(t *testing.T) {
 			clusterPorts[1], syncConfig, &clusterCfg)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -2064,10 +2056,10 @@ func TestPermsDenied(t *testing.T) {
 	Convey("Verify sync feature without perm on sync cache", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -2100,11 +2092,9 @@ func TestPermsDenied(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		destPort := test.GetFreePort()
 		destConfig := config.New()
-		destBaseURL := test.GetBaseURL(destPort)
 
-		destConfig.HTTP.Port = destPort
+		destConfig.HTTP.Port = "0"
 
 		destDir := t.TempDir()
 
@@ -2136,7 +2126,7 @@ func TestPermsDenied(t *testing.T) {
 			_ = os.Chmod(path.Join(destDir, testImage), 0o755)
 		}()
 
-		dcm.StartAndWait(destPort)
+		destBaseURL := dcm.StartAndWait()
 
 		found, err := test.ReadLogFileAndSearchString(dctlr.Config.Log.Output,
 			"failed to sync image", 50*time.Second)
@@ -2168,11 +2158,11 @@ func TestPermsDenied(t *testing.T) {
 
 func TestConfigReloader(t *testing.T) {
 	Convey("Verify periodically sync config reloader works", t, func() {
-		sctlr, srcBaseURL, srcDir, _ := makeUpstreamServer(t, false, false)
+		sctlr, srcDir, _ := makeUpstreamServer(t, false, false)
 		defer os.RemoveAll(srcDir)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -2201,6 +2191,7 @@ func TestConfigReloader(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
+		// Keep GetFreePort: reload JSON must embed the listen port before/during server life.
 		destPort := test.GetFreePort()
 		destConfig := config.New()
 		destBaseURL := test.GetBaseURL(destPort)
@@ -2438,10 +2429,10 @@ func TestMandatoryAnnotations(t *testing.T) {
 	Convey("Verify mandatory annotations failing - on demand disabled", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -2473,13 +2464,10 @@ func TestMandatoryAnnotations(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		destPort := test.GetFreePort()
 		destConfig := config.New()
 		destClient := resty.New()
 
-		destBaseURL := test.GetBaseURL(destPort)
-
-		destConfig.HTTP.Port = destPort
+		destConfig.HTTP.Port = "0"
 
 		destDir := t.TempDir()
 
@@ -2502,7 +2490,7 @@ func TestMandatoryAnnotations(t *testing.T) {
 		dctlr := api.NewController(destConfig)
 		dcm := test.NewControllerManager(dctlr)
 
-		dcm.StartAndWait(destPort)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -2534,10 +2522,10 @@ func TestBadTLS(t *testing.T) {
 	Convey("Verify sync TLS feature", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, true, false)
+		sctlr, _, _ := makeUpstreamServer(t, true, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -2569,10 +2557,10 @@ func TestBadTLS(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, true, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, true, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -2615,10 +2603,10 @@ func TestTLS(t *testing.T) {
 		caCertPath, _, _, clientCertPath, clientKeyPath, caCertPEM := setupTestCertsForSync(t, sharedCertDir)
 
 		// Create upstream server with shared certificates
-		sctlr, srcBaseURL, srcDir, _ := makeUpstreamServerWithCerts(t, true, false, sharedCertDir, caCertPEM)
+		sctlr, srcDir, _ := makeUpstreamServerWithCerts(t, true, false, sharedCertDir, caCertPEM)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -2699,11 +2687,11 @@ func TestTLS(t *testing.T) {
 		}
 
 		// Create downstream server with shared certificates (same CA as upstream)
-		dctlr, destBaseURL, destDir, destClient := makeDownstreamServerWithCerts(
+		dctlr, destDir, destClient := makeDownstreamServerWithCerts(
 			t, true, syncConfig, sharedCertDir, caCertPEM)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -2752,7 +2740,7 @@ func TestBearerAuth(t *testing.T) {
 		authTestServer := authutils.MakeAuthTestServer(serverKeyPath, "RS256", unauthorizedNamespace)
 		defer authTestServer.Close()
 
-		sctlr, srcBaseURL, _, srcClient := makeUpstreamServer(t, false, false)
+		sctlr, _, srcClient := makeUpstreamServer(t, false, false)
 
 		aurl, err := url.Parse(authTestServer.URL)
 		So(err, ShouldBeNil)
@@ -2766,7 +2754,7 @@ func TestBearerAuth(t *testing.T) {
 		}
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -2796,10 +2784,10 @@ func TestBearerAuth(t *testing.T) {
 			Registries:      []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -2905,7 +2893,7 @@ func TestBearerAuth(t *testing.T) {
 		authTestServer := authutils.MakeAuthTestServer(serverKeyPath, "RS256", unauthorizedNamespace)
 		defer authTestServer.Close()
 
-		sctlr, srcBaseURL, _, srcClient := makeUpstreamServer(t, false, false)
+		sctlr, _, srcClient := makeUpstreamServer(t, false, false)
 
 		aurl, err := url.Parse(authTestServer.URL)
 		So(err, ShouldBeNil)
@@ -2919,7 +2907,7 @@ func TestBearerAuth(t *testing.T) {
 		}
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -2949,10 +2937,10 @@ func TestBearerAuth(t *testing.T) {
 			Registries:      []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -3044,10 +3032,10 @@ func TestBasicAuth(t *testing.T) {
 		updateDuration, _ := time.ParseDuration("1h")
 
 		Convey("Verify sync basic auth with file credentials", func() {
-			sctlr, srcBaseURL, _, srcClient := makeUpstreamServer(t, false, true)
+			sctlr, _, srcClient := makeUpstreamServer(t, false, true)
 
 			scm := test.NewControllerManager(sctlr)
-			scm.StartAndWait(sctlr.Config.HTTP.Port)
+			srcBaseURL := scm.StartAndWait()
 			defer scm.StopServer()
 
 			registryName := sync.StripRegistryTransport(srcBaseURL)
@@ -3076,10 +3064,10 @@ func TestBasicAuth(t *testing.T) {
 				Registries:      []syncconf.RegistryConfig{syncRegistryConfig},
 			}
 
-			dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			var (
@@ -3120,17 +3108,14 @@ func TestBasicAuth(t *testing.T) {
 		})
 
 		Convey("Verify sync basic auth with wrong file credentials", func() {
-			sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, true)
+			sctlr, _, _ := makeUpstreamServer(t, false, true)
 
 			scm := test.NewControllerManager(sctlr)
-			scm.StartAndWait(sctlr.Config.HTTP.Port)
+			srcBaseURL := scm.StartAndWait()
 			defer scm.StopServer()
 
-			destPort := test.GetFreePort()
-			destBaseURL := test.GetBaseURL(destPort)
-
 			destConfig := config.New()
-			destConfig.HTTP.Port = destPort
+			destConfig.HTTP.Port = "0"
 
 			destDir := t.TempDir()
 
@@ -3188,7 +3173,7 @@ func TestBasicAuth(t *testing.T) {
 
 			dctlr := api.NewController(destConfig)
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(destPort)
+			destBaseURL := dcm.StartAndWait()
 
 			defer dcm.StopServer()
 
@@ -3213,10 +3198,10 @@ func TestBasicAuth(t *testing.T) {
 		})
 
 		Convey("Verify sync basic auth with bad file credentials", func() {
-			sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, true)
+			sctlr, _, _ := makeUpstreamServer(t, false, true)
 
 			scm := test.NewControllerManager(sctlr)
-			scm.StartAndWait(sctlr.Config.HTTP.Port)
+			srcBaseURL := scm.StartAndWait()
 			defer scm.StopServer()
 
 			registryName := sync.StripRegistryTransport(srcBaseURL)
@@ -3263,10 +3248,10 @@ func TestBasicAuth(t *testing.T) {
 				Registries:      []syncconf.RegistryConfig{syncRegistryConfig},
 			}
 
-			dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			found, err := test.ReadLogFileAndSearchString(dctlr.Config.Log.Output,
@@ -3290,10 +3275,10 @@ func TestBasicAuth(t *testing.T) {
 		})
 
 		Convey("Verify on demand sync with basic auth", func() {
-			sctlr, srcBaseURL, _, srcClient := makeUpstreamServer(t, false, true)
+			sctlr, _, srcClient := makeUpstreamServer(t, false, true)
 
 			scm := test.NewControllerManager(sctlr)
-			scm.StartAndWait(sctlr.Config.HTTP.Port)
+			srcBaseURL := scm.StartAndWait()
 			defer scm.StopServer()
 
 			registryName := sync.StripRegistryTransport(srcBaseURL)
@@ -3332,10 +3317,10 @@ func TestBasicAuth(t *testing.T) {
 				},
 			}
 
-			dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			var (
@@ -3429,10 +3414,10 @@ func TestBadURL(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -3446,10 +3431,10 @@ func TestNoImagesByRegex(t *testing.T) {
 	Convey("Verify sync with no images on source based on regex", t, func() {
 		updateDuration, _ := time.ParseDuration("1h")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -3479,10 +3464,10 @@ func TestNoImagesByRegex(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -3510,10 +3495,10 @@ func TestInvalidRegex(t *testing.T) {
 	Convey("Verify sync with invalid regex", t, func() {
 		updateDuration, _ := time.ParseDuration("1h")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -3544,10 +3529,10 @@ func TestInvalidRegex(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, _, _, _ := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -3572,10 +3557,10 @@ func TestNotSemver(t *testing.T) {
 	Convey("Verify sync feature semver compliant", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -3620,10 +3605,10 @@ func TestNotSemver(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -3655,10 +3640,10 @@ func TestInvalidCerts(t *testing.T) {
 	Convey("Verify sync with bad certs", t, func() {
 		updateDuration, _ := time.ParseDuration("1h")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, true, false)
+		sctlr, _, _ := makeUpstreamServer(t, true, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -3702,9 +3687,9 @@ func TestInvalidCerts(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -3749,22 +3734,10 @@ func TestCertsWithWrongPerms(t *testing.T) {
 		}
 
 		// can't create http client because of no perms on ca cert
-		destPort := test.GetFreePort()
-		destConfig := config.New()
-		destConfig.HTTP.Port = destPort
-
-		destDir := t.TempDir()
-
-		destConfig.Storage.RootDirectory = destDir
-
-		destConfig.Extensions = &extconf.ExtensionConfig{}
-		destConfig.Extensions.Search = nil
-		destConfig.Extensions.Sync = syncConfig
-
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -3823,10 +3796,10 @@ func TestInvalidUrl(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -3840,10 +3813,10 @@ func TestInvalidTags(t *testing.T) {
 	Convey("Verify sync invalid tags", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -3879,10 +3852,10 @@ func TestInvalidTags(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -3896,11 +3869,9 @@ func TestSubPaths(t *testing.T) {
 	Convey("Verify sync with storage subPaths", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		srcPort := test.GetFreePort()
 		srcConfig := config.New()
-		srcBaseURL := test.GetBaseURL(srcPort)
 
-		srcConfig.HTTP.Port = srcPort
+		srcConfig.HTTP.Port = "0"
 
 		srcConfig.Storage.GC = false
 
@@ -3920,7 +3891,7 @@ func TestSubPaths(t *testing.T) {
 		sctlr := api.NewController(srcConfig)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(srcPort)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -3955,7 +3926,6 @@ func TestSubPaths(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		destPort := test.GetFreePort()
 		destConfig := config.New()
 
 		destDir := t.TempDir()
@@ -3974,8 +3944,7 @@ func TestSubPaths(t *testing.T) {
 			},
 		}
 
-		destBaseURL := test.GetBaseURL(destPort)
-		destConfig.HTTP.Port = destPort
+		destConfig.HTTP.Port = "0"
 
 		destConfig.Extensions = &extconf.ExtensionConfig{}
 		destConfig.Extensions.Search = nil
@@ -3984,7 +3953,7 @@ func TestSubPaths(t *testing.T) {
 		dctlr := api.NewController(destConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(destPort)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -4045,10 +4014,10 @@ func TestOnDemandRepoErr(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -4060,10 +4029,10 @@ func TestOnDemandRepoErr(t *testing.T) {
 
 func TestOnDemandContentFiltering(t *testing.T) {
 	Convey("Verify sync on demand feature", t, func() {
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -4099,10 +4068,10 @@ func TestOnDemandContentFiltering(t *testing.T) {
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
 
-			dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 
 			defer dcm.StopServer()
 
@@ -4141,10 +4110,10 @@ func TestOnDemandContentFiltering(t *testing.T) {
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
 
-			dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			resp, err := resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
@@ -4156,10 +4125,10 @@ func TestOnDemandContentFiltering(t *testing.T) {
 
 func TestConfigRules(t *testing.T) {
 	Convey("Verify sync config rules", t, func() {
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -4194,10 +4163,10 @@ func TestConfigRules(t *testing.T) {
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
 
-			dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			// image should not be synced
@@ -4226,10 +4195,10 @@ func TestConfigRules(t *testing.T) {
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
 
-			dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			resp, err := resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
@@ -4253,10 +4222,10 @@ func TestConfigRules(t *testing.T) {
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
 
-			dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			resp, err := resty.R().Get(destBaseURL + "/v2/" + testImage + "/manifests/" + testImageTag)
@@ -4270,10 +4239,10 @@ func TestMultipleURLs(t *testing.T) {
 	Convey("Verify sync feature", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, _, srcClient := makeUpstreamServer(t, false, false)
+		sctlr, _, srcClient := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -4305,10 +4274,10 @@ func TestMultipleURLs(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -4382,10 +4351,10 @@ func TestNoURLsLeftInConfig(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -4400,10 +4369,10 @@ func TestPeriodicallySignaturesErr(t *testing.T) {
 	Convey("Verify sync periodically signatures errors", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, srcDir, _ := makeUpstreamServer(t, false, false)
+		sctlr, srcDir, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -4480,10 +4449,10 @@ func TestPeriodicallySignaturesErr(t *testing.T) {
 			err = os.Chmod(manifestPath, 0o000)
 			So(err, ShouldBeNil)
 
-			dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 
 			defer dcm.StopServer()
 
@@ -4529,10 +4498,10 @@ func TestPeriodicallySignaturesErr(t *testing.T) {
 			}
 
 			// start downstream server
-			dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			found, err := test.ReadLogFileAndSearchString(dctlr.Config.Log.Output,
@@ -4599,10 +4568,10 @@ func TestPeriodicallySignaturesErr(t *testing.T) {
 			}
 
 			// start downstream server
-			dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			found, err := test.ReadLogFileAndSearchString(dctlr.Config.Log.Output,
@@ -4676,10 +4645,10 @@ func TestPeriodicallySignaturesErr(t *testing.T) {
 			// syncConfig.Registries[0].OnDemand = false
 
 			// start downstream server
-			dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+			dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			found, err := test.ReadLogFileAndSearchString(dctlr.Config.Log.Output,
@@ -4712,11 +4681,11 @@ func TestSignatures(t *testing.T) {
 	Convey("Verify sync signatures", t, func() {
 		updateDuration, _ := time.ParseDuration("1m")
 
-		sctlr, srcBaseURL, srcDir, _ := makeUpstreamServer(t, false, false)
+		sctlr, srcDir, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
 
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -4742,7 +4711,7 @@ func TestSignatures(t *testing.T) {
 		So(func() { signImage(tdir, srcPort, repoName, digest) }, ShouldNotPanic)
 
 		// attach sbom
-		attachSBOM(srcDir, sctlr.Config.HTTP.Port, repoName, digest)
+		attachSBOM(srcDir, strconv.Itoa(scm.Port()), repoName, digest)
 
 		// sbom tag
 		sbomTag := strings.Replace(digest.String(), ":", "-", 1) + "." + remote.SBOMTagSuffix
@@ -4835,10 +4804,10 @@ func TestSignatures(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -5241,10 +5210,10 @@ func TestSignatures(t *testing.T) {
 	Convey("Verify sync oci1.1 cosign signatures", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -5296,10 +5265,10 @@ func TestSignatures(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -5355,12 +5324,12 @@ func TestSyncedSignaturesMetaDB(t *testing.T) {
 
 		// Create source registry
 
-		sctlr, srcBaseURL, srcDir, _ := makeUpstreamServer(t, false, false)
+		sctlr, srcDir, _ := makeUpstreamServer(t, false, false)
 		t.Log(srcDir)
-		srcPort := getPortFromBaseURL(srcBaseURL)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
+		srcPort := getPortFromBaseURL(srcBaseURL)
 
 		defer scm.StopServer()
 
@@ -5405,11 +5374,11 @@ func TestSyncedSignaturesMetaDB(t *testing.T) {
 			},
 		}
 
-		dctlr, destBaseURL, dstDir, _ := makeDownstreamServer(t, false, syncConfig)
+		dctlr, dstDir, _ := makeDownstreamServer(t, false, syncConfig)
 		t.Log(dstDir)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -5442,9 +5411,9 @@ func TestSyncedSignaturesMetaDB(t *testing.T) {
 
 func TestSyncLegacyCosignTags(t *testing.T) {
 	Convey("SyncLegacyCosignTags controls whether legacy cosign/SBOM tags are synced", t, func() {
-		sctlr, srcBaseURL, srcDir, _ := makeUpstreamServer(t, false, false)
+		sctlr, srcDir, _ := makeUpstreamServer(t, false, false)
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 		defer scm.StopServer()
 
 		// Get image digest and add legacy SBOM tag on source (sha256-<digest>.sbom)
@@ -5481,9 +5450,9 @@ func TestSyncLegacyCosignTags(t *testing.T) {
 				Enable:     &defaultVal,
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
-			dctlr, destBaseURL, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
+			dctlr, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			// Trigger image sync
@@ -5546,9 +5515,9 @@ func TestSyncLegacyCosignTags(t *testing.T) {
 				Enable:     &defaultVal,
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
-			dctlr, destBaseURL, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
+			dctlr, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			// Wait for periodic sync to complete (do not call GET manifest for legacy tag to avoid on-demand sync)
@@ -5591,9 +5560,9 @@ func TestSyncLegacyCosignTags(t *testing.T) {
 
 func TestSyncLegacyCosignTagsWithSignatures(t *testing.T) {
 	Convey("SyncLegacyCosignTags controls whether legacy cosign signature tags (.sig) are synced", t, func() {
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 		defer scm.StopServer()
 
 		// Push image and sign it (adds legacy .sig tag on source)
@@ -5630,9 +5599,9 @@ func TestSyncLegacyCosignTagsWithSignatures(t *testing.T) {
 				Enable:     &defaultVal,
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
-			dctlr, destBaseURL, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
+			dctlr, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			// Trigger image sync
@@ -5695,9 +5664,9 @@ func TestSyncLegacyCosignTagsWithSignatures(t *testing.T) {
 				Enable:     &defaultVal,
 				Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 			}
-			dctlr, destBaseURL, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
+			dctlr, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
 			dcm := test.NewControllerManager(dctlr)
-			dcm.StartAndWait(dctlr.Config.HTTP.Port)
+			destBaseURL := dcm.StartAndWait()
 			defer dcm.StopServer()
 
 			// Wait for periodic sync to complete for this repo (do not call GET manifest for legacy tag to avoid on-demand sync)
@@ -5740,6 +5709,7 @@ func TestSyncLegacyCosignTagsWithSignatures(t *testing.T) {
 
 func TestOnDemandRetryGoroutine(t *testing.T) {
 	Convey("Verify ondemand sync retries in background on error", t, func() {
+		// Keep GetFreePort for src: sync config must reference srcBaseURL before upstream starts.
 		srcPort := test.GetFreePort()
 		srcConfig := config.New()
 		srcBaseURL := test.GetBaseURL(srcPort)
@@ -5794,10 +5764,10 @@ func TestOnDemandRetryGoroutine(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -5839,10 +5809,10 @@ func TestOnDemandRetryGoroutine(t *testing.T) {
 
 func TestOnDemandWithDigest(t *testing.T) {
 	Convey("Verify ondemand sync works with both digests and tags", t, func() {
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -5874,10 +5844,10 @@ func TestOnDemandWithDigest(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -5929,10 +5899,10 @@ func TestOnDemandRetryGoroutineErr(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -5963,6 +5933,7 @@ func TestOnDemandRetryGoroutineErr(t *testing.T) {
 
 func TestOnDemandMultipleImage(t *testing.T) {
 	Convey("Verify ondemand sync retries in background on error, multiple calls should spawn one routine", t, func() {
+		// Keep GetFreePort for src: sync config must reference srcBaseURL before upstream starts.
 		srcPort := test.GetFreePort()
 		srcConfig := config.New()
 		srcBaseURL := test.GetBaseURL(srcPort)
@@ -6005,11 +5976,11 @@ func TestOnDemandMultipleImage(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
 		defer os.RemoveAll(destDir)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -6047,7 +6018,7 @@ func TestOnDemandMultipleImage(t *testing.T) {
 		}()
 
 		// start upstream server
-		scm.StartAndWait(srcPort)
+		scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -6077,10 +6048,10 @@ func TestOnDemandMultipleImage(t *testing.T) {
 
 func TestOnDemandPullsReferrersOnce(t *testing.T) {
 	Convey("Verify sync on demand pulls only one time", t, func(conv C) {
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -6158,10 +6129,10 @@ func TestOnDemandPullsReferrersOnce(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
 
-		dctlr, destBaseURL, destDir, _ := makeDownstreamServer(t, false, syncConfig)
+		dctlr, destDir, _ := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -6255,10 +6226,10 @@ func TestOnDemandPullsReferrersOnce(t *testing.T) {
 
 func TestOnDemandPullsOnce(t *testing.T) {
 	Convey("Verify sync on demand pulls only one time", t, func(conv C) {
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -6290,10 +6261,10 @@ func TestOnDemandPullsOnce(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, destDir, _ := makeDownstreamServer(t, false, syncConfig)
+		dctlr, destDir, _ := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -6370,10 +6341,10 @@ func TestOnDemandPullsOnce(t *testing.T) {
 
 func TestSignaturesOnDemand(t *testing.T) {
 	Convey("Verify sync signatures on demand feature", t, func() {
-		sctlr, srcBaseURL, srcDir, _ := makeUpstreamServer(t, false, false)
+		sctlr, srcDir, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -6414,10 +6385,10 @@ func TestSignaturesOnDemand(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, destDir, _ := makeDownstreamServer(t, false, syncConfig)
+		dctlr, destDir, _ := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -6497,10 +6468,10 @@ func TestSignaturesOnDemand(t *testing.T) {
 	})
 
 	Convey("Verify sync signatures on demand feature: notation - negative cases", t, func() {
-		sctlr, srcBaseURL, srcDir, _ := makeUpstreamServer(t, false, false)
+		sctlr, srcDir, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -6541,10 +6512,8 @@ func TestSignaturesOnDemand(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		destPort := test.GetFreePort()
 		destConfig := config.New()
-		destBaseURL := test.GetBaseURL(destPort)
-		destConfig.HTTP.Port = destPort
+		destConfig.HTTP.Port = "0"
 
 		destDir := t.TempDir()
 
@@ -6560,7 +6529,7 @@ func TestSignaturesOnDemand(t *testing.T) {
 		dctlr := api.NewController(destConfig)
 		dcm := test.NewControllerManager(dctlr)
 
-		dcm.StartAndWait(destPort)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -6616,10 +6585,10 @@ func TestSignaturesOnDemand(t *testing.T) {
 
 func TestOnlySignaturesOnDemand(t *testing.T) {
 	Convey("Verify sync signatures on demand feature when we already have the image", t, func() {
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -6660,10 +6629,10 @@ func TestOnlySignaturesOnDemand(t *testing.T) {
 			},
 		}
 
-		dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -6731,10 +6700,10 @@ func TestSyncOnlyDiff(t *testing.T) {
 	Convey("Verify sync only difference between local and upstream", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -6760,10 +6729,8 @@ func TestSyncOnlyDiff(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		destPort := test.GetFreePort()
 		destConfig := config.New()
-		destBaseURL := test.GetBaseURL(destPort)
-		destConfig.HTTP.Port = destPort
+		destConfig.HTTP.Port = "0"
 
 		destDir := t.TempDir()
 
@@ -6788,7 +6755,7 @@ func TestSyncOnlyDiff(t *testing.T) {
 		dctlr := api.NewController(destConfig)
 		dcm := test.NewControllerManager(dctlr)
 
-		dcm.StartAndWait(destPort)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -6819,10 +6786,10 @@ func TestSyncWithDiffDigest(t *testing.T) {
 	Convey("Verify sync correctly detects changes in upstream images", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -6848,10 +6815,8 @@ func TestSyncWithDiffDigest(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		destPort := test.GetFreePort()
 		destConfig := config.New()
-		destBaseURL := test.GetBaseURL(destPort)
-		destConfig.HTTP.Port = destPort
+		destConfig.HTTP.Port = "0"
 
 		destDir := t.TempDir()
 
@@ -6938,11 +6903,9 @@ func TestSyncWithDiffDigest(t *testing.T) {
 		So(resp, ShouldNotBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
 
-		dcm.StartServer()
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
-
-		test.WaitTillServerReady(destBaseURL)
 
 		// wait generator to finish generating tasks.
 		waitSyncFinish(dctlr.Config.Log.Output)
@@ -6966,11 +6929,11 @@ func TestSyncSignaturesDiff(t *testing.T) {
 	Convey("Verify sync detects changes in the upstream signatures", t, func() {
 		updateDuration, _ := time.ParseDuration("10s")
 
-		sctlr, srcBaseURL, srcDir, _ := makeUpstreamServer(t, false, false)
+		sctlr, srcDir, _ := makeUpstreamServer(t, false, false)
 		defer os.RemoveAll(srcDir)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -7026,10 +6989,10 @@ func TestSyncSignaturesDiff(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
+		dctlr, destDir, destClient := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -7213,10 +7176,10 @@ func TestSyncSignaturesDiff(t *testing.T) {
 func TestOnlySignedFlag(t *testing.T) {
 	updateDuration, _ := time.ParseDuration("30m")
 
-	sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false) //nolint: dogsled
+	sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 	scm := test.NewControllerManager(sctlr)
-	scm.StartAndWait(sctlr.Config.HTTP.Port)
+	srcBaseURL := scm.StartAndWait()
 
 	defer scm.StopServer()
 
@@ -7253,10 +7216,10 @@ func TestOnlySignedFlag(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, client := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, client := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -7289,10 +7252,10 @@ func TestOnlySignedFlag(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, client := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, client := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -7346,7 +7309,7 @@ func TestSyncWithDestination(t *testing.T) {
 			},
 		}
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		err := os.MkdirAll(path.Join(sctlr.Config.Storage.RootDirectory, "/zot-fold"), storageConstants.DefaultDirPerms)
 		So(err, ShouldBeNil)
@@ -7359,7 +7322,7 @@ func TestSyncWithDestination(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -7403,10 +7366,10 @@ func TestSyncWithDestination(t *testing.T) {
 					Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 				}
 
-				dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+				dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 				dcm := test.NewControllerManager(dctlr)
-				dcm.StartAndWait(dctlr.Config.HTTP.Port)
+				destBaseURL := dcm.StartAndWait()
 				defer dcm.StopServer()
 
 				time.Sleep(2 * time.Second)
@@ -7465,10 +7428,10 @@ func TestSyncWithDestination(t *testing.T) {
 					Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 				}
 
-				dctlr, destBaseURL, _, destClient := makeDownstreamServer(t, false, syncConfig)
+				dctlr, _, destClient := makeDownstreamServer(t, false, syncConfig)
 
 				dcm := test.NewControllerManager(dctlr)
-				dcm.StartAndWait(dctlr.Config.HTTP.Port)
+				destBaseURL := dcm.StartAndWait()
 				defer dcm.StopServer()
 
 				resp, err := destClient.R().Get(destBaseURL + "/v2/" + testCase.expected + "/manifests/0.0.1")
@@ -7511,10 +7474,10 @@ func TestSyncImageIndex(t *testing.T) {
 	Convey("Verify syncing image indexes works", t, func() {
 		updateDuration, _ := time.ParseDuration("30m")
 
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -7569,10 +7532,10 @@ func TestSyncImageIndex(t *testing.T) {
 
 			Convey("sync periodically", func() {
 				// start downstream server
-				dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+				dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 				dcm := test.NewControllerManager(dctlr)
-				dcm.StartAndWait(dctlr.Config.HTTP.Port)
+				destBaseURL := dcm.StartAndWait()
 				defer dcm.StopServer()
 
 				// give it time to set up sync
@@ -7600,10 +7563,10 @@ func TestSyncImageIndex(t *testing.T) {
 				syncConfig.Registries[0].OnDemand = true
 				syncConfig.Registries[0].PollInterval = 0
 
-				dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+				dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 				dcm := test.NewControllerManager(dctlr)
-				dcm.StartAndWait(dctlr.Config.HTTP.Port)
+				destBaseURL := dcm.StartAndWait()
 				defer dcm.StopServer()
 
 				resp, err = resty.R().SetHeader("Content-Type", ispec.MediaTypeImageIndex).
@@ -7696,10 +7659,10 @@ func TestSyncImageIndex(t *testing.T) {
 
 			Convey("sync periodically", func() {
 				// start downstream server
-				dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+				dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 				dcm := test.NewControllerManager(dctlr)
-				dcm.StartAndWait(dctlr.Config.HTTP.Port)
+				destBaseURL := dcm.StartAndWait()
 				defer dcm.StopServer()
 
 				// Wait for SyncRepo to finish processing all tags for the "index" repo.
@@ -7750,10 +7713,10 @@ func TestSyncImageIndex(t *testing.T) {
 				syncConfig.Registries[0].OnDemand = true
 				syncConfig.Registries[0].PollInterval = 0
 
-				dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+				dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 				dcm := test.NewControllerManager(dctlr)
-				dcm.StartAndWait(dctlr.Config.HTTP.Port)
+				destBaseURL := dcm.StartAndWait()
 				defer dcm.StopServer()
 
 				resp, err = resty.R().SetHeader("Content-Type", ispec.MediaTypeImageIndex).
@@ -7835,10 +7798,10 @@ func TestECRCredentialsHelper(t *testing.T) {
 // recursive referrer sync is done only in periodic sync.
 func TestOnDemandReferrerSyncFlags(t *testing.T) {
 	Convey("SyncLegacyCosignTags=false syncs OCI referrers but not digest-tag referrers", t, func() {
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -7950,10 +7913,10 @@ func TestOnDemandReferrerSyncFlags(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 
@@ -7981,10 +7944,10 @@ func TestOnDemandReferrerSyncFlags(t *testing.T) {
 	})
 
 	Convey("On-demand SyncReferrers syncs only direct referrers (no recursion)", t, func() {
-		sctlr, srcBaseURL, _, _ := makeUpstreamServer(t, false, false)
+		sctlr, _, _ := makeUpstreamServer(t, false, false)
 
 		scm := test.NewControllerManager(sctlr)
-		scm.StartAndWait(sctlr.Config.HTTP.Port)
+		srcBaseURL := scm.StartAndWait()
 
 		defer scm.StopServer()
 
@@ -8105,10 +8068,10 @@ func TestOnDemandReferrerSyncFlags(t *testing.T) {
 			Registries: []syncconf.RegistryConfig{syncRegistryConfig},
 		}
 
-		dctlr, destBaseURL, _, _ := makeDownstreamServer(t, false, syncConfig)
+		dctlr, _, _ := makeDownstreamServer(t, false, syncConfig)
 
 		dcm := test.NewControllerManager(dctlr)
-		dcm.StartAndWait(dctlr.Config.HTTP.Port)
+		destBaseURL := dcm.StartAndWait()
 
 		defer dcm.StopServer()
 

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -40,15 +40,13 @@ func TestAuditLogMessages(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		dir := t.TempDir()
 
-		port := test.GetFreePort()
-		baseURL := test.GetBaseURL(port)
 		conf := config.New()
 
 		outputPath := dir + "/zot.log"
 		auditPath := dir + "/zot-audit.log"
 		conf.Log = &config.LogConfig{Level: "debug", Output: outputPath, Audit: auditPath}
 
-		conf.HTTP.Port = port
+		conf.HTTP.Port = "0"
 
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
@@ -65,7 +63,7 @@ func TestAuditLogMessages(t *testing.T) {
 		ctlr.Config.Storage.RootDirectory = dir
 
 		ctlrManager := test.NewControllerManager(ctlr)
-		ctlrManager.StartAndWait(port)
+		baseURL := ctlrManager.StartAndWait()
 		defer ctlrManager.StopServer()
 
 		Convey("Open auditLog file", func() {

--- a/pkg/test/common/utils.go
+++ b/pkg/test/common/utils.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"bytes"
+	"crypto/tls"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -26,6 +28,9 @@ const (
 	SleepTime             = 100 * time.Millisecond
 	boundPortWaitTimeout  = 30 * time.Second
 	AuthorizationAllRepos = "**"
+	// Must match the log message in pkg/api/controller.go when Port is "0".
+	kernelChosenPortMsg   = "port is unspecified, listening on kernel chosen port"
+	kernelPortWaitTimeout = 30 * time.Second
 )
 
 type isser interface {
@@ -72,6 +77,7 @@ type Controller interface {
 	Run() error
 	Shutdown()
 	GetPort() int
+	TLSEnabled() bool
 }
 
 type ControllerManager struct {
@@ -99,17 +105,17 @@ func (cm *ControllerManager) StopServer() {
 	cm.controller.Shutdown()
 }
 
-// StartAndWait starts the controller and blocks until the server responds to HTTP GET.
-// It returns the HTTP base URL (http://127.0.0.1:<port>).
+// StartAndWait starts the controller and blocks until the server responds to GET.
+// It returns the base URL with the correct scheme (http or https) for the bound port.
 //
 // The listen port comes from the controller config. After bind, the port is
 // read from the controller (including kernel-chosen ports when config uses "0").
 // Prefer conf.HTTP.Port = "0" in new tests to avoid port-allocation races.
-//
-// Optional port arguments are deprecated and ignored; kept for call-site compatibility.
-func (cm *ControllerManager) StartAndWait(_ ...string) string {
+// Controllers with TLSEnabled() true yield an https URL;
+// readiness probing uses InsecureSkipVerify so self-signed test certs work.
+func (cm *ControllerManager) StartAndWait() string {
 	cm.StartServer()
-	baseURL := GetBaseURL(cm.waitForBoundPort())
+	baseURL := cm.baseURLForPort(cm.waitForBoundPort())
 	WaitTillServerReady(baseURL)
 
 	return baseURL
@@ -120,14 +126,23 @@ func (cm *ControllerManager) Port() int {
 	return cm.controller.GetPort()
 }
 
-// BaseURL returns http://127.0.0.1:<port> from the bound listen port, or "" if not listening yet.
+// BaseURL returns http(s)://127.0.0.1:<port> from the bound listen port, or "" if not listening yet.
+// The scheme is https when TLSEnabled() is true.
 func (cm *ControllerManager) BaseURL() string {
 	port := cm.Port()
 	if port <= 0 {
 		return ""
 	}
 
-	return GetBaseURL(strconv.Itoa(port))
+	return cm.baseURLForPort(strconv.Itoa(port))
+}
+
+func (cm *ControllerManager) baseURLForPort(port string) string {
+	if cm.controller.TLSEnabled() {
+		return GetSecureBaseURL(port)
+	}
+
+	return GetBaseURL(port)
 }
 
 func (cm *ControllerManager) waitForBoundPort() string {
@@ -144,9 +159,9 @@ func (cm *ControllerManager) waitForBoundPort() string {
 	panic(fmt.Sprintf("timed out after %s waiting for controller to bind a port", boundPortWaitTimeout))
 }
 
-// WaitServerReady blocks until the server responds to HTTP GET on the bound port.
+// WaitServerReady blocks until the server responds to GET on the bound port (http or https).
 func (cm *ControllerManager) WaitServerReady() {
-	WaitTillServerReady(GetBaseURL(cm.waitForBoundPort()))
+	WaitTillServerReady(cm.baseURLForPort(cm.waitForBoundPort()))
 }
 
 func NewControllerManager(controller Controller) ControllerManager {
@@ -158,8 +173,18 @@ func NewControllerManager(controller Controller) ControllerManager {
 }
 
 func WaitTillServerReady(url string) {
+	client := resty.New()
+
+	if strings.HasPrefix(url, "https://") {
+		// Test servers use self-signed certs; this probe only checks that ServeTLS is accepting.
+		client.SetTLSClientConfig(&tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // test readiness probe only
+			MinVersion:         tls.VersionTLS12,
+		})
+	}
+
 	for {
-		_, err := resty.R().Get(url)
+		_, err := client.R().Get(url)
 		if err == nil {
 			break
 		}
@@ -210,6 +235,43 @@ func GetBaseURL(port string) string {
 
 func GetSecureBaseURL(port string) string {
 	return fmt.Sprintf(BaseSecureURL, port)
+}
+
+// WaitForKernelChosenPortBaseURL polls a zot log file for the kernel-assigned listen
+// port logged when conf.HTTP.Port is "0", then returns http://127.0.0.1:<port>.
+// Used for CLI serve tests that have no ControllerManager to query after bind.
+func WaitForKernelChosenPortBaseURL(logPath string) string {
+	return waitForKernelChosenPortBaseURL(logPath, kernelPortWaitTimeout)
+}
+
+func waitForKernelChosenPortBaseURL(logPath string, timeout time.Duration) string {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		content, err := os.ReadFile(logPath)
+		if err == nil {
+			for line := range strings.SplitSeq(string(content), "\n") {
+				if !strings.Contains(line, kernelChosenPortMsg) {
+					continue
+				}
+
+				var entry struct {
+					Port int `json:"port"`
+				}
+
+				if err := json.Unmarshal([]byte(line), &entry); err != nil || entry.Port <= 0 {
+					continue
+				}
+
+				return GetBaseURL(strconv.Itoa(entry.Port))
+			}
+		}
+
+		time.Sleep(SleepTime)
+	}
+
+	panic(fmt.Sprintf("timed out after %s waiting for kernel chosen port in %s",
+		timeout, logPath))
 }
 
 func CustomRedirectPolicy(noOfRedirect int) resty.RedirectPolicy {

--- a/pkg/test/common/utils_internal_test.go
+++ b/pkg/test/common/utils_internal_test.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestWaitForKernelChosenPortBaseURLTimeout(t *testing.T) {
+	Convey("panics when the kernel-chosen port never appears", t, func() {
+		logPath := path.Join(t.TempDir(), "missing-zot-log.txt")
+		timeout := 50 * time.Millisecond
+
+		So(func() {
+			waitForKernelChosenPortBaseURL(logPath, timeout)
+		}, ShouldPanicWith, fmt.Sprintf(
+			"timed out after %s waiting for kernel chosen port in %s",
+			timeout, logPath,
+		))
+	})
+
+	Convey("panics when log lines never yield a positive port", t, func() {
+		logPath := path.Join(t.TempDir(), "zot-log.txt")
+		content := "" +
+			`{"level":"info","message":"unrelated"}` + "\n" +
+			`{"level":"info","message":"port is unspecified, listening on kernel chosen port","port":0}` + "\n" +
+			`{"level":"info","message":"port is unspecified, listening on kernel chosen port","port":"bad"}` + "\n"
+		So(os.WriteFile(logPath, []byte(content), 0o600), ShouldBeNil)
+
+		timeout := 50 * time.Millisecond
+		So(func() {
+			waitForKernelChosenPortBaseURL(logPath, timeout)
+		}, ShouldPanicWith, fmt.Sprintf(
+			"timed out after %s waiting for kernel chosen port in %s",
+			timeout, logPath,
+		))
+	})
+}
+
+func TestWaitForKernelChosenPortBaseURLSkipsInvalidPortLines(t *testing.T) {
+	Convey("skips non-positive and unparsable ports then returns the first valid one", t, func() {
+		logPath := path.Join(t.TempDir(), "zot-log.txt")
+		content := "" +
+			`{"level":"info","message":"port is unspecified, listening on kernel chosen port","port":0}` + "\n" +
+			`{"level":"info","message":"port is unspecified, listening on kernel chosen port","port":-1}` + "\n" +
+			`{"level":"info","message":"port is unspecified, listening on kernel chosen port","port":"bad"}` + "\n" +
+			`not-json port is unspecified, listening on kernel chosen port` + "\n" +
+			`{"level":"info","message":"port is unspecified, listening on kernel chosen port","port":34567}` + "\n"
+		So(os.WriteFile(logPath, []byte(content), 0o600), ShouldBeNil)
+
+		So(waitForKernelChosenPortBaseURL(logPath, time.Second), ShouldEqual, GetBaseURL("34567"))
+	})
+}

--- a/pkg/test/common/utils_test.go
+++ b/pkg/test/common/utils_test.go
@@ -84,6 +84,16 @@ func TestControllerManager(t *testing.T) {
 	})
 }
 
+func TestWaitForKernelChosenPortBaseURL(t *testing.T) {
+	Convey("parses kernel-chosen port from log file", t, func() {
+		logPath := path.Join(t.TempDir(), "zot-log.txt")
+		line := `{"level":"info","message":"port is unspecified, listening on kernel chosen port","port":34567}` + "\n"
+		So(os.WriteFile(logPath, []byte(line), 0o600), ShouldBeNil)
+
+		So(tcommon.WaitForKernelChosenPortBaseURL(logPath), ShouldEqual, tcommon.GetBaseURL("34567"))
+	})
+}
+
 func TestWaitForLogMessages(t *testing.T) {
 	Convey("Test WaitForLogMessages", t, func() {
 		Convey("should return true when message count reaches minimum", func() {


### PR DESCRIPTION
Use kernel-assigned ports with ControllerManager.StartAndWait across sync,
CLI, compliance, exporter, log, and controller tests so GetFreePort TOCTOU
is avoided where the listen port need not be known before bind.

Derive http/https from Controller.TLSEnabled and readiness-probe HTTPS with
InsecureSkipVerify for self-signed certs. Share WaitForKernelChosenPortBaseURL
for CLI serve JSON with Port "0"; bind the LDAP test mock on :0 and return
the chosen port. Move client TLS tests (home and privileged certs.d) off
fixed 8088/8089/8090 and key cert paths to the bound host:port. Keep
GetFreePort only for true pre-bind needs (OIDC/realm, scale-out members).

Should fix https://github.com/project-zot/zot/actions/runs/31406886891/job/93516038335?pr=4313, along with some other such cases

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
