### PR TITLE
fix(gc): prevent exponential nested-index walks during untagged GC; correctly GC multi-tag and cosign referrers that share a digest

### DIFF
--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -458,7 +458,7 @@ func (gc GarbageCollect) removeManifestsPerRepoPolicy(ctx context.Context, repo 
 		if gc.policyMgr.HasDeleteReferrer(repo) {
 			gc.log.Debug().Str("module", "gc").Str("repository", repo).Msg("manifests with missing referrers")
 
-			gcedReferrer, err = gc.removeIndexReferrers(repo, index, *index)
+			gcedReferrer, err = gc.removeReferrersWithMissingSubject(repo, index, *index, map[godigest.Digest]struct{}{})
 			if err != nil {
 				return err
 			}
@@ -469,7 +469,8 @@ func (gc GarbageCollect) removeManifestsPerRepoPolicy(ctx context.Context, repo 
 
 			/* gather all manifests referenced in multiarch images/by other manifests
 			so that we can skip them in cleanUntaggedManifests */
-			if err := gc.identifyManifestsReferencedInIndex(*index, repo, referenced); err != nil {
+			if err := gc.identifyManifestsReferencedInIndex(*index, repo, referenced,
+				map[godigest.Digest]struct{}{}); err != nil {
 				return err
 			}
 
@@ -488,19 +489,23 @@ func (gc GarbageCollect) removeManifestsPerRepoPolicy(ctx context.Context, repo 
 	return nil
 }
 
-/*
-garbageCollectIndexReferrers will gc all referrers with a missing subject recursively
-
-rootIndex is indexJson, need to pass it down to garbageCollectReferrer()
-rootIndex is the place we look for referrers.
-*/
-func (gc GarbageCollect) removeIndexReferrers(repo string, rootIndex *ispec.Index, index ispec.Index,
+// removeReferrersWithMissingSubject recursively walks index (starting from index.json) and
+// GCs manifests/indexes whose subject is no longer present in rootIndex.
+// seen ensures each digest is fetched and recursed into at most once per walk.
+func (gc GarbageCollect) removeReferrersWithMissingSubject(repo string, rootIndex *ispec.Index, index ispec.Index,
+	seen map[godigest.Digest]struct{},
 ) (bool, error) {
 	var count int
 
 	var err error
 
 	for _, desc := range index.Manifests {
+		if _, ok := seen[desc.Digest]; ok {
+			continue
+		}
+
+		seen[desc.Digest] = struct{}{}
+
 		if common.IsImageIndexMediaType(desc.MediaType) {
 			indexImage, err := common.GetImageIndex(gc.imgStore, repo, desc.Digest, gc.log)
 			if err != nil {
@@ -531,7 +536,7 @@ func (gc GarbageCollect) removeIndexReferrers(repo string, rootIndex *ispec.Inde
 				return true, nil
 			}
 
-			gced, err = gc.removeIndexReferrers(repo, rootIndex, indexImage)
+			gced, err = gc.removeReferrersWithMissingSubject(repo, rootIndex, indexImage, seen)
 			if err != nil {
 				return false, err
 			}
@@ -839,10 +844,18 @@ func (gc GarbageCollect) removeUntaggedManifests(ctx context.Context, repo strin
 }
 
 // Adds both referenced manifests and referrers from an index.
+// seen ensures each digest is fetched and recursed into at most once per walk,
+// so an index DAG with shared/duplicate child digests stays O(distinct objects).
 func (gc GarbageCollect) identifyManifestsReferencedInIndex(index ispec.Index, repo string,
-	referenced map[godigest.Digest]bool,
+	referenced map[godigest.Digest]bool, seen map[godigest.Digest]struct{},
 ) error {
 	for _, desc := range index.Manifests {
+		if _, ok := seen[desc.Digest]; ok {
+			continue
+		}
+
+		seen[desc.Digest] = struct{}{}
+
 		if common.IsImageIndexMediaType(desc.MediaType) {
 			indexImage, err := common.GetImageIndex(gc.imgStore, repo, desc.Digest, gc.log)
 			if err != nil {
@@ -869,7 +882,7 @@ func (gc GarbageCollect) identifyManifestsReferencedInIndex(index ispec.Index, r
 				referenced[indexDesc.Digest] = true
 			}
 
-			if err := gc.identifyManifestsReferencedInIndex(indexImage, repo, referenced); err != nil {
+			if err := gc.identifyManifestsReferencedInIndex(indexImage, repo, referenced, seen); err != nil {
 				return err
 			}
 		} else if common.IsImageManifestMediaType(desc.MediaType) {

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -190,8 +190,8 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 
 	// update repos's index.json in storage
 	if !gc.opts.ImageRetention.DryRun {
-		/* this will update the index.json with manifests deleted above
-		and the manifests blobs will be removed by gc.removeUnreferencedBlobs()*/
+		/* this will update the index.json with manifest references removed above;
+		orphan manifest/config/layer blobs are deleted by gc.deleteUnreferencedBlobs() */
 		if err := gc.imgStore.PutIndexContent(repo, index); err != nil {
 			return err
 		}
@@ -205,14 +205,14 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 	// must not delete anything either - it re-reads the on-disk index.json, so running it here would
 	// delete blobs for real (e.g. orphaned by manifest-pass edits) while their index entries survive.
 	if !gc.opts.ImageRetention.DryRun {
-		// gc unreferenced blobs
-		blobsDeleted, err = gc.removeUnreferencedBlobs(repo, gc.opts.Delay, gc.log)
+		// delete unreferenced blobs from storage
+		blobsDeleted, err = gc.deleteUnreferencedBlobs(repo, gc.opts.Delay, gc.log)
 		if err != nil {
 			return err
 		}
 
-		// gc old blob uploads
-		uploadsDeleted, err = gc.removeBlobUploads(repo, gc.opts.Delay)
+		// delete old blob uploads from storage
+		uploadsDeleted, err = gc.deleteBlobUploads(repo, gc.opts.Delay)
 		if err != nil {
 			return err
 		}
@@ -490,8 +490,9 @@ func (gc GarbageCollect) removeManifestsPerRepoPolicy(ctx context.Context, repo 
 }
 
 // removeReferrersWithMissingSubject recursively walks index (starting from index.json) and
-// GCs manifests/indexes whose subject is no longer present in rootIndex.
-// seen ensures each digest is fetched and recursed into at most once per walk.
+// removes from rootIndex any manifest/index whose subject is no longer present there.
+// It does not delete blobs from storage. seen ensures each digest is fetched and recursed
+// into at most once per walk.
 func (gc GarbageCollect) removeReferrersWithMissingSubject(repo string, rootIndex *ispec.Index, index ispec.Index,
 	seen map[godigest.Digest]struct{},
 ) (bool, error) {
@@ -598,7 +599,7 @@ func (gc GarbageCollect) removeReferrer(repo string, index *ispec.Index, manifes
 		}
 
 		if !referenced {
-			gced, err = gc.gcManifest(repo, index, manifestDesc, signatureType, subject.Digest, gc.opts.ImageRetention.Delay)
+			gced, err = gc.removeManifestIfOlderThan(repo, index, manifestDesc, signatureType, subject.Digest, gc.opts.ImageRetention.Delay)
 			if err != nil {
 				return false, err
 			}
@@ -631,7 +632,7 @@ func (gc GarbageCollect) removeReferrer(repo string, index *ispec.Index, manifes
 			referenced := isManifestReferencedInIndex(index, subjectDigest)
 
 			if !referenced {
-				gced, err = gc.gcManifest(repo, index, manifestDesc, storage.CosignType, subjectDigest, gc.opts.Delay)
+				gced, err = gc.removeManifestIfOlderThan(repo, index, manifestDesc, storage.CosignType, subjectDigest, gc.opts.Delay)
 				if err != nil {
 					return false, err
 				}
@@ -703,8 +704,9 @@ func (gc GarbageCollect) removeTagsPerRetentionPolicy(ctx context.Context, repo 
 	return nil
 }
 
-// gcManifest removes a manifest entry from an index and syncs metaDB accordingly if the blob is older than gc.Delay.
-func (gc GarbageCollect) gcManifest(repo string, index *ispec.Index, desc ispec.Descriptor,
+// removeManifestIfOlderThan removes a manifest reference from an index (and syncs metaDB) when
+// the blob is older than delay. It does not delete the blob from storage.
+func (gc GarbageCollect) removeManifestIfOlderThan(repo string, index *ispec.Index, desc ispec.Descriptor,
 	signatureType string, subjectDigest godigest.Digest, delay time.Duration,
 ) (bool, error) {
 	var gced bool
@@ -726,7 +728,8 @@ func (gc GarbageCollect) gcManifest(repo string, index *ispec.Index, desc ispec.
 	return gced, nil
 }
 
-// removeManifest removes a manifest entry from an index and syncs metaDB accordingly.
+// removeManifest removes a manifest reference from an index and syncs metaDB. It does not delete
+// the blob from storage (orphan blobs are deleted later by deleteUnreferencedBlobs).
 func (gc GarbageCollect) removeManifest(repo string, index *ispec.Index,
 	desc ispec.Descriptor, reference string, signatureType string, subjectDigest godigest.Digest,
 ) (bool, error) {
@@ -814,7 +817,7 @@ func (gc GarbageCollect) removeUntaggedManifests(ctx context.Context, repo strin
 					continue
 				}
 
-				gced, err = gc.gcManifest(repo, index, desc, "", "", gc.opts.ImageRetention.Delay)
+				gced, err = gc.removeManifestIfOlderThan(repo, index, desc, "", "", gc.opts.ImageRetention.Delay)
 				if err != nil {
 					return false, err
 				}
@@ -912,8 +915,8 @@ func (gc GarbageCollect) identifyManifestsReferencedInIndex(index ispec.Index, r
 	return nil
 }
 
-// removeBlobUploads gc all temporary uploads which are past their gc delay.
-func (gc GarbageCollect) removeBlobUploads(repo string, delay time.Duration) (int, error) {
+// deleteBlobUploads deletes temporary blob uploads from storage that are past their gc delay.
+func (gc GarbageCollect) deleteBlobUploads(repo string, delay time.Duration) (int, error) {
 	gc.log.Debug().Str("module", "gc").Str("repository", repo).Msg("cleaning unclaimed blob uploads")
 
 	if dir := path.Join(gc.imgStore.RootDir(), repo); !gc.imgStore.DirExists(dir) {
@@ -962,8 +965,9 @@ func (gc GarbageCollect) removeBlobUploads(repo string, delay time.Duration) (in
 	return deleted, aggregatedErr
 }
 
-// removeUnreferencedBlobs gc all blobs which are not referenced by any manifest found in repo's index.json.
-func (gc GarbageCollect) removeUnreferencedBlobs(repo string, delay time.Duration, log zlog.Logger,
+// deleteUnreferencedBlobs deletes from storage all blobs not referenced by the repo's index.json
+// (and nested manifests/indexes), when older than delay.
+func (gc GarbageCollect) deleteUnreferencedBlobs(repo string, delay time.Duration, log zlog.Logger,
 ) (int, error) {
 	gc.log.Debug().Str("module", "gc").Str("repository", repo).Msg("cleaning orphan blobs")
 

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -458,7 +458,7 @@ func (gc GarbageCollect) removeManifestsPerRepoPolicy(ctx context.Context, repo 
 		if gc.policyMgr.HasDeleteReferrer(repo) {
 			gc.log.Debug().Str("module", "gc").Str("repository", repo).Msg("manifests with missing referrers")
 
-			gcedReferrer, err = gc.removeReferrersWithMissingSubject(repo, index, *index, map[godigest.Digest]struct{}{})
+			gcedReferrer, err = gc.removeReferrersWithMissingSubject(repo, index)
 			if err != nil {
 				return err
 			}
@@ -489,94 +489,131 @@ func (gc GarbageCollect) removeManifestsPerRepoPolicy(ctx context.Context, repo 
 	return nil
 }
 
-// removeReferrersWithMissingSubject recursively walks index (starting from index.json) and
-// removes from rootIndex any manifest/index whose subject is no longer present there.
-// It does not delete blobs from storage. seen ensures each digest is fetched and recursed
-// into at most once per walk.
-func (gc GarbageCollect) removeReferrersWithMissingSubject(repo string, rootIndex *ispec.Index, index ispec.Index,
-	seen map[godigest.Digest]struct{},
-) (bool, error) {
+func isMissingBlobErr(err error) bool {
+	var pathNotFoundErr driver.PathNotFoundError
+
+	return errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr)
+}
+
+// removeReferrersWithMissingSubject walks root index.json and removes rows whose subject is no
+// longer listed there. It does not delete blobs from storage.
+//
+// Flat iteration only: every root row is visited (multi-tag and cosign siblings share a digest but
+// differ by ref annotation). missing skips re-fetch of absent blobs; indexes/manifests cache
+// successful reads so duplicate digest siblings do not hit storage again (cleanRepo holds the lock).
+func (gc GarbageCollect) removeReferrersWithMissingSubject(repo string, rootIndex *ispec.Index) (bool, error) {
+	missing := make(map[godigest.Digest]struct{})
+	indexes := make(map[godigest.Digest]ispec.Index)
+	manifests := make(map[godigest.Digest]ispec.Manifest)
+
 	var count int
 
-	var err error
+	// Range captures the original Manifests slice; removals reassign rootIndex.Manifests.
+	// Each original row is still visited. Rows re-added mid-pass (untagged leftovers from
+	// last-tag delete) are handled by removeManifestsPerRepoPolicy's outer loop.
+	for _, desc := range rootIndex.Manifests {
+		var gced bool
 
-	for _, desc := range index.Manifests {
-		if _, ok := seen[desc.Digest]; ok {
+		var err error
+
+		switch {
+		case common.IsImageIndexMediaType(desc.MediaType):
+			gced, err = gc.removeReferrerByIndexDesc(repo, rootIndex, desc, missing, indexes)
+		case common.IsImageManifestMediaType(desc.MediaType):
+			gced, err = gc.removeReferrerByManifestDesc(repo, rootIndex, desc, missing, manifests)
+		default:
 			continue
 		}
 
-		seen[desc.Digest] = struct{}{}
+		if err != nil {
+			return false, err
+		}
 
-		if common.IsImageIndexMediaType(desc.MediaType) {
-			indexImage, err := common.GetImageIndex(gc.imgStore, repo, desc.Digest, gc.log)
-			if err != nil {
-				// Handle missing blobs (not found) gracefully
-				var pathNotFoundErr driver.PathNotFoundError
-				if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
-					gc.log.Warn().Err(err).Str("module", "gc").Str("repository", repo).Str("digest", desc.Digest.String()).
-						Msg("skipping missing image index blob, continuing GC")
-
-					continue
-				}
-
-				gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).Str("digest", desc.Digest.String()).
-					Msg("failed to read multiarch(index) image")
-
-				return false, err
-			}
-
-			gced, err := gc.removeReferrer(repo, rootIndex, desc, indexImage.Subject, indexImage.ArtifactType)
-			if err != nil {
-				return false, err
-			}
-
-			/* if we gc index then no need to continue searching for referrers inside it.
-			they will be gced when the next garbage collect is executed(if they are older than retentionDelay),
-			 because manifests part of indexes will still be referenced in index.json */
-			if gced {
-				return true, nil
-			}
-
-			gced, err = gc.removeReferrersWithMissingSubject(repo, rootIndex, indexImage, seen)
-			if err != nil {
-				return false, err
-			}
-
-			if gced {
-				count++
-			}
-		} else if common.IsImageManifestMediaType(desc.MediaType) {
-			image, err := common.GetImageManifest(gc.imgStore, repo, desc.Digest, gc.log)
-			if err != nil {
-				// Handle missing blobs (not found) gracefully
-				var pathNotFoundErr driver.PathNotFoundError
-				if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
-					gc.log.Warn().Err(err).Str("module", "gc").Str("repo", repo).Str("digest", desc.Digest.String()).
-						Msg("skipping missing image manifest blob, continuing GC")
-
-					continue
-				}
-
-				gc.log.Error().Err(err).Str("module", "gc").Str("repo", repo).Str("digest", desc.Digest.String()).
-					Msg("failed to read manifest image")
-
-				return false, err
-			}
-
-			artifactType := zcommon.GetManifestArtifactType(image)
-
-			gced, err := gc.removeReferrer(repo, rootIndex, desc, image.Subject, artifactType)
-			if err != nil {
-				return false, err
-			}
-
-			if gced {
-				count++
-			}
+		if gced {
+			count++
 		}
 	}
 
-	return count > 0, err
+	return count > 0, nil
+}
+
+// removeReferrerByIndexDesc handles one root index.json row whose media type is an image
+// index: fetch/cache that index blob (or record it missing), then decide whether to remove
+// the root index.json entry via removeReferrer. It does not mutate nested index blobs.
+func (gc GarbageCollect) removeReferrerByIndexDesc(repo string, rootIndex *ispec.Index, desc ispec.Descriptor,
+	missing map[godigest.Digest]struct{}, indexes map[godigest.Digest]ispec.Index,
+) (bool, error) {
+	if _, ok := missing[desc.Digest]; ok {
+		return false, nil
+	}
+
+	indexImage, cached := indexes[desc.Digest]
+	if !cached {
+		var err error
+
+		indexImage, err = common.GetImageIndex(gc.imgStore, repo, desc.Digest, gc.log)
+		if err != nil {
+			if isMissingBlobErr(err) {
+				missing[desc.Digest] = struct{}{}
+				gc.log.Warn().Err(err).Str("module", "gc").Str("repository", repo).Str("digest", desc.Digest.String()).
+					Msg("skipping missing image index blob, continuing GC")
+
+				return false, nil
+			}
+
+			// Transient/hard read failures: skip this row so cleanRepo can still run stale
+			// prune and blob/upload cleanup for the rest of the repo.
+			gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).Str("digest", desc.Digest.String()).
+				Msg("failed to read multiarch(index) image, continuing GC")
+
+			return false, nil
+		}
+
+		indexes[desc.Digest] = indexImage
+	}
+
+	return gc.removeReferrer(repo, rootIndex, desc, indexImage.Subject, indexImage.ArtifactType)
+}
+
+// removeReferrerByManifestDesc handles one root index.json row whose media type is an image
+// manifest: fetch/cache that manifest blob (or record it missing), then decide whether to
+// remove the root index.json entry via removeReferrer (including legacy cosign tags when
+// the blob is absent). It does not mutate the manifest blob itself.
+func (gc GarbageCollect) removeReferrerByManifestDesc(repo string, rootIndex *ispec.Index, desc ispec.Descriptor,
+	missing map[godigest.Digest]struct{}, manifests map[godigest.Digest]ispec.Manifest,
+) (bool, error) {
+	if _, ok := missing[desc.Digest]; ok {
+		return gc.removeReferrer(repo, rootIndex, desc, nil, "")
+	}
+
+	image, cached := manifests[desc.Digest]
+	if !cached {
+		var err error
+
+		image, err = common.GetImageManifest(gc.imgStore, repo, desc.Digest, gc.log)
+		if err != nil {
+			if isMissingBlobErr(err) {
+				missing[desc.Digest] = struct{}{}
+				gc.log.Warn().Err(err).Str("module", "gc").Str("repo", repo).Str("digest", desc.Digest.String()).
+					Msg("skipping missing image manifest blob, continuing GC")
+
+				return gc.removeReferrer(repo, rootIndex, desc, nil, "")
+			}
+
+			// Transient/hard read failures: skip this row so cleanRepo can still run stale
+			// prune and blob/upload cleanup for the rest of the repo.
+			gc.log.Error().Err(err).Str("module", "gc").Str("repo", repo).Str("digest", desc.Digest.String()).
+				Msg("failed to read manifest image, continuing GC")
+
+			return false, nil
+		}
+
+		manifests[desc.Digest] = image
+	}
+
+	artifactType := zcommon.GetManifestArtifactType(image)
+
+	return gc.removeReferrer(repo, rootIndex, desc, image.Subject, artifactType)
 }
 
 func (gc GarbageCollect) removeReferrer(repo string, index *ispec.Index, manifestDesc ispec.Descriptor,
@@ -599,7 +636,8 @@ func (gc GarbageCollect) removeReferrer(repo string, index *ispec.Index, manifes
 		}
 
 		if !referenced {
-			gced, err = gc.removeManifestIfOlderThan(repo, index, manifestDesc, signatureType, subject.Digest, gc.opts.ImageRetention.Delay)
+			gced, err = gc.removeManifestIfOlderThan(repo, index, manifestDesc, signatureType,
+				subject.Digest, gc.opts.ImageRetention.Delay)
 			if err != nil {
 				return false, err
 			}
@@ -624,7 +662,13 @@ func (gc GarbageCollect) removeReferrer(repo string, index *ispec.Index, manifes
 		}
 	}
 
-	// cosign
+	// Legacy cosign tags (sha256-<digest>.sig / .sbom). Skip when the subject path above
+	// already removed this descriptor — otherwise a second tag delete returns
+	// ErrManifestNotFound and aborts GC after a partial metaDB update.
+	if gced {
+		return gced, nil
+	}
+
 	tag, ok := getDescriptorTag(manifestDesc)
 	if ok {
 		if zcommon.IsCosignTag(tag) {
@@ -632,7 +676,8 @@ func (gc GarbageCollect) removeReferrer(repo string, index *ispec.Index, manifes
 			referenced := isManifestReferencedInIndex(index, subjectDigest)
 
 			if !referenced {
-				gced, err = gc.removeManifestIfOlderThan(repo, index, manifestDesc, storage.CosignType, subjectDigest, gc.opts.Delay)
+				gced, err = gc.removeManifestIfOlderThan(repo, index, manifestDesc, storage.CosignType,
+					subjectDigest, gc.opts.Delay)
 				if err != nil {
 					return false, err
 				}
@@ -720,7 +765,16 @@ func (gc GarbageCollect) removeManifestIfOlderThan(repo string, index *ispec.Ind
 	}
 
 	if canGC {
-		if gced, err = gc.removeManifest(repo, index, desc, desc.Digest.String(), signatureType, subjectDigest); err != nil {
+		// Prefer tag when present so duplicate digest siblings (multi-tag, cosign .sig +
+		// untagged) remove one index.json row. Digest-only removal hits ErrManifestConflict.
+		// Last-tag delete re-adds an untagged row (RemoveManifestDescByReference API
+		// semantics); removeManifestsPerRepoPolicy's outer loop clears it on a later pass.
+		reference := desc.Digest.String()
+		if tag, ok := getDescriptorTag(desc); ok {
+			reference = tag
+		}
+
+		if gced, err = gc.removeManifest(repo, index, desc, reference, signatureType, subjectDigest); err != nil {
 			return false, err
 		}
 	}
@@ -735,7 +789,7 @@ func (gc GarbageCollect) removeManifest(repo string, index *ispec.Index,
 ) (bool, error) {
 	_, err := common.RemoveManifestDescByReference(index, reference, true)
 	if err != nil {
-		if errors.Is(err, zerr.ErrManifestConflict) {
+		if errors.Is(err, zerr.ErrManifestConflict) || errors.Is(err, zerr.ErrManifestNotFound) {
 			return false, nil
 		}
 
@@ -862,15 +916,15 @@ func (gc GarbageCollect) identifyManifestsReferencedInIndex(index ispec.Index, r
 		if common.IsImageIndexMediaType(desc.MediaType) {
 			indexImage, err := common.GetImageIndex(gc.imgStore, repo, desc.Digest, gc.log)
 			if err != nil {
-				// Handle missing blobs (not found) gracefully
-				var pathNotFoundErr driver.PathNotFoundError
-				if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
+				if isMissingBlobErr(err) {
 					gc.log.Warn().Err(err).Str("module", "gc").Str("repository", repo).
 						Str("digest", desc.Digest.String()).Msg("skipping missing image index blob, continuing GC")
 
 					continue
 				}
 
+				// Fail closed: without this index's nested digests, removeUntaggedManifests
+				// could delete platform/child manifests that are only "referenced" via this blob.
 				gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).
 					Str("digest", desc.Digest.String()).Msg("failed to read multiarch(index) image")
 
@@ -891,15 +945,16 @@ func (gc GarbageCollect) identifyManifestsReferencedInIndex(index ispec.Index, r
 		} else if common.IsImageManifestMediaType(desc.MediaType) {
 			image, err := common.GetImageManifest(gc.imgStore, repo, desc.Digest, gc.log)
 			if err != nil {
-				// Handle missing blobs (not found) gracefully
-				var pathNotFoundErr driver.PathNotFoundError
-				if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
+				if isMissingBlobErr(err) {
 					gc.log.Warn().Err(err).Str("module", "gc").Str("repo", repo).
 						Str("digest", desc.Digest.String()).Msg("skipping missing image manifest blob, continuing GC")
 
 					continue
 				}
 
+				// Fail closed: subject-bearing untagged referrers are marked referenced only
+				// after a successful read; skipping would allow removeUntaggedManifests to
+				// drop them while their subject is still present.
 				gc.log.Error().Err(err).Str("module", "gc").Str("repo", repo).
 					Str("digest", desc.Digest.String()).Msg("failed to read manifest image")
 
@@ -1044,6 +1099,10 @@ func isBlobOlderThan(imgStore types.ImageStore, repo string,
 ) (bool, error) {
 	_, _, modtime, err := imgStore.StatBlob(repo, digest)
 	if err != nil {
+		// Fail closed: ImageStore.StatBlob maps any underlying Stat failure (including
+		// transient S3/network errors) to ErrBlobNotFound, so treating "missing" as
+		// GC-eligible would risk deleting live index rows during storage blips.
+		// Stale prune can still remove truly absent blobs later when CleanRepo succeeds.
 		log.Error().Err(err).Str("module", "gc").Str("repository", repo).Str("digest", digest.String()).
 			Msg("failed to stat blob")
 

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -150,13 +150,19 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 		})
 
 		Convey("Error on gc.removeManifest()", func() {
-			gc := NewGarbageCollect(mocks.MockedImageStore{}, mocks.MetaDBMock{
-				GetRepoMetaFn: func(ctx context.Context, repo string) (types.RepoMeta, error) {
-					return types.RepoMeta{}, errGC
+			metaDB := mocks.MetaDBMock{
+				RemoveRepoReferenceFn: func(repo, reference string, manifestDigest godigest.Digest) error {
+					return errGC
 				},
-			}, gcOptions, audit, log, metrics)
+			}
+			gc := NewGarbageCollect(mocks.MockedImageStore{}, metaDB, gcOptions, audit, log, metrics)
 
-			_, err := gc.removeManifest("", &ispec.Index{}, ispec.DescriptorEmptyJSON, "tag", "", "")
+			desc := ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    godigest.FromString("digest"),
+			}
+			index := &ispec.Index{Manifests: []ispec.Descriptor{desc}}
+			_, err := gc.removeManifest(repoName, index, desc, desc.Digest.String(), "", "")
 			So(err, ShouldNotBeNil)
 		})
 
@@ -564,10 +570,195 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
 			// removeReferrersWithMissingSubject should skip the missing nested index and continue
-			gced, err := gc.removeReferrersWithMissingSubject(repoName, &topLevelIndex, topLevelIndex,
-				map[godigest.Digest]struct{}{})
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &topLevelIndex)
 			So(err, ShouldBeNil)
 			So(gced, ShouldBeFalse)
+		})
+
+		Convey("removeReferrersWithMissingSubject skips unknown media types", func() {
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: "application/vnd.unknown.manifest.v1+json",
+						Digest:    godigest.FromString("unknown-media"),
+						Size:      10,
+					},
+				},
+			}
+
+			readCount := 0
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					readCount++
+
+					return nil, zerr.ErrBlobNotFound
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeFalse)
+			So(readCount, ShouldEqual, 0)
+			So(len(parentIndex.Manifests), ShouldEqual, 1)
+		})
+
+		Convey("removeReferrersWithMissingSubject continues when index blob read fails", func() {
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageIndex,
+						Digest:    godigest.FromString("bad-index"),
+						Size:      10,
+					},
+				},
+			}
+
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					return nil, errGC
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeFalse)
+			So(len(parentIndex.Manifests), ShouldEqual, 1)
+		})
+
+		Convey("removeReferrersWithMissingSubject continues when manifest blob read fails", func() {
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    godigest.FromString("bad-manifest"),
+						Size:      10,
+					},
+				},
+			}
+
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					return nil, errGC
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeFalse)
+			So(len(parentIndex.Manifests), ShouldEqual, 1)
+		})
+
+		Convey("removeReferrer GCs orphaned notation signature via subject path", func() {
+			missingSubject := godigest.FromString("missing-subject")
+
+			desc := ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    godigest.FromString("notation-sig"),
+				Size:      10,
+			}
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{desc},
+			}
+
+			imgStore := mocks.MockedImageStore{
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return true, 10, time.Now().Add(-24 * time.Hour), nil
+				},
+			}
+
+			deletedSig := false
+			metaDB := mocks.MetaDBMock{
+				DeleteSignatureFn: func(repo string, signedManifestDigest godigest.Digest, sm types.SignatureMetadata) error {
+					deletedSig = signedManifestDigest == missingSubject &&
+						sm.SignatureDigest == desc.Digest.String() &&
+						sm.SignatureType == storage.NotationType
+
+					return nil
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{Delay: 0}
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			subject := &ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    missingSubject,
+				Size:      1,
+			}
+			gced, err := gc.removeReferrer(repoName, &parentIndex, desc, subject, zcommon.ArtifactTypeNotation)
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeTrue)
+			So(deletedSig, ShouldBeTrue)
+			So(len(parentIndex.Manifests), ShouldEqual, 0)
+		})
+
+		Convey("removeReferrer returns error when cosign path cannot stat blob", func() {
+			missingSubject := godigest.FromString("missing-subject")
+			cosignTag := "sha256-" + missingSubject.Encoded() + ".sig"
+
+			desc := ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    godigest.FromString("cosign-sig"),
+				Size:      10,
+				Annotations: map[string]string{
+					ispec.AnnotationRefName: cosignTag,
+				},
+			}
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{desc},
+			}
+
+			imgStore := mocks.MockedImageStore{
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return false, 0, time.Time{}, errGC
+				},
+			}
+
+			gcOptions.Delay = 0
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrer(repoName, &parentIndex, desc, nil, "")
+			So(err, ShouldNotBeNil)
+			So(gced, ShouldBeFalse)
+			So(len(parentIndex.Manifests), ShouldEqual, 1)
 		})
 
 		Convey("Missing nested index blob in identifyManifestsReferencedInIndex is skipped gracefully", func() {
@@ -730,8 +921,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
-			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex, parentIndex,
-				map[godigest.Digest]struct{}{})
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
 			So(err, ShouldBeNil)
 			So(gced, ShouldBeFalse)
 			So(readCount, ShouldEqual, 1)
@@ -754,8 +944,6 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			So(err, ShouldBeNil)
 			orphanedDigest := godigest.FromBytes(orphanedBuf)
 
-			// Single index.json entry: RemoveManifestDescByReference rejects duplicate digests
-			// (ErrManifestConflict), so the successful GC path uses one descriptor.
 			parentIndex := ispec.Index{
 				MediaType: ispec.MediaTypeImageIndex,
 				Manifests: []ispec.Descriptor{
@@ -801,13 +989,629 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
-			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex, parentIndex,
-				map[godigest.Digest]struct{}{})
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
 			So(err, ShouldBeNil)
 			So(gced, ShouldBeTrue)
 			So(readCount, ShouldEqual, 1)
 			So(statCount, ShouldEqual, 1)
 			So(len(parentIndex.Manifests), ShouldEqual, 0)
+		})
+
+		Convey("removeReferrer removes cosign .sig by tag when digest is also listed untagged", func() {
+			missingSubject := godigest.FromString("missing-subject")
+			cosignTag := "sha256-" + missingSubject.Encoded() + ".sig"
+
+			sharedManifest := ispec.Manifest{
+				MediaType: ispec.MediaTypeImageManifest,
+				Config:    ispec.Descriptor{Digest: godigest.FromString("cfg"), Size: 1},
+			}
+			sharedBuf, err := json.Marshal(sharedManifest)
+			So(err, ShouldBeNil)
+			sharedDigest := godigest.FromBytes(sharedBuf)
+
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    sharedDigest,
+						Size:      int64(len(sharedBuf)),
+					},
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    sharedDigest,
+						Size:      int64(len(sharedBuf)),
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: cosignTag,
+						},
+					},
+				},
+			}
+			cosignDesc := parentIndex.Manifests[1]
+
+			imgStore := mocks.MockedImageStore{
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return true, int64(len(sharedBuf)), time.Now().Add(-24 * time.Hour), nil
+				},
+			}
+
+			deletedSig := false
+			metaDB := mocks.MetaDBMock{
+				DeleteSignatureFn: func(repo string, signedManifestDigest godigest.Digest, sm types.SignatureMetadata) error {
+					deletedSig = signedManifestDigest == missingSubject &&
+						sm.SignatureDigest == sharedDigest.String() &&
+						sm.SignatureType == storage.CosignType
+
+					return nil
+				},
+			}
+
+			gcOptions.Delay = 0
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrer(repoName, &parentIndex, cosignDesc, nil, "")
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeTrue)
+			So(deletedSig, ShouldBeTrue)
+			So(len(parentIndex.Manifests), ShouldEqual, 1)
+			_, hasTag := parentIndex.Manifests[0].Annotations[ispec.AnnotationRefName]
+			So(hasTag, ShouldBeFalse)
+		})
+
+		Convey("removeReferrersWithMissingSubject GCs cosign .sig when digest is also listed untagged", func() {
+			missingSubject := godigest.FromString("missing-subject")
+			cosignTag := "sha256-" + missingSubject.Encoded() + ".sig"
+
+			sharedManifest := ispec.Manifest{
+				MediaType: ispec.MediaTypeImageManifest,
+				Config:    ispec.Descriptor{Digest: godigest.FromString("cfg"), Size: 1},
+			}
+			sharedBuf, err := json.Marshal(sharedManifest)
+			So(err, ShouldBeNil)
+			sharedDigest := godigest.FromBytes(sharedBuf)
+
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    sharedDigest,
+						Size:      int64(len(sharedBuf)),
+					},
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    sharedDigest,
+						Size:      int64(len(sharedBuf)),
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: cosignTag,
+						},
+					},
+				},
+			}
+
+			readCount := 0
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == sharedDigest {
+						readCount++
+
+						return sharedBuf, nil
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return true, int64(len(sharedBuf)), time.Now().Add(-24 * time.Hour), nil
+				},
+			}
+
+			deletedSig := false
+			metaDB := mocks.MetaDBMock{
+				DeleteSignatureFn: func(repo string, signedManifestDigest godigest.Digest, sm types.SignatureMetadata) error {
+					deletedSig = signedManifestDigest == missingSubject &&
+						sm.SignatureDigest == sharedDigest.String() &&
+						sm.SignatureType == storage.CosignType
+
+					return nil
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Delay: 0,
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeTrue)
+			So(deletedSig, ShouldBeTrue)
+			So(readCount, ShouldEqual, 1)
+			So(len(parentIndex.Manifests), ShouldEqual, 1)
+			_, hasTag := parentIndex.Manifests[0].Annotations[ispec.AnnotationRefName]
+			So(hasTag, ShouldBeFalse)
+		})
+
+		Convey("removeReferrer skips cosign path after subject path already GCd the row", func() {
+			// OCI cosign referrer: subject in blob AND legacy .sig tag on the descriptor.
+			// Subject path removes by tag first; cosign path must not retry the same tag
+			// (ErrManifestNotFound would abort GC).
+			missingSubject := godigest.FromString("missing-subject")
+			cosignTag := "sha256-" + missingSubject.Encoded() + ".sig"
+
+			referrer := ispec.Manifest{
+				MediaType:    ispec.MediaTypeImageManifest,
+				ArtifactType: zcommon.ArtifactTypeCosign,
+				Config:       ispec.Descriptor{Digest: godigest.FromString("cfg"), Size: 1},
+				Subject: &ispec.Descriptor{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    missingSubject,
+					Size:      1,
+				},
+			}
+			referrerBuf, err := json.Marshal(referrer)
+			So(err, ShouldBeNil)
+			referrerDigest := godigest.FromBytes(referrerBuf)
+
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    referrerDigest,
+						Size:      int64(len(referrerBuf)),
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: cosignTag,
+						},
+					},
+				},
+			}
+			cosignDesc := parentIndex.Manifests[0]
+
+			imgStore := mocks.MockedImageStore{
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return true, int64(len(referrerBuf)), time.Now().Add(-24 * time.Hour), nil
+				},
+			}
+
+			deleteSignatureCalls := 0
+			metaDB := mocks.MetaDBMock{
+				DeleteSignatureFn: func(repo string, signedManifestDigest godigest.Digest, sm types.SignatureMetadata) error {
+					deleteSignatureCalls++
+					So(signedManifestDigest, ShouldEqual, missingSubject)
+					So(sm.SignatureDigest, ShouldEqual, referrerDigest.String())
+					So(sm.SignatureType, ShouldEqual, storage.CosignType)
+
+					return nil
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{Delay: 0}
+			gcOptions.Delay = 0
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrer(repoName, &parentIndex, cosignDesc, referrer.Subject, zcommon.ArtifactTypeCosign)
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeTrue)
+			So(deleteSignatureCalls, ShouldEqual, 1)
+			// Last-tag delete re-adds an untagged row.
+			So(len(parentIndex.Manifests), ShouldEqual, 1)
+			_, hasTag := parentIndex.Manifests[0].Annotations[ispec.AnnotationRefName]
+			So(hasTag, ShouldBeFalse)
+		})
+
+		Convey("removeReferrersWithMissingSubject GCs OCI cosign referrer that also has a .sig tag", func() {
+			missingSubject := godigest.FromString("missing-subject")
+			cosignTag := "sha256-" + missingSubject.Encoded() + ".sig"
+
+			referrer := ispec.Manifest{
+				MediaType:    ispec.MediaTypeImageManifest,
+				ArtifactType: zcommon.ArtifactTypeCosign,
+				Config:       ispec.Descriptor{Digest: godigest.FromString("cfg"), Size: 1},
+				Subject: &ispec.Descriptor{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    missingSubject,
+					Size:      1,
+				},
+			}
+			referrerBuf, err := json.Marshal(referrer)
+			So(err, ShouldBeNil)
+			referrerDigest := godigest.FromBytes(referrerBuf)
+
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    referrerDigest,
+						Size:      int64(len(referrerBuf)),
+					},
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    referrerDigest,
+						Size:      int64(len(referrerBuf)),
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: cosignTag,
+						},
+					},
+				},
+			}
+
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == referrerDigest {
+						return referrerBuf, nil
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return true, int64(len(referrerBuf)), time.Now().Add(-24 * time.Hour), nil
+				},
+			}
+
+			deleteSignatureCalls := 0
+			metaDB := mocks.MetaDBMock{
+				DeleteSignatureFn: func(repo string, signedManifestDigest godigest.Digest, sm types.SignatureMetadata) error {
+					deleteSignatureCalls++
+
+					return nil
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Delay: 0,
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+			gcOptions.Delay = 0
+
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeTrue)
+			So(deleteSignatureCalls, ShouldBeGreaterThan, 0)
+			// Untagged sibling remains; tagged .sig row is gone.
+			So(len(parentIndex.Manifests), ShouldEqual, 1)
+			_, hasTag := parentIndex.Manifests[0].Annotations[ispec.AnnotationRefName]
+			So(hasTag, ShouldBeFalse)
+		})
+
+		Convey("removeManifestsPerRepoPolicy GCs both tags when orphaned referrer shares a digest", func() {
+			// Last-tag delete re-adds an untagged row (RemoveManifestDescByReference).
+			// A single removeReferrersWithMissingSubject pass leaves that row; the outer
+			// removeManifestsPerRepoPolicy loop clears it on a later referrer pass.
+			missingSubject := godigest.FromString("missing-subject")
+
+			referrer := ispec.Manifest{
+				MediaType: ispec.MediaTypeImageManifest,
+				Config:    ispec.Descriptor{Digest: godigest.FromString("cfg"), Size: 1},
+				Subject: &ispec.Descriptor{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    missingSubject,
+					Size:      1,
+				},
+			}
+			referrerBuf, err := json.Marshal(referrer)
+			So(err, ShouldBeNil)
+			referrerDigest := godigest.FromBytes(referrerBuf)
+
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    referrerDigest,
+						Size:      int64(len(referrerBuf)),
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: "referrer-v1",
+						},
+					},
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    referrerDigest,
+						Size:      int64(len(referrerBuf)),
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: "referrer-v2",
+						},
+					},
+				},
+			}
+
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == referrerDigest {
+						return referrerBuf, nil
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return true, int64(len(referrerBuf)), time.Now().Add(-24 * time.Hour), nil
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Delay: 0,
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			err = gc.removeManifestsPerRepoPolicy(context.Background(), repoName, &parentIndex)
+			So(err, ShouldBeNil)
+			So(len(parentIndex.Manifests), ShouldEqual, 0)
+		})
+
+		Convey("removeReferrersWithMissingSubject keeps both tags when subject is present", func() {
+			subjectDigest := godigest.FromString("present-subject")
+
+			referrer := ispec.Manifest{
+				MediaType: ispec.MediaTypeImageManifest,
+				Config:    ispec.Descriptor{Digest: godigest.FromString("cfg"), Size: 1},
+				Subject: &ispec.Descriptor{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    subjectDigest,
+					Size:      1,
+				},
+			}
+			referrerBuf, err := json.Marshal(referrer)
+			So(err, ShouldBeNil)
+			referrerDigest := godigest.FromBytes(referrerBuf)
+
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    subjectDigest,
+						Size:      1,
+					},
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    referrerDigest,
+						Size:      int64(len(referrerBuf)),
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: "referrer-v1",
+						},
+					},
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    referrerDigest,
+						Size:      int64(len(referrerBuf)),
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: "referrer-v2",
+						},
+					},
+				},
+			}
+
+			readCount := 0
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == referrerDigest {
+						readCount++
+
+						return referrerBuf, nil
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Delay: 0,
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeFalse)
+			So(readCount, ShouldEqual, 1)
+			So(len(parentIndex.Manifests), ShouldEqual, 3)
+
+			tags := map[string]bool{}
+			for _, desc := range parentIndex.Manifests {
+				if tag, ok := desc.Annotations[ispec.AnnotationRefName]; ok {
+					tags[tag] = true
+				}
+			}
+			So(tags["referrer-v1"], ShouldBeTrue)
+			So(tags["referrer-v2"], ShouldBeTrue)
+		})
+
+		Convey("removeReferrersWithMissingSubject skips duplicate missing index blobs once", func() {
+			missingDigest := godigest.FromString("missing-nested-index")
+
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageIndex,
+						Digest:    missingDigest,
+						Size:      100,
+					},
+					{
+						MediaType: ispec.MediaTypeImageIndex,
+						Digest:    missingDigest,
+						Size:      100,
+					},
+				},
+			}
+
+			readCount := 0
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == missingDigest {
+						readCount++
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeFalse)
+			So(readCount, ShouldEqual, 1)
+			So(len(parentIndex.Manifests), ShouldEqual, 2)
+		})
+
+		Convey("removeReferrersWithMissingSubject GCs cosign .sig after a sibling missing blob miss", func() {
+			missingSubject := godigest.FromString("missing-subject")
+			cosignTag := "sha256-" + missingSubject.Encoded() + ".sig"
+			missingDigest := godigest.FromString("missing-shared-manifest")
+
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    missingDigest,
+						Size:      10,
+					},
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    missingDigest,
+						Size:      10,
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: cosignTag,
+						},
+					},
+				},
+			}
+
+			readCount := 0
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == missingDigest {
+						readCount++
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+				// Age check is independent of GetBlobContent: mock Stat success so this
+				// case covers missing-cache + cosign sibling GC, not StatBlob fail-closed.
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return true, 10, time.Now().Add(-24 * time.Hour), nil
+				},
+			}
+
+			deletedSig := false
+			metaDB := mocks.MetaDBMock{
+				DeleteSignatureFn: func(repo string, signedManifestDigest godigest.Digest, sm types.SignatureMetadata) error {
+					deletedSig = signedManifestDigest == missingSubject &&
+						sm.SignatureDigest == missingDigest.String() &&
+						sm.SignatureType == storage.CosignType
+
+					return nil
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Delay: 0,
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+			gcOptions.Delay = 0
+
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeTrue)
+			So(deletedSig, ShouldBeTrue)
+			So(readCount, ShouldEqual, 1)
+			So(len(parentIndex.Manifests), ShouldEqual, 1)
+			_, hasTag := parentIndex.Manifests[0].Annotations[ispec.AnnotationRefName]
+			So(hasTag, ShouldBeFalse)
+		})
+
+		Convey("removeReferrersWithMissingSubject aborts when StatBlob reports missing", func() {
+			// Match main: StatBlob errors (including ErrBlobNotFound from ImageStore's
+			// error collapsing) fail closed in isBlobOlderThan.
+			missingSubject := godigest.FromString("missing-subject")
+			cosignTag := "sha256-" + missingSubject.Encoded() + ".sig"
+			missingDigest := godigest.FromString("missing-cosign-blob")
+
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    missingDigest,
+						Size:      10,
+						Annotations: map[string]string{
+							ispec.AnnotationRefName: cosignTag,
+						},
+					},
+				},
+			}
+
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					return nil, driver.PathNotFoundError{Path: digest.String(), DriverName: "local"}
+				},
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return false, -1, time.Time{}, driver.PathNotFoundError{Path: digest.String(), DriverName: "local"}
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Delay: 0,
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+			gcOptions.Delay = 0
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
+			So(err, ShouldNotBeNil)
+			So(gced, ShouldBeFalse)
+			So(len(parentIndex.Manifests), ShouldEqual, 1)
 		})
 
 		Convey("identifyManifestsReferencedInIndex walks a diamond DAG once per node", func() {
@@ -829,9 +1633,10 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			midRight := ispec.Index{
 				MediaType: ispec.MediaTypeImageIndex,
 				Manifests: []ispec.Descriptor{{
-					MediaType: ispec.MediaTypeImageManifest,
-					Digest:    leafDigest,
-					Size:      1,
+					MediaType:   ispec.MediaTypeImageManifest,
+					Digest:      leafDigest,
+					Size:        1,
+					Annotations: map[string]string{"branch": "right"},
 				}},
 			}
 			midRightBuf, err := json.Marshal(midRight)
@@ -890,6 +1695,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			err = gc.identifyManifestsReferencedInIndex(root, repoName, referenced,
 				map[godigest.Digest]struct{}{})
 			So(err, ShouldBeNil)
+			So(midLeftDigest, ShouldNotEqual, midRightDigest)
 			So(reads[midLeftDigest], ShouldEqual, 1)
 			So(reads[midRightDigest], ShouldEqual, 1)
 			So(reads[leafDigest], ShouldEqual, 1)

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -138,14 +138,14 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Error on GetIndex in gc.removeUnreferencedBlobs()", func() {
+		Convey("Error on GetIndex in gc.deleteUnreferencedBlobs()", func() {
 			gc := NewGarbageCollect(mocks.MockedImageStore{}, mocks.MetaDBMock{
 				GetRepoMetaFn: func(ctx context.Context, repo string) (types.RepoMeta, error) {
 					return types.RepoMeta{}, errGC
 				},
 			}, gcOptions, audit, log, metrics)
 
-			_, err := gc.removeUnreferencedBlobs("repo", time.Hour, log)
+			_, err := gc.deleteUnreferencedBlobs("repo", time.Hour, log)
 			So(err, ShouldNotBeNil)
 		})
 
@@ -384,7 +384,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Error on gc.gcManifest() in gc.cleanManifests() with image", func() {
+		Convey("Error on gc.removeManifestIfOlderThan() in gc.cleanManifests() with image", func() {
 			returnedImage := ispec.Manifest{
 				MediaType: ispec.MediaTypeImageManifest,
 			}
@@ -424,7 +424,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			})
 			So(err, ShouldNotBeNil)
 		})
-		Convey("Error on gc.gcManifest() in gc.cleanManifests() with signature", func() {
+		Convey("Error on gc.removeManifestIfOlderThan() in gc.cleanManifests() with signature", func() {
 			returnedImage := ispec.Manifest{
 				MediaType:    ispec.MediaTypeImageManifest,
 				ArtifactType: zcommon.NotationSignature,
@@ -897,7 +897,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			So(referenced[leafDigest], ShouldBeTrue)
 		})
 
-		Convey("Error on ListBlobUploads in removeBlobUploads", func() {
+		Convey("Error on ListBlobUploads in deleteBlobUploads", func() {
 			imgStore := mocks.MockedImageStore{
 				DirExistsFn: func(d string) bool {
 					return true
@@ -909,12 +909,12 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
-			deleted, err := gc.removeBlobUploads(repoName, time.Hour)
+			deleted, err := gc.deleteBlobUploads(repoName, time.Hour)
 			So(err, ShouldNotBeNil)
 			So(deleted, ShouldEqual, 0)
 		})
 
-		Convey("Error on GetReferencedBlobs in removeUnreferencedBlobs", func() {
+		Convey("Error on GetReferencedBlobs in deleteUnreferencedBlobs", func() {
 			returnedIndex := ispec.Index{
 				Manifests: []ispec.Descriptor{
 					{
@@ -937,12 +937,12 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
-			deleted, err := gc.removeUnreferencedBlobs(repoName, time.Hour, log)
+			deleted, err := gc.deleteUnreferencedBlobs(repoName, time.Hour, log)
 			So(err, ShouldNotBeNil)
 			So(deleted, ShouldEqual, 0)
 		})
 
-		Convey("PathNotFoundError on GetAllBlobs in removeUnreferencedBlobs", func() {
+		Convey("PathNotFoundError on GetAllBlobs in deleteUnreferencedBlobs", func() {
 			returnedIndex := ispec.Index{}
 			returnedIndexBuf, err := json.Marshal(returnedIndex)
 			So(err, ShouldBeNil)
@@ -958,12 +958,12 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
-			deleted, err := gc.removeUnreferencedBlobs(repoName, time.Hour, log)
+			deleted, err := gc.deleteUnreferencedBlobs(repoName, time.Hour, log)
 			So(err, ShouldBeNil)
 			So(deleted, ShouldEqual, 0)
 		})
 
-		Convey("Error on GetAllBlobs in removeUnreferencedBlobs", func() {
+		Convey("Error on GetAllBlobs in deleteUnreferencedBlobs", func() {
 			returnedIndex := ispec.Index{}
 			returnedIndexBuf, err := json.Marshal(returnedIndex)
 			So(err, ShouldBeNil)
@@ -979,12 +979,12 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
-			deleted, err := gc.removeUnreferencedBlobs(repoName, time.Hour, log)
+			deleted, err := gc.deleteUnreferencedBlobs(repoName, time.Hour, log)
 			So(err, ShouldNotBeNil)
 			So(deleted, ShouldEqual, 0)
 		})
 
-		Convey("StatBlobUpload error in removeBlobUploads", func() {
+		Convey("StatBlobUpload error in deleteBlobUploads", func() {
 			imgStore := mocks.MockedImageStore{
 				DirExistsFn: func(d string) bool {
 					return true
@@ -999,12 +999,12 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
-			deleted, err := gc.removeBlobUploads(repoName, time.Hour)
+			deleted, err := gc.deleteBlobUploads(repoName, time.Hour)
 			So(err, ShouldNotBeNil)
 			So(deleted, ShouldEqual, 0)
 		})
 
-		Convey("Invalid digest from GetAllBlobs in removeUnreferencedBlobs", func() {
+		Convey("Invalid digest from GetAllBlobs in deleteUnreferencedBlobs", func() {
 			returnedIndex := ispec.Index{}
 			returnedIndexBuf, err := json.Marshal(returnedIndex)
 			So(err, ShouldBeNil)
@@ -1020,12 +1020,12 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
-			deleted, err := gc.removeUnreferencedBlobs(repoName, time.Hour, log)
+			deleted, err := gc.deleteUnreferencedBlobs(repoName, time.Hour, log)
 			So(err, ShouldNotBeNil)
 			So(deleted, ShouldEqual, 0)
 		})
 
-		Convey("StatBlob error in removeUnreferencedBlobs", func() {
+		Convey("StatBlob error in deleteUnreferencedBlobs", func() {
 			blobDigest := godigest.FromBytes([]byte("blob-content"))
 
 			returnedIndex := ispec.Index{}
@@ -1046,12 +1046,12 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
-			deleted, err := gc.removeUnreferencedBlobs(repoName, time.Hour, log)
+			deleted, err := gc.deleteUnreferencedBlobs(repoName, time.Hour, log)
 			So(err, ShouldNotBeNil)
 			So(deleted, ShouldEqual, 0)
 		})
 
-		Convey("CleanupRepo error in removeUnreferencedBlobs", func() {
+		Convey("CleanupRepo error in deleteUnreferencedBlobs", func() {
 			blobDigest := godigest.FromBytes([]byte("blob-content"))
 
 			returnedIndex := ispec.Index{}
@@ -1075,7 +1075,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
-			deleted, err := gc.removeUnreferencedBlobs(repoName, time.Hour, log)
+			deleted, err := gc.deleteUnreferencedBlobs(repoName, time.Hour, log)
 			So(err, ShouldNotBeNil)
 			So(deleted, ShouldEqual, 0)
 		})

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -531,7 +531,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Missing nested index blob in removeIndexReferrers is skipped gracefully", func() {
+		Convey("Missing nested index blob in removeReferrersWithMissingSubject is skipped gracefully", func() {
 			// Create a top-level index that contains a nested index
 			// The nested index blob will be missing
 			topLevelIndex := ispec.Index{
@@ -563,8 +563,9 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
-			// removeIndexReferrers should skip the missing nested index and continue
-			gced, err := gc.removeIndexReferrers(repoName, &topLevelIndex, topLevelIndex)
+			// removeReferrersWithMissingSubject should skip the missing nested index and continue
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &topLevelIndex, topLevelIndex,
+				map[godigest.Digest]struct{}{})
 			So(err, ShouldBeNil)
 			So(gced, ShouldBeFalse)
 		})
@@ -594,10 +595,306 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			// identifyManifestsReferencedInIndex should skip the missing nested index and continue
 			referenced := make(map[godigest.Digest]bool)
-			err := gc.identifyManifestsReferencedInIndex(topLevelIndex, repoName, referenced)
+			err := gc.identifyManifestsReferencedInIndex(topLevelIndex, repoName, referenced,
+				map[godigest.Digest]struct{}{})
 			So(err, ShouldBeNil)
 			// No manifests should be marked as referenced since the nested index is missing
 			So(len(referenced), ShouldEqual, 0)
+		})
+
+		Convey("identifyManifestsReferencedInIndex reads a shared nested index once", func() {
+			childManifestDigest := godigest.FromString("leaf-manifest")
+			subjectDigest := godigest.FromString("referrer-subject")
+
+			sharedIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Subject: &ispec.Descriptor{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    subjectDigest,
+					Size:      1,
+				},
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    childManifestDigest,
+						Size:      10,
+					},
+				},
+			}
+			sharedIndexBuf, err := json.Marshal(sharedIndex)
+			So(err, ShouldBeNil)
+			sharedIndexDigest := godigest.FromBytes(sharedIndexBuf)
+
+			// Parent index names the same nested index digest twice (duplicate sibling refs).
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageIndex,
+						Digest:    sharedIndexDigest,
+						Size:      int64(len(sharedIndexBuf)),
+					},
+					{
+						MediaType: ispec.MediaTypeImageIndex,
+						Digest:    sharedIndexDigest,
+						Size:      int64(len(sharedIndexBuf)),
+					},
+				},
+			}
+
+			readCount := 0
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == sharedIndexDigest {
+						readCount++
+
+						return sharedIndexBuf, nil
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			referenced := make(map[godigest.Digest]bool)
+			err = gc.identifyManifestsReferencedInIndex(parentIndex, repoName, referenced,
+				map[godigest.Digest]struct{}{})
+			So(err, ShouldBeNil)
+			So(readCount, ShouldEqual, 1)
+			So(referenced[childManifestDigest], ShouldBeTrue)
+			// Nested index with a subject is itself marked as referenced (referrer).
+			So(referenced[sharedIndexDigest], ShouldBeTrue)
+		})
+
+		Convey("removeReferrersWithMissingSubject keeps a shared referrer whose subject is present", func() {
+			subjectDigest := godigest.FromString("present-subject")
+
+			sharedIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Subject: &ispec.Descriptor{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    subjectDigest,
+					Size:      1,
+				},
+				Manifests: []ispec.Descriptor{},
+			}
+			sharedIndexBuf, err := json.Marshal(sharedIndex)
+			So(err, ShouldBeNil)
+			sharedIndexDigest := godigest.FromBytes(sharedIndexBuf)
+
+			// rootIndex / parent lists the subject and duplicate refs to the shared referrer index.
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageManifest,
+						Digest:    subjectDigest,
+						Size:      1,
+					},
+					{
+						MediaType: ispec.MediaTypeImageIndex,
+						Digest:    sharedIndexDigest,
+						Size:      int64(len(sharedIndexBuf)),
+					},
+					{
+						MediaType: ispec.MediaTypeImageIndex,
+						Digest:    sharedIndexDigest,
+						Size:      int64(len(sharedIndexBuf)),
+					},
+				},
+			}
+
+			readCount := 0
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == sharedIndexDigest {
+						readCount++
+
+						return sharedIndexBuf, nil
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Delay: 0,
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex, parentIndex,
+				map[godigest.Digest]struct{}{})
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeFalse)
+			So(readCount, ShouldEqual, 1)
+			So(len(parentIndex.Manifests), ShouldEqual, 3)
+		})
+
+		Convey("removeReferrersWithMissingSubject GCs an orphaned referrer with missing subject", func() {
+			missingSubject := godigest.FromString("missing-subject")
+
+			orphanedReferrer := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Subject: &ispec.Descriptor{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    missingSubject,
+					Size:      1,
+				},
+				Manifests: []ispec.Descriptor{},
+			}
+			orphanedBuf, err := json.Marshal(orphanedReferrer)
+			So(err, ShouldBeNil)
+			orphanedDigest := godigest.FromBytes(orphanedBuf)
+
+			// Single index.json entry: RemoveManifestDescByReference rejects duplicate digests
+			// (ErrManifestConflict), so the successful GC path uses one descriptor.
+			parentIndex := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageIndex,
+						Digest:    orphanedDigest,
+						Size:      int64(len(orphanedBuf)),
+					},
+				},
+			}
+
+			readCount := 0
+			statCount := 0
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == orphanedDigest {
+						readCount++
+
+						return orphanedBuf, nil
+					}
+
+					return nil, zerr.ErrBlobNotFound
+				},
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					if digest == orphanedDigest {
+						statCount++
+					}
+
+					// Old enough to pass the retention delay check.
+					return true, int64(len(orphanedBuf)), time.Now().Add(-24 * time.Hour), nil
+				},
+			}
+
+			gcOptions.ImageRetention = config.ImageRetention{
+				Delay: 0,
+				Policies: []config.RetentionPolicy{
+					{
+						Repositories:    []string{"**"},
+						DeleteReferrers: true,
+					},
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex, parentIndex,
+				map[godigest.Digest]struct{}{})
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeTrue)
+			So(readCount, ShouldEqual, 1)
+			So(statCount, ShouldEqual, 1)
+			So(len(parentIndex.Manifests), ShouldEqual, 0)
+		})
+
+		Convey("identifyManifestsReferencedInIndex walks a diamond DAG once per node", func() {
+			leafDigest := godigest.FromString("diamond-leaf")
+			subjectDigest := godigest.FromString("leaf-subject")
+
+			midLeft := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    leafDigest,
+					Size:      1,
+				}},
+			}
+			midLeftBuf, err := json.Marshal(midLeft)
+			So(err, ShouldBeNil)
+			midLeftDigest := godigest.FromBytes(midLeftBuf)
+
+			midRight := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    leafDigest,
+					Size:      1,
+				}},
+			}
+			midRightBuf, err := json.Marshal(midRight)
+			So(err, ShouldBeNil)
+			midRightDigest := godigest.FromBytes(midRightBuf)
+
+			root := ispec.Index{
+				MediaType: ispec.MediaTypeImageIndex,
+				Manifests: []ispec.Descriptor{
+					{
+						MediaType: ispec.MediaTypeImageIndex,
+						Digest:    midLeftDigest,
+						Size:      int64(len(midLeftBuf)),
+					},
+					{
+						MediaType: ispec.MediaTypeImageIndex,
+						Digest:    midRightDigest,
+						Size:      int64(len(midRightBuf)),
+					},
+				},
+			}
+
+			leafManifest := ispec.Manifest{
+				MediaType: ispec.MediaTypeImageManifest,
+				Config:    ispec.Descriptor{Digest: godigest.FromString("cfg"), Size: 1},
+				Subject: &ispec.Descriptor{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    subjectDigest,
+					Size:      1,
+				},
+			}
+			leafBuf, err := json.Marshal(leafManifest)
+			So(err, ShouldBeNil)
+
+			reads := map[godigest.Digest]int{}
+			imgStore := mocks.MockedImageStore{
+				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					reads[digest]++
+
+					switch digest {
+					case midLeftDigest:
+						return midLeftBuf, nil
+					case midRightDigest:
+						return midRightBuf, nil
+					case leafDigest:
+						return leafBuf, nil
+					default:
+						return nil, zerr.ErrBlobNotFound
+					}
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			referenced := make(map[godigest.Digest]bool)
+			err = gc.identifyManifestsReferencedInIndex(root, repoName, referenced,
+				map[godigest.Digest]struct{}{})
+			So(err, ShouldBeNil)
+			So(reads[midLeftDigest], ShouldEqual, 1)
+			So(reads[midRightDigest], ShouldEqual, 1)
+			So(reads[leafDigest], ShouldEqual, 1)
+			// Leaf is referenced both as a nested manifest and as a referrer (has subject).
+			So(referenced[leafDigest], ShouldBeTrue)
 		})
 
 		Convey("Error on ListBlobUploads in removeBlobUploads", func() {

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -2926,50 +2926,11 @@ func TestGarbageCollectErrors(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Trigger error on GetBlobContent and Unmarshal for untagged manifest", func() {
-			// upload image config blob
-			upload, err = imgStore.NewBlobUpload(context.Background(), repoName)
-			So(err, ShouldBeNil)
-			So(upload, ShouldNotBeEmpty)
+		Convey("Missing untagged manifest blob aborts GC on StatBlob", func() {
+			digest = putUntaggedManifestForGCErrors(imgStore, repoName, bdgst1, bsize1)
 
-			cblob, cdigest := GetRandomImageConfig()
-			buf = bytes.NewBuffer(cblob)
-			buflen = buf.Len()
-			blob, err = imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
-			So(err, ShouldBeNil)
-			So(blob, ShouldEqual, buflen)
-
-			err = imgStore.FinishBlobUpload(repoName, upload, buf, cdigest)
-			So(err, ShouldBeNil)
-			So(blob, ShouldEqual, buflen)
-
-			// create a manifest
-			manifest := ispec.Manifest{
-				Config: ispec.Descriptor{
-					MediaType: ispec.MediaTypeImageConfig,
-					Digest:    cdigest,
-					Size:      int64(len(cblob)),
-				},
-				Layers: []ispec.Descriptor{
-					{
-						MediaType: ispec.MediaTypeImageLayer,
-						Digest:    bdgst1,
-						Size:      int64(bsize1),
-					},
-				},
-			}
-			manifest.SchemaVersion = 2
-			content, err = json.Marshal(manifest)
-			So(err, ShouldBeNil)
-
-			digest = godigest.FromBytes(content)
-			So(digest, ShouldNotBeNil)
-
-			_, _, err = imgStore.PutImageManifest(context.Background(),
-				repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
-			So(err, ShouldBeNil)
-
-			// trigger GetBlobContent error
+			// Identify soft-continues on Get miss, but untagged removal still Stats the digest
+			// for the retention delay; StatBlob miss fails closed (same as main).
 			err = os.Remove(imgStore.BlobPath(repoName, digest))
 			So(err, ShouldBeNil)
 
@@ -2977,10 +2938,17 @@ func TestGarbageCollectErrors(t *testing.T) {
 
 			err = gc.CleanRepo(ctx, repoName)
 			So(err, ShouldNotBeNil)
+		})
 
-			// trigger Unmarshal error
-			_, err = os.Create(imgStore.BlobPath(repoName, digest))
+		Convey("Corrupt untagged manifest blob aborts GC", func() {
+			digest = putUntaggedManifestForGCErrors(imgStore, repoName, bdgst1, bsize1)
+
+			// Non-empty corrupt content: size 0 is treated as a dedupe placeholder (blob not found)
+			// and soft-continues; invalid JSON must fail closed in identify.
+			err = os.WriteFile(imgStore.BlobPath(repoName, digest), []byte("not-a-manifest"), 0o600)
 			So(err, ShouldBeNil)
+
+			time.Sleep(500 * time.Millisecond)
 
 			err = gc.CleanRepo(ctx, repoName)
 			So(err, ShouldNotBeNil)
@@ -3044,6 +3012,52 @@ func TestGarbageCollectErrors(t *testing.T) {
 			So(found, ShouldEqual, true)
 		})
 	})
+}
+
+func putUntaggedManifestForGCErrors(imgStore storageTypes.ImageStore, repoName string,
+	layerDigest godigest.Digest, layerSize int,
+) godigest.Digest {
+	upload, err := imgStore.NewBlobUpload(context.Background(), repoName)
+	So(err, ShouldBeNil)
+	So(upload, ShouldNotBeEmpty)
+
+	cblob, cdigest := GetRandomImageConfig()
+	buf := bytes.NewBuffer(cblob)
+	buflen := buf.Len()
+	blob, err := imgStore.PutBlobChunkStreamed(context.Background(), repoName, upload, buf)
+	So(err, ShouldBeNil)
+	So(blob, ShouldEqual, buflen)
+
+	err = imgStore.FinishBlobUpload(repoName, upload, buf, cdigest)
+	So(err, ShouldBeNil)
+	So(blob, ShouldEqual, buflen)
+
+	manifest := ispec.Manifest{
+		Config: ispec.Descriptor{
+			MediaType: ispec.MediaTypeImageConfig,
+			Digest:    cdigest,
+			Size:      int64(len(cblob)),
+		},
+		Layers: []ispec.Descriptor{
+			{
+				MediaType: ispec.MediaTypeImageLayer,
+				Digest:    layerDigest,
+				Size:      int64(layerSize),
+			},
+		},
+	}
+	manifest.SchemaVersion = 2
+	content, err := json.Marshal(manifest)
+	So(err, ShouldBeNil)
+
+	digest := godigest.FromBytes(content)
+	So(digest, ShouldNotBeNil)
+
+	_, _, err = imgStore.PutImageManifest(context.Background(),
+		repoName, digest.String(), ispec.MediaTypeImageManifest, content, nil)
+	So(err, ShouldBeNil)
+
+	return digest
 }
 
 func randSeq(n int) string {


### PR DESCRIPTION
**What type of PR is this?**

bug

**What does this PR do / Why do we need it**:

Three related GC fixes for correctness and availability under nested / shared index DAGs and multi-tag cosign siblings.

### 1. Untagged walk DoS / exponential nested-index walks
`identifyManifestsReferencedInIndex` re-fetched and recursed shared/duplicate nested index digests per path (`O(2^N)`), holding the store lock for the whole `CleanRepo` pass. Add a digest `seen` set so each object is walked once (`O(distinct)`).

### 2. Referrer GC correctness for multi-tag / cosign siblings
A digest-level `seen` on the referrer walk skipped later `index.json` rows that share a digest (multi-tag referrers, cosign `.sig` + untagged sibling). Removing by digest also hit `ErrManifestConflict` and silently no-op'd.

Final behavior:
- Walk **only root `index.json` rows** (removal only mutates root descriptors).
- Visit **every** root descriptor; cache parsed blobs by digest; track known-missing digests for that pass.
- Prefer **tag** when present so one row is removed at a time. Last-tag delete may re-add an untagged row; the outer retention loop clears it in the same `CleanRepo` pass when untagged GC is enabled (otherwise a later pass / stale prune).
- After a subject-path delete, skip the legacy cosign tag path so a second delete does not abort with `ErrManifestNotFound`.
- Soft-ignore `ErrManifestNotFound` in `removeManifest` (alongside existing `ErrManifestConflict`).

### 3. Naming cleanup
`remove*` = drop index references (+ metaDB sync); `delete*` = remove storage objects.

### User-visible: when repo GC continues vs stops

If `CleanRepo` returns an error for a repo, later steps for that pass are skipped (stale prune, orphan blob deletion, upload cleanup). The next successful pass retries them.

#### Continues (skip row / keep going)
| Situation | Effect |
|---|---|
| Manifest/index blob **missing** (`ErrBlobNotFound` / path not found) while scanning orphaned referrers | Skip / continue (manifests may still try cosign-tag path). |
| Manifest/index blob **unreadable for other reasons** during **orphaned-referrer** scan | Skip that row; GC keeps going so later cleanup can run. |
| Manifest/index blob **missing** while building the untagged “still referenced” set | Skip that digest (same soft-continue as main). |
| `ErrManifestNotFound` / `ErrManifestConflict` during a removal | No-op for that removal. |

#### Stops that repo’s GC for this pass
| Situation | Effect |
|---|---|
| Manifest/index blob **present but unreadable/corrupt** while building the untagged “still referenced” set | Fail closed (avoid under-marking nested/subject-bearing manifests). |
| Any `StatBlob` error during the retention-delay check (`isBlobOlderThan`) | Fail closed (**same as main**). `ImageStore.StatBlob` maps many underlying Stat failures (including transient S3/network errors) to `ErrBlobNotFound`, so treating “missing” as GC-eligible would risk deleting live index rows. |
| Cannot read `index.json`, metaDB update errors, other hard failures | Fail as before. |

**Net effect:** nested-index DoS is fixed; multi-tag/cosign orphaned referrers are GC’d correctly; incomplete storage no longer gets stuck solely because of hard Get errors mid-referrer walk. Retention delay / StatBlob behavior stays fail-closed like main to avoid false “missing” deletes on S3 blips.

**Testing done on this change**:
- `pkg/storage/gc` unit tests: shared nested index read-once, diamond DAG, multi-tag/cosign siblings, missing Get continue, StatBlob miss aborts, hard-read continue in referrer walk, fail-closed identify
- `TestGarbageCollectErrors`: missing blob aborts on Stat; corrupt blob aborts identify

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.