### PR TITLE
fix: stop metrics goroutine leak in sync without metrics build

### DIFF
--- a/pkg/api/authn_test.go
+++ b/pkg/api/authn_test.go
@@ -2272,9 +2272,7 @@ func TestAPIKeysGeneratorErrors(t *testing.T) {
 
 func TestCookiestoreCleanup(t *testing.T) {
 	log := log.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(true, log)
-
-	defer metrics.Stop() // Clean up metrics server to prevent resource leaks
+	metrics := monitoring.NewNopMetricServer()
 
 	authCfgTestCases := []struct {
 		name string

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -3620,8 +3620,7 @@ func TestDeleteManifestSucceedsAfterSignatureSubjectOrphaned(t *testing.T) {
 	Convey("Deleting a signature referrer whose subject was already untagged", t, func() {
 		rootDir := t.TempDir()
 		testLog := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, testLog)
-		defer metrics.Stop()
+		metrics := monitoring.NewNopMetricServer()
 
 		imgStore := local.NewImageStore(rootDir, true, true, testLog, metrics, nil, nil, nil, nil)
 

--- a/pkg/api/session_test.go
+++ b/pkg/api/session_test.go
@@ -175,7 +175,7 @@ func TestSessionLogger_redactsAuthorizationAndLogsUsernameFromContext(t *testing
 
 	ctlr := &zotapi.Controller{
 		Log:     log.NewLoggerWithWriter("info", &buf),
-		Metrics: monitoring.NewMetricsServer(false, log.NewTestLogger()),
+		Metrics: monitoring.NewNopMetricServer(),
 	}
 	t.Cleanup(ctlr.Metrics.Stop)
 
@@ -213,7 +213,7 @@ func TestSessionLogger_omitsUsernameWhenAnonymous(t *testing.T) {
 
 	ctlr := &zotapi.Controller{
 		Log:     log.NewLoggerWithWriter("info", &buf),
-		Metrics: monitoring.NewMetricsServer(false, log.NewTestLogger()),
+		Metrics: monitoring.NewNopMetricServer(),
 	}
 	t.Cleanup(ctlr.Metrics.Stop)
 

--- a/pkg/cli/client/cve_cmd_test.go
+++ b/pkg/cli/client/cve_cmd_test.go
@@ -109,7 +109,7 @@ func TestNegativeServerResponse(t *testing.T) {
 		dir := t.TempDir()
 
 		imageStore := local.NewImageStore(dir, false, false,
-			log.NewTestLogger(), monitoring.NewMetricsServer(false, log.NewTestLogger()), nil, nil, nil, nil)
+			log.NewTestLogger(), monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -169,6 +169,7 @@ func newScrubCmd(conf *config.Config) *cobra.Command {
 				// server is down
 				ctlr := api.NewController(conf)
 				ctlr.Metrics = monitoring.NewMetricsServer(false, ctlr.Log)
+				defer ctlr.Metrics.Stop()
 
 				if err := ctlr.InitImageStore(); err != nil {
 					return err

--- a/pkg/cli/server/verify_retention.go
+++ b/pkg/cli/server/verify_retention.go
@@ -100,6 +100,7 @@ func newVerifyFeatureRetentionCmd(conf *config.Config) *cobra.Command {
 
 			// Initialize metrics server
 			metricsServer := monitoring.NewMetricsServer(false, logger)
+			defer metricsServer.Stop()
 
 			// Initialize store controller
 			storeController, err := storage.New(conf, nil, metricsServer, logger, nil)

--- a/pkg/cli/server/verify_retention_test.go
+++ b/pkg/cli/server/verify_retention_test.go
@@ -345,7 +345,7 @@ func TestRetentionCheckWithRetentionEnabledAndRedisDriver(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// Initialize storage and metaDB using the same approach as gc tests
-		metricsServer := monitoring.NewMetricsServer(false, zlog.NewLogger("info", ""))
+		metricsServer := monitoring.NewNopMetricServer()
 		// Create ImageStore directly (like gc tests)
 		imgStore := local.NewImageStore(storageDir, false, false, zlog.NewLogger("info", ""), metricsServer,
 			nil, nil, nil, nil)
@@ -575,7 +575,7 @@ func TestRetentionCheckWithRetentionEnabled(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// Initialize storage and metaDB using the same approach as gc tests
-		metricsServer := monitoring.NewMetricsServer(false, zlog.NewLogger("info", ""))
+		metricsServer := monitoring.NewNopMetricServer()
 		// Create ImageStore directly (like gc tests)
 		imgStore := local.NewImageStore(storageDir, false, false, zlog.NewLogger("info", ""), metricsServer,
 			nil, nil, nil, nil)
@@ -864,7 +864,7 @@ func TestRetentionCheckWithDeleteReferrers(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// Initialize storage and metaDB
-		metricsServer := monitoring.NewMetricsServer(false, zlog.NewLogger("info", ""))
+		metricsServer := monitoring.NewNopMetricServer()
 		imgStore := local.NewImageStore(storageDir, false, false, zlog.NewLogger("info", ""), metricsServer,
 			nil, nil, nil, nil)
 		params := boltdb.DBParameters{
@@ -1027,7 +1027,7 @@ func TestRetentionCheckWithRetentionDisabled(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// Initialize storage only (no MetaDB needed when retention is disabled)
-		metricsServer := monitoring.NewMetricsServer(false, zlog.NewLogger("info", ""))
+		metricsServer := monitoring.NewNopMetricServer()
 		imgStore := local.NewImageStore(storageDir, false, false, zlog.NewLogger("info", ""), metricsServer,
 			nil, nil, nil, nil)
 		storeController := storage.StoreController{}
@@ -1219,7 +1219,7 @@ func TestRetentionCheckWithSubpaths(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		// Initialize storage and metaDB
-		metricsServer := monitoring.NewMetricsServer(false, zlog.NewLogger("info", ""))
+		metricsServer := monitoring.NewNopMetricServer()
 		imgStore := local.NewImageStore(storageDir, false, false, zlog.NewLogger("info", ""), metricsServer,
 			nil, nil, nil, nil)
 		subpathStore := local.NewImageStore(subpathStoreDir, false, false,

--- a/pkg/extensions/extension_image_trust_test.go
+++ b/pkg/extensions/extension_image_trust_test.go
@@ -236,7 +236,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		logger := log.NewLoggerWithWriter("debug", writers)
 
 		imageStore := local.NewImageStore(globalDir, false, false,
-			logger, monitoring.NewMetricsServer(false, logger), nil, nil, nil, nil)
+			logger, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,
@@ -353,7 +353,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		logger := log.NewLoggerWithWriter("debug", writers)
 
 		imageStore := local.NewImageStore(globalDir, false, false,
-			logger, monitoring.NewMetricsServer(false, logger), nil, nil, nil, nil)
+			logger, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,
@@ -455,7 +455,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		logger := log.NewLoggerWithWriter("debug", writers)
 
 		imageStore := local.NewImageStore(globalDir, false, false,
-			logger, monitoring.NewMetricsServer(false, logger), nil, nil, nil, nil)
+			logger, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,
@@ -614,7 +614,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		logger := log.NewLoggerWithWriter("debug", writers)
 
 		imageStore := local.NewImageStore(globalDir, false, false,
-			logger, monitoring.NewMetricsServer(false, logger), nil, nil, nil, nil)
+			logger, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,
@@ -868,7 +868,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		logger := log.NewLoggerWithWriter("debug", writers)
 
 		imageStore := local.NewImageStore(globalDir, false, false,
-			logger, monitoring.NewMetricsServer(false, logger), nil, nil, nil, nil)
+			logger, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,

--- a/pkg/extensions/lint/lint_test.go
+++ b/pkg/extensions/lint/lint_test.go
@@ -467,7 +467,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 
 		linter := lint.NewLinter(lintConfig, log.NewTestLogger())
 		imgStore := local.NewImageStore(dir, false, false,
-			log.NewTestLogger(), monitoring.NewMetricsServer(false, log.NewTestLogger()), linter, nil, nil, nil)
+			log.NewTestLogger(), monitoring.NewNopMetricServer(), linter, nil, nil, nil)
 
 		indexContent, err := imgStore.GetIndexContent("zot-test")
 		So(err, ShouldBeNil)
@@ -499,7 +499,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 
 		linter := lint.NewLinter(lintConfig, log.NewTestLogger())
 		imgStore := local.NewImageStore(dir, false, false,
-			log.NewTestLogger(), monitoring.NewMetricsServer(false, log.NewTestLogger()), linter, nil, nil, nil)
+			log.NewTestLogger(), monitoring.NewNopMetricServer(), linter, nil, nil, nil)
 
 		indexContent, err := imgStore.GetIndexContent("zot-test")
 		So(err, ShouldBeNil)
@@ -569,7 +569,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 
 		linter := lint.NewLinter(lintConfig, log.NewTestLogger())
 		imgStore := local.NewImageStore(dir, false, false,
-			log.NewTestLogger(), monitoring.NewMetricsServer(false, log.NewTestLogger()), linter, nil, nil, nil)
+			log.NewTestLogger(), monitoring.NewNopMetricServer(), linter, nil, nil, nil)
 
 		pass, err := linter.CheckMandatoryAnnotations("zot-test", digest, imgStore)
 		So(err, ShouldBeNil)
@@ -631,7 +631,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 
 		linter := lint.NewLinter(lintConfig, log.NewTestLogger())
 		imgStore := local.NewImageStore(dir, false, false,
-			log.NewTestLogger(), monitoring.NewMetricsServer(false, log.NewTestLogger()), linter, nil, nil, nil)
+			log.NewTestLogger(), monitoring.NewNopMetricServer(), linter, nil, nil, nil)
 
 		pass, err := linter.CheckMandatoryAnnotations("zot-test", digest, imgStore)
 		So(err, ShouldNotBeNil)
@@ -695,7 +695,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 
 		linter := lint.NewLinter(lintConfig, log.NewTestLogger())
 		imgStore := local.NewImageStore(dir, false, false,
-			log.NewTestLogger(), monitoring.NewMetricsServer(false, log.NewTestLogger()), linter, nil, nil, nil)
+			log.NewTestLogger(), monitoring.NewNopMetricServer(), linter, nil, nil, nil)
 
 		pass, err := linter.CheckMandatoryAnnotations("zot-test", digest, imgStore)
 		So(err, ShouldBeNil)
@@ -758,7 +758,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 
 		linter := lint.NewLinter(lintConfig, log.NewTestLogger())
 		imgStore := local.NewImageStore(dir, false, false,
-			log.NewTestLogger(), monitoring.NewMetricsServer(false, log.NewTestLogger()), linter, nil, nil, nil)
+			log.NewTestLogger(), monitoring.NewNopMetricServer(), linter, nil, nil, nil)
 
 		err = os.Chmod(path.Join(dir, "zot-test", "blobs"), 0o000)
 		if err != nil {
@@ -856,7 +856,7 @@ func TestVerifyMandatoryAnnotationsFunction(t *testing.T) {
 
 		linter := lint.NewLinter(lintConfig, log.NewTestLogger())
 		imgStore := local.NewImageStore(dir, false, false,
-			log.NewTestLogger(), monitoring.NewMetricsServer(false, log.NewTestLogger()), linter, nil, nil, nil)
+			log.NewTestLogger(), monitoring.NewNopMetricServer(), linter, nil, nil, nil)
 
 		err = os.Chmod(path.Join(dir, "zot-test", "blobs", "sha256", manifest.Config.Digest.Encoded()), 0o000)
 		if err != nil {

--- a/pkg/extensions/monitoring/minimal.go
+++ b/pkg/extensions/monitoring/minimal.go
@@ -492,7 +492,9 @@ func SetStorageUsage(ms MetricServer, rootDir, repo string) {
 
 	repoSize, err := GetDirSize(dir)
 	if err != nil {
-		ms.(*metricServer).log.Error().Err(err).Msg("failed to set storage usage")
+		if server, ok := ms.(*metricServer); ok {
+			server.log.Error().Err(err).Msg("failed to set storage usage")
+		}
 	}
 
 	storage := GaugeValue{

--- a/pkg/extensions/monitoring/minimal_test.go
+++ b/pkg/extensions/monitoring/minimal_test.go
@@ -1,0 +1,184 @@
+//go:build !metrics
+
+package monitoring_test
+
+import (
+	"fmt"
+	"math/rand"
+	"slices"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	"zotregistry.dev/zot/v2/pkg/log"
+)
+
+func TestMetricHelpersUpdateWhenEnabled(t *testing.T) {
+	Convey("Metric helpers update the minimal metrics server when active", t, func() {
+		logger := log.NewTestLogger()
+
+		Convey("IncDownloadCounter", func() {
+			repo := uniqueMetricLabel("download")
+			assertMinimalCounterDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.IncDownloadCounter(metricsServer, repo)
+			}, "zot.repo.downloads", []string{repo}, 1)
+		})
+
+		Convey("IncUploadCounter", func() {
+			repo := uniqueMetricLabel("upload")
+			assertMinimalCounterDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.IncUploadCounter(metricsServer, repo)
+			}, "zot.repo.uploads", []string{repo}, 1)
+		})
+
+		Convey("IncHTTPConnRequests", func() {
+			code := uniqueMetricLabel("code")
+			assertMinimalCounterDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.IncHTTPConnRequests(metricsServer, "GET", code)
+			}, "zot.http.requests", []string{"GET", code}, 1)
+		})
+
+		Convey("ObserveHTTPMethodLatency", func() {
+			method := uniqueMetricLabel("method")
+			assertMinimalHistogramCountDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.ObserveHTTPMethodLatency(metricsServer, method, time.Millisecond)
+			}, "zot.http.method.latency.seconds", []string{method}, 1)
+		})
+
+		Convey("IncGCRuns", func() {
+			assertMinimalCounterDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.IncGCRuns(metricsServer, false)
+			}, "zot.gc.runs", []string{"false"}, 1)
+		})
+
+		Convey("IncGCDeleted", func() {
+			artifactType := uniqueMetricLabel("artifact")
+			assertMinimalCounterDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.IncGCDeleted(metricsServer, artifactType, 3)
+			}, "zot.gc.deleted", []string{artifactType}, 3)
+		})
+
+		Convey("SetSchedulerWorkers", func() {
+			state := uniqueMetricLabel("state")
+			assertMinimalGaugeSet(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.SetSchedulerWorkers(metricsServer, map[string]int{state: 7})
+			}, "zot.scheduler.workers", []string{state}, 7)
+		})
+	})
+}
+
+func assertMinimalCounterDelta(logger log.Logger, emit func(monitoring.MetricServer),
+	metricName string, labelValues []string, delta int,
+) {
+	activeMetricsServer := monitoring.NewMetricsServer(true, logger)
+	Reset(activeMetricsServer.Stop)
+
+	inactiveMetricsServer := monitoring.NewMetricsServer(false, logger)
+	Reset(inactiveMetricsServer.Stop)
+
+	before := minimalCounter(activeMetricsServer, metricName, labelValues)
+
+	emit(inactiveMetricsServer)
+	So(minimalCounter(inactiveMetricsServer, metricName, labelValues), ShouldEqual, 0)
+
+	emit(activeMetricsServer)
+	So(minimalCounter(activeMetricsServer, metricName, labelValues), ShouldEqual, before+delta)
+}
+
+func assertMinimalHistogramCountDelta(logger log.Logger, emit func(monitoring.MetricServer),
+	metricName string, labelValues []string, delta int,
+) {
+	activeMetricsServer := monitoring.NewMetricsServer(true, logger)
+	Reset(activeMetricsServer.Stop)
+
+	inactiveMetricsServer := monitoring.NewMetricsServer(false, logger)
+	Reset(inactiveMetricsServer.Stop)
+
+	before := minimalHistogramCount(activeMetricsServer, metricName, labelValues)
+
+	emit(inactiveMetricsServer)
+	So(minimalHistogramCount(inactiveMetricsServer, metricName, labelValues), ShouldEqual, 0)
+
+	emit(activeMetricsServer)
+	So(minimalHistogramCount(activeMetricsServer, metricName, labelValues), ShouldEqual, before+delta)
+}
+
+func assertMinimalGaugeSet(logger log.Logger, emit func(monitoring.MetricServer),
+	metricName string, labelValues []string, want float64,
+) {
+	activeMetricsServer := monitoring.NewMetricsServer(true, logger)
+	Reset(activeMetricsServer.Stop)
+
+	inactiveMetricsServer := monitoring.NewMetricsServer(false, logger)
+	Reset(inactiveMetricsServer.Stop)
+
+	emit(inactiveMetricsServer)
+	_, found := minimalGauge(inactiveMetricsServer, metricName, labelValues)
+	So(found, ShouldBeFalse)
+
+	emit(activeMetricsServer)
+
+	got, found := minimalGauge(activeMetricsServer, metricName, labelValues)
+	So(found, ShouldBeTrue)
+	So(got, ShouldEqual, want)
+}
+
+func uniqueMetricLabel(prefix string) string {
+	return fmt.Sprintf("%s_%s_%d", prefix, generateRandomString(), time.Now().UnixNano())
+}
+
+func generateRandomString() string {
+	//nolint: gosec
+	seededRand := rand.New(rand.NewSource(time.Now().UnixNano()))
+	charset := "abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	randomBytes := make([]byte, 10)
+	for i := range randomBytes {
+		randomBytes[i] = charset[seededRand.Intn(len(charset))]
+	}
+
+	return string(randomBytes)
+}
+
+func receiveCopy(metricsServer monitoring.MetricServer) monitoring.MetricsCopy {
+	data := metricsServer.ReceiveMetrics()
+
+	metricsCopy, ok := data.(monitoring.MetricsCopy)
+	if !ok {
+		return monitoring.MetricsCopy{}
+	}
+
+	return metricsCopy
+}
+
+func minimalCounter(metricsServer monitoring.MetricServer, name string, labelValues []string) int {
+	for _, counter := range receiveCopy(metricsServer).Counters {
+		if counter.Name == name && slices.Equal(counter.LabelValues, labelValues) {
+			return counter.Count
+		}
+	}
+
+	return 0
+}
+
+func minimalHistogramCount(metricsServer monitoring.MetricServer, name string, labelValues []string) int {
+	for _, histogram := range receiveCopy(metricsServer).Histograms {
+		if histogram.Name == name && slices.Equal(histogram.LabelValues, labelValues) {
+			return histogram.Count
+		}
+	}
+
+	return 0
+}
+
+func minimalGauge(metricsServer monitoring.MetricServer, name string, labelValues []string) (float64, bool) {
+	for _, gauge := range receiveCopy(metricsServer).Gauges {
+		if gauge.Name == name && slices.Equal(gauge.LabelValues, labelValues) {
+			return gauge.Value, true
+		}
+	}
+
+	return 0, false
+}

--- a/pkg/extensions/monitoring/monitoring_test.go
+++ b/pkg/extensions/monitoring/monitoring_test.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	godigest "github.com/opencontainers/go-digest"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
 
@@ -651,6 +653,10 @@ func TestPopulateStorageMetrics(t *testing.T) {
 		rootDir := t.TempDir()
 
 		conf.Storage.RootDirectory = rootDir
+		// This test asserts scraped storage gauges against a live GetDirSize. Default GC
+		// rewrites index.json via a .uploads staging file, so GetDirSize can briefly
+		// include an extra index.json-sized file and disagree with the gauge.
+		conf.Storage.GC = false
 		conf.Extensions = &extconf.ExtensionConfig{}
 		enabled := true
 		conf.Extensions.Metrics = &extconf.MetricsConfig{
@@ -669,7 +675,6 @@ func TestPopulateStorageMetrics(t *testing.T) {
 		So(ctlr, ShouldNotBeNil)
 		ctlr.Log = log.NewLoggerWithWriter("debug", writers)
 
-		// Write images before starting controller to avoid race condition with garbage collection
 		srcStorageCtlr := ociutils.GetDefaultStoreController(rootDir, ctlr.Log)
 		err := WriteImageToFileSystem(CreateDefaultImage(), "alpine", "0.0.1", srcStorageCtlr)
 		So(err, ShouldBeNil)
@@ -681,6 +686,7 @@ func TestPopulateStorageMetrics(t *testing.T) {
 		defer cm.StopServer()
 
 		metrics := monitoring.NewMetricsServer(true, ctlr.Log)
+		defer metrics.Stop()
 		sch := scheduler.NewScheduler(conf, metrics, ctlr.Log)
 		sch.RunScheduler()
 
@@ -771,6 +777,186 @@ func TestGCMetrics(t *testing.T) {
 		So(respStr, ShouldContainSubstring, "zot_gc_duration_seconds")
 		So(respStr, ShouldContainSubstring, "zot_gc_deleted_total{type=\"blob\"}")
 	})
+}
+
+func TestMetricHelpersUpdateWhenEnabled(t *testing.T) {
+	Convey("Metric helpers update prometheus when the metrics server is active", t, func() {
+		logger := log.NewTestLogger()
+
+		Convey("IncDownloadCounter", func() {
+			repo := uniqueMetricLabel("download")
+			assertCounterDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.IncDownloadCounter(metricsServer, repo)
+			}, "zot_repo_downloads_total", map[string]string{"repo": repo}, 1)
+		})
+
+		Convey("IncUploadCounter", func() {
+			repo := uniqueMetricLabel("upload")
+			assertCounterDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.IncUploadCounter(metricsServer, repo)
+			}, "zot_repo_uploads_total", map[string]string{"repo": repo}, 1)
+		})
+
+		Convey("IncHTTPConnRequests", func() {
+			code := uniqueMetricLabel("code")
+			assertCounterDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.IncHTTPConnRequests(metricsServer, "GET", code)
+			}, "zot_http_requests_total", map[string]string{"method": "GET", "code": code}, 1)
+		})
+
+		Convey("ObserveHTTPMethodLatency", func() {
+			method := uniqueMetricLabel("method")
+			assertHistogramCountDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.ObserveHTTPMethodLatency(metricsServer, method, time.Millisecond)
+			}, "zot_http_method_latency_seconds", map[string]string{"method": method}, 1)
+		})
+
+		Convey("IncGCRuns", func() {
+			assertCounterDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.IncGCRuns(metricsServer, false)
+			}, "zot_gc_runs_total", map[string]string{"error": "false"}, 1)
+		})
+
+		Convey("IncGCDeleted", func() {
+			artifactType := uniqueMetricLabel("artifact")
+			assertCounterDelta(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.IncGCDeleted(metricsServer, artifactType, 3)
+			}, "zot_gc_deleted_total", map[string]string{"type": artifactType}, 3)
+		})
+
+		Convey("SetSchedulerWorkers", func() {
+			state := uniqueMetricLabel("state")
+			assertGaugeSet(logger, func(metricsServer monitoring.MetricServer) {
+				monitoring.SetSchedulerWorkers(metricsServer, map[string]int{state: 7})
+			}, "zot_scheduler_workers", map[string]string{"state": state}, 7)
+		})
+	})
+}
+
+func assertCounterDelta(logger log.Logger, emit func(monitoring.MetricServer),
+	metricName string, labels map[string]string, delta float64,
+) {
+	activeMetricsServer := monitoring.NewMetricsServer(true, logger)
+	inactiveMetricsServer := monitoring.NewMetricsServer(false, logger)
+
+	before := prometheusCounter(metricName, labels)
+
+	emit(inactiveMetricsServer)
+	So(prometheusCounter(metricName, labels), ShouldEqual, before)
+
+	emit(activeMetricsServer)
+	So(prometheusCounter(metricName, labels), ShouldEqual, before+delta)
+}
+
+func assertHistogramCountDelta(logger log.Logger, emit func(monitoring.MetricServer),
+	metricName string, labels map[string]string, delta uint64,
+) {
+	activeMetricsServer := monitoring.NewMetricsServer(true, logger)
+	inactiveMetricsServer := monitoring.NewMetricsServer(false, logger)
+
+	before := prometheusHistogramCount(metricName, labels)
+
+	emit(inactiveMetricsServer)
+	So(prometheusHistogramCount(metricName, labels), ShouldEqual, before)
+
+	emit(activeMetricsServer)
+	So(prometheusHistogramCount(metricName, labels), ShouldEqual, before+delta)
+}
+
+func assertGaugeSet(logger log.Logger, emit func(monitoring.MetricServer),
+	metricName string, labels map[string]string, want float64,
+) {
+	activeMetricsServer := monitoring.NewMetricsServer(true, logger)
+	inactiveMetricsServer := monitoring.NewMetricsServer(false, logger)
+
+	before := prometheusGauge(metricName, labels)
+
+	emit(inactiveMetricsServer)
+	So(prometheusGauge(metricName, labels), ShouldEqual, before)
+
+	emit(activeMetricsServer)
+	So(prometheusGauge(metricName, labels), ShouldEqual, want)
+}
+
+func uniqueMetricLabel(prefix string) string {
+	return fmt.Sprintf("%s_%s_%d", prefix, generateRandomString(), time.Now().UnixNano())
+}
+
+func prometheusCounter(name string, labels map[string]string) float64 {
+	metric := findPrometheusMetric(name, labels)
+	if metric == nil || metric.Counter == nil {
+		return 0
+	}
+
+	return metric.GetCounter().GetValue()
+}
+
+func prometheusGauge(name string, labels map[string]string) float64 {
+	metric := findPrometheusMetric(name, labels)
+	if metric == nil || metric.Gauge == nil {
+		return 0
+	}
+
+	return metric.GetGauge().GetValue()
+}
+
+func prometheusHistogramCount(name string, labels map[string]string) uint64 {
+	metric := findPrometheusMetric(name, labels)
+	if metric == nil || metric.Histogram == nil {
+		return 0
+	}
+
+	return metric.GetHistogram().GetSampleCount()
+}
+
+func findPrometheusMetric(name string, labels map[string]string) *dto.Metric {
+	families, err := prometheus.DefaultGatherer.Gather()
+	So(err, ShouldBeNil)
+
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+
+		for _, metric := range family.GetMetric() {
+			if prometheusLabelsMatch(metric.GetLabel(), labels) {
+				return metric
+			}
+		}
+	}
+
+	return nil
+}
+
+func prometheusLabelsMatch(pairs []*dto.LabelPair, want map[string]string) bool {
+	if len(pairs) < len(want) {
+		return false
+	}
+
+	for _, pair := range pairs {
+		value, ok := want[pair.GetName()]
+		if ok && pair.GetValue() != value {
+			return false
+		}
+	}
+
+	for name := range want {
+		found := false
+
+		for _, pair := range pairs {
+			if pair.GetName() == name {
+				found = true
+
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
 }
 
 func generateRandomString() string {

--- a/pkg/extensions/monitoring/noop.go
+++ b/pkg/extensions/monitoring/noop.go
@@ -1,0 +1,26 @@
+package monitoring
+
+// nopMetricServer is a MetricServer that discards all metrics and does not
+// start background goroutines. Use it for short-lived ImageStores (e.g. sync
+// temp OCI layouts) that must satisfy the MetricServer dependency without
+// leaking the Run() loops from NewMetricsServer under the !metrics build.
+type nopMetricServer struct{}
+
+// NewNopMetricServer returns a no-op MetricServer.
+func NewNopMetricServer() MetricServer {
+	return nopMetricServer{}
+}
+
+func (nopMetricServer) SendMetric(any) {}
+
+func (nopMetricServer) ForceSendMetric(any) {}
+
+func (nopMetricServer) ReceiveMetrics() any {
+	return MetricsCopy{}
+}
+
+func (nopMetricServer) IsEnabled() bool {
+	return false
+}
+
+func (nopMetricServer) Stop() {}

--- a/pkg/extensions/monitoring/noop_test.go
+++ b/pkg/extensions/monitoring/noop_test.go
@@ -1,0 +1,26 @@
+package monitoring_test
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+)
+
+func TestNopMetricServer(t *testing.T) {
+	Convey("nop MetricServer discards metrics without panicking", t, func() {
+		metricsServer := monitoring.NewNopMetricServer()
+
+		So(metricsServer.IsEnabled(), ShouldBeFalse)
+		So(func() { metricsServer.SendMetric(monitoring.CounterValue{Name: "x"}) }, ShouldNotPanic)
+		So(func() { metricsServer.ForceSendMetric(monitoring.GaugeValue{Name: "y"}) }, ShouldNotPanic)
+		So(metricsServer.ReceiveMetrics(), ShouldResemble, monitoring.MetricsCopy{})
+		So(func() { metricsServer.Stop() }, ShouldNotPanic)
+
+		// SetStorageUsage used to type-assert *metricServer; must tolerate nop.
+		So(func() {
+			monitoring.SetStorageUsage(metricsServer, t.TempDir(), "missing-repo")
+		}, ShouldNotPanic)
+	})
+}

--- a/pkg/extensions/scrub/scrub_test.go
+++ b/pkg/extensions/scrub/scrub_test.go
@@ -169,7 +169,7 @@ func TestRunScrubRepo(t *testing.T) {
 
 		dir := t.TempDir()
 		log := log.NewLogger("debug", logPath)
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -202,7 +202,7 @@ func TestRunScrubRepo(t *testing.T) {
 
 		dir := t.TempDir()
 		log := log.NewLogger("debug", logPath)
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -241,7 +241,7 @@ func TestRunScrubRepo(t *testing.T) {
 
 		dir := t.TempDir()
 		log := log.NewLogger("debug", logPath)
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",

--- a/pkg/extensions/search/cve/cve_test.go
+++ b/pkg/extensions/search/cve/cve_test.go
@@ -318,7 +318,7 @@ func TestImageFormat(t *testing.T) {
 		imgDir := "../../../../test/data"
 		dbDir := t.TempDir()
 
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		defaultStore := local.NewImageStore(imgDir, false, false, log, metrics, nil, nil, nil, nil)
 		storeController := storage.StoreController{DefaultStore: defaultStore}
 

--- a/pkg/extensions/search/cve/scan_test.go
+++ b/pkg/extensions/search/cve/scan_test.go
@@ -56,7 +56,7 @@ func TestScanGeneratorWithMockedData(t *testing.T) { //nolint: gocyclo
 
 		cfg := config.New()
 		cfg.Scheduler = &config.SchedulerConfig{NumWorkers: 3}
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(cfg, metrics, logger)
 
 		params := boltdb.DBParameters{
@@ -501,7 +501,7 @@ func TestScanGeneratorWithRealData(t *testing.T) {
 		metaDB, err := boltdb.New(boltDriver, logger)
 		So(err, ShouldBeNil)
 
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		imageStore := local.NewImageStore(rootDir, false, false,
 			logger, metrics, nil, nil, nil, nil)
 		storeController := storage.StoreController{DefaultStore: imageStore}

--- a/pkg/extensions/search/cve/trivy/scanner_internal_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_internal_test.go
@@ -144,7 +144,7 @@ func TestRunTrivySBOMGenerationFailureIsNonFatal(t *testing.T) {
 		err = os.WriteFile(metadata.Path(dbDir), []byte(`{"Version":2}`), 0o600)
 		So(err, ShouldBeNil)
 
-		store := local.NewImageStore(rootDir, false, false, logger, monitoring.NewMetricsServer(false, logger), nil, nil, nil, nil)
+		store := local.NewImageStore(rootDir, false, false, logger, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 		storeController := storage.StoreController{DefaultStore: store}
 
 		scanner := Scanner{
@@ -189,7 +189,7 @@ func TestMultipleStoragePath(t *testing.T) {
 		thirdRootDir := t.TempDir()
 
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		// Create ImageStore
 
@@ -315,7 +315,7 @@ func TestTrivyLibraryErrors(t *testing.T) {
 		rootDir := t.TempDir()
 
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		// Create ImageStore
 		store := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
@@ -481,7 +481,7 @@ func TestImageScannable(t *testing.T) {
 	}
 
 	// Continue with initializing the objects the scanner depends on
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 
 	store := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
 
@@ -544,7 +544,7 @@ func TestTrivyDBUrl(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		// Create ImageStore
 		store := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
@@ -725,8 +725,7 @@ func TestStoreSBOMAsOCIArtifact(t *testing.T) {
 		rootDir := t.TempDir()
 
 		logger := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, logger)
-		defer metrics.Stop()
+		metrics := monitoring.NewNopMetricServer()
 		store := local.NewImageStore(rootDir, false, false, logger, metrics, nil, nil, nil, nil)
 
 		storeController := storage.StoreController{

--- a/pkg/extensions/search/cve/trivy/scanner_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_test.go
@@ -180,7 +180,7 @@ func TestVulnerableLayer(t *testing.T) {
 
 		log := log.NewTestLogger()
 		imageStore := local.NewImageStore(tempDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,
@@ -256,7 +256,7 @@ func TestVulnerableLayer(t *testing.T) {
 
 		log := log.NewTestLogger()
 		imageStore := local.NewImageStore(tempDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,
@@ -342,7 +342,7 @@ func TestWithTempDirErrorHandling(t *testing.T) {
 
 		log := log.NewTestLogger()
 		imageStore := local.NewImageStore(tempDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,

--- a/pkg/extensions/search/cve/update_test.go
+++ b/pkg/extensions/search/cve/update_test.go
@@ -36,7 +36,7 @@ func TestCVEDBGenerator(t *testing.T) {
 
 		cfg := config.New()
 		cfg.Scheduler = &config.SchedulerConfig{NumWorkers: 3}
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(cfg, metrics, logger)
 
 		metaDB := &mocks.MetaDBMock{

--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -1145,7 +1145,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		imageStore := local.NewImageStore(tempDir, false, false,
-			log.NewTestLogger(), monitoring.NewMetricsServer(false, log.NewTestLogger()), nil, nil, nil, nil)
+			log.NewTestLogger(), monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,
@@ -1265,7 +1265,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		testStorage := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
 
 		resp, err := resty.R().Get(baseURL + "/v2/")
@@ -1617,7 +1617,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		ctlr := api.NewController(conf)
 
 		imageStore := local.NewImageStore(conf.Storage.RootDirectory, false, false,
-			log.NewTestLogger(), monitoring.NewMetricsServer(false, log.NewTestLogger()), nil, nil, nil, nil)
+			log.NewTestLogger(), monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,
@@ -1777,7 +1777,7 @@ func TestExpandedRepoInfo(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		testStorage := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
 
 		resp, err := resty.R().Get(baseURL + "/v2/")
@@ -6345,7 +6345,7 @@ func TestMetaDBWhenDeletingImages(t *testing.T) {
 
 			// get signatur digest
 			log := log.NewTestLogger()
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 			storage := local.NewImageStore(dir, false, false, log, metrics, nil, nil, nil, nil)
 
 			indexBlob, err := storage.GetIndexContent(repo)
@@ -6419,7 +6419,7 @@ func TestMetaDBWhenDeletingImages(t *testing.T) {
 
 			// get signatur digest
 			log := log.NewTestLogger()
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 			storage := local.NewImageStore(dir, false, false, log, metrics, nil, nil, nil, nil)
 
 			indexBlob, err := storage.GetIndexContent(repo)

--- a/pkg/extensions/sync/destination.go
+++ b/pkg/extensions/sync/destination.go
@@ -439,7 +439,6 @@ func getImageStoreFromImageReference(repo string, imageReference ref.Ref, log lo
 }
 
 func getImageStore(rootDir string, log log.Logger) storageTypes.ImageStore {
-	metrics := monitoring.NewMetricsServer(false, log)
-
-	return local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
+	// Temp sync layouts are short-lived and don't need an active metrics server.
+	return local.NewImageStore(rootDir, false, false, log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 }

--- a/pkg/extensions/sync/destination_internal_test.go
+++ b/pkg/extensions/sync/destination_internal_test.go
@@ -1,0 +1,43 @@
+//go:build sync
+
+package sync
+
+import (
+	"bytes"
+	"runtime"
+	"testing"
+
+	"zotregistry.dev/zot/v2/pkg/log"
+)
+
+func TestGetImageStoreDoesNotLeakMetricsGoroutines(t *testing.T) {
+	logger := log.NewTestLogger()
+
+	before := countMetricServerRunGoroutines()
+
+	const iterations = 25
+
+	for range iterations {
+		store := getImageStore(t.TempDir(), logger)
+		if store == nil {
+			t.Fatal("expected temp image store")
+		}
+	}
+
+	// Yield once so a leaked go ms.Run() is scheduled into a stack dump.
+	// getImageStore uses a nop server, so this count must stay exactly at `before`.
+	runtime.Gosched()
+
+	after := countMetricServerRunGoroutines()
+	if after != before {
+		t.Fatalf("getImageStore leaked metrics goroutines: before=%d after=%d", before, after)
+	}
+}
+
+func countMetricServerRunGoroutines() int {
+	buf := make([]byte, 1<<22)
+	stackLen := runtime.Stack(buf, true)
+
+	// Each NewMetricsServer(!metrics) leaves (*metricServer).Run and Run.func1.
+	return bytes.Count(buf[:stackLen], []byte("(*metricServer).Run"))
+}

--- a/pkg/extensions/sync/oci_digest_predict_internal_test.go
+++ b/pkg/extensions/sync/oci_digest_predict_internal_test.go
@@ -422,7 +422,7 @@ func newTestStore(t *testing.T) (string, stypes.StoreController) {
 	logger := log.NewTestLogger()
 
 	store := local.NewImageStore(root, false, false, logger,
-		monitoring.NewMetricsServer(false, logger),
+		monitoring.NewNopMetricServer(),
 		mocks.MockedLint{
 			LintFn: func(repo string, manifestDigest godigest.Digest, imageStore stypes.ImageStore) (bool, error) {
 				return true, nil

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -1210,8 +1210,7 @@ func TestDestinationRegistry(t *testing.T) {
 		dir := t.TempDir()
 
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
-		defer metrics.Stop() // Clean up metrics server to prevent resource leaks
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -1798,8 +1797,7 @@ func TestSyncTempLayoutPathHelpers(t *testing.T) {
 func TestDestinationRegistryCommitAllErrors(t *testing.T) {
 	Convey("CommitAll and CleanupImage temp path errors", t, func() {
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
-		defer metrics.Stop()
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 		store := local.NewImageStore(dir, true, true, log, metrics, nil, nil, nil, nil)
@@ -1837,8 +1835,7 @@ func TestDestinationRegistryCommitAllErrors(t *testing.T) {
 func TestCopyManifestInvalidJSON(t *testing.T) {
 	Convey("copyManifest rejects invalid manifest JSON", t, func() {
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
-		defer metrics.Stop()
+		metrics := monitoring.NewNopMetricServer()
 
 		tempDir := t.TempDir()
 		destDir := t.TempDir()
@@ -1868,8 +1865,7 @@ func TestCopyManifestInvalidJSON(t *testing.T) {
 func TestCopyManifestReferrersTag(t *testing.T) {
 	Convey("referrers-shaped layout entries are not committed as tags", t, func() {
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
-		defer metrics.Stop()
+		metrics := monitoring.NewNopMetricServer()
 
 		repoName := "repo"
 		subjectImage := CreateImageWith().RandomLayers(1, 10).RandomConfig().Build()

--- a/pkg/meta/hooks_test.go
+++ b/pkg/meta/hooks_test.go
@@ -79,9 +79,8 @@ func TestOnUpdateManifestDigestTags_success(t *testing.T) {
 		rootDir := t.TempDir()
 		storeController := storage.StoreController{}
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
-		defer metrics.Stop()
 		storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
 
 		params := boltdb.DBParameters{RootDir: rootDir}
@@ -135,9 +134,8 @@ func TestOnUpdateManifestDigestTags_rollbackPartialMeta(t *testing.T) {
 			rootDir := t.TempDir()
 			storeController := storage.StoreController{}
 			log := log.NewTestLogger()
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 
-			defer metrics.Stop()
 			storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
 
 			params := boltdb.DBParameters{RootDir: rootDir}
@@ -203,9 +201,8 @@ func TestOnUpdateManifestDigestTags_rollbackRestoresMovedTag(t *testing.T) {
 			rootDir := t.TempDir()
 			storeController := storage.StoreController{}
 			log := log.NewTestLogger()
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 
-			defer metrics.Stop()
 			storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
 
 			params := boltdb.DBParameters{RootDir: rootDir}
@@ -298,9 +295,8 @@ func TestOnUpdateManifestDigestTags_whenRepoMetaMissing(t *testing.T) {
 		rootDir := t.TempDir()
 		storeController := storage.StoreController{}
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
-		defer metrics.Stop()
 		storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
 
 		params := boltdb.DBParameters{RootDir: rootDir}
@@ -351,9 +347,8 @@ func TestOnUpdateManifest_setRepoReferenceFailsRemovesManifest(t *testing.T) {
 		rootDir := t.TempDir()
 		storeController := storage.StoreController{}
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
-		defer metrics.Stop()
 		storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
 
 		metaDB := mocks.MetaDBMock{
@@ -387,9 +382,8 @@ func TestOnUpdateManifest_whenDeleteAfterMetaFailureFails(t *testing.T) {
 		rootDir := t.TempDir()
 		storeController := storage.StoreController{}
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
-		defer metrics.Stop()
 		baseStore := local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
 		storeController.DefaultStore = &failDeleteImageStore{
 			ImageStore: baseStore,
@@ -422,9 +416,8 @@ func TestOnUpdateManifest(t *testing.T) {
 		rootDir := t.TempDir()
 		storeController := storage.StoreController{}
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
-		defer metrics.Stop() // Clean up metrics server to prevent resource leaks
 		storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
 
 		params := boltdb.DBParameters{
@@ -481,9 +474,8 @@ func TestOnDeleteManifest_OrphanedSignatureReferrerReturnsErrImageMetaNotFound(t
 			rootDir := t.TempDir()
 			storeController := storage.StoreController{}
 			log := log.NewTestLogger()
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 
-			defer metrics.Stop()
 			storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
 
 			params := boltdb.DBParameters{RootDir: rootDir}

--- a/pkg/meta/parse_test.go
+++ b/pkg/meta/parse_test.go
@@ -438,7 +438,7 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 
 	Convey("Push timestamp falls back to the manifest blob storage mod time", func() {
 		imageStore := local.NewImageStore(rootDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{DefaultStore: imageStore}
 
@@ -469,7 +469,7 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 
 	Convey("Test with simple case", func() {
 		imageStore := local.NewImageStore(rootDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{DefaultStore: imageStore}
 		manifests := []ispec.Manifest{}
@@ -544,7 +544,7 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 
 	Convey("Accept orphan signatures", func() {
 		imageStore := local.NewImageStore(rootDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{DefaultStore: imageStore}
 
@@ -589,7 +589,7 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 
 	Convey("Detect cosign bundle signatures by artifact type and subject", func() {
 		imageStore := local.NewImageStore(rootDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{DefaultStore: imageStore}
 
@@ -618,7 +618,7 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 
 	Convey("Check statistics after load", func() {
 		imageStore := local.NewImageStore(rootDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{DefaultStore: imageStore}
 		// add an image
@@ -658,7 +658,7 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 
 	Convey("preserve TaggedTimestamp during ParseRepo", func() {
 		imageStore := local.NewImageStore(rootDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{DefaultStore: imageStore}
 
@@ -704,7 +704,7 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 	// make sure pushTimestamp is always populated to not interfere with retention logic
 	Convey("Always update pushTimestamp if its value is 0(time.Time{})", func() {
 		imageStore := local.NewImageStore(rootDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{DefaultStore: imageStore}
 		// add an image
@@ -839,9 +839,9 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 		substoreDir := filepath.Join(rootDir, "a")
 
 		defaultStore := local.NewImageStore(defaultStoreDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 		substore := local.NewImageStore(substoreDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: defaultStore,
@@ -901,7 +901,7 @@ func RunParseStorageTests(rootDir string, metaDB mTypes.MetaDB, log log.Logger) 
 
 	Convey("ParseStorage should parse repos without metadata", func() {
 		imageStore := local.NewImageStore(rootDir, false, false,
-			log, monitoring.NewMetricsServer(false, log), nil, nil, nil, nil)
+			log, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{DefaultStore: imageStore}
 

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -141,7 +141,7 @@ func TestScheduler(t *testing.T) {
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		logger := log.NewLogger("debug", logPath)
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(config.New(), metrics, logger)
 
 		genH := &shortGenerator{log: logger, priority: "high priority"}
@@ -163,7 +163,7 @@ func TestScheduler(t *testing.T) {
 		logger := log.NewLogger("debug", logPath)
 		cfg := config.New()
 		cfg.Scheduler = &config.SchedulerConfig{NumWorkers: 3}
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(cfg, metrics, logger)
 		sch.RateLimit = 5 * time.Second
 
@@ -195,7 +195,7 @@ func TestScheduler(t *testing.T) {
 		logger := log.NewLogger("debug", logPath)
 		cfg := config.New()
 		cfg.Scheduler = &config.SchedulerConfig{NumWorkers: 3}
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(cfg, metrics, logger)
 		sch.RateLimit = 1 * time.Nanosecond
 
@@ -293,7 +293,7 @@ func TestScheduler(t *testing.T) {
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		logger := log.NewLogger("debug", logPath)
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(config.New(), metrics, logger)
 
 		t := &task{log: logger, msg: "", err: true}
@@ -313,7 +313,7 @@ func TestScheduler(t *testing.T) {
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		logger := log.NewLogger("debug", logPath)
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(config.New(), metrics, logger)
 
 		genL := &generator{log: logger, priority: "low priority", limit: 100, taskDelay: 100 * time.Millisecond}
@@ -333,7 +333,7 @@ func TestScheduler(t *testing.T) {
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		logger := log.NewLogger("debug", logPath)
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(config.New(), metrics, logger)
 
 		t := &task{log: logger, msg: "", err: false}
@@ -348,7 +348,7 @@ func TestScheduler(t *testing.T) {
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		logger := log.NewLogger("debug", logPath)
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(config.New(), metrics, logger)
 
 		sch.RunScheduler()
@@ -367,7 +367,7 @@ func TestScheduler(t *testing.T) {
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		logger := log.NewLogger("debug", logPath)
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(config.New(), metrics, logger)
 
 		genL := &generator{log: logger, priority: "medium priority", limit: 100, taskDelay: 100 * time.Millisecond}
@@ -416,7 +416,7 @@ func TestGetNumWorkers(t *testing.T) {
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 		logger := log.NewLogger("debug", logPath)
 
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(config.New(), metrics, logger)
 
 		So(sch.NumWorkers, ShouldEqual, runtime.NumCPU()*4)
@@ -427,7 +427,7 @@ func TestGetNumWorkers(t *testing.T) {
 		cfg.Scheduler = &config.SchedulerConfig{NumWorkers: 3}
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 		logger := log.NewLogger("debug", logPath)
-		metrics := monitoring.NewMetricsServer(true, logger)
+		metrics := monitoring.NewNopMetricServer()
 		sch := scheduler.NewScheduler(cfg, metrics, logger)
 
 		So(sch.NumWorkers, ShouldEqual, 3)

--- a/pkg/storage/azure/driver_test.go
+++ b/pkg/storage/azure/driver_test.go
@@ -424,7 +424,7 @@ func TestNewImageStore(t *testing.T) {
 	Convey("NewImageStore", t, func() {
 		storeMock := &mocks.StorageDriverMock{}
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		imgStore := azure.NewImageStore("/tmp", "/tmp", true, true, log, metrics, nil, storeMock, nil, nil, nil)
 		So(imgStore, ShouldNotBeNil)
 	})

--- a/pkg/storage/common/common_test.go
+++ b/pkg/storage/common/common_test.go
@@ -38,9 +38,8 @@ func TestValidateManifest(t *testing.T) {
 		dir := t.TempDir()
 
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
-		defer metrics.Stop() // Clean up metrics server to prevent resource leaks
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -209,9 +208,8 @@ func TestGetReferrersErrors(t *testing.T) {
 		dir := t.TempDir()
 
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
-		defer metrics.Stop() // Clean up metrics server to prevent resource leaks
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -396,9 +394,8 @@ func TestGetReferrersDeduplication(t *testing.T) {
 		dir := t.TempDir()
 
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
-		defer metrics.Stop() // Clean up metrics server to prevent resource leaks
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -510,9 +507,7 @@ func TestGetImageIndexErrors(t *testing.T) {
 
 func TestGetBlobDescriptorFromRepo(t *testing.T) {
 	log := log.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
-
-	defer metrics.Stop() // Clean up metrics server to prevent resource leaks
+	metrics := monitoring.NewNopMetricServer()
 
 	tdir := t.TempDir()
 	cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -112,8 +112,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 	Convey("Cover gc error paths", t, func(c C) {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "")
-		metrics := monitoring.NewMetricsServer(false, log)
-		defer metrics.Stop()
+		metrics := monitoring.NewNopMetricServer()
 
 		gcOptions := Options{
 			Delay: storageConstants.DefaultGCDelay,
@@ -1357,8 +1356,7 @@ func TestCleanRepoWithStaleManifestEntries(t *testing.T) {
 	Convey("cleanRepo end-to-end prunes stale manifest entries", t, func() {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "")
-		metrics := monitoring.NewMetricsServer(false, log)
-		defer metrics.Stop()
+		metrics := monitoring.NewNopMetricServer()
 
 		existingDigest := godigest.FromString("existing-blob")
 		missingDigest := godigest.FromString("missing-blob")
@@ -1479,8 +1477,7 @@ func TestCleanupRepoMissingBlob(t *testing.T) {
 
 		log := zlog.NewTestLogger()
 
-		metrics := monitoring.NewMetricsServer(false, log)
-		defer metrics.Stop()
+		metrics := monitoring.NewNopMetricServer()
 
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -65,15 +65,6 @@ var testCases = []struct {
 	},
 }
 
-func newTestMetricsServer(t *testing.T, log zlog.Logger) monitoring.MetricServer {
-	t.Helper()
-
-	metrics := monitoring.NewMetricsServer(false, log)
-	t.Cleanup(metrics.Stop)
-
-	return metrics
-}
-
 // The backend subtests run in parallel, but the top-level test stays sequential on
 // purpose: parallelising it too would run this and the other retention test's backends
 // concurrently, multiplying the load on the runner and the storage emulators.
@@ -83,7 +74,7 @@ func TestGarbageCollectAndRetentionMetaDB(t *testing.T) {
 	log := zlog.NewTestLogger()
 	audit := zlog.NewAuditLogger("debug", "/dev/null")
 
-	metrics := newTestMetricsServer(t, log)
+	metrics := monitoring.NewNopMetricServer()
 
 	trueVal := true
 
@@ -1388,7 +1379,7 @@ func TestGarbageCollectDeletion(t *testing.T) {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "/dev/null")
 
-		metrics := newTestMetricsServer(t, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		trueVal := true
 		falseVal := false
@@ -1831,7 +1822,7 @@ func TestGarbageCollectAndRetentionNoMetaDB(t *testing.T) {
 	log := zlog.NewTestLogger()
 	audit := zlog.NewAuditLogger("debug", "/dev/null")
 
-	metrics := newTestMetricsServer(t, log)
+	metrics := monitoring.NewNopMetricServer()
 
 	trueVal := true
 
@@ -2757,7 +2748,7 @@ func TestGCMultiArchIndexKeepsNestedConfigAndLayers(t *testing.T) {
 	Convey("tagged image index whose platform manifests are nested-only", t, func() {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "/dev/null")
-		metrics := newTestMetricsServer(t, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		rootDir := t.TempDir()
 		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
@@ -2871,7 +2862,7 @@ func TestGCDockerSchema2ListNotOverDeleted(t *testing.T) {
 	Convey("tagged docker manifest-list image", t, func() {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "/dev/null")
-		metrics := newTestMetricsServer(t, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		rootDir := t.TempDir()
 		compatMediaTypes := []compat.MediaCompatibility{compat.DockerManifestV2SchemaV2}
@@ -2932,7 +2923,7 @@ func TestGCUnknownMediaTypeManifestPruned(t *testing.T) {
 	Convey("index.json entry with unsupported manifest media type", t, func() {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "/dev/null")
-		metrics := newTestMetricsServer(t, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		rootDir := t.TempDir()
 		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
@@ -3089,7 +3080,7 @@ func TestGCUnknownMediaTypePruneReason(t *testing.T) {
 		auditPath := path.Join(t.TempDir(), "audit.log")
 		audit := zlog.NewAuditLogger("debug", auditPath)
 
-		metrics := newTestMetricsServer(t, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		rootDir := t.TempDir()
 		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
@@ -3190,7 +3181,7 @@ func TestGCStaleManifestPruneReason(t *testing.T) {
 		auditPath := path.Join(t.TempDir(), "audit.log")
 		audit := zlog.NewAuditLogger("debug", auditPath)
 
-		metrics := newTestMetricsServer(t, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		rootDir := t.TempDir()
 		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
@@ -3248,7 +3239,7 @@ func TestGCDryRunDeletesNothing(t *testing.T) {
 	Convey("DryRun with a true orphan blob and an unknown media type entry", t, func() {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "/dev/null")
-		metrics := newTestMetricsServer(t, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		rootDir := t.TempDir()
 		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
@@ -3371,7 +3362,7 @@ func TestGCRemoveRepoAfterAllBlobsGCed(t *testing.T) {
 	Convey("repo directory is removed once every blob is GCed and no upload is in progress", t, func() {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "/dev/null")
-		metrics := newTestMetricsServer(t, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		rootDir := t.TempDir()
 		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
@@ -3410,7 +3401,7 @@ func TestGCRemoveRepoAfterAllBlobsGCed(t *testing.T) {
 	Convey("repo directory is kept when a blob upload is in progress even though every blob was GCed", t, func() {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "/dev/null")
-		metrics := newTestMetricsServer(t, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		rootDir := t.TempDir()
 		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
@@ -3458,7 +3449,7 @@ func TestGCUnknownMediaTypeManifestPrunedSharedBlobKept(t *testing.T) {
 	Convey("unknown media type manifest sharing a config blob with a healthy image", t, func() {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "/dev/null")
-		metrics := newTestMetricsServer(t, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		rootDir := t.TempDir()
 		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)

--- a/pkg/storage/gcs/driver_test.go
+++ b/pkg/storage/gcs/driver_test.go
@@ -424,7 +424,7 @@ func TestNewImageStore(t *testing.T) {
 	Convey("NewImageStore", t, func() {
 		storeMock := &mocks.StorageDriverMock{}
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		imgStore := gcs.NewImageStore("/tmp", "/tmp", true, true, log, metrics, nil, storeMock, nil, nil, nil)
 		So(imgStore, ShouldNotBeNil)
 	})

--- a/pkg/storage/gcs/gcs_test.go
+++ b/pkg/storage/gcs/gcs_test.go
@@ -422,8 +422,7 @@ func createObjectsStore(rootDir string, cacheDir string, dedupe bool) (
 	}
 
 	log := log.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
-	defer metrics.Stop()
+	metrics := monitoring.NewNopMetricServer()
 
 	var cacheDriver storageTypes.Cache
 
@@ -1858,8 +1857,7 @@ func TestGCSMandatoryAnnotations(t *testing.T) {
 	tdir := t.TempDir()
 
 	testLog := log.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, testLog)
-	defer metrics.Stop()
+	metrics := monitoring.NewNopMetricServer()
 
 	storeDriver, imgStore, err := createObjectsStore(testDir, tdir, true)
 	if err != nil {
@@ -2037,8 +2035,7 @@ func TestGCSGarbageCollectImageManifest(t *testing.T) {
 
 	testLog := log.NewTestLogger()
 	audit := log.NewAuditLogger("debug", "")
-	metrics := monitoring.NewMetricsServer(false, testLog)
-	defer metrics.Stop()
+	metrics := monitoring.NewNopMetricServer()
 
 	ctx := context.Background()
 
@@ -2259,8 +2256,7 @@ func TestGCSGarbageCollectImageIndex(t *testing.T) {
 
 	testLog := log.NewTestLogger()
 	audit := log.NewAuditLogger("debug", "")
-	metrics := monitoring.NewMetricsServer(false, testLog)
-	defer metrics.Stop()
+	metrics := monitoring.NewNopMetricServer()
 
 	ctx := context.Background()
 
@@ -2414,8 +2410,7 @@ func TestGCSGarbageCollectChainedImageIndexes(t *testing.T) {
 
 	testLog := log.NewTestLogger()
 	audit := log.NewAuditLogger("debug", "")
-	metrics := monitoring.NewMetricsServer(false, testLog)
-	defer metrics.Stop()
+	metrics := monitoring.NewNopMetricServer()
 
 	ctx := context.Background()
 

--- a/pkg/storage/gcs/nextrepo_walk_abort_test.go
+++ b/pkg/storage/gcs/nextrepo_walk_abort_test.go
@@ -152,7 +152,7 @@ func TestGetNextRepositoryVisitsAllReposDespiteGhostUploadsPrefix(t *testing.T) 
 	}
 
 	log := zlog.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 
 	// iterate exactly like GCTaskGenerator.Next: stop on repo == "" (done)
 	collectRepos := func(memfs *memFS) []string {

--- a/pkg/storage/imagestore/imagestore_test.go
+++ b/pkg/storage/imagestore/imagestore_test.go
@@ -25,7 +25,7 @@ var errDeleteFailed = errors.New("delete failed") //nolint: gochecknoglobals
 func TestGetBlobRedirectURL(t *testing.T) {
 	Convey("GetBlobRedirectURL", t, func() {
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		Convey("returns bad digest for invalid digest", func() {
 			store := imagestore.NewImageStore(t.TempDir(), "", false, false, log, metrics, nil,
@@ -104,8 +104,7 @@ func TestGetBlobRedirectURL(t *testing.T) {
 func TestCleanupRepoToleratesDeletePathNotFound(t *testing.T) {
 	Convey("CleanupRepo tolerates PathNotFound on delete", t, func() {
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
-		defer metrics.Stop()
+		metrics := monitoring.NewNopMetricServer()
 
 		rootDir := t.TempDir()
 		storeMock := &mocks.StorageDriverMock{}
@@ -149,8 +148,7 @@ func TestCleanupRepoToleratesDeletePathNotFound(t *testing.T) {
 func TestCleanupRepoFailsOnUnexpectedDeleteBlobError(t *testing.T) {
 	Convey("CleanupRepo returns error when deleteBlob fails unexpectedly", t, func() {
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
-		defer metrics.Stop()
+		metrics := monitoring.NewNopMetricServer()
 
 		rootDir := t.TempDir()
 		storeMock := &mocks.StorageDriverMock{}

--- a/pkg/storage/local/local_elevated_test.go
+++ b/pkg/storage/local/local_elevated_test.go
@@ -27,7 +27,7 @@ func TestElevatedPrivilegesInvalidDedupe(t *testing.T) {
 		dir := t.TempDir()
 
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -71,7 +71,7 @@ var (
 
 func runAndGetScheduler() *scheduler.Scheduler {
 	log := zlog.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(true, log)
+	metrics := monitoring.NewNopMetricServer()
 	taskScheduler := scheduler.NewScheduler(config.New(), metrics, log)
 	taskScheduler.RateLimit = 50 * time.Millisecond
 
@@ -84,7 +84,7 @@ func TestStorageFSAPIs(t *testing.T) {
 	dir := t.TempDir()
 
 	log := zlog.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 	cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 		RootDir:     dir,
 		Name:        "cache",
@@ -221,7 +221,7 @@ func FuzzNewBlobUpload(f *testing.F) {
 		t.Logf("Input argument is %s", data)
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -249,7 +249,7 @@ func FuzzPutBlobChunk(f *testing.F) {
 
 		log := zlog.NewTestLogger()
 
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -285,7 +285,7 @@ func FuzzPutBlobChunkStreamed(f *testing.F) {
 		t.Logf("Input argument is %s", data)
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -318,7 +318,7 @@ func FuzzGetBlobUpload(f *testing.F) {
 		dir := t.TempDir()
 		defer os.RemoveAll(dir)
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -341,7 +341,7 @@ func FuzzGetBlobUpload(f *testing.F) {
 func FuzzTestPutGetImageManifest(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 		defer os.RemoveAll(dir)
@@ -398,7 +398,7 @@ func FuzzTestPutGetImageManifest(f *testing.F) {
 func FuzzTestPutDeleteImageManifest(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 		defer os.RemoveAll(dir)
@@ -460,7 +460,7 @@ func FuzzTestPutDeleteImageManifest(f *testing.F) {
 func FuzzTestDeleteImageManifest(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 		defer os.RemoveAll(dir)
@@ -497,7 +497,7 @@ func FuzzDirExists(f *testing.F) {
 func FuzzInitRepo(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 		defer os.RemoveAll(dir)
@@ -523,7 +523,7 @@ func FuzzInitRepo(f *testing.F) {
 func FuzzInitValidateRepo(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 		defer os.RemoveAll(dir)
@@ -558,7 +558,7 @@ func FuzzInitValidateRepo(f *testing.F) {
 func FuzzGetImageTags(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 		defer os.RemoveAll(dir)
@@ -584,7 +584,7 @@ func FuzzGetImageTags(f *testing.F) {
 func FuzzBlobUploadPath(f *testing.F) {
 	f.Fuzz(func(t *testing.T, repo, uuid string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 		defer os.RemoveAll(dir)
@@ -603,7 +603,7 @@ func FuzzBlobUploadPath(f *testing.F) {
 func FuzzBlobUploadInfo(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string, uuid string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 		defer os.RemoveAll(dir)
@@ -633,7 +633,7 @@ func FuzzTestGetImageManifest(f *testing.F) {
 		defer os.RemoveAll(dir)
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -662,7 +662,7 @@ func FuzzFinishBlobUpload(f *testing.F) {
 		defer os.RemoveAll(dir)
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -709,7 +709,7 @@ func FuzzFinishBlobUpload(f *testing.F) {
 func FuzzFullBlobUpload(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data []byte) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 		repoName := "test"
 
 		dir := t.TempDir()
@@ -741,7 +741,7 @@ func FuzzFullBlobUpload(f *testing.F) {
 func TestStorageCacheErrors(t *testing.T) {
 	Convey("get error in DedupeBlob() when cache.Put() deduped blob", t, func() {
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 
@@ -783,7 +783,7 @@ func TestStorageCacheErrors(t *testing.T) {
 func FuzzDedupeBlob(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 		defer os.RemoveAll(dir)
@@ -823,7 +823,7 @@ func FuzzDedupeBlob(f *testing.F) {
 func FuzzDeleteBlobUpload(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 		repoName := data
 
 		dir := t.TempDir()
@@ -855,7 +855,7 @@ func FuzzDeleteBlobUpload(f *testing.F) {
 func FuzzBlobPath(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 		repoName := data
 
 		dir := t.TempDir()
@@ -876,7 +876,7 @@ func FuzzBlobPath(f *testing.F) {
 func FuzzCheckBlob(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 		repoName := data
 
 		dir := t.TempDir()
@@ -915,7 +915,7 @@ func TestMissingBlobChecksDoNotLogErrors(t *testing.T) {
 		var buf bytes.Buffer
 
 		logger := zlog.NewLoggerWithWriter("debug", &buf)
-		metrics := monitoring.NewMetricsServer(false, logger)
+		metrics := monitoring.NewNopMetricServer()
 		t.Cleanup(metrics.Stop)
 
 		dir := t.TempDir()
@@ -995,7 +995,7 @@ func TestMissingBlobChecksDoNotLogErrors(t *testing.T) {
 func FuzzGetBlob(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 		repoName := data
 
 		dir := t.TempDir()
@@ -1036,7 +1036,7 @@ func FuzzGetBlob(f *testing.F) {
 func FuzzDeleteBlob(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 		repoName := data
 
 		dir := t.TempDir()
@@ -1073,7 +1073,7 @@ func FuzzDeleteBlob(f *testing.F) {
 func FuzzGetIndexContent(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 		repoName := data
 
 		dir := t.TempDir()
@@ -1110,7 +1110,7 @@ func FuzzGetIndexContent(f *testing.F) {
 func FuzzGetBlobContent(f *testing.F) {
 	f.Fuzz(func(t *testing.T, data string) {
 		log := zlog.NewTestLoggerPtr()
-		metrics := monitoring.NewMetricsServer(false, *log)
+		metrics := monitoring.NewNopMetricServer()
 		repoName := data
 
 		dir := t.TempDir()
@@ -1149,7 +1149,7 @@ func FuzzRunGCRepo(f *testing.F) {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "")
 
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		dir := t.TempDir()
 		defer os.RemoveAll(dir)
@@ -1188,7 +1188,7 @@ func TestDedupeLinks(t *testing.T) {
 	}
 
 	log := zlog.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 
 	for _, testCase := range testCases {
 		Convey(fmt.Sprintf("Dedupe %t", testCase.dedupe), t, func(c C) {
@@ -1598,7 +1598,7 @@ func TestDedupeRestoreCompleteMarker(t *testing.T) {
 		logBuf := test.NewThreadSafeLogBuffer()
 
 		log := zlog.NewLoggerWithWriter("debug", logBuf)
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		markerPath := path.Join(dir, storageConstants.DedupeRestoreCompleteMarker)
 
@@ -1682,7 +1682,7 @@ func TestCheckBlobTreatsRealEmptyBlobAsPresent(t *testing.T) {
 		dir := t.TempDir()
 
 		logger := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, logger)
+		metrics := monitoring.NewNopMetricServer()
 
 		imgStore := local.NewImageStore(dir, false, true, logger, metrics, nil, nil, nil, nil)
 
@@ -1738,7 +1738,7 @@ func (d *recheckDriver) Stat(path string) (storagedriver.FileInfo, error) {
 func TestRestoreDedupedBlobsRecheck(t *testing.T) {
 	Convey("restoreDedupedBlobs re-checks blob size under the write lock", t, func() {
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		Convey("a blob restored by a concurrent task is left untouched", func() {
 			dir := t.TempDir()
@@ -1845,7 +1845,7 @@ func TestRunDedupeBlobsMarkerDeleteError(t *testing.T) {
 			logBuf := test.NewThreadSafeLogBuffer()
 
 			log := zlog.NewLoggerWithWriter("debug", logBuf)
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 
 			testDriver := &errMarkerDriver{
 				Driver:    local.New(true),
@@ -1870,7 +1870,7 @@ func TestRunDedupeBlobsMarkerDeleteError(t *testing.T) {
 			logBuf := test.NewThreadSafeLogBuffer()
 
 			log := zlog.NewLoggerWithWriter("debug", logBuf)
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 
 			testDriver := &errMarkerDriver{
 				Driver:    local.New(true),
@@ -1903,7 +1903,7 @@ func TestDedupe(t *testing.T) {
 			dir := t.TempDir()
 
 			log := zlog.NewTestLogger()
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 			cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 				RootDir:     dir,
 				Name:        "cache",
@@ -1923,7 +1923,7 @@ func TestNegativeCases(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -1947,7 +1947,7 @@ func TestNegativeCases(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -1997,7 +1997,7 @@ func TestNegativeCases(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -2111,7 +2111,7 @@ func TestNegativeCases(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -2138,7 +2138,7 @@ func TestNegativeCases(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -2186,7 +2186,7 @@ func TestNegativeCases(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -2364,7 +2364,7 @@ func TestInjectWriteFile(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -2393,7 +2393,7 @@ func TestGarbageCollectForImageStore(t *testing.T) {
 			log := zlog.NewLogger("debug", logPath)
 			audit := zlog.NewAuditLogger("debug", "")
 
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 			cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 				RootDir:     dir,
 				Name:        "cache",
@@ -2442,7 +2442,7 @@ func TestGarbageCollectForImageStore(t *testing.T) {
 			log := zlog.NewLogger("debug", logPath)
 			audit := zlog.NewAuditLogger("debug", "")
 
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 			cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 				RootDir:     dir,
 				Name:        "cache",
@@ -2481,7 +2481,7 @@ func TestGarbageCollectForImageStore(t *testing.T) {
 			log := zlog.NewTestLogger()
 			audit := zlog.NewAuditLogger("debug", "")
 
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 			cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 				RootDir:     dir,
 				Name:        "cache",
@@ -2556,7 +2556,7 @@ func TestGarbageCollectForImageStore(t *testing.T) {
 			log := zlog.NewLogger("debug", logPath)
 			audit := zlog.NewAuditLogger("debug", "")
 
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 			cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 				RootDir:     dir,
 				Name:        "cache",
@@ -2631,7 +2631,7 @@ func TestGarbageCollectImageUnknownManifest(t *testing.T) {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "")
 
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -2814,7 +2814,7 @@ func TestGarbageCollectErrors(t *testing.T) {
 		log := zlog.NewTestLogger()
 		audit := zlog.NewAuditLogger("debug", "")
 
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -3067,7 +3067,7 @@ func TestInitRepo(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -3089,7 +3089,7 @@ func TestValidateRepo(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -3109,7 +3109,7 @@ func TestValidateRepo(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -3154,7 +3154,7 @@ func TestGetRepositories(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -3249,7 +3249,7 @@ func TestGetRepositories(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -3295,7 +3295,7 @@ func TestGetRepositories(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     rootDir,
 			Name:        "cache",
@@ -3339,7 +3339,7 @@ func TestGetRepositories(t *testing.T) {
 func TestGetNextRepository(t *testing.T) {
 	dir := t.TempDir()
 	log := zlog.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 	cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 		RootDir:     dir,
 		Name:        "cache",
@@ -3416,7 +3416,7 @@ func TestPutBlobChunkStreamed(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -3444,7 +3444,7 @@ func TestPullRange(t *testing.T) {
 		dir := t.TempDir()
 
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		Convey("Negative cases", func() {
 			cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
@@ -3494,7 +3494,7 @@ func TestStatIndex(t *testing.T) {
 	Convey("NewImageStore", t, func() {
 		dir := t.TempDir()
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, nil, nil, nil)
 
 		err := WriteImageToFileSystem(CreateRandomImage(), "repo", "tag",
@@ -3512,7 +3512,7 @@ func TestStorageDriverErr(t *testing.T) {
 	dir := t.TempDir()
 
 	log := zlog.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 	cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 		RootDir:     dir,
 		Name:        "cache",
@@ -3637,7 +3637,7 @@ func TestGetNextDigestWithBlobPathsPathNotFound(t *testing.T) {
 	Convey("GetNextDigestWithBlobPaths PathNotFoundError handling", t, func() {
 		dir := t.TempDir()
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",
@@ -3664,7 +3664,7 @@ func TestGetNextDigestWithBlobPathsNestedRepo(t *testing.T) {
 	Convey("GetNextDigestWithBlobPaths must visit nested-namespace repositories", t, func() {
 		dir := t.TempDir()
 		log := zlog.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     dir,
 			Name:        "cache",

--- a/pkg/storage/s3/s3_test.go
+++ b/pkg/storage/s3/s3_test.go
@@ -73,7 +73,7 @@ func emptyIndexContent() []byte {
 func createMockStorage(rootDir string, cacheDir string, dedupe bool, store driver.StorageDriver,
 ) storageTypes.ImageStore {
 	log := log.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(true, log)
+	metrics := monitoring.NewNopMetricServer()
 
 	var cacheDriver storageTypes.Cache
 
@@ -96,7 +96,7 @@ func createMockStorageWithMockCache(rootDir string, store driver.StorageDriver,
 	cacheDriver storageTypes.Cache,
 ) storageTypes.ImageStore {
 	log := log.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 
 	il := s3.NewImageStore(rootDir, "", true, false, log, metrics, nil, store, cacheDriver, nil, nil)
 
@@ -143,7 +143,7 @@ func createObjectsStore(rootDir string, cacheDir string, dedupe bool) (
 	store := createStoreDriver(rootDir)
 
 	log := log.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 
 	var cacheDriver storageTypes.Cache
 
@@ -173,7 +173,7 @@ func createObjectsStoreDynamo(rootDir string, cacheDir string, dedupe bool, tabl
 	store := createStoreDriver(rootDir)
 
 	log := log.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 
 	var cacheDriver storageTypes.Cache
 
@@ -201,7 +201,7 @@ func createObjectsStoreDynamo(rootDir string, cacheDir string, dedupe bool, tabl
 
 func runAndGetScheduler() *scheduler.Scheduler {
 	log := log.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 	taskScheduler := scheduler.NewScheduler(config.New(), metrics, log)
 	taskScheduler.RateLimit = 50 * time.Millisecond
 
@@ -1866,7 +1866,7 @@ func TestRebuildDedupeIndex(t *testing.T) {
 		Convey("Intrerrupt rebuilding and restart, checking idempotency", func() {
 			for i := range 10 {
 				log := log.NewTestLogger()
-				metrics := monitoring.NewMetricsServer(false, log)
+				metrics := monitoring.NewNopMetricServer()
 				taskScheduler := scheduler.NewScheduler(config.New(), metrics, log)
 				taskScheduler.RateLimit = 1 * time.Millisecond
 
@@ -1908,7 +1908,7 @@ func TestRebuildDedupeIndex(t *testing.T) {
 			// now from dedupe false to true
 			for i := range 10 {
 				log := log.NewTestLogger()
-				metrics := monitoring.NewMetricsServer(false, log)
+				metrics := monitoring.NewNopMetricServer()
 				taskScheduler := scheduler.NewScheduler(config.New(), metrics, log)
 				taskScheduler.RateLimit = 1 * time.Millisecond
 
@@ -4051,7 +4051,7 @@ func TestDeleteBlobDeferredDuringDedupeRebuild(t *testing.T) {
 
 	newStoppedScheduler := func() *scheduler.Scheduler {
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		taskScheduler := scheduler.NewScheduler(config.New(), metrics, log)
 		taskScheduler.RateLimit = 50 * time.Millisecond
 
@@ -4244,7 +4244,7 @@ func TestDeleteBlobDeferredDuringRestoreWalk(t *testing.T) {
 
 	newStoppedScheduler := func() *scheduler.Scheduler {
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		taskScheduler := scheduler.NewScheduler(config.New(), metrics, log)
 		taskScheduler.RateLimit = 50 * time.Millisecond
 
@@ -4396,7 +4396,7 @@ func TestDeleteBlobDeferredIssue2625CrossRepoOriginal(t *testing.T) {
 
 	newStoppedScheduler := func() *scheduler.Scheduler {
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 		taskScheduler := scheduler.NewScheduler(config.New(), metrics, log)
 		taskScheduler.RateLimit = 50 * time.Millisecond
 

--- a/pkg/storage/scrub_test.go
+++ b/pkg/storage/scrub_test.go
@@ -44,9 +44,8 @@ func TestLocalCheckAllBlobsIntegrity(t *testing.T) {
 	Convey("test with local storage", t, func() {
 		tdir := t.TempDir()
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
-		defer metrics.Stop() // Clean up metrics server to prevent resource leaks
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     tdir,
 			Name:        "cache",
@@ -66,7 +65,7 @@ func TestRedisCheckAllBlobsIntegrity(t *testing.T) {
 		tdir := t.TempDir()
 		log := log.NewTestLogger()
 
-		metrics := monitoring.NewMetricsServer(false, log)
+		metrics := monitoring.NewNopMetricServer()
 
 		client, _ := rediscfg.GetRedisClient(map[string]any{"url": "redis://" + miniRedis.Addr()}, log)
 
@@ -140,9 +139,7 @@ func TestScrubDetectsCorruptedConfigContent(t *testing.T) {
 	Convey("scrub detects config corruption that stays valid JSON", t, func() {
 		tdir := t.TempDir()
 		log := log.NewTestLogger()
-		metrics := monitoring.NewMetricsServer(false, log)
-
-		defer metrics.Stop()
+		metrics := monitoring.NewNopMetricServer()
 
 		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
 			RootDir:     tdir,

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -111,7 +111,7 @@ func createObjectsStore(options createObjectStoreOpts) (
 		}, log)
 	}
 
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 
 	if options.storageType == storageConstants.AzureStorageDriverName {
 		params := azurite.DriverParams(options.rootDir)
@@ -206,14 +206,14 @@ func newLocalImageStoreWithEventRecorderAndLinter(t *testing.T, recorder events.
 	}
 
 	storeDriver := local.New(true)
-	metrics := monitoring.NewMetricsServer(false, log)
+	metrics := monitoring.NewNopMetricServer()
 
 	return imagestore.NewImageStore(rootDir, cacheDir, true, true, log, metrics, linter,
 		storeDriver, cacheDriver, nil, recorder)
 }
 
 // newLocalImageStoreWithDriver builds a filesystem-backed image store for tests with a configurable
-// storage driver (nil means local.New(true)). The returned cleanup stops the metrics server and must be deferred.
+// storage driver (nil means local.New(true)). The returned cleanup is a no-op retained for call-site compatibility.
 func newLocalImageStoreWithDriver(t *testing.T, storeDriver storageTypes.Driver) (
 	string, storageTypes.ImageStore, func(),
 ) {
@@ -221,8 +221,8 @@ func newLocalImageStoreWithDriver(t *testing.T, storeDriver storageTypes.Driver)
 
 	rootDir := t.TempDir()
 	log := zlog.NewTestLogger()
-	metrics := monitoring.NewMetricsServer(false, log)
-	cleanup := func() { metrics.Stop() }
+	metrics := monitoring.NewNopMetricServer()
+	cleanup := func() {}
 
 	cacheDriver, err := storage.Create("boltdb", cache.BoltDBDriverParameters{
 		RootDir:     rootDir,
@@ -1690,7 +1690,7 @@ func TestMandatoryAnnotations(t *testing.T) {
 			)
 
 			log := zlog.NewTestLogger()
-			metrics := monitoring.NewMetricsServer(false, log)
+			metrics := monitoring.NewNopMetricServer()
 
 			cacheDir := t.TempDir()
 
@@ -2650,8 +2650,7 @@ func TestGarbageCollectImageManifest(t *testing.T) {
 		t.Run(testcase.testCaseName, func(t *testing.T) {
 			log := zlog.NewTestLogger()
 			audit := zlog.NewAuditLogger("debug", "")
-			metrics := monitoring.NewMetricsServer(false, log)
-			defer metrics.Stop()
+			metrics := monitoring.NewNopMetricServer()
 
 			ctx := context.Background()
 
@@ -3398,8 +3397,7 @@ func TestGarbageCollectImageIndex(t *testing.T) {
 		t.Run(testcase.testCaseName, func(t *testing.T) {
 			log := zlog.NewTestLogger()
 			audit := zlog.NewAuditLogger("debug", "")
-			metrics := monitoring.NewMetricsServer(false, log)
-			defer metrics.Stop()
+			metrics := monitoring.NewNopMetricServer()
 
 			ctx := context.Background()
 
@@ -3849,8 +3847,7 @@ func TestGarbageCollectChainedImageIndexes(t *testing.T) {
 		t.Run(testcase.testCaseName, func(t *testing.T) {
 			log := zlog.NewTestLogger()
 			audit := zlog.NewAuditLogger("debug", "")
-			metrics := monitoring.NewMetricsServer(false, log)
-			defer metrics.Stop()
+			metrics := monitoring.NewNopMetricServer()
 
 			ctx := context.Background()
 

--- a/pkg/test/oci-utils/oci_layout_test.go
+++ b/pkg/test/oci-utils/oci_layout_test.go
@@ -430,7 +430,7 @@ func TestExtractImageDetails(t *testing.T) {
 		dir := t.TempDir()
 		testLogger := log.NewTestLogger()
 		imageStore := local.NewImageStore(dir, false, false,
-			testLogger, monitoring.NewMetricsServer(false, testLogger), nil, nil, nil, nil)
+			testLogger, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,
@@ -454,7 +454,7 @@ func TestExtractImageDetails(t *testing.T) {
 		dir := t.TempDir()
 		testLogger := log.NewTestLogger()
 		imageStore := local.NewImageStore(dir, false, false,
-			testLogger, monitoring.NewMetricsServer(false, testLogger), nil, nil, nil, nil)
+			testLogger, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,
@@ -474,7 +474,7 @@ func TestExtractImageDetails(t *testing.T) {
 		dir := t.TempDir()
 		testLogger := log.NewTestLogger()
 		imageStore := local.NewImageStore(dir, false, false,
-			testLogger, monitoring.NewMetricsServer(false, testLogger), nil, nil, nil, nil)
+			testLogger, monitoring.NewNopMetricServer(), nil, nil, nil, nil)
 
 		storeController := storage.StoreController{
 			DefaultStore: imageStore,

--- a/pkg/test/oci-utils/store.go
+++ b/pkg/test/oci-utils/store.go
@@ -13,7 +13,7 @@ import (
 
 func GetDefaultImageStore(rootDir string, log zLog.Logger) stypes.ImageStore {
 	return local.NewImageStore(rootDir, false, false, log,
-		monitoring.NewMetricsServer(false, log),
+		monitoring.NewNopMetricServer(),
 		mocks.MockedLint{
 			LintFn: func(repo string, manifestDigest godigest.Digest, imageStore stypes.ImageStore) (bool, error) {
 				return true, nil


### PR DESCRIPTION
Temp sync ImageStores called NewMetricsServer under !metrics, which starts Run() loops that were never stopped (issue #4319). Use a nop MetricServer for those stores, Stop CLI-scoped servers, and switch test stubs to the nop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
