### PR TITLE
ci: update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,10 +1,8 @@
 # This is a comment.
 # Each line is a file pattern followed by one or more owners.
 
-*                 @rchincha @andaaron @peusebiu
-
-/pkg/storage/                   @peusebiu
+*                 @rchincha @andaaron
 
 /pkg/extensions/search/         @vrajashkr
 
-/pkg/extensions/sync/           @peusebiu
+/pkg/extensions/sync/           @vrajashkr


### PR DESCRIPTION
peusebiu is no longer a valid GH user, so automatic reviewer assignments are broken for certain subpaths

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
