### PR TITLE
feat(sync): make upstream request concurrency/rate configurable

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1399,8 +1399,8 @@ Configure each registry sync:
 				"maxRetries": 5,                    # maxRetries in case of temporary errors (default: no retries)
 				"retryDelay": "1s",                 # initial HTTP retry delay; mandatory when using maxRetries
 				"maxRetryDelay": "30s",             # max HTTP retry backoff; optional, defaults to retryDelay (fixed interval). Set higher than retryDelay for exponential backoff.
-				"reqConcurrent": 30,                # max concurrent in-flight requests to this upstream and its mirrors (default: 3); raise it when one zot proxies many concurrent on-demand pulls from a single upstream
-				"reqPerSec": 100,                   # max request rate (requests/second) to this upstream and its mirrors (default: unlimited)
+				"reqConcurrent": 30,                # max concurrent in-flight requests per host, applied independently to this upstream and to each of its mirrors, not shared across them (default: 3); raise it when one zot proxies many concurrent on-demand pulls from a single upstream
+				"reqPerSec": 100,                   # max request rate (requests/second) per host, applied independently to this upstream and to each of its mirrors, not shared across them (default: unlimited)
 				"onlySigned": true,                 # sync only signed images (either notary or cosign)
 				"content":[                         # which content to periodically pull, also it's used for filtering ondemand images, if not set then periodically polling will not run
 					{

--- a/examples/README.md
+++ b/examples/README.md
@@ -1399,6 +1399,8 @@ Configure each registry sync:
 				"maxRetries": 5,                    # maxRetries in case of temporary errors (default: no retries)
 				"retryDelay": "1s",                 # initial HTTP retry delay; mandatory when using maxRetries
 				"maxRetryDelay": "30s",             # max HTTP retry backoff; optional, defaults to retryDelay (fixed interval). Set higher than retryDelay for exponential backoff.
+				"reqConcurrent": 30,                # max concurrent in-flight requests to this upstream and its mirrors (default: 3); raise it when one zot proxies many concurrent on-demand pulls from a single upstream
+				"reqPerSec": 100,                   # max request rate (requests/second) to this upstream and its mirrors (default: unlimited)
 				"onlySigned": true,                 # sync only signed images (either notary or cosign)
 				"content":[                         # which content to periodically pull, also it's used for filtering ondemand images, if not set then periodically polling will not run
 					{

--- a/examples/config-sync.json
+++ b/examples/config-sync.json
@@ -76,7 +76,9 @@
 					"maxRetries": 5,
 					"retryDelay": "1s",
 					"maxRetryDelay": "30s",
-					"syncTimeout": "10m"
+					"syncTimeout": "10m",
+					"reqConcurrent": 30,
+					"reqPerSec": 100
 				},
 				{
 					"urls": [

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -1699,125 +1700,152 @@ func validateSync(config *config.Config, logger zlog.Logger) error {
 	// check glob patterns in sync config are compilable
 	extensionsConfig := config.CopyExtensionsConfig()
 	// can't check with IsSyncEnabled(), because it can't test invalid sync configs
-	if extensionsConfig != nil && extensionsConfig.Sync != nil && len(extensionsConfig.Sync.Registries) > 0 {
-		for regID, regCfg := range extensionsConfig.Sync.Registries {
-			if intervalValidationErr := validateRegistryManifestCheckInterval(regCfg); intervalValidationErr != nil {
-				logger.Error().Err(intervalValidationErr).Int("id", regID).Interface("extensions.sync.registries[id]",
-					extensionsConfig.Sync.Registries[regID]).Msg("invalid config for manifestCheckInterval")
+	if extensionsConfig == nil || extensionsConfig.Sync == nil || len(extensionsConfig.Sync.Registries) == 0 {
+		return nil
+	}
 
-				return intervalValidationErr
-			}
+	for regID, regCfg := range extensionsConfig.Sync.Registries {
+		if err := validateSyncRegistry(config, regID, regCfg, logger); err != nil {
+			return err
+		}
+	}
 
-			// check retry options are configured for sync
-			if regCfg.MaxRetries != nil && regCfg.RetryDelay == nil {
-				msg := "retryDelay is required when using maxRetries"
-				logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
-					extensionsConfig.Sync.Registries[regID]).Msg(msg)
+	return nil
+}
 
-				return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
-			}
+func validateSyncRegistry(config *config.Config, regID int, regCfg syncconf.RegistryConfig, logger zlog.Logger) error {
+	if intervalValidationErr := validateRegistryManifestCheckInterval(regCfg); intervalValidationErr != nil {
+		logger.Error().Err(intervalValidationErr).Int("id", regID).Interface("extensions.sync.registries[id]",
+			regCfg).Msg("invalid config for manifestCheckInterval")
 
-			if regCfg.MaxRetryDelay != nil && regCfg.RetryDelay == nil {
-				msg := "retryDelay is required when using maxRetryDelay"
-				logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
-					extensionsConfig.Sync.Registries[regID]).Msg(msg)
+		return intervalValidationErr
+	}
 
-				return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
-			}
+	// check retry options are configured for sync
+	if regCfg.MaxRetries != nil && regCfg.RetryDelay == nil {
+		msg := "retryDelay is required when using maxRetries"
+		logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
+			regCfg).Msg(msg)
 
-			if regCfg.MaxRetryDelay != nil && regCfg.RetryDelay != nil &&
-				*regCfg.MaxRetryDelay < *regCfg.RetryDelay {
-				msg := "maxRetryDelay must be greater than or equal to retryDelay"
-				logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
-					extensionsConfig.Sync.Registries[regID]).Msg(msg)
+		return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
+	}
 
-				return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
-			}
+	if regCfg.MaxRetryDelay != nil && regCfg.RetryDelay == nil {
+		msg := "retryDelay is required when using maxRetryDelay"
+		logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
+			regCfg).Msg(msg)
 
-			if regCfg.ReqConcurrent != nil && *regCfg.ReqConcurrent <= 0 {
-				msg := "reqConcurrent must be greater than 0"
-				logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
-					extensionsConfig.Sync.Registries[regID]).Msg(msg)
+		return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
+	}
 
-				return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
-			}
+	if regCfg.MaxRetryDelay != nil && regCfg.RetryDelay != nil &&
+		*regCfg.MaxRetryDelay < *regCfg.RetryDelay {
+		msg := "maxRetryDelay must be greater than or equal to retryDelay"
+		logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
+			regCfg).Msg(msg)
 
-			if regCfg.ReqPerSec != nil && *regCfg.ReqPerSec <= 0 {
-				msg := "reqPerSec must be greater than 0"
-				logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
-					extensionsConfig.Sync.Registries[regID]).Msg(msg)
+		return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
+	}
 
-				return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
-			}
+	if err := validateSyncReqLimits(regID, regCfg, logger); err != nil {
+		return err
+	}
 
-			// check the oauth2 credential helper config is complete and consistent
-			if regCfg.CredentialHelper == "oauth2" {
-				oauth2Config, err := syncconf.OAuth2HelperConfigFromMap(regCfg.Oauth2CredentialHelper)
-				if err == nil {
-					err = oauth2Config.Validate()
-				}
+	// check the oauth2 credential helper config is complete and consistent
+	if regCfg.CredentialHelper == "oauth2" {
+		oauth2Config, err := syncconf.OAuth2HelperConfigFromMap(regCfg.Oauth2CredentialHelper)
+		if err == nil {
+			err = oauth2Config.Validate()
+		}
 
-				if err != nil {
-					msg := "invalid oauth2CredentialHelper config"
-					logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
-						extensionsConfig.Sync.Registries[regID]).Msg(msg)
+		if err != nil {
+			msg := "invalid oauth2CredentialHelper config"
+			logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
+				regCfg).Msg(msg)
 
-					return fmt.Errorf("%w: %s: %w", zerr.ErrBadConfig, msg, err)
-				}
-			}
+			return fmt.Errorf("%w: %s: %w", zerr.ErrBadConfig, msg, err)
+		}
+	}
 
-			// check preserveDigest without compat
-			if regCfg.PreserveDigest && !config.IsCompatEnabled() {
-				msg := "can not use PreserveDigest option without enabling http.Compat"
-				logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
-					extensionsConfig.Sync.Registries[regID]).Msg(msg)
+	// check preserveDigest without compat
+	if regCfg.PreserveDigest && !config.IsCompatEnabled() {
+		msg := "can not use PreserveDigest option without enabling http.Compat"
+		logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
+			regCfg).Msg(msg)
 
-				return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
-			}
+		return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
+	}
 
-			if regCfg.Content != nil {
-				for _, content := range regCfg.Content {
-					ok := glob.ValidatePattern(content.Prefix)
-					if !ok {
-						msg := "sync prefix could not be compiled"
-						logger.Error().Err(glob.ErrBadPattern).Str("prefix", content.Prefix).Msg(msg)
+	return validateSyncContent(config, regCfg, logger)
+}
 
-						return fmt.Errorf("%w: %s: %s", zerr.ErrBadConfig, msg, content.Prefix)
-					}
+// invalidOptionalPositiveFloat reports whether an optional float setting is set to a value that is
+// not a finite number strictly greater than zero. NaN and +/-Inf bypass a naive `*v <= 0` check
+// (NaN compares false against everything), so they are rejected explicitly.
+func invalidOptionalPositiveFloat(value *float64) bool {
+	return value != nil && (*value <= 0 || math.IsNaN(*value) || math.IsInf(*value, 0))
+}
 
-					if content.Tags != nil && content.Tags.Regex != nil {
-						_, err := regexp.Compile(*content.Tags.Regex)
-						if err != nil {
-							msg := "sync content regex could not be compiled"
-							logger.Error().Err(glob.ErrBadPattern).Str("regex", *content.Tags.Regex).Msg(msg)
+func validateSyncReqLimits(regID int, regCfg syncconf.RegistryConfig, logger zlog.Logger) error {
+	if regCfg.ReqConcurrent != nil && *regCfg.ReqConcurrent <= 0 {
+		msg := "reqConcurrent must be greater than 0"
+		logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
+			regCfg).Msg(msg)
 
-							return fmt.Errorf("%w: %s: %s", zerr.ErrBadConfig, msg, *content.Tags.Regex)
-						}
-					}
+		return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
+	}
 
-					if content.Tags != nil && content.Tags.ExcludeRegex != nil {
-						_, err := regexp.Compile(*content.Tags.ExcludeRegex)
-						if err != nil {
-							msg := "sync content excludeRegex could not be compiled"
-							logger.Error().Err(glob.ErrBadPattern).Str("excludeRegex", *content.Tags.ExcludeRegex).Msg(msg)
+	if invalidOptionalPositiveFloat(regCfg.ReqPerSec) {
+		msg := "reqPerSec must be a finite value greater than 0"
+		logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
+			regCfg).Msg(msg)
 
-							return fmt.Errorf("%w: %s: %s", zerr.ErrBadConfig, msg, *content.Tags.ExcludeRegex)
-						}
-					}
+		return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
+	}
 
-					if content.StripPrefix && !strings.Contains(content.Prefix, "/*") && content.Destination == "/" {
-						msg := "can not use stripPrefix true and destination '/' without using glob patterns in prefix"
-						logger.Error().Err(zerr.ErrBadConfig).
-							Interface("sync content", content).Str("component", "sync").Msg(msg)
+	return nil
+}
 
-						return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
-					}
+func validateSyncContent(config *config.Config, regCfg syncconf.RegistryConfig, logger zlog.Logger) error {
+	for _, content := range regCfg.Content {
+		ok := glob.ValidatePattern(content.Prefix)
+		if !ok {
+			msg := "sync prefix could not be compiled"
+			logger.Error().Err(glob.ErrBadPattern).Str("prefix", content.Prefix).Msg(msg)
 
-					// check sync config doesn't overlap with retention config
-					validateRetentionSyncOverlaps(config, content, regCfg.URLs, logger)
-				}
+			return fmt.Errorf("%w: %s: %s", zerr.ErrBadConfig, msg, content.Prefix)
+		}
+
+		if content.Tags != nil && content.Tags.Regex != nil {
+			_, err := regexp.Compile(*content.Tags.Regex)
+			if err != nil {
+				msg := "sync content regex could not be compiled"
+				logger.Error().Err(glob.ErrBadPattern).Str("regex", *content.Tags.Regex).Msg(msg)
+
+				return fmt.Errorf("%w: %s: %s", zerr.ErrBadConfig, msg, *content.Tags.Regex)
 			}
 		}
+
+		if content.Tags != nil && content.Tags.ExcludeRegex != nil {
+			_, err := regexp.Compile(*content.Tags.ExcludeRegex)
+			if err != nil {
+				msg := "sync content excludeRegex could not be compiled"
+				logger.Error().Err(glob.ErrBadPattern).Str("excludeRegex", *content.Tags.ExcludeRegex).Msg(msg)
+
+				return fmt.Errorf("%w: %s: %s", zerr.ErrBadConfig, msg, *content.Tags.ExcludeRegex)
+			}
+		}
+
+		if content.StripPrefix && !strings.Contains(content.Prefix, "/*") && content.Destination == "/" {
+			msg := "can not use stripPrefix true and destination '/' without using glob patterns in prefix"
+			logger.Error().Err(zerr.ErrBadConfig).
+				Interface("sync content", content).Str("component", "sync").Msg(msg)
+
+			return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
+		}
+
+		// check sync config doesn't overlap with retention config
+		validateRetentionSyncOverlaps(config, content, regCfg.URLs, logger)
 	}
 
 	return nil

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -1734,6 +1734,22 @@ func validateSync(config *config.Config, logger zlog.Logger) error {
 				return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
 			}
 
+			if regCfg.ReqConcurrent != nil && *regCfg.ReqConcurrent <= 0 {
+				msg := "reqConcurrent must be greater than 0"
+				logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
+					extensionsConfig.Sync.Registries[regID]).Msg(msg)
+
+				return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
+			}
+
+			if regCfg.ReqPerSec != nil && *regCfg.ReqPerSec <= 0 {
+				msg := "reqPerSec must be greater than 0"
+				logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
+					extensionsConfig.Sync.Registries[regID]).Msg(msg)
+
+				return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
+			}
+
 			// check the oauth2 credential helper config is complete and consistent
 			if regCfg.CredentialHelper == "oauth2" {
 				oauth2Config, err := syncconf.OAuth2HelperConfigFromMap(regCfg.Oauth2CredentialHelper)

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -2036,6 +2036,35 @@ storage:
 		So(err, ShouldNotBeNil)
 	})
 
+	Convey("Test verify rejects non-finite sync reqPerSec", t, func(c C) {
+		// JSON can't express NaN/Inf, so use YAML where `.nan`/`.inf` are valid floats that
+		// would otherwise slip past a naive `<= 0` check.
+		for _, badValue := range []string{".nan", ".inf", "-.inf"} {
+			content := `
+storage:
+  rootDirectory: /tmp/zot
+http:
+  address: 127.0.0.1
+  port: "8080"
+  realm: zot
+  auth:
+    htpasswd:
+      path: test/data/htpasswd
+    failDelay: 1
+extensions:
+  sync:
+    registries:
+      - urls:
+          - localhost:9999
+        reqPerSec: ` + badValue
+			tmpfile := MakeTempFileWithContent(t, "zot-test.yaml", content)
+
+			os.Args = []string{"cli_test", "verify", tmpfile}
+			err := cli.NewServerRootCmd().Execute()
+			So(err, ShouldNotBeNil)
+		}
+	})
+
 	Convey("Test verify with valid sync reqConcurrent and reqPerSec", t, func(c C) {
 		content := `{"storage":{"rootDirectory":"/tmp/zot"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -2010,6 +2010,45 @@ storage:
 		So(err, ShouldNotBeNil)
 	})
 
+	Convey("Test verify with non-positive sync reqConcurrent", t, func(c C) {
+		content := `{"storage":{"rootDirectory":"/tmp/zot"},
+							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
+							"reqConcurrent": 0}]}}}`
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+
+		os.Args = []string{"cli_test", "verify", tmpfile}
+		err := cli.NewServerRootCmd().Execute()
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Test verify with non-positive sync reqPerSec", t, func(c C) {
+		content := `{"storage":{"rootDirectory":"/tmp/zot"},
+							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
+							"reqPerSec": 0}]}}}`
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+
+		os.Args = []string{"cli_test", "verify", tmpfile}
+		err := cli.NewServerRootCmd().Execute()
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Test verify with valid sync reqConcurrent and reqPerSec", t, func(c C) {
+		content := `{"storage":{"rootDirectory":"/tmp/zot"},
+							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
+							"reqConcurrent": 30, "reqPerSec": 100}]}}}`
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+
+		os.Args = []string{"cli_test", "verify", tmpfile}
+		err := cli.NewServerRootCmd().Execute()
+		So(err, ShouldBeNil)
+	})
+
 	Convey("Test verify with good sync content config", t, func(c C) {
 		content := `{"storage":{"rootDirectory":"/tmp/zot"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -70,6 +70,14 @@ type RegistryConfig struct {
 	PreserveDigest         bool           // sync without converting
 	SyncTimeout            time.Duration  // overall HTTP client timeout for all sync operations
 	ResponseHeaderTimeout  time.Duration  `yaml:"-"` // response header timeout; set in root.go
+	// ReqConcurrent caps the number of in-flight requests to the upstream registry (and each of its
+	// mirrors). When unset it defaults to regclient's default (3). Raising it helps when a single zot
+	// proxies many concurrent on-demand pulls of different images from one upstream, where the default
+	// causes head-of-line blocking.
+	ReqConcurrent *int
+	// ReqPerSec caps the request rate (requests/second) to the upstream registry (and each of its
+	// mirrors). When unset it defaults to regclient's default (0, i.e. unlimited).
+	ReqPerSec *float64
 }
 
 // OAuth2HelperConfig holds the options used by the "oauth2" credential helper,

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -70,13 +70,15 @@ type RegistryConfig struct {
 	PreserveDigest         bool           // sync without converting
 	SyncTimeout            time.Duration  // overall HTTP client timeout for all sync operations
 	ResponseHeaderTimeout  time.Duration  `yaml:"-"` // response header timeout; set in root.go
-	// ReqConcurrent caps the number of in-flight requests to the upstream registry (and each of its
-	// mirrors). When unset it defaults to regclient's default (3). Raising it helps when a single zot
-	// proxies many concurrent on-demand pulls of different images from one upstream, where the default
-	// causes head-of-line blocking.
+	// ReqConcurrent caps the number of in-flight requests per upstream host. The limit is applied
+	// independently to the upstream registry and to each of its mirrors (regclient copies it onto every
+	// host), so it is a per-host cap, not a shared total across hosts. When unset it defaults to
+	// regclient's default (3). Raising it helps when a single zot proxies many concurrent on-demand pulls
+	// of different images from one upstream, where the default causes head-of-line blocking.
 	ReqConcurrent *int
-	// ReqPerSec caps the request rate (requests/second) to the upstream registry (and each of its
-	// mirrors). When unset it defaults to regclient's default (0, i.e. unlimited).
+	// ReqPerSec caps the request rate (requests/second) per upstream host, applied independently to the
+	// upstream registry and to each of its mirrors (a per-host cap, not a shared total across hosts).
+	// When unset it defaults to regclient's default (0, i.e. unlimited).
 	ReqPerSec *float64
 }
 

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -974,9 +974,10 @@ func newClient(opts syncconf.RegistryConfig, credentials syncconf.CredentialsFil
 	hostConfig.Mirrors = mirrorsHosts
 	hostConfig.RepoAuth = true
 
-	// Override regclient's per-host concurrency/rate limits when configured. These apply to the
-	// upstream host; mirrors below inherit them via the hostConfig copy. When unset, regclient's
-	// defaults are kept (ReqConcurrent=3, ReqPerSec=0 i.e. unlimited).
+	// Override regclient's per-host concurrency/rate limits when configured. regclient applies these
+	// limits independently per host: the value set here on the upstream host is also copied onto each
+	// mirror, so the effective cap is per host, not a shared total across the upstream and its mirrors.
+	// When unset, regclient's defaults are kept (ReqConcurrent=3, ReqPerSec=0 i.e. unlimited).
 	if opts.ReqConcurrent != nil {
 		hostConfig.ReqConcurrent = int64(*opts.ReqConcurrent)
 	}

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -974,6 +974,17 @@ func newClient(opts syncconf.RegistryConfig, credentials syncconf.CredentialsFil
 	hostConfig.Mirrors = mirrorsHosts
 	hostConfig.RepoAuth = true
 
+	// Override regclient's per-host concurrency/rate limits when configured. These apply to the
+	// upstream host; mirrors below inherit them via the hostConfig copy. When unset, regclient's
+	// defaults are kept (ReqConcurrent=3, ReqPerSec=0 i.e. unlimited).
+	if opts.ReqConcurrent != nil {
+		hostConfig.ReqConcurrent = int64(*opts.ReqConcurrent)
+	}
+
+	if opts.ReqPerSec != nil {
+		hostConfig.ReqPerSec = *opts.ReqPerSec
+	}
+
 	// set TLS configuration
 	tls := getTLSConfigOption(urls[0], opts.TLSVerify)
 	hostConfig.TLS = tls

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -2062,6 +2062,60 @@ func TestNewClientTimeoutBehavior(t *testing.T) {
 	})
 }
 
+// TestNewClientReqConcurrentReqPerSec verifies that reqConcurrent/reqPerSec from the sync config
+// override regclient's per-host defaults, and that configured mirrors inherit the same limits.
+func TestNewClientReqConcurrentReqPerSec(t *testing.T) {
+	Convey("Test newClient reqConcurrent/reqPerSec overrides", t, func() {
+		logger := log.NewTestLogger()
+		regclientDefaults := regconfig.HostNew()
+
+		Convey("Unset keeps regclient defaults", func() {
+			opts := syncconf.RegistryConfig{URLs: []string{"http://localhost:9000"}}
+
+			_, hosts, err := newClient(opts, syncconf.CredentialsFile{}, logger)
+			So(err, ShouldBeNil)
+			So(hosts, ShouldNotBeEmpty)
+			So(hosts[0].ReqConcurrent, ShouldEqual, regclientDefaults.ReqConcurrent)
+			So(hosts[0].ReqPerSec, ShouldEqual, regclientDefaults.ReqPerSec)
+		})
+
+		Convey("Set values override the defaults on the main host", func() {
+			reqConcurrent := 42
+			reqPerSec := 100.0
+			opts := syncconf.RegistryConfig{
+				URLs:          []string{"http://localhost:9000"},
+				ReqConcurrent: &reqConcurrent,
+				ReqPerSec:     &reqPerSec,
+			}
+
+			_, hosts, err := newClient(opts, syncconf.CredentialsFile{}, logger)
+			So(err, ShouldBeNil)
+			So(hosts, ShouldNotBeEmpty)
+			So(hosts[0].ReqConcurrent, ShouldEqual, int64(reqConcurrent))
+			So(hosts[0].ReqPerSec, ShouldEqual, reqPerSec)
+		})
+
+		Convey("Mirrors inherit the configured limits", func() {
+			reqConcurrent := 20
+			reqPerSec := 50.0
+			opts := syncconf.RegistryConfig{
+				// first URL is the main host, the rest are mirrors
+				URLs:          []string{"http://localhost:9000", "http://localhost:9001"},
+				ReqConcurrent: &reqConcurrent,
+				ReqPerSec:     &reqPerSec,
+			}
+
+			_, hosts, err := newClient(opts, syncconf.CredentialsFile{}, logger)
+			So(err, ShouldBeNil)
+			So(len(hosts), ShouldEqual, 2)
+			for _, host := range hosts {
+				So(host.ReqConcurrent, ShouldEqual, int64(reqConcurrent))
+				So(host.ReqPerSec, ShouldEqual, reqPerSec)
+			}
+		})
+	})
+}
+
 func TestHTTPRetryDelayBounds(t *testing.T) {
 	Convey("httpRetryDelayBounds maps sync config to regclient delay args", t, func() {
 		retryDelay := 1 * time.Second


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:

Related to #4215 (scale-out as a Kubernetes/containerd pull-through cache). This PR
addresses one concrete bottleneck in that scenario rather than closing the umbrella issue.

**What does this PR do / Why do we need it**:

Sync uses a single shared `RegClient`, and regclient throttles requests per upstream
host to `ReqConcurrent = 3` by default. When one zot proxies many concurrent on-demand
pulls of *different* images from a *single* upstream (the typical pull-through-cache
deployment: one upstream Harbor, many Kubernetes node containerd clients), this cap
serializes requests to that host. Small manifest lookups then queue behind large blob
transfers, which shows up as slow manifest responses even when there is plenty of
bandwidth — a head-of-line-blocking symptom that is not tunable today.

This PR exposes two optional per-registry knobs so operators can raise the cap:

| field | type | meaning | unset default (regclient) |
|-------|------|---------|---------------------------|
| `reqConcurrent` | `*int` | max in-flight requests to the upstream and its mirrors | 3 |
| `reqPerSec` | `*float64` | max request rate (req/s) to the upstream and its mirrors | 0 (unlimited) |

Both are applied to the upstream `hostConfig` in `newClient()`; mirrors inherit them via
the existing `hostConfig` value copy. The fields are pointers so they are fully optional —
existing configs are unaffected and keep regclient's defaults. `validateSync()` rejects
non-positive values.

**If an issue # is not available please add repro steps and logs showing the issue**:

Repro: point one zot at a single upstream with `onDemand: true`, then drive concurrent
on-demand pulls of many different images (e.g. many k8s nodes pulling at once). With the
default cap of 3, manifest requests for small images stall behind in-flight blob copies to
the same host. Raising `reqConcurrent` removes the serialization.

**Testing done on this change**:

- Unit tests added:
  - `pkg/extensions/sync/sync_internal_test.go` — `TestNewClientReqConcurrentReqPerSec`:
    verifies defaults are kept when unset, the upstream host picks up overrides, and mirrors
    inherit them.
  - `pkg/cli/server/root_test.go` — verify rejects `reqConcurrent: 0` and `reqPerSec: 0`,
    and accepts positive values.
  - Both suites pass locally (`go test -tags <ext> ./pkg/extensions/sync/`,
    `./pkg/cli/server/`).
- Manual end-to-end: built a linux/amd64 image and deployed it to a dev cluster as an
  on-demand pull-through cache against a single upstream. Startup `configuration settings`
  log confirms the values are parsed and loaded into the sync registry config
  (`"ReqConcurrent":30,"ReqPerSec":100`), config validation passes, and concurrent
  on-demand pulls of different images succeed.

**Automation added to e2e**:

No. Covered by unit tests above.

**Will this break upgrades or downgrades?**

No. The new fields are optional pointers; when unset, behavior is identical to today
(regclient defaults). Downgrading simply ignores the fields.

**Does this PR introduce any user-facing change?**:

Yes — two new optional sync registry config fields, documented in `examples/README.md`
and `examples/config-sync.json`.

```release-note
sync: add optional per-registry `reqConcurrent` and `reqPerSec` settings to configure the
concurrency and request rate limits used when syncing from an upstream registry (and its
mirrors). When unset, regclient's defaults are kept (concurrency 3, rate unlimited).
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
