### PR TITLE
fix(storage): honor docker2s2 compat media types in delete/prune/scrub

### DIFF
--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -405,11 +405,11 @@ func RemoveManifestDescByReference(index *ispec.Index, reference string, detectC
 func UpdateIndexWithPrunedImageManifests(imgStore storageTypes.ImageStore, index *ispec.Index, repo string,
 	desc ispec.Descriptor, oldDgst godigest.Digest, log zlog.Logger,
 ) error {
-	if (desc.MediaType == ispec.MediaTypeImageIndex) && (oldDgst != "") {
+	if IsImageIndexMediaType(desc.MediaType) && (oldDgst != "") {
 		otherImgIndexes := []ispec.Descriptor{}
 
 		for _, manifest := range index.Manifests {
-			if manifest.MediaType == ispec.MediaTypeImageIndex {
+			if IsImageIndexMediaType(manifest.MediaType) {
 				otherImgIndexes = append(otherImgIndexes, manifest)
 			}
 		}
@@ -485,7 +485,7 @@ func PruneImageManifestsFromIndex(imgStore storageTypes.ImageStore, repo string,
 	// for all manifests in the index, skip those that either have a tag or
 	// are used in other imgIndexes
 	for _, outManifest := range outIndex.Manifests {
-		if outManifest.MediaType != ispec.MediaTypeImageManifest {
+		if !IsImageManifestMediaType(outManifest.MediaType) {
 			prunedManifests = append(prunedManifests, outManifest)
 
 			continue

--- a/pkg/storage/common/common_test.go
+++ b/pkg/storage/common/common_test.go
@@ -1547,6 +1547,132 @@ func TestIsBlobReferencedInImageIndexDockerCompat(t *testing.T) {
 	})
 }
 
+func TestUpdateIndexWithPrunedImageManifestsDockerCompat(t *testing.T) {
+	log := log.NewTestLogger()
+
+	Convey("Deleting a tagged docker manifest-list triggers pruning of its own children", t, func(c C) {
+		childDigest := godigest.FromString("docker-child-manifest")
+		deletedIndexDigest := godigest.FromString("docker-deleted-index")
+
+		deletedIndex := ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{MediaType: docker.MediaTypeManifest, Digest: childDigest},
+			},
+		}
+		deletedIndexBlob, err := json.Marshal(deletedIndex)
+		So(err, ShouldBeNil)
+
+		getBlobContentCalls := 0
+
+		imgStore := &mocks.MockedImageStore{
+			GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+				getBlobContentCalls++
+
+				return deletedIndexBlob, nil
+			},
+		}
+
+		index := ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{MediaType: docker.MediaTypeManifest, Digest: childDigest},
+			},
+		}
+
+		desc := ispec.Descriptor{MediaType: manifestlist.MediaTypeManifestList, Digest: deletedIndexDigest}
+
+		err = common.UpdateIndexWithPrunedImageManifests(imgStore, &index, "repo", desc, deletedIndexDigest, log)
+		So(err, ShouldBeNil)
+		// PruneImageManifestsFromIndex must have run (fetched the deleted docker manifest-list's
+		// own content to compute in-use counts) - before the fix, desc.MediaType being a docker
+		// type meant this whole block was skipped and index.Manifests was left untouched.
+		So(getBlobContentCalls, ShouldBeGreaterThan, 0)
+	})
+}
+
+func TestPruneImageManifestsFromIndexDockerCompat(t *testing.T) {
+	log := log.NewTestLogger()
+
+	Convey("An untagged docker manifest with no other referrer is pruned", t, func(c C) {
+		mainIndexDigest := godigest.FromString("docker-main-index")
+		manifest1Digest := godigest.FromString("docker-manifest1")
+		mainIndex := ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{MediaType: docker.MediaTypeManifest, Digest: manifest1Digest},
+			},
+		}
+		mainIndexBlob, err := json.Marshal(mainIndex)
+		So(err, ShouldBeNil)
+
+		// one other index in the repo, missing on disk - gracefully skipped, so it
+		// contributes nothing to the in-use count.
+		otherImgIndexes := []ispec.Descriptor{
+			{
+				MediaType: manifestlist.MediaTypeManifestList,
+				Digest:    godigest.FromString("missing-docker-index"),
+				Size:      100,
+			},
+		}
+
+		imgStore := &mocks.MockedImageStore{
+			GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+				if digest == mainIndexDigest {
+					return mainIndexBlob, nil
+				}
+
+				return nil, zerr.ErrBlobNotFound
+			},
+		}
+
+		outIndex := ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{
+					MediaType: docker.MediaTypeManifest,
+					Digest:    manifest1Digest,
+					// no tag annotation, and referenced nowhere else, so it should be pruned
+				},
+			},
+		}
+
+		prunedManifests, err := common.PruneImageManifestsFromIndex(
+			imgStore, "repo", mainIndexDigest, outIndex, otherImgIndexes, log)
+		So(err, ShouldBeNil)
+		So(len(prunedManifests), ShouldEqual, 0)
+	})
+
+	Convey("A tagged docker manifest is preserved regardless of use count", t, func(c C) {
+		mainIndexDigest := godigest.FromString("docker-main-index-2")
+		manifest1Digest := godigest.FromString("docker-manifest2")
+		mainIndex := ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{MediaType: docker.MediaTypeManifest, Digest: manifest1Digest},
+			},
+		}
+		mainIndexBlob, err := json.Marshal(mainIndex)
+		So(err, ShouldBeNil)
+
+		imgStore := &mocks.MockedImageStore{
+			GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+				return mainIndexBlob, nil
+			},
+		}
+
+		outIndex := ispec.Index{
+			Manifests: []ispec.Descriptor{
+				{
+					MediaType:   docker.MediaTypeManifest,
+					Digest:      manifest1Digest,
+					Annotations: map[string]string{ispec.AnnotationRefName: "v1"},
+				},
+			},
+		}
+
+		prunedManifests, err := common.PruneImageManifestsFromIndex(
+			imgStore, "repo", mainIndexDigest, outIndex, nil, log)
+		So(err, ShouldBeNil)
+		So(len(prunedManifests), ShouldEqual, 1)
+	})
+}
+
 func TestGetReferencedBlobsDockerCompatManifestList(t *testing.T) {
 	log := log.NewTestLogger()
 

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -844,9 +844,9 @@ func (is *ImageStore) deleteImageManifest(ctx context.Context, repo, reference s
 	/* check if manifest is referenced in image indexes, do not allow index images manipulations
 	(ie. remove manifest being part of an image index)	*/
 	if zcommon.IsDigest(reference) &&
-		(manifestDesc.MediaType == ispec.MediaTypeImageManifest || manifestDesc.MediaType == ispec.MediaTypeImageIndex) {
+		(common.IsImageManifestMediaType(manifestDesc.MediaType) || common.IsImageIndexMediaType(manifestDesc.MediaType)) {
 		for _, mDesc := range index.Manifests {
-			if mDesc.MediaType == ispec.MediaTypeImageIndex {
+			if common.IsImageIndexMediaType(mDesc.MediaType) {
 				ok, err := common.IsBlobReferencedInImageIndex(is, repo, manifestDesc.Digest, ispec.Index{
 					Manifests: []ispec.Descriptor{mDesc},
 				}, is.log)

--- a/pkg/storage/scrub.go
+++ b/pkg/storage/scrub.go
@@ -16,7 +16,8 @@ import (
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	zerr "zotregistry.dev/zot/v2/errors"
-	"zotregistry.dev/zot/v2/pkg/common"
+	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	common "zotregistry.dev/zot/v2/pkg/storage/common"
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 )
 
@@ -112,7 +113,7 @@ func CheckRepo(ctx context.Context, imageName string, imgStore storageTypes.Imag
 	scrubbedManifests := make(map[godigest.Digest]ScrubImageResult)
 
 	for _, manifest := range index.Manifests {
-		if common.IsContextDone(ctx) {
+		if zcommon.IsContextDone(ctx) {
 			return results, ctx.Err()
 		}
 
@@ -198,8 +199,8 @@ func scrubManifest(
 		return layers, nil
 	}
 
-	switch manifest.MediaType {
-	case ispec.MediaTypeImageIndex:
+	switch {
+	case common.IsImageIndexMediaType(manifest.MediaType):
 		var idx ispec.Index
 		if err := json.Unmarshal(manifestContent, &idx); err != nil {
 			imgRes := getResult(imageName, tag, manifest.Digest, zerr.ErrBadBlobDigest)
@@ -296,7 +297,7 @@ func scrubManifest(
 		}
 
 		return layers, nil
-	case ispec.MediaTypeImageManifest:
+	case common.IsImageManifestMediaType(manifest.MediaType):
 		affectedBlob, man, err := CheckManifestAndConfig(imageName, manifest, manifestContent, imgStore)
 		if err == nil {
 			layers = append(layers, man.Layers...)
@@ -349,7 +350,7 @@ func scrubManifest(
 func CheckManifestAndConfig(
 	imageName string, manifestDesc ispec.Descriptor, manifestContent []byte, imgStore storageTypes.ImageStore,
 ) (godigest.Digest, ispec.Manifest, error) {
-	if manifestDesc.MediaType != ispec.MediaTypeImageManifest {
+	if !common.IsImageManifestMediaType(manifestDesc.MediaType) {
 		return manifestDesc.Digest, ispec.Manifest{}, zerr.ErrBadManifest
 	}
 

--- a/pkg/storage/scrub_test.go
+++ b/pkg/storage/scrub_test.go
@@ -20,6 +20,7 @@ import (
 
 	zerr "zotregistry.dev/zot/v2/errors"
 	rediscfg "zotregistry.dev/zot/v2/pkg/api/config/redis"
+	"zotregistry.dev/zot/v2/pkg/compat"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
 	"zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/storage"
@@ -185,6 +186,84 @@ func TestScrubDetectsCorruptedConfigContent(t *testing.T) {
 		space := regexp.MustCompile(`\s+`)
 		actual := strings.TrimSpace(space.ReplaceAllString(buff.String(), " "))
 		So(actual, ShouldContainSubstring, fmt.Sprintf("test 1.0 affected %s bad blob digest", configDig))
+	})
+}
+
+// TestScrubDockerCompat guards D4: scrub must recurse into a docker manifest-list and
+// validate its nested docker manifests' layers/config the same way it does for an OCI
+// index, instead of rejecting every docker manifest as a bad manifest media type.
+func TestScrubDockerCompat(t *testing.T) {
+	Convey("scrub a healthy docker manifest-list image", t, func() {
+		tdir := t.TempDir()
+		log := log.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+
+		compatMediaTypes := []compat.MediaCompatibility{compat.DockerManifestV2SchemaV2}
+		imgStore := local.NewImageStore(tdir, false, false, log, metrics, nil, nil, compatMediaTypes, nil)
+
+		storeCtlr := storage.StoreController{}
+		storeCtlr.DefaultStore = imgStore
+
+		dockerRepo := "docker-compat-scrub"
+
+		dockerList := CreateRandomMultiarch().AsDockerImage()
+
+		err := WriteMultiArchImageToFileSystem(dockerList, dockerRepo, "0.0.1", storeCtlr)
+		So(err, ShouldBeNil)
+
+		buff := bytes.NewBufferString("")
+
+		res, err := storeCtlr.CheckAllBlobsIntegrity(context.Background())
+		res.PrintScrubResults(buff)
+		So(err, ShouldBeNil)
+
+		space := regexp.MustCompile(`\s+`)
+		actual := strings.TrimSpace(space.ReplaceAllString(buff.String(), " "))
+		So(actual, ShouldContainSubstring, dockerRepo+" 0.0.1 ok")
+		So(actual, ShouldNotContainSubstring, "affected")
+	})
+
+	Convey("scrub detects a corrupted docker manifest's config content", t, func() {
+		tdir := t.TempDir()
+		log := log.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+
+		compatMediaTypes := []compat.MediaCompatibility{compat.DockerManifestV2SchemaV2}
+		imgStore := local.NewImageStore(tdir, true, true, log, metrics, nil, nil, compatMediaTypes, nil)
+		driver := local.New(true)
+
+		storeCtlr := storage.StoreController{}
+		storeCtlr.DefaultStore = imgStore
+
+		dockerRepo := "docker-compat-scrub-corrupted"
+
+		dockerList := CreateRandomMultiarch().AsDockerImage()
+
+		err := WriteMultiArchImageToFileSystem(dockerList, dockerRepo, "0.0.1", storeCtlr)
+		So(err, ShouldBeNil)
+
+		// corrupt the first nested docker manifest's config blob on disk, keeping it valid JSON
+		corruptedConfig := dockerList.Images[0].Config
+		corruptedConfig.Architecture += "-corrupted"
+
+		corruptedContent, err := json.Marshal(corruptedConfig)
+		So(err, ShouldBeNil)
+
+		configDig := dockerList.Images[0].ConfigDescriptor.Digest.Encoded()
+		configFile := path.Join(imgStore.RootDir(), dockerRepo, "/blobs/sha256", configDig)
+		_, err = driver.WriteFile(configFile, corruptedContent)
+		So(err, ShouldBeNil)
+
+		buff := bytes.NewBufferString("")
+
+		res, err := storeCtlr.CheckAllBlobsIntegrity(context.Background())
+		res.PrintScrubResults(buff)
+		So(err, ShouldBeNil)
+
+		space := regexp.MustCompile(`\s+`)
+		actual := strings.TrimSpace(space.ReplaceAllString(buff.String(), " "))
+		So(actual, ShouldContainSubstring,
+			fmt.Sprintf("%s 0.0.1 affected %s bad blob digest", dockerRepo, configDig))
 	})
 }
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -32,6 +32,7 @@ import (
 	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	rediscfg "zotregistry.dev/zot/v2/pkg/api/config/redis"
+	"zotregistry.dev/zot/v2/pkg/compat"
 	"zotregistry.dev/zot/v2/pkg/extensions/events"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
@@ -2376,6 +2377,44 @@ func TestDeleteBlobsInUse(t *testing.T) {
 			})
 		})
 	}
+}
+
+// TestDeleteImageManifestDockerCompatReferenced guards D3: a docker schema2 manifest
+// referenced by a tagged docker manifest-list must be protected from digest-delete the
+// same way an OCI manifest referenced by an OCI index already is (see the "Try to
+// delete manifest being referenced by image index" case above); the manifest-list
+// itself must be deletable once nothing references it anymore.
+func TestDeleteImageManifestDockerCompatReferenced(t *testing.T) {
+	Convey("tagged docker manifest-list image", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		rootDir := t.TempDir()
+
+		compatMediaTypes := []compat.MediaCompatibility{compat.DockerManifestV2SchemaV2}
+		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, compatMediaTypes, nil)
+
+		storeController := storage.StoreController{}
+		storeController.DefaultStore = imgStore
+
+		repoName := "docker-compat-referenced"
+
+		dockerList := CreateRandomMultiarch().AsDockerImage()
+
+		err := WriteMultiArchImageToFileSystem(dockerList, repoName, "0.0.1", storeController)
+		So(err, ShouldBeNil)
+
+		Convey("deleting a nested docker manifest by digest is blocked", func() {
+			err := imgStore.DeleteImageManifest(context.Background(), repoName,
+				dockerList.Images[0].ManifestDescriptor.Digest.String(), false)
+			So(err, ShouldEqual, zerr.ErrManifestReferenced)
+		})
+
+		Convey("deleting the tagged manifest-list by digest succeeds once it is the target", func() {
+			err := imgStore.DeleteImageManifest(context.Background(), repoName,
+				dockerList.IndexDescriptor.Digest.String(), false)
+			So(err, ShouldBeNil)
+		})
+	})
 }
 
 func TestReuploadCorruptedBlob(t *testing.T) {


### PR DESCRIPTION
IsBlobReferencedInImageIndex, GetReferencedBlobs, and GetBlobDescriptorFromIndex already treat docker manifest-lists/ manifests as OCI-index/manifest-equivalent via IsImageIndexMediaType/ IsImageManifestMediaType when docker2s2 compat is enabled. Several other code paths still compared against the literal OCI media type constants only, so they silently mishandled docker2s2 content:

- UpdateIndexWithPrunedImageManifests and PruneImageManifestsFromIndex (common.go) didn't recognize a docker manifest-list as an index to prune from, or a docker manifest as a prune candidate.
- deleteImageManifest (imagestore.go) didn't guard a digest-delete of a docker manifest/manifest-list against still being referenced by a parent docker manifest-list, the same way it does for OCI.
- scrubManifest and CheckManifestAndConfig (scrub.go) only recognized OCI media types, so every docker-schema2 manifest was reported as a bad manifest instead of having its layers/config checked. Restructured scrubManifest's switch into a tagless switch (a value-switch can't host bool-returning case expressions) and fixed CheckManifestAndConfig's own independent media-type guard, which would otherwise still reject every docker manifest even after the switch recognized it.

Added coverage mirroring the existing OCI-only tests for each path, verified each new test fails without its corresponding fix and passes with it.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
