### PR TITLE
feat(sync): add manifestCheckInterval to throttle on-demand upstream manifest checks

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1393,6 +1393,7 @@ Configure each registry sync:
 				"urls": ["https://registry1:5000"],
 				"onDemand": false,                  # pull any image which the local registry doesn't have
 				"pollInterval": "6h",               # polling interval, if not set then periodically polling will not run
+				"manifestCheckInterval": "1h",      # minimum interval between upstream manifest checks for the same repo:tag when serving on-demand requests; when 0 or unset every request checks upstream. Requires onDemand.
 				"tlsVerify": true,                  # whether or not to verify tls (default is true)
 				"certDir": "/home/user/certs",      # use certificates at certDir path similar to Docker's /etc/docker/certs.d., if not specified then use the default certs dir,
 				"maxRetries": 5,                    # maxRetries in case of temporary errors (default: no retries)
@@ -1451,6 +1452,30 @@ Configure each registry sync:
 		}
 ```
 Prefixes can be strings that exactly match repositories or they can be [glob](https://en.wikipedia.org/wiki/Glob_(programming)) patterns.
+
+### Sync's manifestCheckInterval option
+
+With `onDemand` enabled, every request for a tag validates the manifest against the upstream
+registry, because a tag is mutable and may have been repushed. When pulls are frequent and
+upstream rarely changes, `manifestCheckInterval` throttles that validation:
+
+```
+			"registries": [{
+				"urls": ["https://registry-1.docker.io"],
+				"onDemand": true,
+				"manifestCheckInterval": "10m"
+			}]
+```
+
+While the interval has not elapsed since the last successful upstream check, a locally present
+manifest is served without contacting upstream, which makes already synced images effectively
+local. Notes:
+
+ - the default is 0, which keeps checking upstream on every request
+ - it requires `onDemand`, since it only affects on-demand requests, never periodic sync
+ - requests by digest are unaffected, a locally present digest is already served without contacting upstream
+ - a local miss, for instance after garbage collection, always falls back to a normal sync
+ - the last check time is kept in memory, so the first request after a restart checks upstream again
 
 ### Sync's certDir option
 

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -666,4 +666,5 @@ func RunGCTasks(conf *config.Config, storeController storage.StoreController, me
 type SyncOnDemand interface {
 	SyncImage(ctx context.Context, repo, reference string) error
 	SyncReferrers(ctx context.Context, repo string, subjectDigestStr string, referenceTypes []string) error
+	ShouldCheckUpstreamManifest(repo, reference string) bool
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -2764,6 +2764,19 @@ func getImageManifest(ctx context.Context, routeHandler *RouteHandler, imgStore 
 	}
 
 	if syncEnabled {
+		// When manifestCheckInterval is configured and a recent upstream check already
+		// validated this reference, serve the local manifest instead of contacting upstream.
+		// A local miss (for instance after garbage collection) falls through to a normal sync.
+		if !routeHandler.c.SyncOnDemand.ShouldCheckUpstreamManifest(name, reference) {
+			content, digest, mediaType, err := imgStore.GetImageManifest(name, reference)
+			if err == nil {
+				routeHandler.c.Log.Debug().Str("repository", name).Str("reference", reference).
+					Msg("manifest check interval has not elapsed, serving local manifest")
+
+				return content, digest, mediaType, nil
+			}
+		}
+
 		routeHandler.c.Log.Info().Str("repository", name).Str("reference", reference).
 			Msg("trying to get updated image by syncing on demand")
 

--- a/pkg/api/routes_manifest_test.go
+++ b/pkg/api/routes_manifest_test.go
@@ -1,0 +1,177 @@
+//go:build sync && scrub && metrics && search && lint && userprefs && mgmt && imagetrust && ui
+
+package api_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	. "github.com/smartystreets/goconvey/convey"
+
+	zerr "zotregistry.dev/zot/v2/errors"
+	"zotregistry.dev/zot/v2/pkg/api"
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/api/constants"
+	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
+	syncconf "zotregistry.dev/zot/v2/pkg/extensions/config/sync"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+type mockSyncOnDemand struct {
+	syncImageFn                   func(ctx context.Context, repo, reference string) error
+	shouldCheckUpstreamManifestFn func(repo, reference string) bool
+}
+
+func (m *mockSyncOnDemand) SyncImage(ctx context.Context, repo, reference string) error {
+	if m.syncImageFn != nil {
+		return m.syncImageFn(ctx, repo, reference)
+	}
+
+	return nil
+}
+
+func (m *mockSyncOnDemand) SyncReferrers(_ context.Context, _, _ string, _ []string) error {
+	return nil
+}
+
+func (m *mockSyncOnDemand) ShouldCheckUpstreamManifest(repo, reference string) bool {
+	if m.shouldCheckUpstreamManifestFn != nil {
+		return m.shouldCheckUpstreamManifestFn(repo, reference)
+	}
+
+	return true
+}
+
+func newSyncTestRouteHandler(
+	t *testing.T,
+	store mocks.MockedImageStore,
+	syncOnDemand api.SyncOnDemand,
+) *api.RouteHandler {
+	t.Helper()
+
+	trueVal := true
+
+	ctlr := api.NewController(config.New())
+	ctlr.Router = mux.NewRouter()
+	ctlr.Config.Extensions = &extconf.ExtensionConfig{
+		Sync: &syncconf.Config{Enable: &trueVal},
+	}
+	ctlr.StoreController.DefaultStore = store
+	ctlr.SyncOnDemand = syncOnDemand
+
+	return api.NewRouteHandler(ctlr)
+}
+
+func TestGetManifestCheckInterval(t *testing.T) {
+	Convey("GetManifest honours the manifest check interval", t, func() {
+		const reference = "v1.0"
+
+		newReq := func() *http.Request {
+			req := httptest.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				"http://example.com/v2/test/manifests/"+reference,
+				http.NoBody,
+			)
+
+			return mux.SetURLVars(req, map[string]string{
+				"name":      "test",
+				"reference": reference,
+			})
+		}
+
+		localManifest := []byte(`{"schemaVersion":2}`)
+		localDigest := godigest.FromBytes(localManifest)
+
+		localStore := mocks.MockedImageStore{
+			GetImageManifestFn: func(_ string, _ string) ([]byte, godigest.Digest, string, error) {
+				return localManifest, localDigest, ispec.MediaTypeImageManifest, nil
+			},
+		}
+
+		Convey("serves the local manifest without syncing while the interval has not elapsed", func() {
+			syncCalls := 0
+
+			syncOnDemand := &mockSyncOnDemand{
+				shouldCheckUpstreamManifestFn: func(_, _ string) bool { return false },
+				syncImageFn: func(_ context.Context, _, _ string) error {
+					syncCalls++
+
+					return nil
+				},
+			}
+			handler := newSyncTestRouteHandler(t, localStore, syncOnDemand)
+
+			rec := httptest.NewRecorder()
+			handler.GetManifest(rec, newReq())
+
+			resp := rec.Result()
+			defer resp.Body.Close()
+
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+			So(resp.Header.Get(constants.DistContentDigestKey), ShouldEqual, localDigest.String())
+
+			body, readErr := io.ReadAll(resp.Body)
+			So(readErr, ShouldBeNil)
+			So(body, ShouldResemble, localManifest)
+
+			So(syncCalls, ShouldEqual, 0)
+		})
+
+		Convey("falls through to sync when the local manifest is missing", func() {
+			syncCalls := 0
+
+			syncOnDemand := &mockSyncOnDemand{
+				shouldCheckUpstreamManifestFn: func(_, _ string) bool { return false },
+				syncImageFn: func(_ context.Context, _, _ string) error {
+					syncCalls++
+
+					return nil
+				},
+			}
+			handler := newSyncTestRouteHandler(t, mocks.MockedImageStore{
+				GetImageManifestFn: func(_ string, _ string) ([]byte, godigest.Digest, string, error) {
+					return nil, "", "", zerr.ErrManifestNotFound
+				},
+			}, syncOnDemand)
+
+			rec := httptest.NewRecorder()
+			handler.GetManifest(rec, newReq())
+
+			resp := rec.Result()
+			defer resp.Body.Close()
+
+			So(resp.StatusCode, ShouldEqual, http.StatusNotFound)
+			So(syncCalls, ShouldEqual, 1)
+		})
+
+		Convey("syncs when the interval has elapsed even though the manifest is local", func() {
+			syncCalls := 0
+
+			syncOnDemand := &mockSyncOnDemand{
+				shouldCheckUpstreamManifestFn: func(_, _ string) bool { return true },
+				syncImageFn: func(_ context.Context, _, _ string) error {
+					syncCalls++
+
+					return nil
+				},
+			}
+			handler := newSyncTestRouteHandler(t, localStore, syncOnDemand)
+
+			rec := httptest.NewRecorder()
+			handler.GetManifest(rec, newReq())
+
+			resp := rec.Result()
+			defer resp.Body.Close()
+
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+			So(syncCalls, ShouldEqual, 1)
+		})
+	})
+}

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -1681,12 +1681,33 @@ func validateGCRules(retention config.ImageRetention, logger zlog.Logger) error 
 	return nil
 }
 
+// validateRegistryManifestCheckInterval rejects a manifestCheckInterval that cannot take effect.
+// The interval only throttles on-demand manifest checks, so it is meaningless without onDemand.
+func validateRegistryManifestCheckInterval(regCfg syncconf.RegistryConfig) error {
+	if regCfg.ManifestCheckInterval < 0 {
+		return fmt.Errorf("%w: %s", zerr.ErrBadConfig, "manifestCheckInterval cannot be negative")
+	}
+
+	if regCfg.ManifestCheckInterval > 0 && !regCfg.OnDemand {
+		return fmt.Errorf("%w: %s", zerr.ErrBadConfig, "manifestCheckInterval requires onDemand to be enabled")
+	}
+
+	return nil
+}
+
 func validateSync(config *config.Config, logger zlog.Logger) error {
 	// check glob patterns in sync config are compilable
 	extensionsConfig := config.CopyExtensionsConfig()
 	// can't check with IsSyncEnabled(), because it can't test invalid sync configs
 	if extensionsConfig != nil && extensionsConfig.Sync != nil && len(extensionsConfig.Sync.Registries) > 0 {
 		for regID, regCfg := range extensionsConfig.Sync.Registries {
+			if intervalValidationErr := validateRegistryManifestCheckInterval(regCfg); intervalValidationErr != nil {
+				logger.Error().Err(intervalValidationErr).Int("id", regID).Interface("extensions.sync.registries[id]",
+					extensionsConfig.Sync.Registries[regID]).Msg("invalid config for manifestCheckInterval")
+
+				return intervalValidationErr
+			}
+
 			// check retry options are configured for sync
 			if regCfg.MaxRetries != nil && regCfg.RetryDelay == nil {
 				msg := "retryDelay is required when using maxRetries"

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -4138,3 +4138,87 @@ func TestMetricsConfigurationValidation(t *testing.T) {
 		})
 	})
 }
+
+func TestManifestCheckIntervalConfig(t *testing.T) {
+	Convey("manifestCheckInterval validation", t, func() {
+		Convey("Parse a valid manifestCheckInterval", func() {
+			content := `{"storage":{"rootDirectory":"/tmp/zot"},
+				"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+				"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+				"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
+				"onDemand": true, "manifestCheckInterval": "10m"}]}}}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldBeNil)
+			So(cfg.Extensions.Sync.Registries[0].ManifestCheckInterval, ShouldEqual, 10*time.Minute)
+		})
+
+		Convey("Omitting manifestCheckInterval leaves it disabled", func() {
+			content := `{"storage":{"rootDirectory":"/tmp/zot"},
+				"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+				"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+				"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
+				"onDemand": true}]}}}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldBeNil)
+			So(cfg.Extensions.Sync.Registries[0].ManifestCheckInterval, ShouldEqual, time.Duration(0))
+		})
+
+		Convey("A zero manifestCheckInterval is accepted without onDemand", func() {
+			content := `{"storage":{"rootDirectory":"/tmp/zot"},
+				"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+				"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+				"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
+				"onDemand": false, "pollInterval": "12h", "manifestCheckInterval": "0s"}]}}}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("Reject manifestCheckInterval when onDemand is false", func() {
+			content := `{"storage":{"rootDirectory":"/tmp/zot"},
+				"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+				"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+				"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
+				"onDemand": false, "pollInterval": "12h", "manifestCheckInterval": "10m"}]}}}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldWrap, zerr.ErrBadConfig)
+			So(err.Error(), ShouldContainSubstring, "manifestCheckInterval requires onDemand to be enabled")
+		})
+
+		Convey("Reject a negative manifestCheckInterval", func() {
+			content := `{"storage":{"rootDirectory":"/tmp/zot"},
+				"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+				"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+				"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
+				"onDemand": true, "manifestCheckInterval": "-10m"}]}}}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldNotBeNil)
+			So(err, ShouldWrap, zerr.ErrBadConfig)
+			So(err.Error(), ShouldContainSubstring, "manifestCheckInterval cannot be negative")
+		})
+
+		Convey("manifestCheckInterval coexists with a periodic upstream on another registry", func() {
+			content := `{"storage":{"rootDirectory":"/tmp/zot"},
+				"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+				"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+				"extensions":{"sync": {"registries": [
+					{"urls":["localhost:9999"], "onDemand": true, "manifestCheckInterval": "1h"},
+					{"urls":["localhost:9998"], "onDemand": true, "pollInterval": "12h", "manifestCheckInterval": "30m"}
+				]}}}`
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldBeNil)
+		})
+	})
+}

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -58,6 +58,7 @@ type RegistryConfig struct {
 	Content                []Content
 	TLSVerify              *bool
 	OnDemand               bool
+	ManifestCheckInterval  time.Duration
 	CertDir                string
 	MaxRetries             *int
 	RetryDelay             *time.Duration

--- a/pkg/extensions/config/sync/config_test.go
+++ b/pkg/extensions/config/sync/config_test.go
@@ -2,6 +2,7 @@ package sync_test
 
 import (
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -26,6 +27,20 @@ func TestRegistryConfig_ShouldSyncLegacyCosignTags(t *testing.T) {
 			v := false
 			cfg := syncconf.RegistryConfig{SyncLegacyCosignTags: &v}
 			So(cfg.ShouldSyncLegacyCosignTags(), ShouldBeFalse)
+		})
+	})
+}
+
+func TestRegistryConfig_ManifestCheckInterval(t *testing.T) {
+	Convey("ManifestCheckInterval", t, func() {
+		Convey("defaults to zero, which keeps checking upstream on every request", func() {
+			cfg := syncconf.RegistryConfig{}
+			So(cfg.ManifestCheckInterval, ShouldEqual, time.Duration(0))
+		})
+
+		Convey("holds the configured duration", func() {
+			cfg := syncconf.RegistryConfig{ManifestCheckInterval: 10 * time.Minute}
+			So(cfg.ManifestCheckInterval, ShouldEqual, 10*time.Minute)
 		})
 	})
 }

--- a/pkg/extensions/sync/manifest_check_tracker.go
+++ b/pkg/extensions/sync/manifest_check_tracker.go
@@ -1,0 +1,96 @@
+//go:build sync
+
+package sync
+
+import (
+	"sync"
+	"time"
+)
+
+// minEvictPeriod bounds how often the tracker sweeps expired entries, so that a short
+// manifestCheckInterval does not turn every MarkChecked call into a full map walk.
+const minEvictPeriod = 10 * time.Minute
+
+// manifestCheckTracker remembers when an upstream manifest check last succeeded for a
+// repo:reference, so that on-demand requests arriving within manifestCheckInterval can be
+// served from local storage without contacting upstream.
+//
+// Entries are dropped lazily on lookup and swept in an amortized pass from MarkChecked, which
+// keeps the map bounded to the references seen within the interval without a background
+// goroutine to own and shut down.
+type manifestCheckTracker struct {
+	store     map[string]time.Time
+	interval  time.Duration
+	lastEvict time.Time
+	mu        sync.Mutex
+}
+
+func newManifestCheckTracker(interval time.Duration) *manifestCheckTracker {
+	return &manifestCheckTracker{
+		store:     make(map[string]time.Time),
+		interval:  interval,
+		lastEvict: time.Now(),
+	}
+}
+
+// trackerKey joins repo and reference with a byte that cannot appear in either, so that
+// distinct pairs can never collide on the same key.
+func trackerKey(repo, reference string) string {
+	return repo + "\x00" + reference
+}
+
+// ShouldCheckUpstream reports whether an upstream check is due for repo:reference.
+// An expired entry is dropped on the way out, which is the common path for references
+// that are requested once per interval.
+func (t *manifestCheckTracker) ShouldCheckUpstream(repo, reference string) bool {
+	key := trackerKey(repo, reference)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	lastChecked, ok := t.store[key]
+	if !ok {
+		return true
+	}
+
+	if time.Since(lastChecked) >= t.interval {
+		delete(t.store, key)
+
+		return true
+	}
+
+	return false
+}
+
+// MarkChecked records that an upstream check just succeeded for repo:reference.
+func (t *manifestCheckTracker) MarkChecked(repo, reference string) {
+	now := time.Now()
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	t.store[trackerKey(repo, reference)] = now
+
+	if now.Sub(t.lastEvict) >= t.evictPeriod() {
+		t.evictExpired(now)
+		t.lastEvict = now
+	}
+}
+
+// evictPeriod returns the sweep period, never shorter than minEvictPeriod.
+func (t *manifestCheckTracker) evictPeriod() time.Duration {
+	if t.interval > minEvictPeriod {
+		return t.interval
+	}
+
+	return minEvictPeriod
+}
+
+// evictExpired drops every entry past the interval. Caller must hold the lock.
+func (t *manifestCheckTracker) evictExpired(now time.Time) {
+	for key, lastChecked := range t.store {
+		if now.Sub(lastChecked) >= t.interval {
+			delete(t.store, key)
+		}
+	}
+}

--- a/pkg/extensions/sync/on_demand.go
+++ b/pkg/extensions/sync/on_demand.go
@@ -42,6 +42,20 @@ func (onDemand *BaseOnDemand) Add(service Service) {
 	onDemand.services = append(onDemand.services, service)
 }
 
+// ShouldCheckUpstreamManifest reports whether the manifest for repo:reference has to be
+// validated against upstream. Only a service that completed a successful check records a
+// timestamp, so a single service reporting that the interval has not elapsed means this
+// reference was verified recently and can be served from local storage.
+func (onDemand *BaseOnDemand) ShouldCheckUpstreamManifest(repo, reference string) bool {
+	for _, service := range onDemand.services {
+		if !service.ShouldCheckUpstream(repo, reference) {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (onDemand *BaseOnDemand) SyncImage(ctx context.Context, repo, reference string) error {
 	req := request{
 		repo:      repo,

--- a/pkg/extensions/sync/on_demand_disabled.go
+++ b/pkg/extensions/sync/on_demand_disabled.go
@@ -15,3 +15,7 @@ func (onDemand *BaseOnDemand) SyncReferrers(ctx context.Context, repo string,
 ) error {
 	return nil
 }
+
+func (onDemand *BaseOnDemand) ShouldCheckUpstreamManifest(repo, reference string) bool {
+	return true
+}

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -49,6 +49,7 @@ type BaseService struct {
 	rc               *regclient.RegClient
 	hosts            []config.Host
 	tagsCache        *tagsCache
+	checkTracker     *manifestCheckTracker
 
 	clientLock sync.RWMutex
 	log        log.Logger
@@ -71,6 +72,10 @@ func New(
 	service.contentManager = NewContentManager(config.Content, log)
 	service.storeController = storeController
 	service.tagsCache = newTagsCache(defaultExpireMinutes)
+
+	if config.ManifestCheckInterval > 0 {
+		service.checkTracker = newManifestCheckTracker(config.ManifestCheckInterval)
+	}
 
 	var err error
 
@@ -283,6 +288,27 @@ func (service *BaseService) CanRetryOnError() bool {
 	return false
 }
 
+// ShouldCheckUpstream reports whether an upstream manifest check is due for repo:reference.
+// It is always true when manifestCheckInterval is not configured, which keeps the default
+// behaviour of validating every on-demand request against upstream.
+func (service *BaseService) ShouldCheckUpstream(repo, reference string) bool {
+	if service.checkTracker == nil {
+		return true
+	}
+
+	return service.checkTracker.ShouldCheckUpstream(repo, reference)
+}
+
+// markUpstreamChecked records a successful upstream check, so that subsequent on-demand
+// requests for the same reference can be served locally until the interval elapses.
+func (service *BaseService) markUpstreamChecked(repo, reference string) {
+	if service.checkTracker == nil {
+		return
+	}
+
+	service.checkTracker.MarkChecked(repo, reference)
+}
+
 func (service *BaseService) GetSyncTimeout() time.Duration {
 	if service.config.SyncTimeout == 0 {
 		return syncConstants.DefaultSyncTimeout
@@ -395,7 +421,13 @@ func (service *BaseService) SyncImage(ctx context.Context, repo, reference strin
 		service.log.Error().Err(err).Msg("failed to refresh credentials")
 	}
 
-	return service.syncImage(ctx, repo, remoteRepo, reference, nil, false)
+	if err := service.syncImage(ctx, repo, remoteRepo, reference, nil, false); err != nil {
+		return err
+	}
+
+	service.markUpstreamChecked(repo, reference)
+
+	return nil
 }
 
 func (service *BaseService) SyncReferrers(ctx context.Context, repo string,
@@ -544,6 +576,10 @@ func (service *BaseService) SyncRepo(ctx context.Context, repo string) error {
 
 			return err
 		}
+
+		// periodic sync just validated this tag against upstream, so on-demand requests
+		// arriving right after do not need to check it again.
+		service.markUpstreamChecked(localRepo, tag)
 	}
 
 	service.log.Info().Str("repo", repo).Msg("sync: finished syncing repo")

--- a/pkg/extensions/sync/sync.go
+++ b/pkg/extensions/sync/sync.go
@@ -36,6 +36,9 @@ type Service interface {
 	CanRetryOnError() bool // used by sync on demand to retry in background
 	// Get the sync timeout configured for this service
 	GetSyncTimeout() time.Duration
+	// Returns whether an upstream manifest check is due for repo:reference.
+	// Always true unless manifestCheckInterval is configured and a recent check succeeded.
+	ShouldCheckUpstream(repo, reference string) bool
 }
 
 // Registry interface must be implemented by local and remote registries.

--- a/pkg/extensions/sync/sync_disabled_test.go
+++ b/pkg/extensions/sync/sync_disabled_test.go
@@ -3,6 +3,7 @@
 package sync_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -13,8 +14,19 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
 	syncconf "zotregistry.dev/zot/v2/pkg/extensions/config/sync"
+	"zotregistry.dev/zot/v2/pkg/extensions/sync"
 	test "zotregistry.dev/zot/v2/pkg/test/common"
 )
+
+func TestOnDemandStub(t *testing.T) {
+	Convey("stubbed on demand always allows upstream manifest checks", t, func() {
+		onDemand := &sync.BaseOnDemand{}
+
+		So(onDemand.SyncImage(context.Background(), "repo", "latest"), ShouldBeNil)
+		So(onDemand.SyncReferrers(context.Background(), "repo", "sha256:digest", nil), ShouldBeNil)
+		So(onDemand.ShouldCheckUpstreamManifest("repo", "latest"), ShouldBeTrue)
+	})
+}
 
 func TestSyncExtension(t *testing.T) {
 	Convey("Make a new controller", t, func() {

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2442,5 +2443,183 @@ func TestCredentialRefreshOnEverySyncEntryPoint(t *testing.T) {
 				So(err.Error(), ShouldNotEqual, refreshErr)
 			})
 		})
+	})
+}
+
+// mockCheckService is a minimal Service implementation for exercising
+// BaseOnDemand.ShouldCheckUpstreamManifest.
+type mockCheckService struct {
+	shouldCheckUpstreamFn func(repo, reference string) bool
+}
+
+func (s *mockCheckService) GetNextRepo(_ string) (string, error) { return "", nil }
+
+func (s *mockCheckService) SyncRepo(_ context.Context, _ string) error { return nil }
+
+func (s *mockCheckService) SyncImage(_ context.Context, _, _ string) error { return nil }
+
+func (s *mockCheckService) SyncReferrers(_ context.Context, _ string, _ string, _ []string) error {
+	return nil
+}
+
+func (s *mockCheckService) ResetCatalog() {}
+
+func (s *mockCheckService) CanRetryOnError() bool { return false }
+
+func (s *mockCheckService) GetSyncTimeout() time.Duration { return time.Minute }
+
+func (s *mockCheckService) ShouldCheckUpstream(repo, reference string) bool {
+	if s.shouldCheckUpstreamFn != nil {
+		return s.shouldCheckUpstreamFn(repo, reference)
+	}
+
+	return true
+}
+
+func TestManifestCheckTracker(t *testing.T) {
+	Convey("A reference that was never checked is due for an upstream check", t, func() {
+		tracker := newManifestCheckTracker(time.Hour)
+
+		So(tracker.ShouldCheckUpstream("repo", "latest"), ShouldBeTrue)
+	})
+
+	Convey("A reference checked within the interval is served locally", t, func() {
+		tracker := newManifestCheckTracker(time.Hour)
+		tracker.MarkChecked("repo", "latest")
+
+		So(tracker.ShouldCheckUpstream("repo", "latest"), ShouldBeFalse)
+
+		Convey("Only the marked reference is throttled", func() {
+			So(tracker.ShouldCheckUpstream("repo", "v1"), ShouldBeTrue)
+			So(tracker.ShouldCheckUpstream("other", "latest"), ShouldBeTrue)
+		})
+	})
+
+	Convey("A reference checked before the interval elapsed is due again and dropped", t, func() {
+		tracker := newManifestCheckTracker(time.Millisecond)
+		tracker.MarkChecked("repo", "latest")
+
+		time.Sleep(5 * time.Millisecond)
+
+		So(tracker.ShouldCheckUpstream("repo", "latest"), ShouldBeTrue)
+		So(tracker.store, ShouldNotContainKey, trackerKey("repo", "latest"))
+	})
+
+	Convey("Keys of different repo and reference pairs never collide", t, func() {
+		tracker := newManifestCheckTracker(time.Hour)
+		tracker.MarkChecked("a", "b/c")
+
+		So(tracker.ShouldCheckUpstream("a/b", "c"), ShouldBeTrue)
+	})
+
+	Convey("The sweep period is never shorter than the minimum", t, func() {
+		So(newManifestCheckTracker(time.Second).evictPeriod(), ShouldEqual, minEvictPeriod)
+		So(newManifestCheckTracker(24*time.Hour).evictPeriod(), ShouldEqual, 24*time.Hour)
+	})
+
+	Convey("MarkChecked sweeps expired entries once the sweep period has passed", t, func() {
+		tracker := newManifestCheckTracker(time.Millisecond)
+
+		for i := range 100 {
+			tracker.MarkChecked("repo", "tag"+strconv.Itoa(i))
+		}
+
+		So(len(tracker.store), ShouldEqual, 100)
+
+		time.Sleep(5 * time.Millisecond)
+
+		// force the sweep to be due, then mark one more reference
+		tracker.lastEvict = time.Now().Add(-2 * minEvictPeriod)
+		tracker.MarkChecked("repo", "fresh")
+
+		So(len(tracker.store), ShouldEqual, 1)
+		So(tracker.store, ShouldContainKey, trackerKey("repo", "fresh"))
+	})
+
+	Convey("Concurrent access is safe", t, func() {
+		tracker := newManifestCheckTracker(time.Hour)
+
+		var waitGroup sync.WaitGroup
+
+		for i := range 50 {
+			waitGroup.Add(2)
+
+			go func(idx int) {
+				defer waitGroup.Done()
+				tracker.MarkChecked("repo", "tag"+strconv.Itoa(idx))
+			}(i)
+
+			go func(idx int) {
+				defer waitGroup.Done()
+				tracker.ShouldCheckUpstream("repo", "tag"+strconv.Itoa(idx))
+			}(i)
+		}
+
+		waitGroup.Wait()
+
+		So(len(tracker.store), ShouldEqual, 50)
+	})
+}
+
+func TestBaseServiceShouldCheckUpstream(t *testing.T) {
+	Convey("Without manifestCheckInterval every request checks upstream", t, func() {
+		service := &BaseService{config: syncconf.RegistryConfig{}}
+
+		So(service.checkTracker, ShouldBeNil)
+		So(service.ShouldCheckUpstream("repo", "latest"), ShouldBeTrue)
+
+		Convey("Marking a check is a no-op", func() {
+			service.markUpstreamChecked("repo", "latest")
+			So(service.ShouldCheckUpstream("repo", "latest"), ShouldBeTrue)
+		})
+	})
+
+	Convey("With manifestCheckInterval a marked reference is throttled", t, func() {
+		service := &BaseService{checkTracker: newManifestCheckTracker(time.Hour)}
+
+		So(service.ShouldCheckUpstream("repo", "latest"), ShouldBeTrue)
+
+		service.markUpstreamChecked("repo", "latest")
+		So(service.ShouldCheckUpstream("repo", "latest"), ShouldBeFalse)
+	})
+
+	Convey("New wires the tracker only when the interval is configured", t, func() {
+		withInterval, err := New(syncconf.RegistryConfig{
+			URLs:                  []string{"http://localhost:9999"},
+			ManifestCheckInterval: time.Hour,
+		}, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		So(err, ShouldBeNil)
+		So(withInterval.checkTracker, ShouldNotBeNil)
+
+		withoutInterval, err := New(syncconf.RegistryConfig{
+			URLs: []string{"http://localhost:9999"},
+		}, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+		So(err, ShouldBeNil)
+		So(withoutInterval.checkTracker, ShouldBeNil)
+	})
+}
+
+func TestOnDemandShouldCheckUpstreamManifest(t *testing.T) {
+	Convey("With no services configured the check is due", t, func() {
+		onDemand := NewOnDemand(log.NewTestLogger())
+
+		So(onDemand.ShouldCheckUpstreamManifest("repo", "latest"), ShouldBeTrue)
+	})
+
+	Convey("A single service reporting a recent check is enough to serve locally", t, func() {
+		onDemand := NewOnDemand(log.NewTestLogger())
+		onDemand.Add(&mockCheckService{})
+		onDemand.Add(&mockCheckService{
+			shouldCheckUpstreamFn: func(_, _ string) bool { return false },
+		})
+
+		So(onDemand.ShouldCheckUpstreamManifest("repo", "latest"), ShouldBeFalse)
+	})
+
+	Convey("All services reporting a due check means upstream is contacted", t, func() {
+		onDemand := NewOnDemand(log.NewTestLogger())
+		onDemand.Add(&mockCheckService{})
+
+		So(onDemand.ShouldCheckUpstreamManifest("repo", "latest"), ShouldBeTrue)
 	})
 }

--- a/test/blackbox/sync.bats
+++ b/test/blackbox/sync.bats
@@ -35,12 +35,16 @@ function setup_file() {
 
     # Download test data to folder common for the entire suite, not just this file
     skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/golang:1.20 oci:${TEST_DATA_DIR}/golang:1.20
+    # A second, distinct image used to mutate an upstream tag in the manifestCheckInterval test
+    skopeo --insecure-policy copy --format=oci docker://ghcr.io/project-zot/test-images/busybox:1.36 oci:${TEST_DATA_DIR}/busybox:1.36
     # Setup zot server
     local zot_sync_per_root_dir=${BATS_FILE_TMPDIR}/zot-per
     local zot_sync_ondemand_root_dir=${BATS_FILE_TMPDIR}/zot-ondemand
+    local zot_sync_interval_root_dir=${BATS_FILE_TMPDIR}/zot-interval
 
     local zot_sync_per_config_file=${BATS_FILE_TMPDIR}/zot_sync_per_config.json
     local zot_sync_ondemand_config_file=${BATS_FILE_TMPDIR}/zot_sync_ondemand_config.json
+    local zot_sync_interval_config_file=${BATS_FILE_TMPDIR}/zot_sync_interval_config.json
 
     local zot_minimal_root_dir=${BATS_FILE_TMPDIR}/zot-minimal
     local zot_minimal_config_file=${BATS_FILE_TMPDIR}/zot_minimal_config.json
@@ -48,6 +52,7 @@ function setup_file() {
     local oci_data_dir=${BATS_FILE_TMPDIR}/oci
     mkdir -p ${zot_sync_per_root_dir}
     mkdir -p ${zot_sync_ondemand_root_dir}
+    mkdir -p ${zot_sync_interval_root_dir}
     mkdir -p ${zot_minimal_root_dir}
     mkdir -p ${oci_data_dir}
     zot_port1=$(get_free_port_for_service "zot1")
@@ -56,6 +61,8 @@ function setup_file() {
     echo ${zot_port2} > ${BATS_FILE_TMPDIR}/zot.port2
     zot_port3=$(get_free_port_for_service "zot3")
     echo ${zot_port3} > ${BATS_FILE_TMPDIR}/zot.port3
+    zot_port4=$(get_free_port_for_service "zot4")
+    echo ${zot_port4} > ${BATS_FILE_TMPDIR}/zot.port4
 
     cat >${zot_sync_per_config_file} <<EOF
 {
@@ -140,6 +147,40 @@ EOF
     }
 }
 EOF
+    cat >${zot_sync_interval_config_file} <<EOF
+{
+    "distSpecVersion": "1.1.1",
+    "storage": {
+        "rootDirectory": "${zot_sync_interval_root_dir}"
+    },
+    "http": {
+        "address": "0.0.0.0",
+        "port": "${zot_port4}"
+    },
+    "log": {
+        "level": "debug"
+    },
+    "extensions": {
+        "sync": {
+            "registries": [
+                {
+                    "urls": [
+                        "http://localhost:${zot_port3}"
+                    ],
+                    "onDemand": true,
+                    "tlsVerify": false,
+                    "manifestCheckInterval": "30s",
+                    "content": [
+                        {
+                            "prefix": "**"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+EOF
     git -C ${BATS_FILE_TMPDIR} clone https://github.com/project-zot/helm-charts.git
 
     zot_serve ${ZOT_MINIMAL_PATH} ${zot_minimal_config_file}
@@ -150,6 +191,9 @@ EOF
 
     zot_serve ${ZOT_PATH} ${zot_sync_ondemand_config_file}
     wait_zot_reachable ${zot_port2}
+
+    zot_serve ${ZOT_PATH} ${zot_sync_interval_config_file}
+    wait_zot_reachable ${zot_port4}
 }
 
 function teardown_file() {
@@ -210,6 +254,55 @@ function teardown_file() {
     run curl http://127.0.0.1:${zot_port2}/v2/golang/tags/list
     [ "$status" -eq 0 ]
     [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.20"' ]
+}
+
+# returns the manifest digest a registry serves for repo:reference on stdout
+function manifest_digest() {
+    local url=$1
+    curl -s -D - -o /dev/null \
+        -H "Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json" \
+        "${url}" | grep -i "docker-content-digest" | tr -d '\r' | awk '{print $2}'
+}
+
+# manifestCheckInterval: within the interval a locally-present manifest is served without
+# re-checking upstream, so a tag mutated upstream is only picked up after the interval elapses.
+@test "sync image ondemand honors manifestCheckInterval" {
+    zot_port3=`cat ${BATS_FILE_TMPDIR}/zot.port3`
+    zot_port4=`cat ${BATS_FILE_TMPDIR}/zot.port4`
+
+    # push image A (golang) upstream under a dedicated repo:tag
+    run skopeo --insecure-policy copy --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/golang:1.20 \
+        docker://127.0.0.1:${zot_port3}/interval-test:latest
+    [ "$status" -eq 0 ]
+
+    digest_a=$(manifest_digest http://127.0.0.1:${zot_port3}/v2/interval-test/manifests/latest)
+    [ -n "${digest_a}" ]
+
+    # first on-demand pull contacts upstream and caches image A
+    downstream_digest=$(manifest_digest http://127.0.0.1:${zot_port4}/v2/interval-test/manifests/latest)
+    [ "${downstream_digest}" = "${digest_a}" ]
+
+    # mutate upstream: overwrite the SAME tag with a different image B (busybox)
+    run skopeo --insecure-policy copy --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/busybox:1.36 \
+        docker://127.0.0.1:${zot_port3}/interval-test:latest
+    [ "$status" -eq 0 ]
+
+    digest_b=$(manifest_digest http://127.0.0.1:${zot_port3}/v2/interval-test/manifests/latest)
+    [ -n "${digest_b}" ]
+    [ "${digest_b}" != "${digest_a}" ]
+
+    # within the interval the downstream must keep serving cached image A (no upstream re-check)
+    downstream_digest=$(manifest_digest http://127.0.0.1:${zot_port4}/v2/interval-test/manifests/latest)
+    [ "${downstream_digest}" = "${digest_a}" ]
+
+    # wait for manifestCheckInterval (30s) to elapse
+    run sleep 40s
+
+    # after the interval the downstream re-checks upstream and serves the updated image B
+    downstream_digest=$(manifest_digest http://127.0.0.1:${zot_port4}/v2/interval-test/manifests/latest)
+    [ "${downstream_digest}" = "${digest_b}" ]
 }
 
 # sync index

--- a/test/ports.json
+++ b/test/ports.json
@@ -239,6 +239,10 @@
     "zot3": {
       "begin": 3060,
       "end": 3069
+    },
+    "zot4": {
+      "begin": 3080,
+      "end": 3089
     }
   },
   "scale-out/cloud_scale_out_basic_auth_tls_scale.bats": {


### PR DESCRIPTION
**What type of PR is this?**

feature

**What does this PR do / Why do we need it**:

With onDemand enabled, every request for a tag validates the manifest against upstream, because a tag is mutable. When pulls are frequent and upstream rarely changes, that is one upstream request per pull even though the image is already synced locally.

`manifestCheckInterval`, configured per registry, sets the minimum interval between upstream checks for the same repo:reference. While the interval has not elapsed since the last successful check, a locally present manifest is served without contacting upstream, making already synced images effectively local. The default of 0 keeps the current behaviour.

The last check time is kept in a map guarded by a mutex, with entries dropped lazily on lookup and swept in an amortized pass from MarkChecked, so the map stays bounded to the references seen within the interval without a background goroutine to own and shut down.

Periodic sync always checks upstream and only refreshes the timestamp, and requests by digest are unaffected since a locally present digest is already served without a sync.

For simplicity, the manifest interval is implemented per instance with simply a map in memory, so this feature will add a litter overhead to memory usage if enabled.

**Testing done on this change**:

First, we set up a sync with DockerHub and set its `manifestCheckInterval` to `1m`:
```
    registries:
      # ── Docker Hub ──
      - urls: ["https://registry-1.docker.io"]
        onDemand: true
        preserveDigest: true
        tlsVerify: true
        manifestCheckInterval: "1m"
        content:
          - prefix: "**"
```

Second, we pulled a specific image tag, one after another, waited over 1 minute, then one after another. The logs:

a. First request, Zot checked the remote manifest:
```
{"time":"2026-08-17T03:23:46.311783643Z","level":"info","message":"HTTP API","module":"http","component":"session","clientIP":"10.x.x.x:42632","method":"GET","path":"/v2/","statusCod
e":200,"latency":"0s","bodySize":0,"headers":{"Accept-Encoding":["gzip"],"Connection":["close"],"User-Agent":["docker/26.1.4 go/go1.21.11 git-commit/de5c9cf kernel/5.10.0-1.0.0.29 os/linu
x arch/amd64 UpstreamClient(Docker-Client/26.1.4 \\(linux\\))"]},"caller":"zotregistry.dev/zot/v2/pkg/api/session.go:92","func":"zotregistry.dev/zot/v2/pkg/api.SessionLogger.func1.1","gor
outine":417}
{"time":"2026-08-17T03:23:46.3299906Z","level":"info","message":"trying to get updated image by syncing on demand","repository":"ubuntu","reference":"resolute","caller":"zotregistry.dev/z
ot/v2/pkg/api/routes.go:2780","func":"zotregistry.dev/zot/v2/pkg/api.getImageManifest","goroutine":80}
{"time":"2026-08-17T03:23:46.330463624Z","level":"debug","message":"starting on-demand image sync","repo":"ubuntu","reference":"resolute","serviceID":0,"timeout":10800000000000,"caller":"
zotregistry.dev/zot/v2/pkg/extensions/sync/on_demand.go:207","func":"zotregistry.dev/zot/v2/pkg/extensions/sync.(*BaseOnDemand).syncImage","goroutine":434}
{"time":"2026-08-17T03:23:46.330649955Z","level":"info","message":"sync: syncing image","remote":"registry-1.docker.io","repo":"ubuntu","reference":"resolute","caller":"zotregistry.dev/zo
t/v2/pkg/extensions/sync/service.go:417","func":"zotregistry.dev/zot/v2/pkg/extensions/sync.(*BaseService).SyncImage","goroutine":434}
{"time":"2026-08-17T03:23:47.42325653Z","level":"debug","message":"Auth request parsed","challenge":[{}],"goroutine":434,"caller":"github.com/regclient/regclient@v0.11.5/internal/auth/aut
h.go:212","func":"github.com/regclient/regclient/internal/auth.(*Auth).HandleResponse"}
{"time":"2026-08-17T03:23:48.702226624Z","level":"info","message":"skipping image because it's already synced","image":"docker.io/library/ubuntu:resolute","caller":"zotregistry.dev/zot/v2
/pkg/extensions/sync/service.go:629","func":"zotregistry.dev/zot/v2/pkg/extensions/sync.(*BaseService).syncRef","goroutine":434}
{"time":"2026-08-17T03:23:48.702915849Z","level":"info","message":"successfully synced image","repo":"ubuntu","reference":"resolute","caller":"zotregistry.dev/zot/v2/pkg/extensions/sync/s
ervice.go:783","func":"zotregistry.dev/zot/v2/pkg/extensions/sync.(*BaseService).syncImage","goroutine":434}
{"time":"2026-08-17T03:23:48.904184369Z","level":"info","message":"HTTP API","module":"http","component":"session","clientIP":"10.x.x.x:42634","method":"HEAD","path":"/v2/ubuntu/mani
fests/resolute","statusCode":200,"latency":"2s","bodySize":0,"headers":{"Accept":["application/vnd.oci.image.manifest.v1+json","application/vnd.docker.distribution.manifest.v1+prettyjws",
"application/json","application/vnd.docker.distribution.manifest.v2+json","application/vnd.docker.distribution.manifest.list.v2+json","application/vnd.oci.image.index.v1+json"],"Connectio
n":["close"],"User-Agent":["docker/26.1.4 go/go1.21.11 git-commit/de5c9cf kernel/5.10.0-1.0.0.29 os/linux arch/amd64 UpstreamClient(Docker-Client/26.1.4 \\(linux\\))"]},"caller":"zotregis
try.dev/zot/v2/pkg/api/session.go:92","func":"zotregistry.dev/zot/v2/pkg/api.SessionLogger.func1.1","goroutine":80}
{"time":"2026-08-17T03:23:54.17737272Z","level":"info","message":"HTTP API","module":"http","component":"session","clientIP":"10.x.x.x:42708","method":"GET","path":"/v2/","statusCode
":200,"latency":"0s","bodySize":0,"headers":{"Accept-Encoding":["gzip"],"Connection":["close"],"User-Agent":["docker/26.1.4 go/go1.21.11 git-commit/de5c9cf kernel/5.10.0-1.0.0.29 os/linux
 arch/amd64 UpstreamClient(Docker-Client/26.1.4 \\(linux\\))"]},"caller":"zotregistry.dev/zot/v2/pkg/api/session.go:92","func":"zotregistry.dev/zot/v2/pkg/api.SessionLogger.func1.1","goro
utine":491}
```

b. Second request a few seconds later, Zot didn't check the remote and gave an instant response:
```
{"time":"2026-08-17T03:23:54.398384939Z","level":"debug","message":"manifest check interval has not elapsed, serving local manifest","repository":"ubuntu","reference":"resolute","caller":
"zotregistry.dev/zot/v2/pkg/api/routes.go:2773","func":"zotregistry.dev/zot/v2/pkg/api.getImageManifest","goroutine":493}
{"time":"2026-08-17T03:23:54.398856394Z","level":"info","message":"HTTP API","module":"http","component":"session","clientIP":"10.x.x.x:42710","method":"HEAD","path":"/v2/ubuntu/mani
fests/resolute","statusCode":200,"latency":"0s","bodySize":0,"headers":{"Accept":["application/vnd.docker.distribution.manifest.list.v2+json","application/vnd.oci.image.index.v1+json","ap
plication/vnd.oci.image.manifest.v1+json","application/vnd.docker.distribution.manifest.v1+prettyjws","application/json","application/vnd.docker.distribution.manifest.v2+json"],"Connectio
n":["close"],"User-Agent":["docker/26.1.4 go/go1.21.11 git-commit/de5c9cf kernel/5.10.0-1.0.0.29 os/linux arch/amd64 UpstreamClient(Docker-Client/26.1.4 \\(linux\\))"]},"caller":"zotregis
try.dev/zot/v2/pkg/api/session.go:92","func":"zotregistry.dev/zot/v2/pkg/api.SessionLogger.func1.1","goroutine":493}
```

c. Minutes later with the same request, Zot checked the remote manifest:
```
{"time":"2026-08-17T03:26:18.590518966Z","level":"info","message":"HTTP API","module":"http","component":"session","clientIP":"10.x.x.x:43792","method":"GET","path":"/v2/","statusCode":200,"latency":"0s","bodySize":0,"headers":{"Accept-Encoding":["gzip"],"Connection":["close"],"User-Agent":["docker/26.1.4 go/go1.21.11 git-commit/de5c9cf kernel/5.10.0-1.0.0.29 os/linux arch/amd64 UpstreamClient(Docker-Client/26.1.4 \\(linux\\))"]},"caller":"zotregistry.dev/zot/v2/pkg/api/session.go:92","func":"zotregistry.dev/zot/v2/pkg/api.SessionLogger.func1.1","goroutine":188}
{"time":"2026-08-17T03:26:18.610095584Z","level":"info","message":"trying to get updated image by syncing on demand","repository":"ubuntu","reference":"resolute","caller":"zotregistry.dev/zot/v2/pkg/api/routes.go:2780","func":"zotregistry.dev/zot/v2/pkg/api.getImageManifest","goroutine":190}
{"time":"2026-08-17T03:26:18.610485613Z","level":"debug","message":"starting on-demand image sync","repo":"ubuntu","reference":"resolute","serviceID":0,"timeout":10800000000000,"caller":"zotregistry.dev/zot/v2/pkg/extensions/sync/on_demand.go:207","func":"zotregistry.dev/zot/v2/pkg/extensions/sync.(*BaseOnDemand).syncImage","goroutine":192}
{"time":"2026-08-17T03:26:18.610669889Z","level":"info","message":"sync: syncing image","remote":"registry-1.docker.io","repo":"ubuntu","reference":"resolute","caller":"zotregistry.dev/zot/v2/pkg/extensions/sync/service.go:417","func":"zotregistry.dev/zot/v2/pkg/extensions/sync.(*BaseService).SyncImage","goroutine":192}
{"time":"2026-08-17T03:26:19.935204054Z","level":"info","message":"skipping image because it's already synced","image":"docker.io/library/ubuntu:resolute","caller":"zotregistry.dev/zot/v2/pkg/extensions/sync/service.go:629","func":"zotregistry.dev/zot/v2/pkg/extensions/sync.(*BaseService).syncRef","goroutine":192}
{"time":"2026-08-17T03:26:19.935915837Z","level":"info","message":"successfully synced image","repo":"ubuntu","reference":"resolute","caller":"zotregistry.dev/zot/v2/pkg/extensions/sync/service.go:783","func":"zotregistry.dev/zot/v2/pkg/extensions/sync.(*BaseService).syncImage","goroutine":192}
{"time":"2026-08-17T03:26:20.142378361Z","level":"info","message":"HTTP API","module":"http","component":"session","clientIP":"10.x.x.x:43794","method":"HEAD","path":"/v2/ubuntu/manifests/resolute","statusCode":200,"latency":"1s","bodySize":0,"headers":{"Accept":["application/json","application/vnd.docker.distribution.manifest.v2+json","application/vnd.docker.distribution.manifest.list.v2+json","application/vnd.oci.image.index.v1+json","application/vnd.oci.image.manifest.v1+json","application/vnd.docker.distribution.manifest.v1+prettyjws"],"Connection":["close"],"User-Agent":["docker/26.1.4 go/go1.21.11 git-commit/de5c9cf kernel/5.10.0-1.0.0.29 os/linux arch/amd64 UpstreamClient(Docker-Client/26.1.4 \\(linux\\))"]},"caller":"zotregistry.dev/zot/v2/pkg/api/session.go:92","func":"zotregistry.dev/zot/v2/pkg/api.SessionLogger.func1.1","goroutine":190}
```

d. Then a subsequent request, Zot gave instance response:
```
{"time":"2026-08-17T03:26:33.800228136Z","level":"info","message":"HTTP API","module":"http","component":"session","clientIP":"10.x.x.x:44020","method":"GET","path":"/v2/","statusCode":200,"latency":"0s","bodySize":0,"headers":{"Accept-Encoding":["gzip"],"Connection":["close"],"User-Agent":["docker/26.1.4 go/go1.21.11 git-commit/de5c9cf kernel/5.10.0-1.0.0.29 os/linux arch/amd64 UpstreamClient(Docker-Client/26.1.4 \\(linux\\))"]},"caller":"zotregistry.dev/zot/v2/pkg/api/session.go:92","func":"zotregistry.dev/zot/v2/pkg/api.SessionLogger.func1.1","goroutine":577}
{"time":"2026-08-17T03:26:34.013681747Z","level":"debug","message":"manifest check interval has not elapsed, serving local manifest","repository":"ubuntu","reference":"resolute","caller":"zotregistry.dev/zot/v2/pkg/api/routes.go:2773","func":"zotregistry.dev/zot/v2/pkg/api.getImageManifest","goroutine":543}
{"time":"2026-08-17T03:26:34.014097666Z","level":"info","message":"HTTP API","module":"http","component":"session","clientIP":"10.x.x.x:44022","method":"HEAD","path":"/v2/ubuntu/manifests/resolute","statusCode":200,"latency":"0s","bodySize":0,"headers":{"Accept":["application/vnd.docker.distribution.manifest.list.v2+json","application/vnd.oci.image.index.v1+json","application/vnd.oci.image.manifest.v1+json","application/vnd.docker.distribution.manifest.v1+prettyjws","application/json","application/vnd.docker.distribution.manifest.v2+json"],"Connection":["close"],"User-Agent":["docker/26.1.4 go/go1.21.11 git-commit/de5c9cf kernel/5.10.0-1.0.0.29 os/linux arch/amd64 UpstreamClient(Docker-Client/26.1.4 \\(linux\\))"]},"caller":"zotregistry.dev/zot/v2/pkg/api/session.go:92","func":"zotregistry.dev/zot/v2/pkg/api.SessionLogger.func1.1","goroutine":543}
```

**Automation added to e2e**:

Added a blackbox e2e test `sync image ondemand honors manifestCheckInterval` in test/blackbox/sync.bats that verifies on-demand sync serves the cached manifest within the interval and refreshes it once the interval elapses.

**Will this break upgrades or downgrades?**

No. The default value of `manifestCheckInterval` is empty and Zot will keep its original behavior, checking for manifests on every pull request.

**Does this PR introduce any user-facing change?**:

```release-note
sync: add optional `manifestCheckInterval` per-registry config to throttle on-demand upstream manifest checks. When set (e.g. "30s") and `onDemand` is enabled, a locally-present manifest is served directly without contacting the upstream registry until the interval elapses, reducing upstream traffic. Defaults to 0 (check upstream on every request), preserving existing behavior.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
