### PR TITLE
fix(cli): stop test server leaks and initialize Trivy logger safely

### DIFF
--- a/pkg/cli/server/config_reloader.go
+++ b/pkg/cli/server/config_reloader.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 
 	"github.com/fsnotify/fsnotify"
@@ -19,6 +20,9 @@ type HotReloader struct {
 	ldapCredentialsPath string
 	ctlr                *api.Controller
 	logger              log.Logger
+
+	done     chan struct{}
+	stopOnce sync.Once
 }
 
 func NewHotReloader(ctlr *api.Controller, filePath, ldapCredentialsPath string) (*HotReloader, error) {
@@ -34,25 +38,27 @@ func NewHotReloader(ctlr *api.Controller, filePath, ldapCredentialsPath string) 
 		ldapCredentialsPath: ldapCredentialsPath,
 		ctlr:                ctlr,
 		logger:              log.NewLogger("info", ""),
+		done:                make(chan struct{}),
 	}
 
 	return hotReloader, nil
 }
 
-func signalHandler(ctlr *api.Controller, sigCh chan os.Signal) {
+func signalHandler(ctlr *api.Controller, hr *HotReloader, sigCh chan os.Signal) {
 	// if signal then shutdown
 	if sig, ok := <-sigCh; ok {
 		ctlr.Log.Info().Interface("signal", sig).Msg("received signal")
 
+		hr.Stop()
 		// gracefully shutdown http server
 		ctlr.Shutdown() //nolint: contextcheck
 	}
 }
 
-func initShutDownRoutine(ctlr *api.Controller) {
+func initShutDownRoutine(ctlr *api.Controller, hr *HotReloader) {
 	sigCh := make(chan os.Signal, 1)
 
-	go signalHandler(ctlr, sigCh)
+	go signalHandler(ctlr, hr, sigCh)
 
 	// block all async signals to this server
 	signal.Ignore()
@@ -61,9 +67,18 @@ func initShutDownRoutine(ctlr *api.Controller) {
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
 }
 
-func (hr *HotReloader) Start() {
-	done := make(chan bool)
+func (hr *HotReloader) Stop() {
+	hr.stopOnce.Do(func() {
+		if hr.done != nil {
+			close(hr.done)
+		}
+		if hr.watcher != nil {
+			_ = hr.watcher.Close()
+		}
+	})
+}
 
+func (hr *HotReloader) Start() {
 	// run watcher
 	go func() {
 		defer hr.watcher.Close()
@@ -71,8 +86,13 @@ func (hr *HotReloader) Start() {
 		go func() {
 			for {
 				select {
+				case <-hr.done:
+					return
 				// watch for events
-				case event := <-hr.watcher.Events:
+				case event, ok := <-hr.watcher.Events:
+					if !ok {
+						return
+					}
 					if event.Op == fsnotify.Write {
 						hr.logger.Info().Msg("config file changed, trying to reload config")
 
@@ -110,7 +130,10 @@ func (hr *HotReloader) Start() {
 						hr.ctlr.StartBackgroundTasks()
 					}
 				// watch for errors
-				case err := <-hr.watcher.Errors:
+				case err, ok := <-hr.watcher.Errors:
+					if !ok {
+						return
+					}
 					hr.logger.Panic().Err(err).Str("config", hr.configPath).Msg("fsnotfy error while watching config")
 				}
 			}
@@ -127,6 +150,6 @@ func (hr *HotReloader) Start() {
 			}
 		}
 
-		<-done
+		<-hr.done
 	}()
 }

--- a/pkg/cli/server/config_reloader_internal_test.go
+++ b/pkg/cli/server/config_reloader_internal_test.go
@@ -1,0 +1,141 @@
+package server //nolint:testpackage // white-box tests for unexported signalHandler and watcher close
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/api"
+	"zotregistry.dev/zot/v2/pkg/api/config"
+)
+
+func TestHotReloaderStop(t *testing.T) {
+	Convey("Stop is safe with nil done and watcher", t, func() {
+		reloader := &HotReloader{}
+		So(func() { reloader.Stop() }, ShouldNotPanic)
+		So(func() { reloader.Stop() }, ShouldNotPanic)
+	})
+
+	Convey("SIGTERM stops the reloader and shuts down the controller", t, func() {
+		reloader := newTestHotReloader(t)
+		reloader.Start()
+		So(waitForWatch(reloader, 2*time.Second), ShouldBeTrue)
+
+		sigCh := make(chan os.Signal, 1)
+		finished := make(chan struct{})
+
+		go func() {
+			signalHandler(reloader.ctlr, reloader, sigCh)
+			close(finished)
+		}()
+
+		sigCh <- syscall.SIGTERM
+		So(waitChan(finished, 2*time.Second), ShouldBeTrue)
+		So(isClosed(reloader.done), ShouldBeTrue)
+	})
+
+	Convey("closed signal channel returns without stopping the reloader", t, func() {
+		reloader := newTestHotReloader(t)
+		t.Cleanup(reloader.Stop)
+
+		sigCh := make(chan os.Signal)
+		finished := make(chan struct{})
+
+		go func() {
+			signalHandler(reloader.ctlr, reloader, sigCh)
+			close(finished)
+		}()
+
+		close(sigCh)
+		So(waitChan(finished, 2*time.Second), ShouldBeTrue)
+		So(isClosed(reloader.done), ShouldBeFalse)
+	})
+
+	Convey("closed watcher events channel exits the watch loop", t, func() {
+		reloader := newTestHotReloader(t)
+		// Block the Errors case so select must take Events once the watcher is closed.
+		reloader.watcher.Errors = nil
+		startReloaderAndCloseWatcher(t, reloader)
+	})
+
+	Convey("closed watcher errors channel exits the watch loop", t, func() {
+		reloader := newTestHotReloader(t)
+		// Block the Events case so select must take Errors once the watcher is closed.
+		reloader.watcher.Events = nil
+		startReloaderAndCloseWatcher(t, reloader)
+	})
+}
+
+func testServerConfig(t *testing.T) *config.Config {
+	t.Helper()
+
+	conf := config.New()
+	conf.HTTP.Address = "127.0.0.1"
+	conf.HTTP.Port = "0"
+	conf.Storage.RootDirectory = t.TempDir()
+
+	return conf
+}
+
+func newTestHotReloader(t *testing.T) *HotReloader {
+	t.Helper()
+
+	configPath := filepath.Join(t.TempDir(), "zot.json")
+	err := os.WriteFile(configPath, []byte(`{}`), 0o600)
+	So(err, ShouldBeNil)
+
+	reloader, err := NewHotReloader(api.NewController(testServerConfig(t)), configPath, "")
+	So(err, ShouldBeNil)
+
+	return reloader
+}
+
+func startReloaderAndCloseWatcher(t *testing.T, reloader *HotReloader) {
+	t.Helper()
+
+	reloader.Start()
+	So(waitForWatch(reloader, 2*time.Second), ShouldBeTrue)
+
+	err := reloader.watcher.Close()
+	So(err, ShouldBeNil)
+
+	// Let the watch loop observe the closed channel before Stop() also unblocks <-done.
+	time.Sleep(100 * time.Millisecond)
+	reloader.Stop()
+}
+
+func waitForWatch(reloader *HotReloader, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+
+	for time.Now().Before(deadline) {
+		if len(reloader.watcher.WatchList()) > 0 {
+			return true
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	return false
+}
+
+func waitChan(done <-chan struct{}, timeout time.Duration) bool {
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
+func isClosed(done <-chan struct{}) bool {
+	select {
+	case <-done:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/cli/server/config_reloader_test.go
+++ b/pkg/cli/server/config_reloader_test.go
@@ -11,16 +11,11 @@ import (
 
 	. "github.com/smartystreets/goconvey/convey"
 
-	cli "zotregistry.dev/zot/v2/pkg/cli/server"
 	test "zotregistry.dev/zot/v2/pkg/test/common"
 )
 
 func TestConfigReloader(t *testing.T) {
-	oldArgs := os.Args
-
-	defer func() { os.Args = oldArgs }()
-
-	Convey("reload access control config", t, func(conveyCtx C) {
+	Convey("reload access control config", t, func() {
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		username := "alice"
@@ -72,15 +67,7 @@ func TestConfigReloader(t *testing.T) {
 		_, err := cfgfile.WriteString(content)
 		So(err, ShouldBeNil)
 
-		os.Args = []string{"cli_test", "serve", cfgfile.Name()}
-
-		go func() {
-			err = cli.NewServerRootCmd().Execute()
-			conveyCtx.So(err, ShouldBeNil)
-		}()
-
-		baseURL := test.WaitForKernelChosenPortBaseURL(logPath)
-		test.WaitTillServerReady(baseURL)
+		So(startServerFromConfigFile(t, cfgfile.Name()), ShouldBeNil)
 
 		// verify initial startup authentication logs
 		initialData, err := os.ReadFile(logPath)
@@ -171,7 +158,7 @@ func TestConfigReloader(t *testing.T) {
 		})
 	})
 
-	Convey("reload gc config", t, func(ctx C) {
+	Convey("reload gc config", t, func() {
 		logFile := test.MakeTempFile(t, "zot-log.txt")
 		defer logFile.Close()
 
@@ -205,15 +192,7 @@ func TestConfigReloader(t *testing.T) {
 		_, err := cfgfile.WriteString(content)
 		So(err, ShouldBeNil)
 
-		os.Args = []string{"cli_test", "serve", cfgfile.Name()}
-
-		go func() {
-			err = cli.NewServerRootCmd().Execute()
-			ctx.So(err, ShouldBeNil)
-		}()
-
-		baseURL := test.WaitForKernelChosenPortBaseURL(logFile.Name())
-		test.WaitTillServerReady(baseURL)
+		So(startServerFromConfigFile(t, cfgfile.Name()), ShouldBeNil)
 
 		// verify initial startup authentication logs (no auth configured)
 		initialData, err := os.ReadFile(logFile.Name())
@@ -296,7 +275,7 @@ func TestConfigReloader(t *testing.T) {
 		})
 	})
 
-	Convey("reload sync config", t, func(ctx C) {
+	Convey("reload sync config", t, func() {
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		content := fmt.Sprintf(`{
@@ -341,15 +320,7 @@ func TestConfigReloader(t *testing.T) {
 		_, err := cfgfile.WriteString(content)
 		So(err, ShouldBeNil)
 
-		os.Args = []string{"cli_test", "serve", cfgfile.Name()}
-
-		go func() {
-			err = cli.NewServerRootCmd().Execute()
-			ctx.So(err, ShouldBeNil)
-		}()
-
-		baseURL := test.WaitForKernelChosenPortBaseURL(logPath)
-		test.WaitTillServerReady(baseURL)
+		So(startServerFromConfigFile(t, cfgfile.Name()), ShouldBeNil)
 
 		// verify initial startup authentication logs (no auth configured)
 		initialData, err := os.ReadFile(logPath)
@@ -444,7 +415,7 @@ func TestConfigReloader(t *testing.T) {
 		})
 	})
 
-	Convey("reload scrub and CVE config", t, func(ctx C) {
+	Convey("reload scrub and CVE config", t, func() {
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		content := fmt.Sprintf(`{
@@ -482,15 +453,7 @@ func TestConfigReloader(t *testing.T) {
 		_, err := cfgfile.WriteString(content)
 		So(err, ShouldBeNil)
 
-		os.Args = []string{"cli_test", "serve", cfgfile.Name()}
-
-		go func() {
-			err = cli.NewServerRootCmd().Execute()
-			ctx.So(err, ShouldBeNil)
-		}()
-
-		baseURL := test.WaitForKernelChosenPortBaseURL(logPath)
-		test.WaitTillServerReady(baseURL)
+		So(startServerFromConfigFile(t, cfgfile.Name()), ShouldBeNil)
 
 		// verify initial startup authentication logs (no auth configured)
 		initialData, err := os.ReadFile(logPath)
@@ -583,7 +546,7 @@ func TestConfigReloader(t *testing.T) {
 		So(found, ShouldBeTrue)
 	})
 
-	Convey("reload bad config", t, func(conveyCtx C) {
+	Convey("reload bad config", t, func() {
 		logPath := test.MakeTempFilePath(t, "zot-log.txt")
 
 		content := fmt.Sprintf(`{
@@ -628,15 +591,7 @@ func TestConfigReloader(t *testing.T) {
 		_, err := cfgfile.WriteString(content)
 		So(err, ShouldBeNil)
 
-		os.Args = []string{"cli_test", "serve", cfgfile.Name()}
-
-		go func() {
-			err = cli.NewServerRootCmd().Execute()
-			conveyCtx.So(err, ShouldBeNil)
-		}()
-
-		baseURL := test.WaitForKernelChosenPortBaseURL(logPath)
-		test.WaitTillServerReady(baseURL)
+		So(startServerFromConfigFile(t, cfgfile.Name()), ShouldBeNil)
 
 		content = "[]"
 

--- a/pkg/cli/server/extensions_test.go
+++ b/pkg/cli/server/extensions_test.go
@@ -317,11 +317,7 @@ func TestServeExtensions(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	Convey("config file with no extensions", t, func(c C) {
-		logPath := MakeTempFilePath(t, "zot-log.txt")
-
-		tmpFile := t.TempDir()
-
-		content := fmt.Sprintf(`{
+		content := `{
 			"storage": {
 				"rootDirectory": "%s"
 			},
@@ -333,21 +329,10 @@ func TestServeExtensions(t *testing.T) {
 				"level": "debug",
 				"output": "%s"
 			}
-		}`, tmpFile, logPath)
+		}`
 
-		cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
-
-		os.Args = []string{"cli_test", "serve", cfgfile}
-
-		go func() {
-			Convey("run", t, func() {
-				err := cli.NewServerRootCmd().Execute()
-				So(err, ShouldBeNil)
-			})
-		}()
-
-		baseURL := WaitForKernelChosenPortBaseURL(logPath)
-		WaitTillServerReady(baseURL)
+		logPath, _, err := runCLIWithConfig(t, content)
+		So(err, ShouldBeNil)
 
 		data, err := os.ReadFile(logPath)
 
@@ -356,11 +341,7 @@ func TestServeExtensions(t *testing.T) {
 	})
 
 	Convey("config file with empty extensions", t, func(c C) {
-		logPath := MakeTempFilePath(t, "zot-log.txt")
-
-		tmpFile := t.TempDir()
-
-		content := fmt.Sprintf(`{
+		content := `{
 			"storage": {
 				"rootDirectory": "%s"
 			},
@@ -374,21 +355,11 @@ func TestServeExtensions(t *testing.T) {
 			},
 			"extensions": {
 			}
-		}`, tmpFile, logPath)
+		}`
 
-		cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
+		logPath, _, err := runCLIWithConfig(t, content)
+		So(err, ShouldBeNil)
 
-		os.Args = []string{"cli_test", "serve", cfgfile}
-
-		go func() {
-			Convey("run", t, func() {
-				err := cli.NewServerRootCmd().Execute()
-				So(err, ShouldBeNil)
-			})
-		}()
-
-		baseURL := WaitForKernelChosenPortBaseURL(logPath)
-		WaitTillServerReady(baseURL)
 		data, err := os.ReadFile(logPath)
 		So(err, ShouldBeNil)
 		So(string(data), ShouldContainSubstring,
@@ -396,24 +367,13 @@ func TestServeExtensions(t *testing.T) {
 	})
 }
 
-func testWithMetricsEnabled(t *testing.T, rootDir string, cfgContentFormat string) {
+func testWithMetricsEnabled(t *testing.T, cfgContentFormat string) {
 	t.Helper()
-	logPath := MakeTempFilePath(t, "zot-log.txt")
 
-	content := fmt.Sprintf(cfgContentFormat, rootDir, logPath)
-	cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
-
-	os.Args = []string{"cli_test", "serve", cfgfile}
-
-	go func() {
-		Convey("run", t, func() {
-			err := cli.NewServerRootCmd().Execute()
-			So(err, ShouldBeNil)
-		})
-	}()
+	logPath, _, err := runCLIWithConfig(t, cfgContentFormat)
+	So(err, ShouldBeNil)
 
 	baseURL := WaitForKernelChosenPortBaseURL(logPath)
-	WaitTillServerReady(baseURL)
 
 	resp, err := resty.R().Get(baseURL + "/metrics")
 	So(err, ShouldBeNil)
@@ -435,8 +395,6 @@ func TestServeMetricsExtension(t *testing.T) {
 	defer func() { os.Args = oldArgs }()
 
 	Convey("no explicit enable", t, func(c C) {
-		tmpFile := t.TempDir()
-
 		content := `{
 			"storage": {
 				"rootDirectory": "%s"
@@ -454,12 +412,10 @@ func TestServeMetricsExtension(t *testing.T) {
 				}
 			}
 		}`
-		testWithMetricsEnabled(t, tmpFile, content)
+		testWithMetricsEnabled(t, content)
 	})
 
 	Convey("no explicit enable but with prometheus parameter", t, func(c C) {
-		tmpFile := t.TempDir()
-
 		content := `{
 			"storage": {
 				"rootDirectory": "%s"
@@ -480,12 +436,10 @@ func TestServeMetricsExtension(t *testing.T) {
 				}
 			}
 		}`
-		testWithMetricsEnabled(t, tmpFile, content)
+		testWithMetricsEnabled(t, content)
 	})
 
 	Convey("with explicit enable, but without prometheus parameter", t, func(c C) {
-		tmpFile := t.TempDir()
-
 		content := `{
 			"storage": {
 				"rootDirectory": "%s"
@@ -504,15 +458,11 @@ func TestServeMetricsExtension(t *testing.T) {
 				}
 			}
 		}`
-		testWithMetricsEnabled(t, tmpFile, content)
+		testWithMetricsEnabled(t, content)
 	})
 
 	Convey("with explicit disable", t, func(c C) {
-		logPath := MakeTempFilePath(t, "zot-log.txt")
-
-		tmpFile := t.TempDir()
-
-		content := fmt.Sprintf(`{
+		content := `{
 					"storage": {
 						"rootDirectory": "%s"
 					},
@@ -529,21 +479,12 @@ func TestServeMetricsExtension(t *testing.T) {
 							"enable": false
 						}
 					}
-				}`, tmpFile, logPath)
+				}`
 
-		cfgfile := MakeTempFileWithContent(t, "zot-test.json", content)
-
-		os.Args = []string{"cli_test", "serve", cfgfile}
-
-		go func() {
-			Convey("run", t, func() {
-				err := cli.NewServerRootCmd().Execute()
-				So(err, ShouldBeNil)
-			})
-		}()
+		logPath, _, err := runCLIWithConfig(t, content)
+		So(err, ShouldBeNil)
 
 		baseURL := WaitForKernelChosenPortBaseURL(logPath)
-		WaitTillServerReady(baseURL)
 
 		resp, err := resty.R().Get(baseURL + "/metrics")
 		So(err, ShouldBeNil)
@@ -1736,8 +1677,8 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 
 		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
-		os.Args = []string{"cli_test", "serve", tmpfile}
-		err := cli.NewServerRootCmd().Execute()
+		conf := config.New()
+		err := cli.LoadConfiguration(conf, tmpfile)
 		So(err, ShouldNotBeNil)
 
 		data, err := os.ReadFile(logPath)
@@ -1800,8 +1741,8 @@ func TestSyncWithRemoteStorageConfig(t *testing.T) {
 
 		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
 
-		os.Args = []string{"cli_test", "serve", tmpfile}
-		err := cli.NewServerRootCmd().Execute()
+		conf := config.New()
+		err := cli.LoadConfiguration(conf, tmpfile)
 		So(err, ShouldNotBeNil)
 
 		data, err := os.ReadFile(logPath)

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -84,30 +84,14 @@ func newServeCmd(conf *config.Config) *cobra.Command {
 				conf.Storage.FastRestart = &disable
 			}
 
-			ctlr := api.NewController(conf)
-
-			ldapCredentials := ""
-
-			if conf.HTTP.Auth != nil && conf.HTTP.Auth.LDAP != nil {
-				ldapCredentials = conf.HTTP.Auth.LDAP.CredentialsFile
-			}
-			// config reloader
-			hotReloader, err := NewHotReloader(ctlr, args[0], ldapCredentials)
+			ctlr, hotReloader, err := InitController(conf, args[0])
 			if err != nil {
-				ctlr.Log.Error().Err(err).Msg("failed to create a new hot reloader")
-
 				return err
 			}
 
-			hotReloader.Start()
+			defer hotReloader.Stop()
 
-			if err := ctlr.Init(); err != nil {
-				ctlr.Log.Error().Err(err).Msg("failed to init controller")
-
-				return err
-			}
-
-			initShutDownRoutine(ctlr)
+			initShutDownRoutine(ctlr, hotReloader)
 
 			if err := ctlr.Run(); err != nil {
 				logger.Error().Err(err).Msg("failed to start controller, exiting")
@@ -121,6 +105,37 @@ func newServeCmd(conf *config.Config) *cobra.Command {
 		"force a full storage->metaDB reparse on startup, ignoring the fast-restart stamp")
 
 	return serveCmd
+}
+
+// InitController creates a controller, initializes it, then starts the config hot-reloader.
+// On init failure it shuts down the controller and stops the reloader before returning.
+// After a successful return the caller must stop both the controller and the hot reloader.
+func InitController(conf *config.Config, configPath string) (*api.Controller, *HotReloader, error) {
+	ctlr := api.NewController(conf)
+
+	ldapCredentials := ""
+	if conf.HTTP.Auth != nil && conf.HTTP.Auth.LDAP != nil {
+		ldapCredentials = conf.HTTP.Auth.LDAP.CredentialsFile
+	}
+
+	hotReloader, err := NewHotReloader(ctlr, configPath, ldapCredentials)
+	if err != nil {
+		ctlr.Log.Error().Err(err).Msg("failed to create a new hot reloader")
+
+		return nil, nil, err
+	}
+
+	if err := ctlr.Init(); err != nil {
+		hotReloader.Stop()
+		ctlr.Shutdown() //nolint: contextcheck
+		ctlr.Log.Error().Err(err).Msg("failed to init controller")
+
+		return nil, nil, err
+	}
+
+	hotReloader.Start()
+
+	return ctlr, hotReloader, nil
 }
 
 func newScrubCmd(conf *config.Config) *cobra.Command {

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -622,15 +623,8 @@ func TestServe(t *testing.T) {
 			contentStr := string(content)
 			tmpFile := MakeTempFileWithContent(t, "zot-test.json", contentStr)
 
-			os.Args = []string{"cli_test", "serve", tmpFile}
-
-			err := cli.NewServerRootCmd().Execute()
+			err := tryInitControllerFromConfigFile(t, tmpFile)
 			So(err, ShouldNotBeNil)
-
-			// wait for the config reloader goroutine to start watching the config file
-			// if we end the test too fast it will delete the config file
-			// which will cause a panic and mark the test run as a failure
-			time.Sleep(1 * time.Second)
 		})
 	})
 }
@@ -3384,16 +3378,14 @@ func TestUpdateLDAPConfig(t *testing.T) {
 
 		configPath := MakeTempFileWithContent(t, "config.json", configStr)
 
-		server := cli.NewServerRootCmd()
-		server.SetArgs([]string{"serve", configPath})
-		So(server.Execute(), ShouldNotBeNil)
+		err := cli.LoadConfiguration(config.New(), configPath)
+		So(err, ShouldNotBeNil)
 
-		err := os.Chmod(ldapConfigPath, 0o600)
+		err = os.Chmod(ldapConfigPath, 0o600)
 		So(err, ShouldBeNil)
 
-		server = cli.NewServerRootCmd()
-		server.SetArgs([]string{"serve", configPath})
-		So(server.Execute(), ShouldNotBeNil)
+		err = cli.LoadConfiguration(config.New(), configPath)
+		So(err, ShouldNotBeNil)
 	})
 
 	Convey("unauthenticated LDAP config", t, func() {
@@ -3560,27 +3552,56 @@ func runCLIWithConfig(t *testing.T, config string) (string, string, error) {
 
 	cfgfile := MakeTempFileWithContent(t, "zot-test.json", config)
 
-	os.Args = []string{"cli_test", "serve", cfgfile}
-
-	// Run CLI in a goroutine, but handle errors via a channel
-	errCh := make(chan error, 1)
-
-	go func() {
-		errCh <- cli.NewServerRootCmd().Execute()
-	}()
-
-	select {
-	case err := <-errCh:
-		if err != nil {
-			return "", "", err
-		}
-	case <-time.After(250 * time.Millisecond): // No startup error
+	if err := startServerFromConfigFile(t, cfgfile); err != nil {
+		return "", "", err
 	}
 
-	baseURL := WaitForKernelChosenPortBaseURL(logPath)
-	WaitTillServerReady(baseURL)
-
 	return logPath, rootDir, nil
+}
+
+// tryInitControllerFromConfigFile loads config and initializes a controller without
+// starting the HTTP server. InitController shuts down partial init on failure.
+func tryInitControllerFromConfigFile(t *testing.T, cfgPath string) error {
+	t.Helper()
+
+	conf := config.New()
+	if err := cli.LoadConfiguration(conf, cfgPath); err != nil {
+		return err
+	}
+
+	_, _, err := cli.InitController(conf, cfgPath)
+
+	return err
+}
+
+// startServerFromConfigFile loads config, starts a hot-reloading controller, and
+// registers shutdown on both Convey Reset (per-case) and t.Cleanup (test end).
+func startServerFromConfigFile(t *testing.T, cfgPath string) error {
+	t.Helper()
+
+	conf := config.New()
+	if err := cli.LoadConfiguration(conf, cfgPath); err != nil {
+		return err
+	}
+
+	ctlr, hotReloader, err := cli.InitController(conf, cfgPath)
+	if err != nil {
+		return err
+	}
+
+	ctrlManager := NewControllerManager(ctlr)
+	go ctrlManager.RunServer()
+
+	stop := sync.OnceFunc(func() {
+		hotReloader.Stop()
+		ctlr.Shutdown()
+	})
+	t.Cleanup(stop)
+	Reset(stop)
+
+	ctrlManager.WaitServerReady()
+
+	return nil
 }
 
 func TestRetentionDelayDefaults(t *testing.T) {

--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"maps"
 	"os"
 	"path"
@@ -22,6 +23,7 @@ import (
 	fanalTypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	"github.com/aquasecurity/trivy/pkg/javadb"
+	trivylog "github.com/aquasecurity/trivy/pkg/log"
 	"github.com/aquasecurity/trivy/pkg/types"
 	xos "github.com/aquasecurity/trivy/pkg/x/os"
 	xstrings "github.com/aquasecurity/trivy/pkg/x/strings"
@@ -54,6 +56,27 @@ const (
 	cycloneDXArtifactType     = "application/vnd.cyclonedx+json"
 	cycloneDXLayerMediaType   = "application/vnd.cyclonedx+json"
 )
+
+var initTrivyLoggerOnce sync.Once //nolint: gochecknoglobals // trivylog.SetDefault modifies slog.Default()
+
+func initTrivyLogger(logger log.Logger) {
+	initTrivyLoggerOnce.Do(func() {
+		// Trivy CLI InitLogger (after flags) installs a ColorHandler on slog.Default()
+		// (stderr, not JSON). As a library, attach zot's handler so Trivy follows zot's
+		// level/format/output, and replace trivy's non-thread-safe DeferredHandler, which
+		// data-races when scanners log concurrently. trivylog.SetDefault is slog.SetDefault;
+		handler := logger.Handler()
+		oldHandler := slog.Default().Handler()
+
+		// SetDefault before Flush: Handle and Flush share an unlocked buffer;
+		// afterwards new slog.Default() calls no longer append to it.
+		trivylog.SetDefault(trivylog.New(handler))
+
+		if deferred, ok := oldHandler.(*trivylog.DeferredHandler); ok {
+			deferred.Flush(handler)
+		}
+	})
+}
 
 var errImageStoreNotFound = errors.New("image store not found")
 
@@ -144,6 +167,8 @@ type generatedSBOM struct {
 func NewScanner(storeController storage.StoreController,
 	metaDB mTypes.MetaDB, cveConfig *extconf.CVEConfig, log log.Logger,
 ) *Scanner {
+	initTrivyLogger(log)
+
 	var trivyCfg *extconf.TrivyConfig
 	if cveConfig != nil && cveConfig.Trivy != nil {
 		trivyCfg = cveConfig.Trivy


### PR DESCRIPTION
Make HotReloader stoppable, shut down CLI test servers after each case, and route Trivy logs through zot's slog handler to avoid DeferredHandler data races.

This is to fix the race in https://github.com/project-zot/zot/actions/runs/32109063736/job/95624416506?pr=4330

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
