### PR TITLE
fix(meta): release the repo quota slot when a repo is emptied

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -192,6 +192,11 @@ When the limit is reached, pushes that would create a new repository are
 rejected with HTTP 429. Pushes to existing repositories are always allowed.
 Setting maxRepos to 0 or omitting it disables enforcement.
 
+A repository stops counting towards the limit when it is removed from
+storage: immediately when its last manifest is deleted and no blobs or
+uploads remain, or otherwise in a garbage collection cycle once its
+remaining blobs pass the GC delay.
+
 It is also possible to store and serve images from multiple filesystems with
 their own repository paths, dedupe and garbage collection settings with:
 

--- a/pkg/api/quota_test.go
+++ b/pkg/api/quota_test.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"sync"
 	"testing"
+	"time"
 
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 	"gopkg.in/resty.v1"
 
@@ -133,6 +135,226 @@ func TestQuotaConcurrency(t *testing.T) {
 
 			So(created, ShouldBeLessThanOrEqualTo, 5)
 			So(rejected, ShouldBeGreaterThanOrEqualTo, 5)
+		})
+	})
+}
+
+// startQuotaServerAt starts a quota-enforcing registry on a given root directory, so a test can restart
+// the server over the same storage.
+func startQuotaServerAt(t *testing.T, maxRepos int, rootDir string, gc bool) (string, func()) {
+	t.Helper()
+
+	conf := config.New()
+	conf.HTTP.Port = "0"
+	conf.Storage.RootDirectory = rootDir
+	conf.Storage.MaxRepos = maxRepos
+	// Dedupe keeps its cache open past Shutdown, blocking a restart on the same dir.
+	conf.Storage.Dedupe = false
+
+	if gc {
+		conf.Storage.GC = true
+		conf.Storage.GCDelay = 1 * time.Second
+		conf.Storage.GCInterval = 2 * time.Second
+	}
+
+	ctlr := api.NewController(conf)
+	ctlrManager := test.NewControllerManager(ctlr)
+	baseURL := ctlrManager.StartAndWait()
+
+	return baseURL, func() { ctlrManager.StopServer() }
+}
+
+func manifestDigest(t *testing.T, baseURL, repo, ref string) string {
+	t.Helper()
+
+	resp, err := resty.R().
+		SetHeader("Accept", ispec.MediaTypeImageManifest).
+		Get(baseURL + "/v2/" + repo + "/manifests/" + ref)
+	So(err, ShouldBeNil)
+
+	return resp.Header().Get("Docker-Content-Digest")
+}
+
+// uploadNewRepo pushes a complete image into a new repo.
+func uploadNewRepo(t *testing.T, baseURL, repo string) error {
+	t.Helper()
+
+	return UploadImage(CreateRandomImage(), baseURL, repo, "v1")
+}
+
+// catalogRepos lists the repositories the catalog currently reports.
+func catalogRepos(t *testing.T, baseURL string) []string {
+	t.Helper()
+
+	resp, err := resty.R().Get(baseURL + "/v2/_catalog")
+	So(err, ShouldBeNil)
+	So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+	var catalog struct {
+		Repositories []string `json:"repositories"`
+	}
+
+	So(json.Unmarshal(resp.Body(), &catalog), ShouldBeNil)
+
+	return catalog.Repositories
+}
+
+// pushNewRepoStatus reports how the quota answers a new-repo push. Only a refusal is meaningful: the
+// manifest is sent without blobs, so an allowed push fails later in the handler. Use uploadNewRepo to
+// assert acceptance.
+func pushNewRepoStatus(t *testing.T, baseURL, repo string) int {
+	t.Helper()
+
+	img := CreateRandomImage()
+
+	manifestBody, err := json.Marshal(img.Manifest)
+	So(err, ShouldBeNil)
+
+	resp, err := resty.R().
+		SetHeader("Content-Type", ispec.MediaTypeImageManifest).
+		SetBody(manifestBody).
+		Put(baseURL + "/v2/" + repo + "/manifests/v1")
+	So(err, ShouldBeNil)
+
+	return resp.StatusCode()
+}
+
+// TestQuotaSlotReleasedOnDelete checks that a partial delete keeps the slot, a full delete releases it,
+// and the remaining images stay pullable.
+func TestQuotaSlotReleasedOnDelete(t *testing.T) {
+	Convey("Given a registry at its repo limit", t, func() {
+		rootDir := t.TempDir()
+		baseURL, stop := startQuotaServerAt(t, 3, rootDir, false)
+		defer stop()
+
+		first := CreateRandomImage()
+		second := CreateRandomImage()
+
+		So(UploadImage(first, baseURL, "shared", "v1"), ShouldBeNil)
+		So(UploadImage(second, baseURL, "shared", "v2"), ShouldBeNil)
+		So(UploadImage(CreateRandomImage(), baseURL, "second", "v1"), ShouldBeNil)
+		So(UploadImage(CreateRandomImage(), baseURL, "third", "v1"), ShouldBeNil)
+
+		So(pushNewRepoStatus(t, baseURL, "overflow"), ShouldEqual, http.StatusTooManyRequests)
+
+		Convey("Deleting one tag of a two-tag repo releases nothing", func() {
+			resp, err := resty.R().Delete(baseURL + "/v2/shared/manifests/" + first.DigestStr())
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+			// The sibling tag is untouched, and still serves the same bytes.
+			So(manifestDigest(t, baseURL, "shared", "v2"), ShouldEqual, second.DigestStr())
+
+			// The repo still holds content, so it still holds its slot.
+			So(pushNewRepoStatus(t, baseURL, "overflow"), ShouldEqual, http.StatusTooManyRequests)
+
+			Convey("Deleting the last tag releases the slot, and the name is reusable", func() {
+				resp, err := resty.R().Delete(baseURL + "/v2/shared/manifests/" + second.DigestStr())
+				So(err, ShouldBeNil)
+				So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+				// The layout goes with the meta record, so the catalog and the quota
+				// count cannot diverge.
+				So(catalogRepos(t, baseURL), ShouldNotContain, "shared")
+
+				Convey("A differently named repo can take the freed slot", func() {
+					So(uploadNewRepo(t, baseURL, "afterfree"), ShouldBeNil)
+				})
+
+				Convey("The emptied name can be reused, and round-trips intact", func() {
+					reused := CreateRandomImage()
+					So(UploadImage(reused, baseURL, "shared", "again"), ShouldBeNil)
+					So(manifestDigest(t, baseURL, "shared", "again"), ShouldEqual, reused.DigestStr())
+				})
+			})
+		})
+	})
+}
+
+// TestQuotaSlotStaysReleasedAcrossRestart checks the startup reparse does not hand back a slot that a
+// delete released.
+func TestQuotaSlotStaysReleasedAcrossRestart(t *testing.T) {
+	Convey("Given a repo emptied while at the limit", t, func() {
+		rootDir := t.TempDir()
+		baseURL, stop := startQuotaServerAt(t, 2, rootDir, false)
+
+		doomed := CreateRandomImage()
+		keeper := CreateRandomImage()
+
+		So(UploadImage(doomed, baseURL, "doomed", "v1"), ShouldBeNil)
+		So(UploadImage(keeper, baseURL, "keeper", "v1"), ShouldBeNil)
+		So(pushNewRepoStatus(t, baseURL, "extra"), ShouldEqual, http.StatusTooManyRequests)
+
+		resp, err := resty.R().Delete(baseURL + "/v2/doomed/manifests/" + doomed.DigestStr())
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+		stop()
+
+		Convey("The slot is still free after a restart, and the survivor is intact", func() {
+			restartedURL, stopAgain := startQuotaServerAt(t, 2, rootDir, false)
+			defer stopAgain()
+
+			So(manifestDigest(t, restartedURL, "keeper", "v1"), ShouldEqual, keeper.DigestStr())
+			So(uploadNewRepo(t, restartedURL, "extra"), ShouldBeNil)
+		})
+	})
+}
+
+// TestQuotaSlotReleaseWithGCEnabled runs the release path with GC active, since GC also writes to
+// metadata.
+func TestQuotaSlotReleaseWithGCEnabled(t *testing.T) {
+	Convey("Given a registry with GC enabled and at its limit", t, func() {
+		rootDir := t.TempDir()
+		baseURL, stop := startQuotaServerAt(t, 2, rootDir, true)
+		defer stop()
+
+		doomed := CreateRandomImage()
+		keeper := CreateRandomImage()
+
+		So(UploadImage(doomed, baseURL, "doomed", "v1"), ShouldBeNil)
+		So(UploadImage(keeper, baseURL, "keeper", "v1"), ShouldBeNil)
+
+		resp, err := resty.R().Delete(baseURL + "/v2/doomed/manifests/" + doomed.DigestStr())
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+		So(uploadNewRepo(t, baseURL, "extra"), ShouldBeNil)
+
+		// Let several GC cycles run over the emptied repo.
+		time.Sleep(6 * time.Second)
+
+		So(manifestDigest(t, baseURL, "keeper", "v1"), ShouldEqual, keeper.DigestStr())
+		So(pushNewRepoStatus(t, baseURL, "yetanother"), ShouldEqual, http.StatusTooManyRequests)
+	})
+}
+
+// TestQuotaRepushOfRemovedNameCounts checks that a repo whose delete released its slot is treated as
+// brand new when pushed again: it must consume a slot, not slip past the limit.
+func TestQuotaRepushOfRemovedNameCounts(t *testing.T) {
+	Convey("Given a repo emptied while at the limit", t, func() {
+		rootDir := t.TempDir()
+		baseURL, stop := startQuotaServerAt(t, 2, rootDir, false)
+		defer stop()
+
+		doomed := CreateRandomImage()
+
+		So(UploadImage(doomed, baseURL, "doomed", "v1"), ShouldBeNil)
+		So(UploadImage(CreateRandomImage(), baseURL, "keeper", "v1"), ShouldBeNil)
+		So(pushNewRepoStatus(t, baseURL, "extra"), ShouldEqual, http.StatusTooManyRequests)
+
+		resp, err := resty.R().Delete(baseURL + "/v2/doomed/manifests/" + doomed.DigestStr())
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+		So(catalogRepos(t, baseURL), ShouldNotContain, "doomed")
+
+		Convey("Re-pushing the removed name succeeds but consumes the freed slot", func() {
+			repushed := CreateRandomImage()
+			So(UploadImage(repushed, baseURL, "doomed", "v2"), ShouldBeNil)
+			So(manifestDigest(t, baseURL, "doomed", "v2"), ShouldEqual, repushed.DigestStr())
+
+			// Had the re-push slipped past the limit, a further new name would still fit.
+			So(pushNewRepoStatus(t, baseURL, "onemore"), ShouldEqual, http.StatusTooManyRequests)
 		})
 	})
 }

--- a/pkg/meta/hooks.go
+++ b/pkg/meta/hooks.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"time"
 
 	godigest "github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -15,6 +16,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/storage"
+	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 )
 
 // priorTagManifest records where MetaDB believed each tag pointed before a digest PUT with tag=
@@ -220,6 +222,10 @@ func OnDeleteManifest(repo, reference, mediaType string, digest godigest.Digest,
 	storeController storage.StoreController, metaDB mTypes.MetaDB, log log.Logger,
 ) error {
 	if zcommon.IsReferrersTag(reference) {
+		// The store already deleted the referrers tag entry, which may have emptied the
+		// index; still attempt idle release (a no-op while content remains).
+		releaseIdleRepository(repo, storeController.GetImageStore(repo), metaDB, log)
+
 		return nil
 	}
 
@@ -233,29 +239,29 @@ func OnDeleteManifest(repo, reference, mediaType string, digest godigest.Digest,
 		return err
 	}
 
-	manageRepoMetaSuccessfully := true
+	var metaErr error
 
 	if isSignature {
-		err = metaDB.DeleteSignature(repo, signedManifestDigest, mTypes.SignatureMetadata{
+		metaErr = metaDB.DeleteSignature(repo, signedManifestDigest, mTypes.SignatureMetadata{
 			SignatureDigest: digest.String(),
 			SignatureType:   signatureType,
 		})
-		if err != nil {
-			if errors.Is(err, zerr.ErrImageMetaNotFound) {
-				// Expected: RemoveRepoReference already deleted Signatures[signedManifestDigest]
-				// when the last reference to the signed manifest was removed.
-				log.Debug().Err(err).Str("component", "metadb").
-					Msg("signature meta already removed")
-			} else {
-				log.Error().Err(err).Str("component", "metadb").
-					Msg("failed to delete signature meta")
-			}
 
-			manageRepoMetaSuccessfully = false
+		switch {
+		case errors.Is(metaErr, zerr.ErrImageMetaNotFound):
+			// Expected: RemoveRepoReference already deleted Signatures[signedManifestDigest]
+			// when the last reference to the signed manifest was removed.
+			log.Debug().Err(metaErr).Str("component", "metadb").
+				Msg("signature meta already removed")
+
+			metaErr = nil
+		case metaErr != nil:
+			log.Error().Err(metaErr).Str("tag", reference).Str("repository", repo).Str("component", "metadb").
+				Msg("failed to delete signature meta")
 		}
 	} else {
-		err = metaDB.RemoveRepoReference(repo, reference, digest)
-		if err != nil {
+		metaErr = metaDB.RemoveRepoReference(repo, reference, digest)
+		if metaErr != nil {
 			log.Info().Str("component", "metadb").Msg("restoring image store")
 
 			// restore image store
@@ -265,22 +271,53 @@ func OnDeleteManifest(repo, reference, mediaType string, digest godigest.Digest,
 					Msg("failed to restore manifest to image store, database is not consistent")
 			}
 
-			manageRepoMetaSuccessfully = false
+			log.Info().Str("tag", reference).Str("repository", repo).Str("component", "metadb").
+				Msg("failed to delete image meta for tag in repo")
+
+			return fmt.Errorf("%w: %w", zerr.ErrManifestRestoreAttempted, metaErr)
 		}
 	}
 
-	if !manageRepoMetaSuccessfully {
-		log.Info().Str("tag", reference).Str("repository", repo).Str("component", "metadb").
-			Msg("failed to delete image meta for tag in repo")
+	// The store delete has already gone through even when signature meta cleanup failed, so the
+	// index may be empty; always attempt idle release (a no-op while manifests or blobs remain).
+	releaseIdleRepository(repo, imgStore, metaDB, log)
 
-		if !isSignature {
-			return fmt.Errorf("%w: %w", zerr.ErrManifestRestoreAttempted, err)
-		}
+	return metaErr
+}
 
-		return err
+// releaseIdleRepository removes a repo left empty by a manifest delete: the storage layout goes
+// first, and only once it is gone the meta record follows, so the repo stops counting towards
+// maxRepos immediately without _catalog and the quota count diverging. A zero max blob age
+// reclaims the orphan blobs the deletes left behind. Failures are logged, not returned: the
+// manifest delete already succeeded, and ParseStorage corrects a stale record on next start.
+func releaseIdleRepository(repo string, imgStore storageTypes.ImageStore, metaDB mTypes.MetaDB, log log.Logger) {
+	var lockLatency time.Time
+
+	imgStore.Lock(&lockLatency)
+	defer imgStore.Unlock(&lockLatency)
+
+	removed, err := imgStore.RemoveIdleRepository(repo, 0)
+	if err != nil {
+		log.Error().Err(err).Str("repository", repo).Str("component", "metadb").
+			Msg("failed to remove repo emptied by manifest deletes")
+
+		return
 	}
 
-	return nil
+	if !removed {
+		return
+	}
+
+	if err := metaDB.DeleteRepoMeta(repo); err != nil {
+		// the layout is already gone; ParseStorage drops the stale record on next start
+		log.Error().Err(err).Str("repository", repo).Str("component", "metadb").
+			Msg("removed repo layout but failed to delete its meta record")
+
+		return
+	}
+
+	log.Debug().Str("repository", repo).Str("component", "metadb").
+		Msg("removed repo emptied by manifest deletes")
 }
 
 // OnGetManifest is called when a manifest is downloaded. It increments the download counter on that manifest.

--- a/pkg/meta/hooks_internal_test.go
+++ b/pkg/meta/hooks_internal_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
 	zerr "zotregistry.dev/zot/v2/errors"
+	zcommon "zotregistry.dev/zot/v2/pkg/common"
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/storage"
@@ -258,5 +260,141 @@ func TestRollbackDigestManifestTags(t *testing.T) {
 			rollbackDigestManifestTags(ctx, "repo", []string{"t"}, []string{"t"}, mediaType, dgst, body, sc,
 				metaDB, testLog, prior)
 		})
+	})
+}
+
+func TestReleaseIdleRepository(t *testing.T) {
+	Convey("releaseIdleRepository", t, func() {
+		logger := log.NewTestLogger()
+
+		Convey("A store failure is swallowed and keeps the meta record", func() {
+			metaDeleted := false
+			metaDB := mocks.MetaDBMock{
+				DeleteRepoMetaFn: func(repo string) error {
+					metaDeleted = true
+
+					return nil
+				},
+			}
+
+			imgStore := mocks.MockedImageStore{
+				RemoveIdleRepositoryFn: func(repo string, maxBlobAge time.Duration) (bool, error) {
+					return false, errHookInternal
+				},
+			}
+
+			So(func() { releaseIdleRepository("repo", imgStore, metaDB, logger) }, ShouldNotPanic)
+			So(metaDeleted, ShouldBeFalse)
+		})
+
+		Convey("The meta record goes only when the layout was removed", func() {
+			var gotRepo string
+
+			var gotAge time.Duration
+
+			var metaDeleted string
+
+			imgStore := mocks.MockedImageStore{
+				RemoveIdleRepositoryFn: func(repo string, maxBlobAge time.Duration) (bool, error) {
+					gotRepo = repo
+					gotAge = maxBlobAge
+
+					return true, nil
+				},
+			}
+
+			metaDB := mocks.MetaDBMock{
+				DeleteRepoMetaFn: func(repo string) error {
+					metaDeleted = repo
+
+					return nil
+				},
+			}
+
+			releaseIdleRepository("repo", imgStore, metaDB, logger)
+			So(gotRepo, ShouldEqual, "repo")
+			So(gotAge, ShouldEqual, 0)
+			So(metaDeleted, ShouldEqual, "repo")
+		})
+
+		Convey("A kept layout keeps its meta record", func() {
+			metaDeleted := false
+			metaDB := mocks.MetaDBMock{
+				DeleteRepoMetaFn: func(repo string) error {
+					metaDeleted = true
+
+					return nil
+				},
+			}
+
+			imgStore := mocks.MockedImageStore{
+				RemoveIdleRepositoryFn: func(repo string, maxBlobAge time.Duration) (bool, error) {
+					return false, nil
+				},
+			}
+
+			releaseIdleRepository("repo", imgStore, metaDB, logger)
+			So(metaDeleted, ShouldBeFalse)
+		})
+
+		Convey("A meta delete failure after layout removal is swallowed", func() {
+			imgStore := mocks.MockedImageStore{
+				RemoveIdleRepositoryFn: func(repo string, maxBlobAge time.Duration) (bool, error) {
+					return true, nil
+				},
+			}
+
+			metaDB := mocks.MetaDBMock{
+				DeleteRepoMetaFn: func(repo string) error { return errHookInternal },
+			}
+
+			So(func() { releaseIdleRepository("repo", imgStore, metaDB, logger) }, ShouldNotPanic)
+		})
+	})
+}
+
+func TestOnDeleteManifestSignatureMetaFailure(t *testing.T) {
+	Convey("An unexpected signature meta delete failure still attempts the release", t, func() {
+		logger := log.NewTestLogger()
+
+		subjectDigest := godigest.FromString("subject")
+
+		referrer := ispec.Manifest{
+			MediaType:    ispec.MediaTypeImageManifest,
+			ArtifactType: zcommon.ArtifactTypeCosignBundle,
+			Subject: &ispec.Descriptor{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    subjectDigest,
+			},
+		}
+		referrer.SchemaVersion = 2
+
+		referrerBody, err := json.Marshal(referrer)
+		So(err, ShouldBeNil)
+		referrerDigest := godigest.FromBytes(referrerBody)
+
+		released := false
+		imgStore := mocks.MockedImageStore{
+			RemoveIdleRepositoryFn: func(repo string, maxBlobAge time.Duration) (bool, error) {
+				released = true
+
+				return false, nil
+			},
+		}
+
+		metaDB := mocks.MetaDBMock{
+			DeleteSignatureFn: func(repo string, signedManifestDigest godigest.Digest,
+				sigMeta mTypes.SignatureMetadata,
+			) error {
+				return errHookInternal
+			},
+		}
+
+		sc := storage.StoreController{DefaultStore: &imgStore}
+		err = OnDeleteManifest("repo", referrerDigest.String(), ispec.MediaTypeImageManifest, referrerDigest,
+			referrerBody, sc, metaDB, logger)
+
+		So(errors.Is(err, errHookInternal), ShouldBeTrue)
+		So(released, ShouldBeTrue)
 	})
 }

--- a/pkg/meta/hooks_test.go
+++ b/pkg/meta/hooks_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"path"
 	"testing"
 
 	godigest "github.com/opencontainers/go-digest"
@@ -465,11 +466,156 @@ func TestUpdateErrors(t *testing.T) {
 	})
 }
 
-// TestOnDeleteManifest_OrphanedSignatureReferrerReturnsErrImageMetaNotFound verifies that
-// OnDeleteManifest returns ErrImageMetaNotFound when deleting a signature referrer
-// whose subject manifest was already untagged.
-func TestOnDeleteManifest_OrphanedSignatureReferrerReturnsErrImageMetaNotFound(t *testing.T) {
-	Convey("Deleting a signature referrer after its subject's last tag is gone fails with ErrImageMetaNotFound",
+// TestOnDeleteManifest_EmptiedRepoStopsCountingTowardsQuota verifies that deleting the last manifest in
+// a repo removes the repo itself, layout and meta together, so it stops counting towards maxRepos.
+func TestOnDeleteManifest_EmptiedRepoStopsCountingTowardsQuota(t *testing.T) {
+	Convey("Deleting the last manifest in a repo removes its layout and its meta", t, func() {
+		rootDir := t.TempDir()
+		storeController := storage.StoreController{}
+		log := log.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+
+		storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
+
+		params := boltdb.DBParameters{RootDir: rootDir}
+		boltDriver, err := boltdb.GetBoltDriver(params)
+		So(err, ShouldBeNil)
+
+		metaDB, err := boltdb.New(boltDriver, log)
+		So(err, ShouldBeNil)
+
+		imgStore := storeController.GetImageStore("repo")
+		ctx := context.Background()
+
+		image := CreateDefaultImage()
+		digest := image.Digest()
+		body := image.ManifestDescriptor.Data
+
+		So(WriteImageToFileSystem(image, "repo", "latest", storeController), ShouldBeNil)
+		So(meta.OnUpdateManifest(ctx, "repo", "latest", ispec.MediaTypeImageManifest, digest, body,
+			storeController, metaDB, log), ShouldBeNil)
+
+		count, err := metaDB.CountRepos(ctx)
+		So(err, ShouldBeNil)
+		So(count, ShouldEqual, 1)
+
+		So(imgStore.DeleteImageManifest(ctx, "repo", digest.String(), false), ShouldBeNil)
+		So(meta.OnDeleteManifest("repo", digest.String(), ispec.MediaTypeImageManifest, digest, body,
+			storeController, metaDB, log), ShouldBeNil)
+
+		_, err = metaDB.GetRepoMeta(ctx, "repo")
+		So(err, ShouldEqual, zerr.ErrRepoMetaNotFound)
+
+		count, err = metaDB.CountRepos(ctx)
+		So(err, ShouldBeNil)
+		So(count, ShouldEqual, 0)
+	})
+
+	Convey("A repo still holding another tagged manifest keeps its meta", t, func() {
+		rootDir := t.TempDir()
+		storeController := storage.StoreController{}
+		log := log.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+
+		storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
+
+		params := boltdb.DBParameters{RootDir: rootDir}
+		boltDriver, err := boltdb.GetBoltDriver(params)
+		So(err, ShouldBeNil)
+
+		metaDB, err := boltdb.New(boltDriver, log)
+		So(err, ShouldBeNil)
+
+		imgStore := storeController.GetImageStore("repo")
+		ctx := context.Background()
+
+		first := CreateRandomImage()
+		second := CreateRandomImage()
+
+		So(WriteImageToFileSystem(first, "repo", "first", storeController), ShouldBeNil)
+		So(meta.OnUpdateManifest(ctx, "repo", "first", ispec.MediaTypeImageManifest, first.Digest(),
+			first.ManifestDescriptor.Data, storeController, metaDB, log), ShouldBeNil)
+
+		So(WriteImageToFileSystem(second, "repo", "second", storeController), ShouldBeNil)
+		So(meta.OnUpdateManifest(ctx, "repo", "second", ispec.MediaTypeImageManifest, second.Digest(),
+			second.ManifestDescriptor.Data, storeController, metaDB, log), ShouldBeNil)
+
+		So(imgStore.DeleteImageManifest(ctx, "repo", first.Digest().String(), false), ShouldBeNil)
+		So(meta.OnDeleteManifest("repo", first.Digest().String(), ispec.MediaTypeImageManifest, first.Digest(),
+			first.ManifestDescriptor.Data, storeController, metaDB, log), ShouldBeNil)
+
+		_, err = metaDB.GetRepoMeta(ctx, "repo")
+		So(err, ShouldBeNil)
+
+		count, err := metaDB.CountRepos(ctx)
+		So(err, ShouldBeNil)
+		So(count, ShouldEqual, 1)
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldContain, "repo")
+	})
+
+	Convey("A repo holding only an untagged manifest keeps its meta", t, func() {
+		rootDir := t.TempDir()
+		storeController := storage.StoreController{}
+		log := log.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+
+		storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
+
+		params := boltdb.DBParameters{RootDir: rootDir}
+		boltDriver, err := boltdb.GetBoltDriver(params)
+		So(err, ShouldBeNil)
+
+		metaDB, err := boltdb.New(boltDriver, log)
+		So(err, ShouldBeNil)
+
+		imgStore := storeController.GetImageStore("repo")
+		ctx := context.Background()
+
+		tagged := CreateRandomImage()
+		untagged := CreateRandomImage()
+
+		So(WriteImageToFileSystem(tagged, "repo", "v1", storeController), ShouldBeNil)
+		So(meta.OnUpdateManifest(ctx, "repo", "v1", ispec.MediaTypeImageManifest, tagged.Digest(),
+			tagged.ManifestDescriptor.Data, storeController, metaDB, log), ShouldBeNil)
+
+		// Referenced by digest, so it carries no tag, which is how a signature
+		// referrer or an attached artifact sits in a repo.
+		So(WriteImageToFileSystem(untagged, "repo", untagged.Digest().String(), storeController), ShouldBeNil)
+		So(meta.OnUpdateManifest(ctx, "repo", untagged.Digest().String(), ispec.MediaTypeImageManifest,
+			untagged.Digest(), untagged.ManifestDescriptor.Data, storeController, metaDB, log), ShouldBeNil)
+
+		So(imgStore.DeleteImageManifest(ctx, "repo", tagged.Digest().String(), false), ShouldBeNil)
+		So(meta.OnDeleteManifest("repo", tagged.Digest().String(), ispec.MediaTypeImageManifest, tagged.Digest(),
+			tagged.ManifestDescriptor.Data, storeController, metaDB, log), ShouldBeNil)
+
+		// No tag is left, but the untagged manifest still holds the repo, so its
+		// meta must survive and keep counting towards maxRepos.
+		repoMeta, err := metaDB.GetRepoMeta(ctx, "repo")
+		So(err, ShouldBeNil)
+
+		for tag := range repoMeta.Tags {
+			So(tag, ShouldBeEmpty)
+		}
+
+		count, err := metaDB.CountRepos(ctx)
+		So(err, ShouldBeNil)
+		So(count, ShouldEqual, 1)
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldContain, "repo")
+	})
+}
+
+// TestOnDeleteManifest_OrphanedSignatureReferrerReleasesRepo verifies that deleting a signature
+// referrer whose subject manifest was already untagged is not treated as a failure: the signature
+// meta is already gone (an expected miss), and since the delete emptied the repo, the layout and
+// the meta record are released so the repo stops counting towards maxRepos.
+func TestOnDeleteManifest_OrphanedSignatureReferrerReleasesRepo(t *testing.T) {
+	Convey("Deleting the last leftover signature referrer releases the emptied repo",
 		t, func() {
 			rootDir := t.TempDir()
 			storeController := storage.StoreController{}
@@ -534,19 +680,29 @@ func TestOnDeleteManifest_OrphanedSignatureReferrerReturnsErrImageMetaNotFound(t
 			So(err, ShouldBeNil)
 			So(repoMeta.Signatures, ShouldContainKey, subjectDigest.String())
 
-			// Delete the subject's only tag.
-			So(imgStore.DeleteImageManifest(ctx, "repo", "latest", false), ShouldBeNil)
-			So(meta.OnDeleteManifest("repo", "latest", ispec.MediaTypeImageManifest, subjectDigest, subjectBody,
-				storeController, metaDB, log), ShouldBeNil)
+			// Delete the subject by digest, so only the signature referrer is left in the index.
+			So(imgStore.DeleteImageManifest(ctx, "repo", subjectDigest.String(), false), ShouldBeNil)
+			So(meta.OnDeleteManifest("repo", subjectDigest.String(), ispec.MediaTypeImageManifest, subjectDigest,
+				subjectBody, storeController, metaDB, log), ShouldBeNil)
 
 			repoMeta, err = metaDB.GetRepoMeta(ctx, "repo")
 			So(err, ShouldBeNil)
 			So(repoMeta.Signatures, ShouldNotContainKey, subjectDigest.String())
 
-			// The referrer is still present in the image store; deleting it now fails.
+			// The referrer is still present in the image store; deleting it finds its signature
+			// meta already gone, which is expected and must not surface as an error. The repo is
+			// now empty, so both the layout and the meta record are released.
 			So(imgStore.DeleteImageManifest(ctx, "repo", referrerDigest.String(), false), ShouldBeNil)
-			err = meta.OnDeleteManifest("repo", referrerDigest.String(), ispec.MediaTypeImageManifest, referrerDigest,
-				referrerBody, storeController, metaDB, log)
-			So(errors.Is(err, zerr.ErrImageMetaNotFound), ShouldBeTrue)
+			So(meta.OnDeleteManifest("repo", referrerDigest.String(), ispec.MediaTypeImageManifest, referrerDigest,
+				referrerBody, storeController, metaDB, log), ShouldBeNil)
+
+			So(imgStore.DirExists(path.Join(rootDir, "repo")), ShouldBeFalse)
+
+			_, err = metaDB.GetRepoMeta(ctx, "repo")
+			So(errors.Is(err, zerr.ErrRepoMetaNotFound), ShouldBeTrue)
+
+			count, err := metaDB.CountRepos(ctx)
+			So(err, ShouldBeNil)
+			So(count, ShouldEqual, 0)
 		})
 }

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -211,6 +211,30 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 			return err
 		}
 
+		/* remove the repo layout once nothing is left: no manifests, no blobs, no uploads.
+		This is the repository-level analogue of the manifest pruning above; the meta record
+		is dropped right after, keeping metadb on the same lifetime as storage, so a reaped
+		repo also stops counting towards storage.maxRepos. Blobs younger than the GC delay
+		keep their grace period. This runs before deleteBlobUploads so that an upload not yet
+		old enough to be reaped still counts as in progress and keeps the repo, as
+		CleanupRepo's guard used to. */
+		removed, err := gc.imgStore.RemoveIdleRepository(repo, gc.opts.Delay)
+		if err != nil {
+			gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).
+				Msg("failed to remove idle repo")
+
+			return err
+		}
+
+		if removed && gc.metaDB != nil {
+			if err := gc.metaDB.DeleteRepoMeta(repo); err != nil {
+				/* log, don't fail: the layout is already gone, so aborting the rest of cleanRepo
+				would not bring it back, and ParseStorage drops the stale record on next start */
+				gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).
+					Msg("removed repo layout but failed to delete its meta record")
+			}
+		}
+
 		// delete old blob uploads from storage
 		uploadsDeleted, err = gc.deleteBlobUploads(repo, gc.opts.Delay)
 		if err != nil {
@@ -1070,10 +1094,7 @@ func (gc GarbageCollect) deleteUnreferencedBlobs(repo string, delay time.Duratio
 		}
 	}
 
-	// if we removed all blobs from repo
-	removeRepo := len(gcBlobs) > 0 && len(gcBlobs) == len(allBlobs)
-
-	reaped, err := gc.imgStore.CleanupRepo(repo, gcBlobs, removeRepo)
+	reaped, err := gc.imgStore.CleanupRepo(repo, gcBlobs)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -138,6 +138,49 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
+		Convey("Error on RemoveIdleRepository in gc.cleanRepo()", func() {
+			imgStore := mocks.MockedImageStore{
+				GetIndexContentFn: func(repo string) ([]byte, error) {
+					return []byte(`{"schemaVersion":2,"manifests":[]}`), nil
+				},
+				RemoveIdleRepositoryFn: func(repo string, maxBlobAge time.Duration) (bool, error) {
+					return false, errGC
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			err := gc.cleanRepo(ctx, repoName)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("Meta delete failure after idle repo removal is logged, not returned", func() {
+			metaCalled := false
+
+			imgStore := mocks.MockedImageStore{
+				GetIndexContentFn: func(repo string) ([]byte, error) {
+					return []byte(`{"schemaVersion":2,"manifests":[]}`), nil
+				},
+				RemoveIdleRepositoryFn: func(repo string, maxBlobAge time.Duration) (bool, error) {
+					return true, nil
+				},
+			}
+
+			metaDB := mocks.MetaDBMock{
+				DeleteRepoMetaFn: func(repo string) error {
+					metaCalled = true
+
+					return errGC
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, metaDB, gcOptions, audit, log, metrics)
+
+			err := gc.cleanRepo(ctx, repoName)
+			So(err, ShouldBeNil)
+			So(metaCalled, ShouldBeTrue)
+		})
+
 		Convey("Error on GetIndex in gc.deleteUnreferencedBlobs()", func() {
 			gc := NewGarbageCollect(mocks.MockedImageStore{}, mocks.MetaDBMock{
 				GetRepoMetaFn: func(ctx context.Context, repo string) (types.RepoMeta, error) {
@@ -1874,7 +1917,7 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
 					return true, 100, time.Now().Add(-2 * time.Hour), nil
 				},
-				CleanupRepoFn: func(repo string, blobs []godigest.Digest, removeRepo bool) (int, error) {
+				CleanupRepoFn: func(repo string, blobs []godigest.Digest) (int, error) {
 					return 0, errGC
 				},
 			}
@@ -2494,7 +2537,7 @@ func TestCleanRepoWithStaleManifestEntries(t *testing.T) {
 
 				return nil
 			},
-			CleanupRepoFn: func(repo string, blobs []godigest.Digest, removeRepo bool) (int, error) {
+			CleanupRepoFn: func(repo string, blobs []godigest.Digest) (int, error) {
 				return 0, nil
 			},
 			GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
@@ -2599,7 +2642,7 @@ func TestCleanupRepoMissingBlob(t *testing.T) {
 		err = os.Remove(blobPath)
 		So(err, ShouldBeNil)
 
-		count, err := imgStore.CleanupRepo(repoName, []godigest.Digest{digest}, false)
+		count, err := imgStore.CleanupRepo(repoName, []godigest.Digest{digest})
 		So(err, ShouldBeNil)
 		So(count, ShouldEqual, 1)
 	})

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -36,6 +36,7 @@ import (
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 	"zotregistry.dev/zot/v2/pkg/test/azurite"
 	. "zotregistry.dev/zot/v2/pkg/test/image-utils"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
 	tskip "zotregistry.dev/zot/v2/pkg/test/skip"
 )
 
@@ -3438,6 +3439,155 @@ func TestGCRemoveRepoAfterAllBlobsGCed(t *testing.T) {
 		repos, err := imgStore.GetRepositories()
 		So(err, ShouldBeNil)
 		So(repos, ShouldContain, repoName)
+	})
+}
+
+// TestGCRemoveRepoDropsRepoMeta covers the repository-level metadata GC: when GC removes a repo's
+// layout, the repo's meta record goes with it, so storage and metadb keep the same lifetime and a
+// reaped repo stops counting towards storage.maxRepos.
+func TestGCRemoveRepoDropsRepoMeta(t *testing.T) {
+	Convey("GC deletes the meta record together with the repo layout", t, func() {
+		log := zlog.NewTestLogger()
+		audit := zlog.NewAuditLogger("debug", "/dev/null")
+		metrics := monitoring.NewNopMetricServer()
+
+		rootDir := t.TempDir()
+		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
+
+		storeController := storage.StoreController{}
+		storeController.DefaultStore = imgStore
+
+		ctx := context.Background()
+		repoName := "gc-remove-repo-meta"
+
+		img := CreateRandomImage()
+		err := WriteImageToFileSystem(img, repoName, "v1", storeController)
+		So(err, ShouldBeNil)
+
+		err = imgStore.DeleteImageManifest(ctx, repoName, "v1", true)
+		So(err, ShouldBeNil)
+
+		time.Sleep(1 * time.Second)
+
+		var metaDeleted string
+		metaDB := mocks.MetaDBMock{
+			DeleteRepoMetaFn: func(repo string) error {
+				metaDeleted = repo
+
+				return nil
+			},
+		}
+
+		gcInstance := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
+			Delay: 1 * time.Second,
+			ImageRetention: config.ImageRetention{
+				Delay: 1 * time.Second,
+			},
+		}, audit, log, metrics)
+
+		err = gcInstance.CleanRepo(ctx, repoName)
+		So(err, ShouldBeNil)
+
+		So(metaDeleted, ShouldEqual, repoName)
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldNotContain, repoName)
+	})
+
+	Convey("GC removes a blobless empty layout and its meta record", t, func() {
+		log := zlog.NewTestLogger()
+		audit := zlog.NewAuditLogger("debug", "/dev/null")
+		metrics := monitoring.NewNopMetricServer()
+
+		rootDir := t.TempDir()
+		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
+
+		ctx := context.Background()
+		repoName := "gc-remove-blobless-repo"
+
+		// a layout with an empty index and no blobs at all: nothing for blob GC to reap,
+		// so the old removeRepo predicate (len(gcBlobs) > 0) could never fire
+		err := imgStore.InitRepo(ctx, repoName)
+		So(err, ShouldBeNil)
+
+		var metaDeleted string
+		metaDB := mocks.MetaDBMock{
+			DeleteRepoMetaFn: func(repo string) error {
+				metaDeleted = repo
+
+				return nil
+			},
+		}
+
+		gcInstance := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
+			Delay: 1 * time.Second,
+			ImageRetention: config.ImageRetention{
+				Delay: 1 * time.Second,
+			},
+		}, audit, log, metrics)
+
+		err = gcInstance.CleanRepo(ctx, repoName)
+		So(err, ShouldBeNil)
+
+		So(metaDeleted, ShouldEqual, repoName)
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldNotContain, repoName)
+	})
+
+	Convey("dry-run GC removes neither the layout nor the meta record", t, func() {
+		log := zlog.NewTestLogger()
+		audit := zlog.NewAuditLogger("debug", "/dev/null")
+		metrics := monitoring.NewNopMetricServer()
+
+		rootDir := t.TempDir()
+		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
+
+		storeController := storage.StoreController{}
+		storeController.DefaultStore = imgStore
+
+		ctx := context.Background()
+		repoName := "gc-dry-run-repo"
+
+		img := CreateRandomImage()
+		err := WriteImageToFileSystem(img, repoName, "v1", storeController)
+		So(err, ShouldBeNil)
+
+		err = imgStore.DeleteImageManifest(ctx, repoName, "v1", true)
+		So(err, ShouldBeNil)
+
+		time.Sleep(1 * time.Second)
+
+		metaDeleteCalled := false
+		metaDB := mocks.MetaDBMock{
+			DeleteRepoMetaFn: func(repo string) error {
+				metaDeleteCalled = true
+
+				return nil
+			},
+		}
+
+		gcInstance := gc.NewGarbageCollect(imgStore, metaDB, gc.Options{
+			Delay: 1 * time.Second,
+			ImageRetention: config.ImageRetention{
+				Delay:  1 * time.Second,
+				DryRun: true,
+			},
+		}, audit, log, metrics)
+
+		err = gcInstance.CleanRepo(ctx, repoName)
+		So(err, ShouldBeNil)
+		So(metaDeleteCalled, ShouldBeFalse)
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldContain, repoName)
+
+		blobs, err := imgStore.GetAllBlobs(repoName)
+		So(err, ShouldBeNil)
+		So(blobs, ShouldNotBeEmpty)
 	})
 }
 

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -1980,10 +1980,12 @@ func (is *ImageStore) DeleteBlob(repo string, digest godigest.Digest) error {
 }
 
 /*
-CleanupRepo removes blobs from the repository and removes repo if flag is true and all blobs were removed
-the caller function MUST lock from outside.
+CleanupRepo removes blobs from the repository. Repository-level removal lives in
+RemoveIdleRepository, so that every path that deletes a repo directory goes through
+the same idle checks.
+The caller function MUST lock from outside.
 */
-func (is *ImageStore) CleanupRepo(repo string, blobs []godigest.Digest, removeRepo bool) (int, error) {
+func (is *ImageStore) CleanupRepo(repo string, blobs []godigest.Digest) (int, error) {
 	count := 0
 
 	for _, digest := range blobs {
@@ -2012,17 +2014,93 @@ func (is *ImageStore) CleanupRepo(repo string, blobs []godigest.Digest, removeRe
 		}
 	}
 
-	blobUploads, _ := is.ListBlobUploads(repo)
+	// finally update metrics
+	if is.storeDriver.Name() == storageConstants.LocalStorageDriverName {
+		monitoring.SetStorageUsage(is.metrics, is.rootDir, repo)
+	}
 
-	// if removeRepo flag is true and we cleanup all blobs and there are no blobs currently being uploaded.
-	if removeRepo && count == len(blobs) && count > 0 && len(blobUploads) == 0 {
-		is.log.Info().Str("repository", repo).Msg("removed all blobs, removing repo")
+	return count, nil
+}
 
-		if err := is.storeDriver.Delete(path.Join(is.rootDir, repo)); err != nil {
-			is.log.Error().Err(err).Str("repository", repo).Msg("failed to remove repo")
+/*
+RemoveIdleRepository removes a repository's layout once the repository holds no manifests and no
+blob upload is in progress. Any blobs still present are unreferenced by definition (the index is
+empty), so those older than maxBlobAge are deleted first; the layout is removed only if no blobs
+remain afterwards. A zero maxBlobAge reclaims a repo emptied by manifest deletes immediately,
+while GC passes its configured delay so recently uploaded blobs keep their grace period.
 
-			return count, err
+Only the layout is touched here: callers that also track the repository elsewhere (such as a meta
+record counting towards storage.maxRepos) are expected to drop that state themselves when this
+returns true, so the repo stops existing everywhere at once.
+
+The caller function MUST lock from outside.
+
+Returns true when the layout was removed.
+*/
+func (is *ImageStore) RemoveIdleRepository(repo string, maxBlobAge time.Duration) (bool, error) {
+	dir := path.Join(is.rootDir, repo)
+	if !is.DirExists(dir) {
+		return false, nil
+	}
+
+	index, err := common.GetIndex(is, repo, is.log)
+	if err != nil {
+		return false, err
+	}
+
+	if len(index.Manifests) > 0 {
+		return false, nil
+	}
+
+	blobUploads, err := is.ListBlobUploads(repo)
+	if err != nil {
+		return false, err
+	}
+
+	if len(blobUploads) > 0 {
+		return false, nil
+	}
+
+	blobs, err := is.GetAllBlobs(repo)
+	if err != nil {
+		return false, err
+	}
+
+	for _, digest := range blobs {
+		if maxBlobAge > 0 {
+			_, _, modtime, err := is.StatBlob(repo, digest)
+			if err != nil {
+				return false, err
+			}
+
+			if modtime.Add(maxBlobAge).After(time.Now()) {
+				// too young: leave the blob and the repo in place
+				continue
+			}
 		}
+
+		// unconditional delete: the index is empty, so no blob is referenced
+		if err := is.deleteBlobChecked(repo, digest, func() (bool, error) { return false, nil }); err != nil {
+			return false, err
+		}
+	}
+
+	// fail closed on partial sweeps and eventually-consistent listings
+	blobs, err = is.GetAllBlobs(repo)
+	if err != nil {
+		return false, err
+	}
+
+	if len(blobs) > 0 {
+		return false, nil
+	}
+
+	is.log.Info().Str("repository", repo).Msg("removing idle repo")
+
+	if err := is.storeDriver.Delete(dir); err != nil {
+		is.log.Error().Err(err).Str("repository", repo).Msg("failed to remove repo")
+
+		return false, err
 	}
 
 	// finally update metrics
@@ -2030,7 +2108,7 @@ func (is *ImageStore) CleanupRepo(repo string, blobs []godigest.Digest, removeRe
 		monitoring.SetStorageUsage(is.metrics, is.rootDir, repo)
 	}
 
-	return count, nil
+	return true, nil
 }
 
 func (is *ImageStore) deleteBlob(repo string, digest godigest.Digest) error {

--- a/pkg/storage/imagestore/imagestore_test.go
+++ b/pkg/storage/imagestore/imagestore_test.go
@@ -1,14 +1,19 @@
 package imagestore_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"testing"
+	"time"
 
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	godigest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
 	zerr "zotregistry.dev/zot/v2/errors"
@@ -17,10 +22,14 @@ import (
 	"zotregistry.dev/zot/v2/pkg/storage/gcs"
 	"zotregistry.dev/zot/v2/pkg/storage/imagestore"
 	"zotregistry.dev/zot/v2/pkg/storage/local"
+	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
 )
 
-var errDeleteFailed = errors.New("delete failed") //nolint: gochecknoglobals
+var (
+	errDeleteFailed = errors.New("delete failed") //nolint: gochecknoglobals
+	errDriverFailed = errors.New("driver failed") //nolint: gochecknoglobals
+)
 
 func TestGetBlobRedirectURL(t *testing.T) {
 	Convey("GetBlobRedirectURL", t, func() {
@@ -139,7 +148,7 @@ func TestCleanupRepoToleratesDeletePathNotFound(t *testing.T) {
 			return nil, nil
 		}
 
-		count, err := store.CleanupRepo(repo, []godigest.Digest{digest}, false)
+		count, err := store.CleanupRepo(repo, []godigest.Digest{digest})
 		So(err, ShouldBeNil)
 		So(count, ShouldEqual, 1)
 	})
@@ -183,8 +192,319 @@ func TestCleanupRepoFailsOnUnexpectedDeleteBlobError(t *testing.T) {
 			return nil, nil
 		}
 
-		count, err := store.CleanupRepo(repo, []godigest.Digest{digest}, false)
+		count, err := store.CleanupRepo(repo, []godigest.Digest{digest})
 		So(err, ShouldNotBeNil)
 		So(count, ShouldEqual, 0)
+	})
+}
+
+func TestRemoveIdleRepository(t *testing.T) {
+	newStore := func(rootDir string) storageTypes.ImageStore {
+		return imagestore.NewImageStore(rootDir, "", false, false, zlog.NewTestLogger(),
+			monitoring.NewNopMetricServer(), nil, local.New(true), nil, nil, nil)
+	}
+
+	removeIdle := func(store storageTypes.ImageStore, repo string, maxBlobAge time.Duration) (bool, error) {
+		var lockLatency time.Time
+
+		store.Lock(&lockLatency)
+		defer store.Unlock(&lockLatency)
+
+		return store.RemoveIdleRepository(repo, maxBlobAge)
+	}
+
+	Convey("An emptied repo loses its layout, orphan blobs included", t, func() {
+		rootDir := t.TempDir()
+		store := newStore(rootDir)
+		ctx := context.Background()
+
+		So(store.InitRepo(ctx, "repo"), ShouldBeNil)
+
+		// an orphan blob, as left behind by a manifest delete
+		content := []byte("orphan blob")
+		digest := godigest.FromBytes(content)
+		_, _, err := store.FullBlobUpload(ctx, "repo", bytes.NewReader(content), digest)
+		So(err, ShouldBeNil)
+
+		removed, err := removeIdle(store, "repo", 0)
+		So(err, ShouldBeNil)
+		So(removed, ShouldBeTrue)
+		So(store.DirExists(path.Join(rootDir, "repo")), ShouldBeFalse)
+	})
+
+	Convey("A repo still holding a manifest is kept", t, func() {
+		rootDir := t.TempDir()
+		store := newStore(rootDir)
+		ctx := context.Background()
+
+		So(store.InitRepo(ctx, "repo"), ShouldBeNil)
+
+		index := ispec.Index{
+			Versioned: specs.Versioned{SchemaVersion: 2},
+			Manifests: []ispec.Descriptor{{
+				MediaType: ispec.MediaTypeImageManifest,
+				Digest:    godigest.FromString("manifest"),
+				Size:      1,
+			}},
+		}
+		So(store.PutIndexContent("repo", index), ShouldBeNil)
+
+		removed, err := removeIdle(store, "repo", 0)
+		So(err, ShouldBeNil)
+		So(removed, ShouldBeFalse)
+		So(store.DirExists(path.Join(rootDir, "repo")), ShouldBeTrue)
+	})
+
+	Convey("A repo with a blob upload in progress is kept", t, func() {
+		rootDir := t.TempDir()
+		store := newStore(rootDir)
+		ctx := context.Background()
+
+		_, err := store.NewBlobUpload(ctx, "repo")
+		So(err, ShouldBeNil)
+
+		removed, err := removeIdle(store, "repo", 0)
+		So(err, ShouldBeNil)
+		So(removed, ShouldBeFalse)
+		So(store.DirExists(path.Join(rootDir, "repo")), ShouldBeTrue)
+	})
+
+	Convey("Blobs younger than maxBlobAge keep the repo", t, func() {
+		rootDir := t.TempDir()
+		store := newStore(rootDir)
+		ctx := context.Background()
+
+		So(store.InitRepo(ctx, "repo"), ShouldBeNil)
+
+		content := []byte("young blob")
+		digest := godigest.FromBytes(content)
+		_, _, err := store.FullBlobUpload(ctx, "repo", bytes.NewReader(content), digest)
+		So(err, ShouldBeNil)
+
+		removed, err := removeIdle(store, "repo", time.Hour)
+		So(err, ShouldBeNil)
+		So(removed, ShouldBeFalse)
+		So(store.DirExists(path.Join(rootDir, "repo")), ShouldBeTrue)
+
+		ok, _, _, err := store.StatBlob("repo", digest)
+		So(err, ShouldBeNil)
+		So(ok, ShouldBeTrue)
+	})
+
+	Convey("A bare empty layout is removed", t, func() {
+		rootDir := t.TempDir()
+		store := newStore(rootDir)
+		ctx := context.Background()
+
+		So(store.InitRepo(ctx, "repo"), ShouldBeNil)
+
+		removed, err := removeIdle(store, "repo", 0)
+		So(err, ShouldBeNil)
+		So(removed, ShouldBeTrue)
+		So(store.DirExists(path.Join(rootDir, "repo")), ShouldBeFalse)
+	})
+
+	Convey("A repo already gone from storage is a no-op", t, func() {
+		store := newStore(t.TempDir())
+
+		removed, err := removeIdle(store, "ghost", 0)
+		So(err, ShouldBeNil)
+		So(removed, ShouldBeFalse)
+	})
+
+	Convey("Driver failures fail closed", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+
+		repo := "repo"
+		rootDir := t.TempDir()
+		repoDir := path.Join(rootDir, repo)
+		indexPath := path.Join(repoDir, "index.json")
+		uploadsDir := path.Join(repoDir, ".uploads")
+		blobsDir := path.Join(repoDir, "blobs")
+
+		emptyIndex := []byte(`{"schemaVersion":2,"manifests":[]}`)
+
+		blobContent := []byte("orphan blob")
+		blobDigest := godigest.FromBytes(blobContent)
+		sha256Dir := path.Join(blobsDir, "sha256")
+		blobPath := path.Join(sha256Dir, blobDigest.Encoded())
+
+		newMockStore := func(storeMock *mocks.StorageDriverMock) storageTypes.ImageStore {
+			return imagestore.NewImageStore(rootDir, "", false, false, log, metrics, nil,
+				gcs.New(storeMock), nil, nil, nil)
+		}
+
+		dirInfo := func() driver.FileInfo {
+			return &mocks.FileInfoMock{IsDirFn: func() bool { return true }}
+		}
+		notFound := func(path string) error {
+			return driver.PathNotFoundError{Path: path}
+		}
+
+		Convey("an index read failure", func() {
+			storeMock := &mocks.StorageDriverMock{
+				StatFn: func(_ context.Context, _ string) (driver.FileInfo, error) { return dirInfo(), nil },
+				GetContentFn: func(_ context.Context, path string) ([]byte, error) {
+					So(path, ShouldEqual, indexPath)
+
+					return nil, errDriverFailed
+				},
+			}
+
+			removed, err := removeIdle(newMockStore(storeMock), repo, 0)
+			So(err, ShouldNotBeNil)
+			So(removed, ShouldBeFalse)
+		})
+
+		Convey("a blob uploads listing failure", func() {
+			storeMock := &mocks.StorageDriverMock{
+				StatFn:       func(_ context.Context, _ string) (driver.FileInfo, error) { return dirInfo(), nil },
+				GetContentFn: func(_ context.Context, _ string) ([]byte, error) { return emptyIndex, nil },
+				ListFn: func(_ context.Context, path string) ([]string, error) {
+					So(path, ShouldEqual, uploadsDir)
+
+					return nil, errDriverFailed
+				},
+			}
+
+			removed, err := removeIdle(newMockStore(storeMock), repo, 0)
+			So(err, ShouldNotBeNil)
+			So(removed, ShouldBeFalse)
+		})
+
+		Convey("a blob listing failure", func() {
+			storeMock := &mocks.StorageDriverMock{
+				StatFn:       func(_ context.Context, _ string) (driver.FileInfo, error) { return dirInfo(), nil },
+				GetContentFn: func(_ context.Context, _ string) ([]byte, error) { return emptyIndex, nil },
+				ListFn: func(_ context.Context, path string) ([]string, error) {
+					if path == uploadsDir {
+						return nil, notFound(path)
+					}
+
+					return nil, errDriverFailed
+				},
+			}
+
+			removed, err := removeIdle(newMockStore(storeMock), repo, 0)
+			So(err, ShouldNotBeNil)
+			So(removed, ShouldBeFalse)
+		})
+
+		Convey("a blob stat failure under a grace period", func() {
+			storeMock := &mocks.StorageDriverMock{
+				StatFn: func(_ context.Context, path string) (driver.FileInfo, error) {
+					if path == blobPath {
+						return nil, errDriverFailed
+					}
+
+					return dirInfo(), nil
+				},
+				GetContentFn: func(_ context.Context, _ string) ([]byte, error) { return emptyIndex, nil },
+				ListFn: func(_ context.Context, path string) ([]string, error) {
+					switch path {
+					case uploadsDir:
+						return nil, notFound(path)
+					case blobsDir:
+						return []string{sha256Dir}, nil
+					case sha256Dir:
+						return []string{blobPath}, nil
+					}
+
+					return nil, notFound(path)
+				},
+			}
+
+			removed, err := removeIdle(newMockStore(storeMock), repo, time.Hour)
+			So(err, ShouldNotBeNil)
+			So(removed, ShouldBeFalse)
+		})
+
+		Convey("a blob delete failure", func() {
+			storeMock := &mocks.StorageDriverMock{
+				StatFn: func(_ context.Context, path string) (driver.FileInfo, error) {
+					if path == blobPath {
+						return &mocks.FileInfoMock{SizeFn: func() int64 { return 10 }}, nil
+					}
+
+					return dirInfo(), nil
+				},
+				GetContentFn: func(_ context.Context, _ string) ([]byte, error) { return emptyIndex, nil },
+				ListFn: func(_ context.Context, path string) ([]string, error) {
+					switch path {
+					case uploadsDir:
+						return nil, notFound(path)
+					case blobsDir:
+						return []string{sha256Dir}, nil
+					case sha256Dir:
+						return []string{blobPath}, nil
+					}
+
+					return nil, notFound(path)
+				},
+				DeleteFn: func(_ context.Context, path string) error {
+					So(path, ShouldEqual, blobPath)
+
+					return errDriverFailed
+				},
+			}
+
+			removed, err := removeIdle(newMockStore(storeMock), repo, 0)
+			So(err, ShouldNotBeNil)
+			So(removed, ShouldBeFalse)
+		})
+
+		Convey("a relisting failure after the sweep", func() {
+			blobsListCalls := 0
+			storeMock := &mocks.StorageDriverMock{
+				StatFn: func(_ context.Context, path string) (driver.FileInfo, error) {
+					if path == blobPath {
+						return &mocks.FileInfoMock{SizeFn: func() int64 { return 10 }}, nil
+					}
+
+					return dirInfo(), nil
+				},
+				GetContentFn: func(_ context.Context, _ string) ([]byte, error) { return emptyIndex, nil },
+				ListFn: func(_ context.Context, path string) ([]string, error) {
+					switch path {
+					case uploadsDir:
+						return nil, notFound(path)
+					case blobsDir:
+						blobsListCalls++
+						if blobsListCalls > 1 {
+							return nil, errDriverFailed
+						}
+
+						return []string{sha256Dir}, nil
+					case sha256Dir:
+						return []string{blobPath}, nil
+					}
+
+					return nil, notFound(path)
+				},
+				DeleteFn: func(_ context.Context, _ string) error { return nil },
+			}
+
+			removed, err := removeIdle(newMockStore(storeMock), repo, 0)
+			So(err, ShouldNotBeNil)
+			So(removed, ShouldBeFalse)
+		})
+
+		Convey("a layout delete failure", func() {
+			storeMock := &mocks.StorageDriverMock{
+				StatFn:       func(_ context.Context, _ string) (driver.FileInfo, error) { return dirInfo(), nil },
+				GetContentFn: func(_ context.Context, _ string) ([]byte, error) { return emptyIndex, nil },
+				ListFn:       func(_ context.Context, path string) ([]string, error) { return nil, notFound(path) },
+				DeleteFn: func(_ context.Context, path string) error {
+					So(path, ShouldEqual, repoDir)
+
+					return errDriverFailed
+				},
+			}
+
+			removed, err := removeIdle(newMockStore(storeMock), repo, 0)
+			So(err, ShouldNotBeNil)
+			So(removed, ShouldBeFalse)
+		})
 	})
 }

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -58,7 +58,8 @@ type ImageStore interface { //nolint:interfacebloat
 	GetBlobPartial(repo string, digest godigest.Digest, mediaType string, from, to int64,
 	) (io.ReadCloser, int64, int64, error)
 	DeleteBlob(repo string, digest godigest.Digest) error
-	CleanupRepo(repo string, blobs []godigest.Digest, removeRepo bool) (int, error)
+	CleanupRepo(repo string, blobs []godigest.Digest) (int, error)
+	RemoveIdleRepository(repo string, maxBlobAge time.Duration) (bool, error)
 	GetIndexContent(repo string) ([]byte, error)
 	PutIndexContent(repo string, index ispec.Index) error
 	StatIndex(repo string) (bool, int64, time.Time, error)

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -59,7 +59,8 @@ type MockedImageStore struct {
 		duplicateBlobs []string) error
 	GetNextDigestWithBlobPathsFn  func(repos []string, lastDigests []godigest.Digest) (godigest.Digest, []string, error)
 	GetAllBlobsFn                 func(repo string) ([]godigest.Digest, error)
-	CleanupRepoFn                 func(repo string, blobs []godigest.Digest, removeRepo bool) (int, error)
+	CleanupRepoFn                 func(repo string, blobs []godigest.Digest) (int, error)
+	RemoveIdleRepositoryFn        func(repo string, maxBlobAge time.Duration) (bool, error)
 	PutIndexContentFn             func(repo string, index ispec.Index) error
 	PopulateStorageMetricsFn      func(interval time.Duration, sch *scheduler.Scheduler)
 	StatIndexFn                   func(repo string) (bool, int64, time.Time, error)
@@ -444,12 +445,20 @@ func (is MockedImageStore) GetNextDigestWithBlobPaths(repos []string, lastDigest
 	return "", []string{}, nil
 }
 
-func (is MockedImageStore) CleanupRepo(repo string, blobs []godigest.Digest, removeRepo bool) (int, error) {
+func (is MockedImageStore) CleanupRepo(repo string, blobs []godigest.Digest) (int, error) {
 	if is.CleanupRepoFn != nil {
-		return is.CleanupRepoFn(repo, blobs, removeRepo)
+		return is.CleanupRepoFn(repo, blobs)
 	}
 
 	return 0, nil
+}
+
+func (is MockedImageStore) RemoveIdleRepository(repo string, maxBlobAge time.Duration) (bool, error) {
+	if is.RemoveIdleRepositoryFn != nil {
+		return is.RemoveIdleRepositoryFn(repo, maxBlobAge)
+	}
+
+	return false, nil
 }
 
 func (is MockedImageStore) PutIndexContent(repo string, index ispec.Index) error {

--- a/test/blackbox/quota.bats
+++ b/test/blackbox/quota.bats
@@ -122,3 +122,47 @@ function teardown_file() {
         docker://127.0.0.1:${zot_port}/repo1:v2
     [ "$status" -eq 0 ]
 }
+
+@test "deleting a repo at the limit frees a slot for a new repo" {
+    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
+
+    # repo2 holds one tag; remove its manifest so the repo is empty.
+    digest=$(curl -s -o /dev/null -D - \
+        -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+        "http://127.0.0.1:${zot_port}/v2/repo2/manifests/v1" \
+        | tr -d '\r' | grep -i '^docker-content-digest:' | awk '{print $2}')
+    [ -n "$digest" ]
+
+    run curl -s -o /dev/null -w "%{http_code}" -X DELETE \
+        "http://127.0.0.1:${zot_port}/v2/repo2/manifests/${digest}"
+    [ "$status" -eq 0 ]
+    [ "${lines[-1]}" -eq 202 ]
+
+    # The layout goes with the quota slot, so the catalog must not list repo2 anymore.
+    run curl -s http://127.0.0.1:${zot_port}/v2/_catalog
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq 'any(.repositories[]; . == "repo2") | not') = "true" ]
+
+    # The freed slot lets a differently named repo be created.
+    run skopeo --insecure-policy copy --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/golang:1.20 \
+        docker://127.0.0.1:${zot_port}/repo4:v1
+    [ "$status" -eq 0 ]
+
+    run curl -s http://127.0.0.1:${zot_port}/v2/_catalog
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.repositories | sort | join(",")') = '"repo1,repo4"' ]
+}
+
+# Guards the opposite direction to the test above: releasing a slot must not
+# release more than one, so the quota still applies once the freed slot is taken.
+@test "quota still applies after the freed slot is taken" {
+    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
+    run curl -s -o /dev/null -w "%{http_code}" \
+        -X PUT \
+        -H "Content-Type: application/vnd.oci.image.manifest.v1+json" \
+        -d "${MINIMAL_MANIFEST}" \
+        "http://127.0.0.1:${zot_port}/v2/repo5/manifests/v1"
+    [ "$status" -eq 0 ]
+    [ "${lines[-1]}" -eq 429 ]
+}


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix:**

None filed. Repro steps and output are below.

**What does this PR do / Why do we need it:**

storage.maxRepos is enforced against metaDB.CountRepos(), but no code path removed a repo's meta record on delete, and GC removed repo layouts without touching metadb. The count therefore never decreased: once a registry reached maxRepos, pushes creating new repositories were rejected until restart, and a layout GC reaped left a stale key that let a later push to the same name skip the limit.

Repository-level removal now happens in one place, ImageStore.RemoveIdleRepository, which drops the layout and the meta record under the same store lock once a repo holds no manifests, no blob uploads and no blobs:

- OnDeleteManifest calls it with a zero max blob age, so a repo emptied by manifest deletes is reclaimed immediately, orphan blobs included, instead of waiting for GC or a restart.
- cleanRepo calls it with the configured GC delay after blob reaping, so GC removes repos  it emptied, and also blobless empty layouts, which the old removeRepo predicate (len(gcBlobs) > 0) never removed.
- CleanupRepo no longer deletes repo directories, so every layout delete goes through RemoveIdleRepository and cannot skip metadb.

Because the layout and the meta record go together, _catalog and the quota count cannot diverge: the catalog never lists a repo the quota ignores, and the quota never counts a repo whose layout is gone.

**If an issue # is not available please add repro steps and logs showing the issue:**

Start a registry with a small quota:

```json
{
  "distSpecVersion": "1.1.1",
  "storage": { "rootDirectory": "/tmp/zot-quota", "gc": false, "maxRepos": 2 },
  "http": { "address": "127.0.0.1", "port": "15000" }
}
```

1. Push images to repo1 and repo2. Both succeed.
2. Push to repo3. Correctly refused: 429 {"errors":[{"code":"TOOMANYREQUESTS","detail":{"limit":"2"}}]}
3. Delete every manifest in repo1 by digest. Each returns 202.
4. Push to repo3 again. Still refused with 429, though only one repo now holds content.

The count never decreases, so once a registry is at its limit no new repository can ever be created. Observed directly against a Redis metadata backend, where the quota count is HLEN <keyprefix>:RepoMeta:

- before fix, after deleting repo 'alpha': HLEN zot:RepoMeta = 2   fields: alpha beta
- after  fix, after deleting repo 'alpha': HLEN zot:RepoMeta = 1   fields: beta

**Testing done on this change:**

Unit and integration tests added; all of them fail without the change (verified by stubbing RemoveIdleRepository to a no-op and watching every key test fail).

- pkg/storage/imagestore: RemoveIdleRepository removes an idle repo and its meta record, keeps repos with manifests, in-progress uploads or blobs younger than the max age, tolerates a nil metadb and a failed meta delete.
- pkg/storage/gc: GC deletes the meta record together with the layout, removes blobless empty layouts, and removes neither on a dry run.
- pkg/meta: an emptied repo loses layout and meta; a repo holding another tagged manifest, or only an untagged one, keeps both.
- pkg/api: partial delete keeps the slot, full delete releases it and drops the repo from _catalog, the emptied name is reusable and counts as a new repo under the limit, the release survives a restart, and the path holds with GC enabled.
- Manual testing against a running registry, driving the full OCI push/delete flow over HTTP: repeated fill-to-limit / delete / push-new-name cycles across the boltdb and Redis metadata backends, with GC disabled and enabled, and maxRepos of 2 and 3.
- Existing suites: pkg/storage/..., pkg/meta/... (all three backends) and pkg/api green under -race with the full extension tag set; golangci-lint v2.12.2 with the CI tag set reports 0 issues.

**Automation added to e2e:**

Yes, two cases in test/blackbox/quota.bats (wired into test/blackbox/ci.sh): deleting a repo at the limit frees a slot for a new repo, asserting the catalog no longer lists the deleted repo, and the quota is enforced again once that freed slot is taken.

**Will this break upgrades or downgrades?**

No schema, config or API change. One behaviour change to note: a repository whose last manifest is deleted now disappears from _catalog immediately, where previously its empty layout remained listed until GC or restart. On upgrade, stale meta records for layouts already deleted are dropped by the existing startup reparse. On downgrade the previous behaviour resumes, with emptied repos holding their slot until a restart.

**Does this PR introduce any user-facing change?**:

Yes. Deleting the last manifest in a repository now removes the repository immediately, its _catalog entry and its storage.maxRepos quota slot are released together, instead of the slot staying occupied until the registry restarted.

```release-note
Deleting the last manifest in a repository removes the repository: its storage layout, catalog entry and 
storage.maxRepos quota slot are released together. GC also removes emptied repositories (including 
blobless ones) together with their metadata, so a reaped repository no longer leaves a stale record 
that could skip the quota on re-push.
```
