### PR TITLE
fix(sync): add disableHTTP2 option to saturate high-bandwidth links

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1401,6 +1401,8 @@ Configure each registry sync:
 				"maxRetryDelay": "30s",             # max HTTP retry backoff; optional, defaults to retryDelay (fixed interval). Set higher than retryDelay for exponential backoff.
 				"reqConcurrent": 30,                # max concurrent in-flight requests per host, applied independently to this upstream and to each of its mirrors, not shared across them (default: 3); raise it when one zot proxies many concurrent on-demand pulls from a single upstream
 				"reqPerSec": 100,                   # max request rate (requests/second) per host, applied independently to this upstream and to each of its mirrors, not shared across them (default: unlimited)
+				"disableHTTP2": true,               # force HTTP/1.1 to the upstream, so each concurrent request opens its own TCP connection instead of sharing the single connection (and congestion window) HTTP/2 multiplexes requests onto (default: false, i.e. HTTP/2 is negotiated when the upstream supports it)
+				"maxIdleConnsPerHost": 30,           # per-host idle connection pool size (default: 2; when disableHTTP2 is true and this is unset, defaults to reqConcurrent instead, so pooled HTTP/1.1 connections aren't closed under concurrency)
 				"onlySigned": true,                 # sync only signed images (either notary or cosign)
 				"content":[                         # which content to periodically pull, also it's used for filtering ondemand images, if not set then periodically polling will not run
 					{

--- a/examples/config-sync.json
+++ b/examples/config-sync.json
@@ -78,7 +78,9 @@
 					"maxRetryDelay": "30s",
 					"syncTimeout": "10m",
 					"reqConcurrent": 30,
-					"reqPerSec": 100
+					"reqPerSec": 100,
+					"disableHTTP2": true,
+					"maxIdleConnsPerHost": 30
 				},
 				{
 					"urls": [

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -1818,6 +1818,17 @@ func validateSyncReqLimits(regID int, regCfg syncconf.RegistryConfig, logger zlo
 		return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
 	}
 
+	// Only checked when the pointer is set: 0 silently means DefaultMaxIdleConnsPerHost (2) to Go's
+	// transport, and a negative value would otherwise pass straight through to it. disableHTTP2 with
+	// maxIdleConnsPerHost omitted is unaffected by this check; newClient fills the idle pool itself.
+	if regCfg.MaxIdleConnsPerHost != nil && *regCfg.MaxIdleConnsPerHost <= 0 {
+		msg := "maxIdleConnsPerHost must be greater than 0"
+		logger.Error().Err(zerr.ErrBadConfig).Int("id", regID).Interface("extensions.sync.registries[id]",
+			regCfg).Msg(msg)
+
+		return fmt.Errorf("%w: %s", zerr.ErrBadConfig, msg)
+	}
+
 	return nil
 }
 

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -2072,6 +2072,47 @@ extensions:
 		So(err, ShouldBeNil)
 	})
 
+	Convey("Test verify with non-positive sync maxIdleConnsPerHost", t, func(c C) {
+		content := `{"storage":{"rootDirectory":"/tmp/zot"},
+							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
+							"maxIdleConnsPerHost": 0}]}}}`
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+
+		os.Args = []string{"cli_test", "verify", tmpfile}
+		err := cli.NewServerRootCmd().Execute()
+		So(err, ShouldNotBeNil)
+	})
+
+	Convey("Test verify with valid sync disableHTTP2 and maxIdleConnsPerHost", t, func(c C) {
+		content := `{"storage":{"rootDirectory":"/tmp/zot"},
+							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
+							"reqConcurrent": 16, "disableHTTP2": true, "maxIdleConnsPerHost": 30}]}}}`
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+
+		os.Args = []string{"cli_test", "verify", tmpfile}
+		err := cli.NewServerRootCmd().Execute()
+		So(err, ShouldBeNil)
+	})
+
+	Convey("Test verify with disableHTTP2 and maxIdleConnsPerHost omitted", t, func(c C) {
+		// newClient defaults the idle pool to reqConcurrent in this case (see service.go), so
+		// verify must not require maxIdleConnsPerHost to be set alongside disableHTTP2.
+		content := `{"storage":{"rootDirectory":"/tmp/zot"},
+							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",
+							"auth":{"htpasswd":{"path":"test/data/htpasswd"},"failDelay":1}},
+							"extensions":{"sync": {"registries": [{"urls":["localhost:9999"],
+							"disableHTTP2": true}]}}}`
+		tmpfile := MakeTempFileWithContent(t, "zot-test.json", content)
+
+		os.Args = []string{"cli_test", "verify", tmpfile}
+		err := cli.NewServerRootCmd().Execute()
+		So(err, ShouldBeNil)
+	})
+
 	Convey("Test verify with good sync content config", t, func(c C) {
 		content := `{"storage":{"rootDirectory":"/tmp/zot"},
 							"http":{"address":"127.0.0.1","port":"8080","realm":"zot",

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -75,6 +75,12 @@ type RegistryConfig struct {
 	// host), so it is a per-host cap, not a shared total across hosts. When unset it defaults to
 	// regclient's default (3). Raising it helps when a single zot proxies many concurrent on-demand pulls
 	// of different images from one upstream, where the default causes head-of-line blocking.
+	//
+	// ReqConcurrent and DisableHTTP2 compose, and both are usually needed together: ReqConcurrent
+	// alone still funnels every request through one HTTP/2 connection (one TCP congestion window) if
+	// the upstream negotiates h2, while DisableHTTP2 alone still caps concurrency at ReqConcurrent's
+	// default of 3 connections. To actually open more than 3 parallel connections to an HTTP/2
+	// upstream, raise ReqConcurrent and set DisableHTTP2.
 	ReqConcurrent *int
 	// ReqPerSec caps the request rate (requests/second) per upstream host, applied independently to the
 	// upstream registry and to each of its mirrors (a per-host cap, not a shared total across hosts).
@@ -82,12 +88,18 @@ type RegistryConfig struct {
 	ReqPerSec *float64
 	// DisableHTTP2 forces HTTP/1.1 to the upstream, so each concurrent request opens its own TCP
 	// connection instead of sharing the single connection (and congestion window) HTTP/2 multiplexes
-	// requests onto. Useful for saturating high-bandwidth links where ReqConcurrent alone can't help
-	// because everything still funnels through one HTTP/2 connection.
+	// requests onto. See the ReqConcurrent doc comment above: the two settings compose, and raising
+	// ReqConcurrent is what actually lets more than 3 connections open.
 	DisableHTTP2 *bool
-	// MaxIdleConnsPerHost overrides the transport's per-host idle connection pool size (Go default: 2).
-	// Only useful alongside DisableHTTP2, so that concurrent HTTP/1.1 connections are pooled/reused
-	// instead of being closed once the pool is full.
+	// MaxIdleConnsPerHost overrides the transport's per-host idle connection pool size (Go default: 2),
+	// applied whether or not DisableHTTP2 is set (it also helps a plain-HTTP or already-HTTP/1.1
+	// upstream keep its connections pooled). An explicit value here always wins.
+	//
+	// When DisableHTTP2 is true and this is left unset, it defaults to ReqConcurrent's effective
+	// value (the configured value, or regclient's default of 3) instead of Go's default of 2 —
+	// otherwise DisableHTTP2 alone would still hit the handshake-per-request pattern this option
+	// exists to avoid, since concurrent HTTP/1.1 connections beyond 2 would get closed instead of
+	// pooled.
 	MaxIdleConnsPerHost *int
 }
 

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -80,6 +80,15 @@ type RegistryConfig struct {
 	// upstream registry and to each of its mirrors (a per-host cap, not a shared total across hosts).
 	// When unset it defaults to regclient's default (0, i.e. unlimited).
 	ReqPerSec *float64
+	// DisableHTTP2 forces HTTP/1.1 to the upstream, so each concurrent request opens its own TCP
+	// connection instead of sharing the single connection (and congestion window) HTTP/2 multiplexes
+	// requests onto. Useful for saturating high-bandwidth links where ReqConcurrent alone can't help
+	// because everything still funnels through one HTTP/2 connection.
+	DisableHTTP2 *bool
+	// MaxIdleConnsPerHost overrides the transport's per-host idle connection pool size (Go default: 2).
+	// Only useful alongside DisableHTTP2, so that concurrent HTTP/1.1 connections are pooled/reused
+	// instead of being closed once the pool is full.
+	MaxIdleConnsPerHost *int
 }
 
 // OAuth2HelperConfig holds the options used by the "oauth2" credential helper,

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -4,6 +4,7 @@ package sync
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -987,8 +988,8 @@ func newClient(opts syncconf.RegistryConfig, credentials syncconf.CredentialsFil
 	}
 
 	// set TLS configuration
-	tls := getTLSConfigOption(urls[0], opts.TLSVerify)
-	hostConfig.TLS = tls
+	tlsConf := getTLSConfigOption(urls[0], opts.TLSVerify)
+	hostConfig.TLS = tlsConf
 
 	if opts.CertDir != "" {
 		clientCert, clientKey, regCert, err := getCertificates(opts.CertDir)
@@ -1060,6 +1061,28 @@ func newClient(opts syncconf.RegistryConfig, credentials syncconf.CredentialsFil
 	// which are separate component timeouts. Doesn't cover body transfer time, which is expected
 	// to be slow for large images.
 	transport.ResponseHeaderTimeout = opts.ResponseHeaderTimeout
+
+	// DisableHTTP2: net/http multiplexes every request to a host onto a single HTTP/2 connection,
+	// so all of it shares one TCP congestion window regardless of client-side concurrency. Forcing
+	// HTTP/1.1 makes each concurrent request open its own TCP connection instead. Clearing
+	// TLSNextProto alone isn't enough, since the server can still select "h2" during the TLS
+	// handshake; NextProtos must be pinned so ALPN negotiation itself excludes it.
+	if opts.DisableHTTP2 != nil && *opts.DisableHTTP2 {
+		transport.ForceAttemptHTTP2 = false
+		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
+
+		if transport.TLSClientConfig == nil {
+			// No fields set here diverge from http.DefaultTransport's TLS behavior (e.g. MinVersion
+			// stays at Go's secure default); this only exists as a place to pin NextProtos below.
+			transport.TLSClientConfig = &tls.Config{} //nolint:gosec
+		}
+
+		transport.TLSClientConfig.NextProtos = []string{"http/1.1"}
+	}
+
+	if opts.MaxIdleConnsPerHost != nil {
+		transport.MaxIdleConnsPerHost = *opts.MaxIdleConnsPerHost
+	}
 
 	// Use SyncTimeout for overall HTTP client timeout. This is the maximum time for the entire
 	// HTTP request, covering all stages: DialContext (connection establishment), TLSHandshakeTimeout

--- a/pkg/extensions/sync/service.go
+++ b/pkg/extensions/sync/service.go
@@ -949,6 +949,58 @@ func httpRetryDelayBounds(opts syncconf.RegistryConfig) (time.Duration, time.Dur
 	return delayInit, delayMax, true
 }
 
+// effectiveMaxIdleConnsPerHost returns the transport's MaxIdleConnsPerHost setting: the
+// configured override when set, or — when DisableHTTP2 is enabled — reqConcurrent, so the idle
+// pool is sized to match how many HTTP/1.1 connections can actually be in flight (otherwise it
+// stays at Go's default of 2, and connections beyond that get closed instead of pooled, undoing
+// most of DisableHTTP2's benefit under concurrency). Otherwise 0, meaning "leave it at the Go
+// default" (the same value the cloned http.DefaultTransport already carries).
+func effectiveMaxIdleConnsPerHost(opts syncconf.RegistryConfig, reqConcurrent int64) int {
+	if opts.MaxIdleConnsPerHost != nil {
+		return *opts.MaxIdleConnsPerHost
+	}
+
+	if opts.DisableHTTP2 != nil && *opts.DisableHTTP2 {
+		return int(reqConcurrent)
+	}
+
+	return 0
+}
+
+// pinHTTP1ALPN returns tlsConfig with NextProtos pinned to exclude HTTP/2, so ALPN negotiation
+// itself excludes "h2" even if the upstream would otherwise select it (clearing Transport.TLSNextProto
+// alone isn't enough for that). tlsConfig may be nil: http.Transport.Clone() lazily runs Go's own
+// HTTP/2 auto-configuration on its source transport first, which in virtually every real build sets a
+// non-nil TLSClientConfig before Clone() copies it — but that's an internal net/http implementation
+// detail, not a guarantee, so this stays nil-safe rather than assuming it.
+func pinHTTP1ALPN(tlsConfig *tls.Config) *tls.Config {
+	if tlsConfig == nil {
+		// No fields set here diverge from http.DefaultTransport's TLS behavior (e.g. MinVersion
+		// stays at Go's secure default); this only exists as a place to pin NextProtos below.
+		tlsConfig = &tls.Config{} //nolint:gosec
+	}
+
+	tlsConfig.NextProtos = []string{"http/1.1"}
+
+	return tlsConfig
+}
+
+// applySyncTransportOptions applies DisableHTTP2 and MaxIdleConnsPerHost to transport in place.
+// Extracted out of newClient so a unit test can inspect the resulting *http.Transport directly:
+// newClient only returns a *regclient.RegClient, which wraps the transport and doesn't expose it.
+func applySyncTransportOptions(transport *http.Transport, opts syncconf.RegistryConfig, reqConcurrent int64) {
+	// DisableHTTP2: net/http multiplexes every request to a host onto a single HTTP/2 connection,
+	// so all of it shares one TCP congestion window regardless of client-side concurrency. Forcing
+	// HTTP/1.1 makes each concurrent request open its own TCP connection instead.
+	if opts.DisableHTTP2 != nil && *opts.DisableHTTP2 {
+		transport.ForceAttemptHTTP2 = false
+		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
+		transport.TLSClientConfig = pinHTTP1ALPN(transport.TLSClientConfig)
+	}
+
+	transport.MaxIdleConnsPerHost = effectiveMaxIdleConnsPerHost(opts, reqConcurrent)
+}
+
 func newClient(opts syncconf.RegistryConfig, credentials syncconf.CredentialsFile, logger log.Logger,
 ) (*regclient.RegClient, []config.Host, error) {
 	urls, err := parseRegistryURLs(opts.URLs)
@@ -1062,27 +1114,9 @@ func newClient(opts syncconf.RegistryConfig, credentials syncconf.CredentialsFil
 	// to be slow for large images.
 	transport.ResponseHeaderTimeout = opts.ResponseHeaderTimeout
 
-	// DisableHTTP2: net/http multiplexes every request to a host onto a single HTTP/2 connection,
-	// so all of it shares one TCP congestion window regardless of client-side concurrency. Forcing
-	// HTTP/1.1 makes each concurrent request open its own TCP connection instead. Clearing
-	// TLSNextProto alone isn't enough, since the server can still select "h2" during the TLS
-	// handshake; NextProtos must be pinned so ALPN negotiation itself excludes it.
-	if opts.DisableHTTP2 != nil && *opts.DisableHTTP2 {
-		transport.ForceAttemptHTTP2 = false
-		transport.TLSNextProto = map[string]func(string, *tls.Conn) http.RoundTripper{}
-
-		if transport.TLSClientConfig == nil {
-			// No fields set here diverge from http.DefaultTransport's TLS behavior (e.g. MinVersion
-			// stays at Go's secure default); this only exists as a place to pin NextProtos below.
-			transport.TLSClientConfig = &tls.Config{} //nolint:gosec
-		}
-
-		transport.TLSClientConfig.NextProtos = []string{"http/1.1"}
-	}
-
-	if opts.MaxIdleConnsPerHost != nil {
-		transport.MaxIdleConnsPerHost = *opts.MaxIdleConnsPerHost
-	}
+	// hostConfig.ReqConcurrent already holds the effective per-host concurrency cap at this point
+	// (regclient's default of 3, from HostNew() above, or opts.ReqConcurrent if it was set).
+	applySyncTransportOptions(transport, opts, hostConfig.ReqConcurrent)
 
 	// Use SyncTimeout for overall HTTP client timeout. This is the maximum time for the entire
 	// HTTP request, covering all stages: DialContext (connection establishment), TLSHandshakeTimeout

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -2116,6 +2116,82 @@ func TestNewClientReqConcurrentReqPerSec(t *testing.T) {
 	})
 }
 
+// TestNewClientDisableHTTP2 verifies that DisableHTTP2 pins the upstream connection to
+// HTTP/1.1 even against a server that supports and would otherwise negotiate HTTP/2.
+func TestNewClientDisableHTTP2(t *testing.T) {
+	Convey("Test newClient DisableHTTP2 behavior", t, func() {
+		logger := log.NewTestLogger()
+
+		negotiatedProto := make(chan string, 1)
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			negotiatedProto <- r.Proto
+			w.WriteHeader(http.StatusOK)
+		})
+
+		server := httptest.NewUnstartedServer(handler)
+		server.EnableHTTP2 = true // advertise "h2" via ALPN, like a real HTTP/2-capable registry
+		server.StartTLS()
+		defer server.Close()
+
+		host := strings.TrimPrefix(server.URL, "https://")
+
+		// httptest's TLS cert is self-signed, so skip verification to isolate this test
+		// from cert trust; DisableHTTP2/ALPN pinning is orthogonal to cert validation.
+		insecure := false
+		insecureVerify := &insecure
+
+		Convey("DisableHTTP2 forces HTTP/1.1 against an HTTP/2-capable server", func() {
+			disableHTTP2 := true
+			opts := syncconf.RegistryConfig{
+				URLs:                  []string{server.URL},
+				TLSVerify:             insecureVerify,
+				SyncTimeout:           syncConstants.DefaultSyncTimeout,
+				ResponseHeaderTimeout: syncConstants.DefaultResponseHeaderTimeout,
+				DisableHTTP2:          &disableHTTP2,
+			}
+
+			client, _, err := newClient(opts, syncconf.CredentialsFile{}, logger)
+			So(err, ShouldBeNil)
+
+			r, err := ref.New(host + "/repo:tag")
+			So(err, ShouldBeNil)
+
+			_, _ = client.ManifestHead(context.Background(), r)
+
+			select {
+			case proto := <-negotiatedProto:
+				So(proto, ShouldEqual, "HTTP/1.1")
+			case <-time.After(5 * time.Second):
+				t.Fatal("server never received a request")
+			}
+		})
+
+		Convey("without DisableHTTP2, an HTTP/2-capable server negotiates HTTP/2", func() {
+			opts := syncconf.RegistryConfig{
+				URLs:                  []string{server.URL},
+				TLSVerify:             insecureVerify,
+				SyncTimeout:           syncConstants.DefaultSyncTimeout,
+				ResponseHeaderTimeout: syncConstants.DefaultResponseHeaderTimeout,
+			}
+
+			client, _, err := newClient(opts, syncconf.CredentialsFile{}, logger)
+			So(err, ShouldBeNil)
+
+			r, err := ref.New(host + "/repo:tag")
+			So(err, ShouldBeNil)
+
+			_, _ = client.ManifestHead(context.Background(), r)
+
+			select {
+			case proto := <-negotiatedProto:
+				So(proto, ShouldEqual, "HTTP/2.0")
+			case <-time.After(5 * time.Second):
+				t.Fatal("server never received a request")
+			}
+		})
+	})
+}
+
 func TestHTTPRetryDelayBounds(t *testing.T) {
 	Convey("httpRetryDelayBounds maps sync config to regclient delay args", t, func() {
 		retryDelay := 1 * time.Second

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -2116,15 +2116,30 @@ func TestNewClientReqConcurrentReqPerSec(t *testing.T) {
 	})
 }
 
+// drainNegotiatedProto discards any value left over from a previous request on the channel,
+// so a subtest only ever observes the protocol of the request it is about to issue.
+func drainNegotiatedProto(negotiatedProto chan string) {
+	select {
+	case <-negotiatedProto:
+	default:
+	}
+}
+
 // TestNewClientDisableHTTP2 verifies that DisableHTTP2 pins the upstream connection to
 // HTTP/1.1 even against a server that supports and would otherwise negotiate HTTP/2.
 func TestNewClientDisableHTTP2(t *testing.T) {
 	Convey("Test newClient DisableHTTP2 behavior", t, func() {
 		logger := log.NewTestLogger()
 
-		negotiatedProto := make(chan string, 1)
+		// Buffered well past one: a HEAD request can hit the handler more than once (e.g. an
+		// auth-challenge round trip before the real request), and the send below must never
+		// block on a slow/absent reader or the handler goroutine hangs.
+		negotiatedProto := make(chan string, 8)
 		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			negotiatedProto <- r.Proto
+			select {
+			case negotiatedProto <- r.Proto:
+			default:
+			}
 			w.WriteHeader(http.StatusOK)
 		})
 
@@ -2137,14 +2152,14 @@ func TestNewClientDisableHTTP2(t *testing.T) {
 
 		// httptest's TLS cert is self-signed, so skip verification to isolate this test
 		// from cert trust; DisableHTTP2/ALPN pinning is orthogonal to cert validation.
-		insecure := false
-		insecureVerify := &insecure
+		tlsVerifyOff := false
+		tlsVerify := &tlsVerifyOff
 
 		Convey("DisableHTTP2 forces HTTP/1.1 against an HTTP/2-capable server", func() {
 			disableHTTP2 := true
 			opts := syncconf.RegistryConfig{
 				URLs:                  []string{server.URL},
-				TLSVerify:             insecureVerify,
+				TLSVerify:             tlsVerify,
 				SyncTimeout:           syncConstants.DefaultSyncTimeout,
 				ResponseHeaderTimeout: syncConstants.DefaultResponseHeaderTimeout,
 				DisableHTTP2:          &disableHTTP2,
@@ -2156,20 +2171,26 @@ func TestNewClientDisableHTTP2(t *testing.T) {
 			r, err := ref.New(host + "/repo:tag")
 			So(err, ShouldBeNil)
 
-			_, _ = client.ManifestHead(context.Background(), r)
+			drainNegotiatedProto(negotiatedProto)
+
+			// The handler returns a bare 200 with no manifest body/headers, so regclient is
+			// expected to fail parsing it as a manifest; only the transport-level protocol
+			// the request actually reached the server on is under test here.
+			_, err = client.ManifestHead(context.Background(), r)
+			t.Logf("ManifestHead (expected to fail on the stub response): %v", err)
 
 			select {
 			case proto := <-negotiatedProto:
 				So(proto, ShouldEqual, "HTTP/1.1")
 			case <-time.After(5 * time.Second):
-				t.Fatal("server never received a request")
+				t.Fatalf("server never received a request; ManifestHead error: %v", err)
 			}
 		})
 
 		Convey("without DisableHTTP2, an HTTP/2-capable server negotiates HTTP/2", func() {
 			opts := syncconf.RegistryConfig{
 				URLs:                  []string{server.URL},
-				TLSVerify:             insecureVerify,
+				TLSVerify:             tlsVerify,
 				SyncTimeout:           syncConstants.DefaultSyncTimeout,
 				ResponseHeaderTimeout: syncConstants.DefaultResponseHeaderTimeout,
 			}
@@ -2180,13 +2201,17 @@ func TestNewClientDisableHTTP2(t *testing.T) {
 			r, err := ref.New(host + "/repo:tag")
 			So(err, ShouldBeNil)
 
-			_, _ = client.ManifestHead(context.Background(), r)
+			drainNegotiatedProto(negotiatedProto)
+
+			// See the comment in the sibling Convey above: the parse failure is expected.
+			_, err = client.ManifestHead(context.Background(), r)
+			t.Logf("ManifestHead (expected to fail on the stub response): %v", err)
 
 			select {
 			case proto := <-negotiatedProto:
 				So(proto, ShouldEqual, "HTTP/2.0")
 			case <-time.After(5 * time.Second):
-				t.Fatal("server never received a request")
+				t.Fatalf("server never received a request; ManifestHead error: %v", err)
 			}
 		})
 	})

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -2119,9 +2120,12 @@ func TestNewClientReqConcurrentReqPerSec(t *testing.T) {
 // drainNegotiatedProto discards any value left over from a previous request on the channel,
 // so a subtest only ever observes the protocol of the request it is about to issue.
 func drainNegotiatedProto(negotiatedProto chan string) {
-	select {
-	case <-negotiatedProto:
-	default:
+	for {
+		select {
+		case <-negotiatedProto:
+		default:
+			return
+		}
 	}
 }
 
@@ -2244,6 +2248,120 @@ func TestHTTPRetryDelayBounds(t *testing.T) {
 			So(ok, ShouldBeTrue)
 			So(delayInit, ShouldEqual, retryDelay)
 			So(delayMax, ShouldEqual, maxRetryDelay)
+		})
+	})
+}
+
+// TestEffectiveMaxIdleConnsPerHost verifies that DisableHTTP2 without an explicit
+// maxIdleConnsPerHost defaults the idle pool to reqConcurrent, so DisableHTTP2 alone is enough
+// to keep concurrent HTTP/1.1 connections pooled instead of being closed at Go's default of 2.
+func TestEffectiveMaxIdleConnsPerHost(t *testing.T) {
+	Convey("effectiveMaxIdleConnsPerHost", t, func() {
+		Convey("neither set leaves the Go default (0: caller doesn't override)", func() {
+			got := effectiveMaxIdleConnsPerHost(syncconf.RegistryConfig{}, 3)
+			So(got, ShouldEqual, 0)
+		})
+
+		Convey("DisableHTTP2 alone defaults to reqConcurrent", func() {
+			disableHTTP2 := true
+			got := effectiveMaxIdleConnsPerHost(syncconf.RegistryConfig{DisableHTTP2: &disableHTTP2}, 16)
+			So(got, ShouldEqual, 16)
+		})
+
+		Convey("DisableHTTP2 false does not default", func() {
+			disableHTTP2 := false
+			got := effectiveMaxIdleConnsPerHost(syncconf.RegistryConfig{DisableHTTP2: &disableHTTP2}, 16)
+			So(got, ShouldEqual, 0)
+		})
+
+		Convey("explicit maxIdleConnsPerHost always wins, with or without DisableHTTP2", func() {
+			disableHTTP2 := true
+			maxIdle := 42
+			got := effectiveMaxIdleConnsPerHost(syncconf.RegistryConfig{
+				DisableHTTP2:        &disableHTTP2,
+				MaxIdleConnsPerHost: &maxIdle,
+			}, 16)
+			So(got, ShouldEqual, 42)
+
+			got = effectiveMaxIdleConnsPerHost(syncconf.RegistryConfig{MaxIdleConnsPerHost: &maxIdle}, 16)
+			So(got, ShouldEqual, 42)
+		})
+	})
+}
+
+// TestPinHTTP1ALPN covers the nil-TLSClientConfig branch directly: http.Transport.Clone() sets a
+// non-nil TLSClientConfig in virtually every real build (Go's own lazy HTTP/2 auto-configuration
+// runs on the source transport first), so that branch is unreachable through newClient in
+// practice; this exercises it without depending on that net/http implementation detail.
+func TestPinHTTP1ALPN(t *testing.T) {
+	Convey("pinHTTP1ALPN", t, func() {
+		Convey("nil input gets a fresh config with NextProtos pinned", func() {
+			got := pinHTTP1ALPN(nil)
+			So(got, ShouldNotBeNil)
+			So(got.NextProtos, ShouldResemble, []string{"http/1.1"})
+		})
+
+		Convey("existing config is reused and NextProtos overwritten", func() {
+			existing := &tls.Config{InsecureSkipVerify: true, NextProtos: []string{"h2", "http/1.1"}} //nolint:gosec
+			got := pinHTTP1ALPN(existing)
+			So(got, ShouldEqual, existing) // same pointer: mutated in place, not replaced
+			So(got.NextProtos, ShouldResemble, []string{"http/1.1"})
+			So(got.InsecureSkipVerify, ShouldBeTrue) // untouched
+		})
+	})
+}
+
+// TestApplySyncTransportOptions verifies the exact DisableHTTP2 x MaxIdleConnsPerHost x
+// ReqConcurrent combinations that determine the idle connection pool size on the real
+// *http.Transport newClient builds (newClient itself doesn't expose the transport - it only
+// returns a *regclient.RegClient - so this is what actually covers the assignment).
+func TestApplySyncTransportOptions(t *testing.T) {
+	Convey("applySyncTransportOptions", t, func() {
+		Convey("DisableHTTP2 true, ReqConcurrent and MaxIdleConnsPerHost both unset: idle pool is regclient's default of 3", func() {
+			disableHTTP2 := true
+			transport := &http.Transport{}
+
+			applySyncTransportOptions(transport, syncconf.RegistryConfig{DisableHTTP2: &disableHTTP2}, 3)
+
+			So(transport.MaxIdleConnsPerHost, ShouldEqual, 3)
+			So(transport.ForceAttemptHTTP2, ShouldBeFalse)
+			So(transport.TLSNextProto, ShouldNotBeNil)
+			So(transport.TLSNextProto, ShouldBeEmpty)
+			So(transport.TLSClientConfig, ShouldNotBeNil)
+			So(transport.TLSClientConfig.NextProtos, ShouldResemble, []string{"http/1.1"})
+		})
+
+		Convey("DisableHTTP2 true, ReqConcurrent 16, MaxIdleConnsPerHost unset: idle pool follows ReqConcurrent", func() {
+			disableHTTP2 := true
+			transport := &http.Transport{}
+
+			applySyncTransportOptions(transport, syncconf.RegistryConfig{DisableHTTP2: &disableHTTP2}, 16)
+
+			So(transport.MaxIdleConnsPerHost, ShouldEqual, 16)
+		})
+
+		Convey("explicit MaxIdleConnsPerHost wins over the ReqConcurrent-derived default", func() {
+			disableHTTP2 := true
+			maxIdle := 20
+			transport := &http.Transport{}
+
+			applySyncTransportOptions(transport, syncconf.RegistryConfig{
+				DisableHTTP2:        &disableHTTP2,
+				MaxIdleConnsPerHost: &maxIdle,
+			}, 16)
+
+			So(transport.MaxIdleConnsPerHost, ShouldEqual, 20)
+		})
+
+		Convey("DisableHTTP2 unset leaves HTTP/2 transport fields untouched", func() {
+			transport := &http.Transport{ForceAttemptHTTP2: true}
+
+			applySyncTransportOptions(transport, syncconf.RegistryConfig{}, 3)
+
+			So(transport.ForceAttemptHTTP2, ShouldBeTrue)
+			So(transport.TLSNextProto, ShouldBeNil)
+			So(transport.TLSClientConfig, ShouldBeNil)
+			So(transport.MaxIdleConnsPerHost, ShouldEqual, 0)
 		})
 	})
 }

--- a/test/blackbox/sync.bats
+++ b/test/blackbox/sync.bats
@@ -41,10 +41,12 @@ function setup_file() {
     local zot_sync_per_root_dir=${BATS_FILE_TMPDIR}/zot-per
     local zot_sync_ondemand_root_dir=${BATS_FILE_TMPDIR}/zot-ondemand
     local zot_sync_interval_root_dir=${BATS_FILE_TMPDIR}/zot-interval
+    local zot_sync_disablehttp2_root_dir=${BATS_FILE_TMPDIR}/zot-disablehttp2
 
     local zot_sync_per_config_file=${BATS_FILE_TMPDIR}/zot_sync_per_config.json
     local zot_sync_ondemand_config_file=${BATS_FILE_TMPDIR}/zot_sync_ondemand_config.json
     local zot_sync_interval_config_file=${BATS_FILE_TMPDIR}/zot_sync_interval_config.json
+    local zot_sync_disablehttp2_config_file=${BATS_FILE_TMPDIR}/zot_sync_disablehttp2_config.json
 
     local zot_minimal_root_dir=${BATS_FILE_TMPDIR}/zot-minimal
     local zot_minimal_config_file=${BATS_FILE_TMPDIR}/zot_minimal_config.json
@@ -53,6 +55,7 @@ function setup_file() {
     mkdir -p ${zot_sync_per_root_dir}
     mkdir -p ${zot_sync_ondemand_root_dir}
     mkdir -p ${zot_sync_interval_root_dir}
+    mkdir -p ${zot_sync_disablehttp2_root_dir}
     mkdir -p ${zot_minimal_root_dir}
     mkdir -p ${oci_data_dir}
     zot_port1=$(get_free_port_for_service "zot1")
@@ -63,6 +66,8 @@ function setup_file() {
     echo ${zot_port3} > ${BATS_FILE_TMPDIR}/zot.port3
     zot_port4=$(get_free_port_for_service "zot4")
     echo ${zot_port4} > ${BATS_FILE_TMPDIR}/zot.port4
+    zot_port5=$(get_free_port_for_service "zot5")
+    echo ${zot_port5} > ${BATS_FILE_TMPDIR}/zot.port5
 
     cat >${zot_sync_per_config_file} <<EOF
 {
@@ -181,6 +186,42 @@ EOF
     }
 }
 EOF
+    cat >${zot_sync_disablehttp2_config_file} <<EOF
+{
+    "distSpecVersion": "1.1.1",
+    "storage": {
+        "rootDirectory": "${zot_sync_disablehttp2_root_dir}"
+    },
+    "http": {
+        "address": "0.0.0.0",
+        "port": "${zot_port5}"
+    },
+    "log": {
+        "level": "debug"
+    },
+    "extensions": {
+        "sync": {
+            "registries": [
+                {
+                    "urls": [
+                        "http://localhost:${zot_port3}"
+                    ],
+                    "onDemand": false,
+                    "tlsVerify": false,
+                    "PollInterval": "10s",
+                    "disableHTTP2": true,
+                    "maxIdleConnsPerHost": 20,
+                    "content": [
+                        {
+                            "prefix": "**"
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+EOF
     git -C ${BATS_FILE_TMPDIR} clone https://github.com/project-zot/helm-charts.git
 
     zot_serve ${ZOT_MINIMAL_PATH} ${zot_minimal_config_file}
@@ -194,6 +235,9 @@ EOF
 
     zot_serve ${ZOT_PATH} ${zot_sync_interval_config_file}
     wait_zot_reachable ${zot_port4}
+
+    zot_serve ${ZOT_PATH} ${zot_sync_disablehttp2_config_file}
+    wait_zot_reachable ${zot_port5}
 }
 
 function teardown_file() {
@@ -226,6 +270,31 @@ function teardown_file() {
     run curl http://127.0.0.1:${zot_port1}/v2/golang/tags/list
     [ "$status" -eq 0 ]
     [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.20"' ]
+}
+
+# disableHTTP2 only changes upstream transport plumbing, not sync correctness, so this is a
+# functional smoke test (config accepted, sync still completes) rather than a throughput check -
+# verifying HTTP/1.1 actually gets negotiated needs the unit test in sync_internal_test.go.
+@test "sync golang image periodically with disableHTTP2" {
+    zot_port3=`cat ${BATS_FILE_TMPDIR}/zot.port3`
+    zot_port5=`cat ${BATS_FILE_TMPDIR}/zot.port5`
+    run skopeo --insecure-policy copy --dest-tls-verify=false \
+        oci:${TEST_DATA_DIR}/golang:1.20 \
+        docker://127.0.0.1:${zot_port3}/disablehttp2-test:latest
+    [ "$status" -eq 0 ]
+    run curl http://127.0.0.1:${zot_port3}/v2/disablehttp2-test/tags/list
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"latest"' ]
+
+    run sleep 20s
+
+    run curl http://127.0.0.1:${zot_port5}/v2/_catalog
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.repositories[]') = '"disablehttp2-test"' ]
+
+    run curl http://127.0.0.1:${zot_port5}/v2/disablehttp2-test/tags/list
+    [ "$status" -eq 0 ]
+    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"latest"' ]
 }
 
 @test "sync golang image ondemand" {

--- a/test/blackbox/sync.bats
+++ b/test/blackbox/sync.bats
@@ -41,12 +41,10 @@ function setup_file() {
     local zot_sync_per_root_dir=${BATS_FILE_TMPDIR}/zot-per
     local zot_sync_ondemand_root_dir=${BATS_FILE_TMPDIR}/zot-ondemand
     local zot_sync_interval_root_dir=${BATS_FILE_TMPDIR}/zot-interval
-    local zot_sync_disablehttp2_root_dir=${BATS_FILE_TMPDIR}/zot-disablehttp2
 
     local zot_sync_per_config_file=${BATS_FILE_TMPDIR}/zot_sync_per_config.json
     local zot_sync_ondemand_config_file=${BATS_FILE_TMPDIR}/zot_sync_ondemand_config.json
     local zot_sync_interval_config_file=${BATS_FILE_TMPDIR}/zot_sync_interval_config.json
-    local zot_sync_disablehttp2_config_file=${BATS_FILE_TMPDIR}/zot_sync_disablehttp2_config.json
 
     local zot_minimal_root_dir=${BATS_FILE_TMPDIR}/zot-minimal
     local zot_minimal_config_file=${BATS_FILE_TMPDIR}/zot_minimal_config.json
@@ -55,7 +53,6 @@ function setup_file() {
     mkdir -p ${zot_sync_per_root_dir}
     mkdir -p ${zot_sync_ondemand_root_dir}
     mkdir -p ${zot_sync_interval_root_dir}
-    mkdir -p ${zot_sync_disablehttp2_root_dir}
     mkdir -p ${zot_minimal_root_dir}
     mkdir -p ${oci_data_dir}
     zot_port1=$(get_free_port_for_service "zot1")
@@ -66,8 +63,6 @@ function setup_file() {
     echo ${zot_port3} > ${BATS_FILE_TMPDIR}/zot.port3
     zot_port4=$(get_free_port_for_service "zot4")
     echo ${zot_port4} > ${BATS_FILE_TMPDIR}/zot.port4
-    zot_port5=$(get_free_port_for_service "zot5")
-    echo ${zot_port5} > ${BATS_FILE_TMPDIR}/zot.port5
 
     cat >${zot_sync_per_config_file} <<EOF
 {
@@ -92,6 +87,8 @@ function setup_file() {
                     "onDemand": false,
                     "tlsVerify": false,
                     "PollInterval": "10s",
+                    "disableHTTP2": true,
+                    "maxIdleConnsPerHost": 20,
                     "content": [
                         {
                             "prefix": "**"
@@ -186,42 +183,6 @@ EOF
     }
 }
 EOF
-    cat >${zot_sync_disablehttp2_config_file} <<EOF
-{
-    "distSpecVersion": "1.1.1",
-    "storage": {
-        "rootDirectory": "${zot_sync_disablehttp2_root_dir}"
-    },
-    "http": {
-        "address": "0.0.0.0",
-        "port": "${zot_port5}"
-    },
-    "log": {
-        "level": "debug"
-    },
-    "extensions": {
-        "sync": {
-            "registries": [
-                {
-                    "urls": [
-                        "http://localhost:${zot_port3}"
-                    ],
-                    "onDemand": false,
-                    "tlsVerify": false,
-                    "PollInterval": "10s",
-                    "disableHTTP2": true,
-                    "maxIdleConnsPerHost": 20,
-                    "content": [
-                        {
-                            "prefix": "**"
-                        }
-                    ]
-                }
-            ]
-        }
-    }
-}
-EOF
     git -C ${BATS_FILE_TMPDIR} clone https://github.com/project-zot/helm-charts.git
 
     zot_serve ${ZOT_MINIMAL_PATH} ${zot_minimal_config_file}
@@ -235,9 +196,6 @@ EOF
 
     zot_serve ${ZOT_PATH} ${zot_sync_interval_config_file}
     wait_zot_reachable ${zot_port4}
-
-    zot_serve ${ZOT_PATH} ${zot_sync_disablehttp2_config_file}
-    wait_zot_reachable ${zot_port5}
 }
 
 function teardown_file() {
@@ -270,31 +228,6 @@ function teardown_file() {
     run curl http://127.0.0.1:${zot_port1}/v2/golang/tags/list
     [ "$status" -eq 0 ]
     [ $(echo "${lines[-1]}" | jq '.tags[]') = '"1.20"' ]
-}
-
-# disableHTTP2 only changes upstream transport plumbing, not sync correctness, so this is a
-# functional smoke test (config accepted, sync still completes) rather than a throughput check -
-# verifying HTTP/1.1 actually gets negotiated needs the unit test in sync_internal_test.go.
-@test "sync golang image periodically with disableHTTP2" {
-    zot_port3=`cat ${BATS_FILE_TMPDIR}/zot.port3`
-    zot_port5=`cat ${BATS_FILE_TMPDIR}/zot.port5`
-    run skopeo --insecure-policy copy --dest-tls-verify=false \
-        oci:${TEST_DATA_DIR}/golang:1.20 \
-        docker://127.0.0.1:${zot_port3}/disablehttp2-test:latest
-    [ "$status" -eq 0 ]
-    run curl http://127.0.0.1:${zot_port3}/v2/disablehttp2-test/tags/list
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"latest"' ]
-
-    run sleep 20s
-
-    run curl http://127.0.0.1:${zot_port5}/v2/_catalog
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.repositories[]') = '"disablehttp2-test"' ]
-
-    run curl http://127.0.0.1:${zot_port5}/v2/disablehttp2-test/tags/list
-    [ "$status" -eq 0 ]
-    [ $(echo "${lines[-1]}" | jq '.tags[]') = '"latest"' ]
 }
 
 @test "sync golang image ondemand" {


### PR DESCRIPTION
net/http multiplexes every request to a host onto a single HTTP/2 connection, so reqConcurrent-style concurrency cannot open more TCP connections and all traffic shares one congestion window. Add a per-registry disableHTTP2 config option that forces HTTP/1.1 (pinning ALPN, not just clearing TLSNextProto) so concurrent requests each get their own connection, plus a maxIdleConnsPerHost override so those connections get pooled instead of closed after Go's default of 2.

Fixes https://github.com/project-zot/zot/issues/4333

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
