### PR TITLE
fix(storage): serialize index writes across instances

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -129,6 +129,7 @@ var (
 	ErrSortCriteriaNotSupported         = errors.New("the pagination sort criteria is not supported")
 	ErrMediaTypeNotSupported            = errors.New("media type is not supported")
 	ErrTimeout                          = errors.New("operation timeout")
+	ErrRepoLockUnavailable              = errors.New("storage: could not obtain exclusive access to the repository")
 	ErrNotImplemented                   = errors.New("not implemented")
 	ErrDedupeRebuild                    = errors.New("couldn't rebuild dedupe index")
 	ErrDedupeRebuildInProgress          = errors.New("dedupe cache rebuild in progress, blob delete deferred")

--- a/pkg/storage/cache/redis.go
+++ b/pkg/storage/cache/redis.go
@@ -3,8 +3,11 @@ package cache
 import (
 	"context"
 	goerrors "errors"
+	"math"
 	"path/filepath"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/go-redsync/redsync/v4"
 	gors "github.com/go-redsync/redsync/v4/redis/goredis/v9"
@@ -14,6 +17,7 @@ import (
 	zerr "zotregistry.dev/zot/v2/errors"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/storage/constants"
+	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 )
 
 type RedisDriver struct {
@@ -337,4 +341,118 @@ func (d *RedisDriver) DeleteBlob(digest godigest.Digest, path string) error {
 	}
 
 	return nil
+}
+
+// Ample for a manifest write. A gc sweep far exceeds it, which is why the lock
+// is extended while held rather than given a long expiry a crashed holder
+// would sit on. Variables, not constants, so tests can shrink them.
+//
+//nolint:gochecknoglobals // overridden by tests to exercise renewal
+var (
+	repoLockExpiry     = 30 * time.Second
+	repoLockRetryDelay = 250 * time.Millisecond
+)
+
+// LockRepo takes the cross-process lock for one repository. Its own key bucket
+// is deliberate: gc calls the metadata layer, which locks per repo too, while
+// holding this, and redsync mutexes are not reentrant.
+//
+// Acquisition is bounded by the caller's context, not by a try count: a sweep
+// holds the lock for minutes, and a push that gives up after seconds would fail
+// for the duration of every long collection. redsync still requires a finite
+// try count, so it is set effectively unbounded and the context is the deadline.
+func (d *RedisDriver) LockRepo(ctx context.Context, repo string) (storageTypes.RepoLock, error) {
+	mutex := d.rs.NewMutex(
+		d.join(constants.RedisRepoLocksBucket, repo),
+		redsync.WithExpiry(repoLockExpiry),
+		redsync.WithTries(math.MaxInt32),
+		redsync.WithRetryDelay(repoLockRetryDelay),
+	)
+
+	if err := mutex.LockContext(ctx); err != nil {
+		d.log.Error().Err(err).Str("repo", repo).Msg("failed to acquire repo lock")
+
+		return nil, goerrors.Join(zerr.ErrRepoLockUnavailable, err)
+	}
+
+	lock := &redisRepoLock{
+		mutex:   mutex,
+		log:     d.log,
+		repo:    repo,
+		done:    make(chan struct{}),
+		stopped: make(chan struct{}),
+	}
+
+	// Extend while the work runs, or a sweep outlasts its own lock and a second
+	// writer starts on the same index.
+	go func() {
+		defer close(lock.stopped)
+
+		ticker := time.NewTicker(repoLockExpiry / 3) //nolint:mnd // extend well before expiry
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-lock.done:
+				return
+			case <-ticker.C:
+				lock.extend()
+			}
+		}
+	}()
+
+	return lock, nil
+}
+
+// redisRepoLock serializes every redsync mutex operation: redsync mutexes are not
+// safe for concurrent use, and the renewal goroutine, StillHeld and Release would
+// otherwise race on them.
+type redisRepoLock struct {
+	mutex   *redsync.Mutex
+	log     zlog.Logger
+	repo    string
+	done    chan struct{}
+	stopped chan struct{}
+	mu      sync.Mutex
+}
+
+func (l *redisRepoLock) extend() {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if ok, err := l.mutex.Extend(); !ok || err != nil {
+		l.log.Warn().Err(err).Str("repo", l.repo).Msg("failed to extend repo lock")
+	}
+}
+
+// StillHeld revalidates the fence token against the store, extending the lock on
+// success. A writer calls it immediately before committing, so a holder that lost
+// the lock (stalled past expiry, then resumed) fails its write instead of
+// clobbering the commit of whoever acquired the lock meanwhile.
+func (l *redisRepoLock) StillHeld(ctx context.Context) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	ok, err := l.mutex.ExtendContext(ctx)
+	if err != nil || !ok {
+		l.log.Warn().Err(err).Str("repo", l.repo).Msg("repo lock no longer held")
+
+		return false
+	}
+
+	return true
+}
+
+func (l *redisRepoLock) Release() {
+	close(l.done)
+	// wait for a renewal already in flight, so Extend and Unlock never run on the
+	// same mutex concurrently
+	<-l.stopped
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if _, err := l.mutex.Unlock(); err != nil {
+		l.log.Error().Err(err).Str("repo", l.repo).Msg("failed to release repo lock")
+	}
 }

--- a/pkg/storage/cache/redis_internal_test.go
+++ b/pkg/storage/cache/redis_internal_test.go
@@ -1,0 +1,157 @@
+package cache
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-redsync/redsync/v4"
+	gors "github.com/go-redsync/redsync/v4/redis/goredis/v9"
+	"github.com/redis/go-redis/v9"
+	. "github.com/smartystreets/goconvey/convey"
+
+	zerr "zotregistry.dev/zot/v2/errors"
+	"zotregistry.dev/zot/v2/pkg/log"
+)
+
+func newTestRedisDriver(t *testing.T, miniRedis *miniredis.Miniredis) *RedisDriver {
+	t.Helper()
+
+	client := redis.NewClient(&redis.Options{Addr: miniRedis.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	return &RedisDriver{
+		db:        client,
+		log:       log.NewTestLogger(),
+		keyPrefix: "zot",
+		rs:        redsync.New(gors.NewPool(client)),
+	}
+}
+
+func TestLockRepoMutualExclusion(t *testing.T) {
+	Convey("A second holder cannot take the lock until the first releases", t, func() {
+		miniRedis := miniredis.RunT(t)
+		first := newTestRedisDriver(t, miniRedis)
+		second := newTestRedisDriver(t, miniRedis)
+
+		ctx := context.Background()
+
+		lock, err := first.LockRepo(ctx, "repo")
+		So(err, ShouldBeNil)
+
+		waitCtx, cancel := context.WithTimeout(ctx, 300*time.Millisecond)
+		defer cancel()
+
+		_, err = second.LockRepo(waitCtx, "repo")
+		So(errors.Is(err, zerr.ErrRepoLockUnavailable), ShouldBeTrue)
+
+		lock.Release()
+
+		lockSecond, err := second.LockRepo(ctx, "repo")
+		So(err, ShouldBeNil)
+		lockSecond.Release()
+	})
+
+	Convey("An already-canceled context fails acquisition immediately", t, func() {
+		miniRedis := miniredis.RunT(t)
+		driver := newTestRedisDriver(t, miniRedis)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := driver.LockRepo(ctx, "repo")
+		So(errors.Is(err, zerr.ErrRepoLockUnavailable), ShouldBeTrue)
+	})
+}
+
+func TestLockRepoRenewsWhileHeld(t *testing.T) {
+	Convey("The lock stays exclusive past its initial expiry because it is renewed", t, func() {
+		miniRedis := miniredis.RunT(t)
+		first := newTestRedisDriver(t, miniRedis)
+		second := newTestRedisDriver(t, miniRedis)
+
+		// shrink the lock timings so the test can outlive the initial expiry
+		defer func() {
+			repoLockExpiry = 30 * time.Second
+			repoLockRetryDelay = 250 * time.Millisecond
+		}()
+
+		repoLockExpiry = 600 * time.Millisecond
+		repoLockRetryDelay = 50 * time.Millisecond
+
+		ctx := context.Background()
+
+		lock, err := first.LockRepo(ctx, "repo")
+		So(err, ShouldBeNil)
+
+		// well past the initial 600ms expiry; only the renewal can still be holding it
+		time.Sleep(time.Second)
+
+		waitCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+		defer cancel()
+
+		_, err = second.LockRepo(waitCtx, "repo")
+		So(errors.Is(err, zerr.ErrRepoLockUnavailable), ShouldBeTrue)
+
+		lock.Release()
+
+		lockSecond, err := second.LockRepo(ctx, "repo")
+		So(err, ShouldBeNil)
+		lockSecond.Release()
+	})
+}
+
+func TestLockRepoStillHeld(t *testing.T) {
+	Convey("StillHeld validates the fence token", t, func() {
+		miniRedis := miniredis.RunT(t)
+		driver := newTestRedisDriver(t, miniRedis)
+
+		ctx := context.Background()
+
+		lock, err := driver.LockRepo(ctx, "repo")
+		So(err, ShouldBeNil)
+
+		Convey("is true while the lock is held", func() {
+			So(lock.StillHeld(ctx), ShouldBeTrue)
+			lock.Release()
+		})
+
+		Convey("is false once the lock is lost, so a stalled holder fails its commit", func() {
+			// simulate the lock expiring and being taken by someone else
+			miniRedis.Del("zot:repolocks:repo")
+
+			So(lock.StillHeld(ctx), ShouldBeFalse)
+
+			// Release must not panic or delete the new holder's key: redsync's
+			// unlock script only deletes when the token matches
+			So(func() { lock.Release() }, ShouldNotPanic)
+		})
+	})
+}
+
+func TestLockRepoReleaseAfterRedisDown(t *testing.T) {
+	Convey("Renewal and release failures are logged, not panicked on", t, func() {
+		miniRedis := miniredis.RunT(t)
+		driver := newTestRedisDriver(t, miniRedis)
+
+		defer func() {
+			repoLockExpiry = 30 * time.Second
+			repoLockRetryDelay = 250 * time.Millisecond
+		}()
+
+		repoLockExpiry = 300 * time.Millisecond
+		repoLockRetryDelay = 50 * time.Millisecond
+
+		lock, err := driver.LockRepo(context.Background(), "repo")
+		So(err, ShouldBeNil)
+
+		miniRedis.Close()
+
+		// let a renewal tick run against the dead server, then release into it too
+		time.Sleep(300 * time.Millisecond)
+
+		So(func() { lock.Release() }, ShouldNotPanic)
+	})
+}

--- a/pkg/storage/constants/constants.go
+++ b/pkg/storage/constants/constants.go
@@ -21,6 +21,7 @@ const (
 	DynamoDBDriverName      = "dynamodb"
 	RedisDriverName         = "redis"
 	RedisLocksBucket        = "locks"
+	RedisRepoLocksBucket    = "repolocks"
 	DefaultGCDelay          = 1 * time.Hour
 	DefaultGCInterval       = 1 * time.Hour
 	S3StorageDriverName     = "s3"

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -144,6 +144,15 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 		return zerr.ErrRepoNotFound
 	}
 
+	// Rewrites the index like a push does, so it takes the same lock in the same
+	// order: before the store-wide one.
+	repoLock, err := gc.imgStore.LockRepo(ctx, repo)
+	if err != nil {
+		return err
+	}
+
+	defer repoLock.Release()
+
 	gc.imgStore.Lock(&lockLatency)
 	defer gc.imgStore.Unlock(&lockLatency)
 
@@ -195,6 +204,12 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 
 	// update repos's index.json in storage
 	if !gc.opts.ImageRetention.DryRun {
+		// fence: revalidate the repo lock immediately before committing the index,
+		// so a sweep that lost the lock mid-run fails instead of clobbering a push
+		if !repoLock.StillHeld(ctx) {
+			return zerr.ErrRepoLockUnavailable
+		}
+
 		/* this will update the index.json with manifest references removed above;
 		orphan manifest/config/layer blobs are deleted by gc.deleteUnreferencedBlobs() */
 		if err := gc.imgStore.PutIndexContent(repo, index); err != nil {

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/distribution/distribution/v3/registry/storage/driver"
 	"github.com/go-viper/mapstructure/v2"
 	godigest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -27,6 +28,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/storage/cache"
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
 	"zotregistry.dev/zot/v2/pkg/storage/local"
+	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
 )
 
@@ -1941,6 +1943,53 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			err := gc.CleanRepo(ctx, repoName)
 			So(err, ShouldNotBeNil)
 			So(errors.Is(err, zerr.ErrRepoNotFound), ShouldBeTrue)
+		})
+
+		Convey("CleanRepo fails when the repo lock is unavailable", func() {
+			imgStore := mocks.MockedImageStore{
+				DirExistsFn: func(d string) bool {
+					return true
+				},
+				LockRepoFn: func(ctx context.Context, repo string) (storageTypes.RepoLock, error) {
+					return nil, errGC
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			err := gc.CleanRepo(ctx, repoName)
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, errGC), ShouldBeTrue)
+		})
+
+		Convey("CleanRepo fails before the index write when the repo lock was lost mid-sweep", func() {
+			indexWritten := false
+			emptyIndex, err := json.Marshal(ispec.Index{Versioned: specs.Versioned{SchemaVersion: 2}})
+			So(err, ShouldBeNil)
+
+			imgStore := mocks.MockedImageStore{
+				DirExistsFn: func(d string) bool {
+					return true
+				},
+				LockRepoFn: func(ctx context.Context, repo string) (storageTypes.RepoLock, error) {
+					return mocks.RepoLockMock{StillHeldFn: func(context.Context) bool { return false }}, nil
+				},
+				GetIndexContentFn: func(repo string) ([]byte, error) {
+					return emptyIndex, nil
+				},
+				PutIndexContentFn: func(repo string, index ispec.Index) error {
+					indexWritten = true
+
+					return nil
+				},
+			}
+
+			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
+
+			err = gc.CleanRepo(ctx, repoName)
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrRepoLockUnavailable), ShouldBeTrue)
+			So(indexWritten, ShouldBeFalse)
 		})
 
 		Convey("removeStaleManifestEntries removes entries whose blobs are missing", func() {

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -51,10 +51,12 @@ type ImageStore struct {
 	metrics     monitoring.MetricServer
 	events      events.Recorder
 	cache       storageTypes.Cache
-	dedupe      bool
-	linter      common.Lint
-	commit      bool
-	compat      []compat.MediaCompatibility
+	// repoLock is always set; drivers that cannot lock get a no-op.
+	repoLock storageTypes.RepoLocker
+	dedupe   bool
+	linter   common.Lint
+	commit   bool
+	compat   []compat.MediaCompatibility
 	// dedupeRebuildDone is set once RunDedupeBlobs has walked all blobs, i.e. the
 	// cache accounts for every pre-existing blob; see deleteBlob.
 	dedupeRebuildDone atomic.Bool
@@ -95,6 +97,7 @@ func NewImageStore(rootDir string, cacheDir string, dedupe, commit bool, log zlo
 		linter:      linter,
 		commit:      commit,
 		cache:       cacheDriver,
+		repoLock:    repoLockerFor(cacheDriver),
 		compat:      compat,
 		events:      recorder,
 	}
@@ -104,6 +107,33 @@ func NewImageStore(rootDir string, cacheDir string, dedupe, commit bool, log zlo
 
 	return imgStore
 }
+
+// repoLockerFor returns the driver's cross-process lock, or a no-op for
+// drivers without one, which only a single instance can use anyway.
+func repoLockerFor(cacheDriver storageTypes.Cache) storageTypes.RepoLocker {
+	if locker, ok := cacheDriver.(storageTypes.RepoLocker); ok && locker != nil {
+		return locker
+	}
+
+	return noopRepoLocker{}
+}
+
+// LockRepo takes the cross-process lock for one repository.
+func (is *ImageStore) LockRepo(ctx context.Context, repo string) (storageTypes.RepoLock, error) {
+	return is.repoLock.LockRepo(ctx, repo)
+}
+
+type noopRepoLocker struct{}
+
+func (noopRepoLocker) LockRepo(context.Context, string) (storageTypes.RepoLock, error) {
+	return noopRepoLock{}, nil
+}
+
+type noopRepoLock struct{}
+
+func (noopRepoLock) Release() {}
+
+func (noopRepoLock) StillHeld(context.Context) bool { return true }
 
 // RLock read-lock.
 func (is *ImageStore) RLock(lockStart *time.Time) {
@@ -155,7 +185,17 @@ func (is *ImageStore) validateRepoName(name string) error {
 	return nil
 }
 
-func (is *ImageStore) initRepo(ctx context.Context, name string) error {
+func (is *ImageStore) initRepo(ctx context.Context, name string, repoLock storageTypes.RepoLock) error {
+	if err := is.initRepoDirs(name); err != nil {
+		return err
+	}
+
+	return is.initRepoIndex(ctx, name, repoLock)
+}
+
+// initRepoDirs creates a repository's directories and layout marker, stopping
+// short of the index, which only a caller holding the repo lock may write.
+func (is *ImageStore) initRepoDirs(name string) error {
 	repoDir := path.Join(is.rootDir, name)
 
 	if err := is.validateRepoName(name); err != nil {
@@ -196,6 +236,14 @@ func (is *ImageStore) initRepo(ctx context.Context, name string) error {
 		}
 	}
 
+	return nil
+}
+
+// initRepoIndex creates a repository's index if it has none. The caller must
+// hold the repo lock, or this can erase an index another process just wrote.
+func (is *ImageStore) initRepoIndex(ctx context.Context, name string, repoLock storageTypes.RepoLock) error {
+	repoDir := path.Join(is.rootDir, name)
+
 	// "index.json" file - create if it doesn't exist
 	indexPath := path.Join(repoDir, ispec.ImageIndexFile)
 	if _, err := is.storeDriver.Stat(indexPath); err != nil {
@@ -209,8 +257,13 @@ func (is *ImageStore) initRepo(ctx context.Context, name string) error {
 			return err
 		}
 
+		// fence: revalidate the repo lock immediately before committing the index
+		if !repoLock.StillHeld(ctx) {
+			return zerr.ErrRepoLockUnavailable
+		}
+
 		if _, err := is.storeDriver.WriteFile(indexPath, buf); err != nil {
-			is.log.Error().Err(err).Str("file", ilPath).Msg("failed to write file")
+			is.log.Error().Err(err).Str("file", indexPath).Msg("failed to write file")
 
 			return err
 		}
@@ -225,12 +278,19 @@ func (is *ImageStore) initRepo(ctx context.Context, name string) error {
 
 // InitRepo creates an image repository under this store.
 func (is *ImageStore) InitRepo(ctx context.Context, name string) error {
+	repoLock, err := is.repoLock.LockRepo(ctx, name)
+	if err != nil {
+		return err
+	}
+
+	defer repoLock.Release()
+
 	var lockLatency time.Time
 
 	is.Lock(&lockLatency)
 	defer is.Unlock(&lockLatency)
 
-	return is.initRepo(ctx, name)
+	return is.initRepo(ctx, name, repoLock)
 }
 
 // ValidateRepo validates that the repository layout is complaint with the OCI repo layout.
@@ -571,15 +631,16 @@ func (is *ImageStore) GetImageManifest(repo, reference string) ([]byte, godigest
 func (is *ImageStore) PutImageManifest(ctx context.Context, repo, reference, mediaType string, //nolint: gocyclo,cyclop
 	body []byte, extraTags []string,
 ) (godigest.Digest, godigest.Digest, error) {
-	if err := is.InitRepo(ctx, repo); err != nil {
-		is.log.Debug().Err(err).Msg("init repo")
-
+	// Must be outside is.Lock: that mutex is store-wide, and gc takes it before
+	// its own index write, so the reverse order deadlocks.
+	repoLock, err := is.repoLock.LockRepo(ctx, repo)
+	if err != nil {
 		return "", "", err
 	}
 
-	var lockLatency time.Time
+	defer repoLock.Release()
 
-	var err error
+	var lockLatency time.Time
 
 	is.Lock(&lockLatency)
 	defer func() {
@@ -593,6 +654,12 @@ func (is *ImageStore) PutImageManifest(ctx context.Context, repo, reference, med
 			monitoring.IncUploadCounter(is.metrics, repo)
 		}
 	}()
+
+	if err := is.initRepo(ctx, repo, repoLock); err != nil {
+		is.log.Debug().Err(err).Msg("init repo")
+
+		return "", "", err
+	}
 
 	refIsDigest := true
 
@@ -798,6 +865,13 @@ func (is *ImageStore) PutImageManifest(ctx context.Context, repo, reference, med
 		return "", "", err
 	}
 
+	// fence: revalidate the repo lock immediately before committing the index,
+	// so a holder that lost the lock mid-write fails instead of clobbering
+	// another instance's commit
+	if !repoLock.StillHeld(ctx) {
+		return "", "", zerr.ErrRepoLockUnavailable
+	}
+
 	if err := is.PutIndexContent(repo, index); err != nil {
 		return "", "", err
 	}
@@ -819,20 +893,28 @@ func (is *ImageStore) DeleteImageManifest(ctx context.Context, repo, reference s
 		return zerr.ErrRepoNotFound
 	}
 
+	repoLock, err := is.repoLock.LockRepo(ctx, repo)
+	if err != nil {
+		return err
+	}
+
+	defer repoLock.Release()
+
 	var lockLatency time.Time
 
 	is.Lock(&lockLatency)
 	defer is.Unlock(&lockLatency)
 
-	err := is.deleteImageManifest(ctx, repo, reference, detectCollisions)
-	if err != nil {
+	if err := is.deleteImageManifest(ctx, repo, reference, detectCollisions, repoLock); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (is *ImageStore) deleteImageManifest(ctx context.Context, repo, reference string, detectCollisions bool) error {
+func (is *ImageStore) deleteImageManifest(ctx context.Context, repo, reference string, detectCollisions bool,
+	repoLock storageTypes.RepoLock,
+) error {
 	defer func() {
 		if is.storeDriver.Name() == storageConstants.LocalStorageDriverName {
 			monitoring.SetStorageUsage(is.metrics, is.rootDir, repo)
@@ -881,6 +963,11 @@ func (is *ImageStore) deleteImageManifest(ctx context.Context, repo, reference s
 	buf, err := json.Marshal(index)
 	if err != nil {
 		return err
+	}
+
+	// fence: revalidate the repo lock immediately before committing the index
+	if !repoLock.StillHeld(ctx) {
+		return zerr.ErrRepoLockUnavailable
 	}
 
 	if _, err := is.storeDriver.WriteFile(file, buf); err != nil {
@@ -1175,7 +1262,7 @@ func (is *ImageStore) FinishBlobUpload(repo, uuid string, body io.Reader, dstDig
 	// Recreate the OCI layout here, while we already hold the store lock for the move,
 	// so a blob finished after GC deleted the repo is still a walkable repository.
 	// Use initRepo, not InitRepo: InitRepo takes this same lock and would deadlock.
-	if err := is.initRepo(context.Background(), repo); err != nil {
+	if err := is.initRepo(context.Background(), repo, noopRepoLock{}); err != nil {
 		return err
 	}
 
@@ -1285,7 +1372,7 @@ func (is *ImageStore) FullBlobUpload(ctx context.Context, repo string, body io.R
 	is.Lock(&lockLatency)
 	defer is.Unlock(&lockLatency)
 
-	if err := is.initRepo(ctx, repo); err != nil {
+	if err := is.initRepo(ctx, repo, noopRepoLock{}); err != nil {
 		return "", -1, err
 	}
 
@@ -1649,7 +1736,9 @@ func (is *ImageStore) checkCacheBlob(digest godigest.Digest) (string, error) {
 }
 
 func (is *ImageStore) copyBlob(ctx context.Context, repo string, blobPath, dstRecord string) (int64, error) {
-	if err := is.initRepo(ctx, repo); err != nil {
+	// unfenced: this runs under is.Lock, so taking the repo lock would invert
+	// the order, and it only ever creates an index that is not there yet
+	if err := is.initRepo(ctx, repo, noopRepoLock{}); err != nil {
 		is.log.Error().Err(err).Str("repository", repo).Msg("failed to initialize an empty repo")
 
 		return -1, err

--- a/pkg/storage/imagestore/imagestore_test.go
+++ b/pkg/storage/imagestore/imagestore_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path"
 	"testing"
 	"time"
@@ -505,6 +506,76 @@ func TestRemoveIdleRepository(t *testing.T) {
 			removed, err := removeIdle(newMockStore(storeMock), repo, 0)
 			So(err, ShouldNotBeNil)
 			So(removed, ShouldBeFalse)
+		})
+	})
+}
+
+func TestInitRepoErrors(t *testing.T) {
+	Convey("InitRepo error paths", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		ctx := context.Background()
+
+		Convey("rejects an invalid UTF-8 repo name", func() {
+			store := imagestore.NewImageStore(t.TempDir(), "", false, false, log, metrics, nil,
+				local.New(true), nil, nil, nil)
+
+			So(errors.Is(store.InitRepo(ctx, "\xff"), zerr.ErrInvalidRepositoryName), ShouldBeTrue)
+		})
+
+		Convey("rejects a repo name outside the distribution grammar", func() {
+			store := imagestore.NewImageStore(t.TempDir(), "", false, false, log, metrics, nil,
+				local.New(true), nil, nil, nil)
+
+			So(errors.Is(store.InitRepo(ctx, "INVALID??"), zerr.ErrInvalidRepositoryName), ShouldBeTrue)
+		})
+
+		Convey("fails when the repo directory cannot be created", func() {
+			rootDir := t.TempDir()
+
+			// a regular file where the repo's parent directory must be created
+			So(os.WriteFile(path.Join(rootDir, "repo"), []byte("file"), 0o600), ShouldBeNil)
+
+			store := imagestore.NewImageStore(rootDir, "", false, false, log, metrics, nil,
+				local.New(true), nil, nil, nil)
+
+			So(store.InitRepo(ctx, "repo"), ShouldNotBeNil)
+		})
+
+		Convey("fails when the oci-layout marker cannot be written", func() {
+			rootDir := t.TempDir()
+			repoDir := path.Join(rootDir, "repo")
+
+			// directories in place, but the repo dir is read-only, so the marker write fails
+			So(os.MkdirAll(path.Join(repoDir, "blobs", "sha256"), 0o755), ShouldBeNil)
+			So(os.MkdirAll(path.Join(repoDir, ".uploads"), 0o755), ShouldBeNil)
+			So(os.Chmod(repoDir, 0o555), ShouldBeNil)
+
+			t.Cleanup(func() { _ = os.Chmod(repoDir, 0o755) })
+
+			store := imagestore.NewImageStore(rootDir, "", false, false, log, metrics, nil,
+				local.New(true), nil, nil, nil)
+
+			So(store.InitRepo(ctx, "repo"), ShouldNotBeNil)
+		})
+
+		Convey("fails when the index cannot be written", func() {
+			rootDir := t.TempDir()
+			repoDir := path.Join(rootDir, "repo")
+
+			// marker present, directories in place, read-only repo dir: the index write fails
+			So(os.MkdirAll(path.Join(repoDir, "blobs", "sha256"), 0o755), ShouldBeNil)
+			So(os.MkdirAll(path.Join(repoDir, ".uploads"), 0o755), ShouldBeNil)
+			So(os.WriteFile(path.Join(repoDir, "oci-layout"),
+				[]byte(`{"imageLayoutVersion":"1.0.0"}`), 0o600), ShouldBeNil)
+			So(os.Chmod(repoDir, 0o555), ShouldBeNil)
+
+			t.Cleanup(func() { _ = os.Chmod(repoDir, 0o755) })
+
+			store := imagestore.NewImageStore(rootDir, "", false, false, log, metrics, nil,
+				local.New(true), nil, nil, nil)
+
+			So(store.InitRepo(ctx, "repo"), ShouldNotBeNil)
 		})
 	})
 }

--- a/pkg/storage/imagestore/repolock_test.go
+++ b/pkg/storage/imagestore/repolock_test.go
@@ -1,0 +1,325 @@
+package imagestore_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	godigest "github.com/opencontainers/go-digest"
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/redis/go-redis/v9"
+	. "github.com/smartystreets/goconvey/convey"
+
+	zerr "zotregistry.dev/zot/v2/errors"
+	zlog "zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	"zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/storage"
+	"zotregistry.dev/zot/v2/pkg/storage/cache"
+	"zotregistry.dev/zot/v2/pkg/storage/local"
+	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+// Two stores over one directory stand in for two processes over one bucket:
+// separate in-process mutexes, one index.
+func newSharedStore(t *testing.T, rootDir string, cacheDriver storageTypes.Cache) storageTypes.ImageStore {
+	t.Helper()
+
+	return local.NewImageStore(rootDir, false, false, log.NewTestLogger(),
+		zlog.NewMetricsServer(false, log.NewTestLogger()), nil, cacheDriver, nil, nil)
+}
+
+func TestConcurrentTagWritesAcrossStores(t *testing.T) {
+	Convey("Tags pushed concurrently from two stores all survive", t, func() {
+		rootDir := t.TempDir()
+		miniRedis := miniredis.RunT(t)
+
+		connOpts, err := redis.ParseURL("redis://" + miniRedis.Addr())
+		So(err, ShouldBeNil)
+
+		client := redis.NewClient(connOpts)
+		t.Cleanup(func() { _ = client.Close() })
+
+		cacheDriver, err := storage.Create("redis",
+			cache.RedisDriverParameters{Client: client, RootDir: rootDir, UseRelPaths: true, KeyPrefix: "zot"},
+			log.NewTestLogger())
+		So(err, ShouldBeNil)
+		So(cacheDriver, ShouldNotBeNil)
+
+		stores := []storageTypes.ImageStore{
+			newSharedStore(t, rootDir, cacheDriver),
+			newSharedStore(t, rootDir, cacheDriver),
+		}
+
+		const (
+			repo    = "concurrent/tags"
+			tagsNum = 24
+		)
+
+		ctx := context.Background()
+
+		content := []byte("{}")
+		digest := godigest.FromBytes(content)
+
+		_, _, err = stores[0].FullBlobUpload(ctx, repo, bytes.NewReader(content), digest)
+		So(err, ShouldBeNil)
+
+		manifest := ispec.Manifest{}
+		manifest.SchemaVersion = 2
+		manifest.MediaType = ispec.MediaTypeImageManifest
+		manifest.Config = ispec.Descriptor{
+			MediaType: ispec.MediaTypeImageConfig,
+			Digest:    digest,
+			Size:      int64(len(content)),
+		}
+		manifest.Layers = []ispec.Descriptor{{
+			MediaType: ispec.MediaTypeImageLayerGzip,
+			Digest:    digest,
+			Size:      int64(len(content)),
+		}}
+
+		body, err := json.Marshal(manifest)
+		So(err, ShouldBeNil)
+
+		var waitGroup sync.WaitGroup
+
+		errs := make([]error, tagsNum)
+
+		for i := range tagsNum {
+			waitGroup.Add(1)
+
+			go func(i int) {
+				defer waitGroup.Done()
+
+				_, _, errs[i] = stores[i%len(stores)].PutImageManifest(ctx, repo,
+					fmt.Sprintf("t%02d", i), ispec.MediaTypeImageManifest, body, nil)
+			}(i)
+		}
+
+		waitGroup.Wait()
+
+		for i, err := range errs {
+			So(err, ShouldBeNil)
+			_ = i
+		}
+
+		tags, err := stores[0].GetImageTags(repo)
+		So(err, ShouldBeNil)
+		So(len(tags), ShouldEqual, tagsNum)
+	})
+}
+
+// pushTestManifest uploads one shared blob and returns a manifest body referencing it.
+func pushTestManifest(t *testing.T, store storageTypes.ImageStore, repo string) []byte {
+	t.Helper()
+
+	content := []byte("{}")
+	digest := godigest.FromBytes(content)
+
+	_, _, err := store.FullBlobUpload(context.Background(), repo, bytes.NewReader(content), digest)
+	So(err, ShouldBeNil)
+
+	manifest := ispec.Manifest{}
+	manifest.SchemaVersion = 2
+	manifest.MediaType = ispec.MediaTypeImageManifest
+	manifest.Config = ispec.Descriptor{
+		MediaType: ispec.MediaTypeImageConfig,
+		Digest:    digest,
+		Size:      int64(len(content)),
+	}
+	manifest.Layers = []ispec.Descriptor{{
+		MediaType: ispec.MediaTypeImageLayerGzip,
+		Digest:    digest,
+		Size:      int64(len(content)),
+	}}
+
+	body, err := json.Marshal(manifest)
+	So(err, ShouldBeNil)
+
+	return body
+}
+
+func newRedisCacheDriver(t *testing.T, rootDir string) storageTypes.Cache {
+	t.Helper()
+
+	miniRedis := miniredis.RunT(t)
+
+	connOpts, err := redis.ParseURL("redis://" + miniRedis.Addr())
+	So(err, ShouldBeNil)
+
+	client := redis.NewClient(connOpts)
+	t.Cleanup(func() { _ = client.Close() })
+
+	cacheDriver, err := storage.Create("redis",
+		cache.RedisDriverParameters{Client: client, RootDir: rootDir, UseRelPaths: true, KeyPrefix: "zot"},
+		log.NewTestLogger())
+	So(err, ShouldBeNil)
+
+	return cacheDriver
+}
+
+// TestRepoLockHeldByOtherStoreBlocksPush covers the collection-versus-push contract: while one
+// instance holds the repo lock (as gc does for the length of a sweep), another instance's push
+// cannot proceed. The push waits rather than failing outright, errors only when its own context
+// expires, and succeeds once the holder releases.
+func TestRepoLockHeldByOtherStoreBlocksPush(t *testing.T) {
+	Convey("A push cannot take the repo lock another store holds, and succeeds after release", t, func() {
+		rootDir := t.TempDir()
+		cacheDriver := newRedisCacheDriver(t, rootDir)
+
+		stores := []storageTypes.ImageStore{
+			newSharedStore(t, rootDir, cacheDriver),
+			newSharedStore(t, rootDir, cacheDriver),
+		}
+
+		ctx := context.Background()
+		repo := "locked/repo"
+		body := pushTestManifest(t, stores[0], repo)
+
+		heldLock, err := stores[0].LockRepo(ctx, repo)
+		So(err, ShouldBeNil)
+
+		pushCtx, cancel := context.WithTimeout(ctx, 500*time.Millisecond)
+		defer cancel()
+
+		_, _, err = stores[1].PutImageManifest(pushCtx, repo, "t1", ispec.MediaTypeImageManifest, body, nil)
+		So(errors.Is(err, zerr.ErrRepoLockUnavailable), ShouldBeTrue)
+
+		heldLock.Release()
+
+		_, _, err = stores[1].PutImageManifest(ctx, repo, "t1", ispec.MediaTypeImageManifest, body, nil)
+		So(err, ShouldBeNil)
+
+		tags, err := stores[1].GetImageTags(repo)
+		So(err, ShouldBeNil)
+		So(tags, ShouldContain, "t1")
+	})
+}
+
+// failLockCache is a cache driver whose RepoLocker always fails, to prove a write that cannot be
+// serialized fails instead of proceeding unlocked.
+type failLockCache struct {
+	mocks.CacheMock
+}
+
+func (failLockCache) LockRepo(context.Context, string) (storageTypes.RepoLock, error) {
+	return nil, zerr.ErrRepoLockUnavailable
+}
+
+// lostLockCache hands out locks that report themselves lost, simulating a holder that was stalled
+// past expiry and resumed after another instance took the lock.
+type lostLockCache struct {
+	mocks.CacheMock
+}
+
+func (lostLockCache) LockRepo(context.Context, string) (storageTypes.RepoLock, error) {
+	return mocks.RepoLockMock{StillHeldFn: func(context.Context) bool { return false }}, nil
+}
+
+// TestRepoLockLostFenceFailsCommit proves the fence before the index commit: a writer that lost
+// the repo lock mid-write fails instead of clobbering another instance's commit.
+func TestRepoLockLostFenceFailsCommit(t *testing.T) {
+	Convey("A push that lost the repo lock mid-write fails and writes nothing", t, func() {
+		rootDir := t.TempDir()
+		ctx := context.Background()
+
+		// the blob lands through a store with a working lock
+		goodStore := local.NewImageStore(rootDir, false, false, log.NewTestLogger(),
+			zlog.NewMetricsServer(false, log.NewTestLogger()), nil, nil, nil, nil)
+
+		body := pushTestManifest(t, goodStore, "repo")
+
+		// the manifest push then goes through a store whose lock reports lost
+		store := local.NewImageStore(rootDir, false, false, log.NewTestLogger(),
+			zlog.NewMetricsServer(false, log.NewTestLogger()), nil, lostLockCache{}, nil, nil)
+
+		_, _, err := store.PutImageManifest(ctx, "repo", "t1", ispec.MediaTypeImageManifest, body, nil)
+		So(errors.Is(err, zerr.ErrRepoLockUnavailable), ShouldBeTrue)
+
+		// the index was never committed
+		tags, err := goodStore.GetImageTags("repo")
+		So(err, ShouldBeNil)
+		So(tags, ShouldNotContain, "t1")
+	})
+
+	Convey("A delete that lost the repo lock mid-write fails before rewriting the index", t, func() {
+		rootDir := t.TempDir()
+		ctx := context.Background()
+
+		// write a manifest with a working lock first
+		goodStore := local.NewImageStore(rootDir, false, false, log.NewTestLogger(),
+			zlog.NewMetricsServer(false, log.NewTestLogger()), nil, nil, nil, nil)
+
+		body := pushTestManifest(t, goodStore, "repo")
+
+		_, _, err := goodStore.PutImageManifest(ctx, "repo", "t1", ispec.MediaTypeImageManifest, body, nil)
+		So(err, ShouldBeNil)
+
+		// then delete through a store whose lock reports lost
+		store := local.NewImageStore(rootDir, false, false, log.NewTestLogger(),
+			zlog.NewMetricsServer(false, log.NewTestLogger()), nil, lostLockCache{}, nil, nil)
+
+		err = store.DeleteImageManifest(ctx, "repo", "t1", false)
+		So(errors.Is(err, zerr.ErrRepoLockUnavailable), ShouldBeTrue)
+
+		// the tag survived
+		tags, err := goodStore.GetImageTags("repo")
+		So(err, ShouldBeNil)
+		So(tags, ShouldContain, "t1")
+	})
+}
+
+func TestRepoLockFailureFailsWrites(t *testing.T) {
+	Convey("Writes fail when the repo lock is unavailable", t, func() {
+		rootDir := t.TempDir()
+		ctx := context.Background()
+
+		store := local.NewImageStore(rootDir, false, false, log.NewTestLogger(),
+			zlog.NewMetricsServer(false, log.NewTestLogger()), nil, failLockCache{}, nil, nil)
+
+		Convey("InitRepo fails", func() {
+			So(errors.Is(store.InitRepo(ctx, "repo"), zerr.ErrRepoLockUnavailable), ShouldBeTrue)
+		})
+
+		Convey("PutImageManifest fails and writes nothing", func() {
+			_, _, err := store.PutImageManifest(ctx, "repo", "t1", ispec.MediaTypeImageManifest, []byte("{}"), nil)
+			So(errors.Is(err, zerr.ErrRepoLockUnavailable), ShouldBeTrue)
+
+			_, err = store.GetImageTags("repo")
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("DeleteImageManifest fails", func() {
+			// the repo layout exists, so the delete reaches the lock acquisition
+			So(os.MkdirAll(path.Join(rootDir, "repo"), 0o755), ShouldBeNil)
+
+			err := store.DeleteImageManifest(ctx, "repo", "t1", false)
+			So(errors.Is(err, zerr.ErrRepoLockUnavailable), ShouldBeTrue)
+		})
+	})
+
+	Convey("A cache driver without RepoLocker gets the no-op locker", t, func() {
+		rootDir := t.TempDir()
+
+		store := local.NewImageStore(rootDir, false, false, log.NewTestLogger(),
+			zlog.NewMetricsServer(false, log.NewTestLogger()), nil, mocks.CacheMock{}, nil, nil)
+
+		body := pushTestManifest(t, store, "repo")
+
+		_, _, err := store.PutImageManifest(context.Background(), "repo", "t1",
+			ispec.MediaTypeImageManifest, body, nil)
+		So(err, ShouldBeNil)
+
+		tags, err := store.GetImageTags("repo")
+		So(err, ShouldBeNil)
+		So(tags, ShouldContain, "t1")
+	})
+}

--- a/pkg/storage/types/cache.go
+++ b/pkg/storage/types/cache.go
@@ -1,8 +1,29 @@
 package types
 
 import (
+	"context"
+
 	godigest "github.com/opencontainers/go-digest"
 )
+
+// RepoLock is a held repository lock. Release frees it. StillHeld revalidates
+// the fence against the store and extends the lock on success, so a writer can
+// check immediately before committing that it still holds exclusive access —
+// the lock is TTL-based mutual exclusion, and this check is what keeps a holder
+// that lost the lock from clobbering another writer's commit.
+type RepoLock interface {
+	Release()
+	StillHeld(ctx context.Context) bool
+}
+
+// RepoLocker serializes writes to one repository's index across processes.
+// The image store's own mutex covers a single process only, so instances
+// sharing a storage backend can otherwise overwrite each other's tags.
+type RepoLocker interface {
+	// LockRepo blocks until it holds the lock for repo or ctx is done.
+	// It errors rather than proceeding unlocked.
+	LockRepo(ctx context.Context, repo string) (RepoLock, error)
+}
 
 type Cache interface {
 	// Returns the human-readable "name" of the driver.

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -28,6 +28,7 @@ type ImageStore interface { //nolint:interfacebloat
 	RLock(*time.Time)
 	RUnlock(*time.Time)
 	Lock(*time.Time)
+	LockRepo(ctx context.Context, repo string) (RepoLock, error)
 	Unlock(*time.Time)
 	InitRepo(ctx context.Context, name string) error
 	ValidateRepo(name string) (bool, error)

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -18,6 +18,7 @@ type MockedImageStore struct {
 	DirExistsFn           func(d string) bool
 	RootDirFn             func() string
 	InitRepoFn            func(ctx context.Context, name string) error
+	LockRepoFn            func(ctx context.Context, repo string) (storageTypes.RepoLock, error)
 	ValidateRepoFn        func(name string) (bool, error)
 	GetRepositoriesFn     func() ([]string, error)
 	GetNextRepositoryFn   func(processedRepos map[string]struct{}) (string, error)
@@ -78,6 +79,33 @@ func (is MockedImageStore) StatIndex(repo string) (bool, int64, time.Time, error
 }
 
 func (is MockedImageStore) Lock(t *time.Time) {
+}
+
+func (is MockedImageStore) LockRepo(ctx context.Context, repo string) (storageTypes.RepoLock, error) {
+	if is.LockRepoFn != nil {
+		return is.LockRepoFn(ctx, repo)
+	}
+
+	return RepoLockMock{}, nil
+}
+
+type RepoLockMock struct {
+	ReleaseFn   func()
+	StillHeldFn func(ctx context.Context) bool
+}
+
+func (m RepoLockMock) Release() {
+	if m.ReleaseFn != nil {
+		m.ReleaseFn()
+	}
+}
+
+func (m RepoLockMock) StillHeld(ctx context.Context) bool {
+	if m.StillHeldFn != nil {
+		return m.StillHeldFn(ctx)
+	}
+
+	return true
 }
 
 func (is MockedImageStore) Unlock(t *time.Time) {


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

No existing issue covers this exact failure. It is adjacent to #4215 ("Improve scale-out") and to the locking work attempted in #2968, which was closed unmerged. Repro steps and logs are below.

**What does this PR do / Why do we need it**:

Two zot instances sharing one storage backend can silently destroy each
other's tags.

A repository's tag list lives in a single `index.json`, and adding a tag is a read-modify-write of that object: `PutImageManifest` reads the index, appends a descriptor, and writes it back. That sequence is guarded by the image store's own `*sync.RWMutex`, which is per-process. Two instances therefore each read the same index, each append their own descriptor, and whichever writes last erases the other's.

What makes it worth fixing rather than documenting is that nothing about it looks like a failure. Both pushes return `201`. The manifest blob is content-addressed and survives. Only the index entry is gone, so the tag simply
is not there afterwards, and the client was told it was pushed. There is no error anywhere for an operator to find.

The shared cache does not help. Its `Locks:Repo:<repo>` redsync mutexes belong to the metadata layer and are taken *after* the storage write has already happened, so they serialize `RepoMeta` and not the index.

This adds the missing exclusion at the write itself.

Cache drivers that can offer cross-process exclusion expose it through a new optional `RepoLocker`. The image store takes that lock for a repository around every operation that rewrites its index:

- `PutImageManifest`
- `DeleteImageManifest`
- `InitRepo`
- `gc.cleanRepo`

Drivers that cannot are not asked to: they get a locker that does nothing, which is correct for a single instance, the only topology a local cache can serve. Single-instance deployments on boltdb pay nothing, not even a type
assertion at write time. The redis driver implements it using the `*redsync.Redsync` it already holds.

Three details are load-bearing, and each was a way to get this wrong:

1. **The lock is taken outside the store's mutex, never inside.** That mutex is  store-wide rather than per-repository, so waiting on the network while holding it would stall every unrelated read on the instance. More importantly, `gc.cleanRepo` already takes it before reaching its own index write, so acquiring the distributed lock underneath it deadlocks against a concurrent push.

2. **The key lives in its own bucket** (`repolocks`), not the metadata layer's `Locks`. Collection calls into the metadata layer while holding this lock; sharing a key would have it wait on itself, and redsync mutexes are not reentrant.

3. **The lock is extended while held.** A collection sweep can run for minutes,  far past any expiry worth giving a crashed holder. A watchdog renews it until the work ends, so a long operation never expires mid-write and a dead   one still releases quickly.

Repository init is split so that placing a deduplicated blob no longer creates an index. `copyBlob` runs with the store mutex already held and so cannot take the repository lock without inverting the order every other writer uses, and an
unconditional write of an empty index there can erase one another instance has just written. Creating the index belongs to the push that adds the first tag, which holds the lock. One behaviour note: a repository touched only by a
cross-repo blob mount is now not `ValidateRepo`-visible until its first manifest.

A write that cannot be serialized fails rather than proceeding unlocked. Returning success for a write that may be erased is precisely the behaviour this removes.

**If an issue # is not available please add repro steps and logs showing the issue**:

Three zot instances, one S3 bucket, `dedupe: false`, `remoteCache: true` against a shared redis, no `cluster` block, behind a round-robin load balancer.

Push one manifest under 24 tags concurrently, then read them back:

```
pushed 24/24 tags of the same manifest concurrently
tags NOT resolvable via manifest GET: 9 [t00 t01 t05 t06 t09 t13 t16 t18 t21]
tags/list: ["t02","t03","t04","t07","t08","t10","t11","t12","t14","t15",
            "t17","t19","t20","t22","t23"]
```

Every push reported success. Nine tags are absent from both the manifest endpoint and the tag listing. Pulling one:

```
GET /v2/<repo>/manifests/t00
404 {"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown"}]}
```

With this patch, the same 24-way push on the same three instances returns all 24 tags, repeated four times consecutively.

**Testing done on this change**:

*Unit.* `TestConcurrentTagWritesAcrossStores` drives two `ImageStore` instances over one directory, which is what two processes look like to the storage layer, sharing one miniredis-backed cache, and pushes 24 tags of one manifest
concurrently while alternating stores.

With the locker disabled it fails, which is the point of including it:

```
Failures:
  Line 121:
  Expected: 24
  Actual:   19
--- FAIL: TestConcurrentTagWritesAcrossStores
```

With the locker it passes.

*Existing suites.* `go test ./pkg/storage/...` runs to completion with no new failures. This matters beyond the assertions: a lock-ordering mistake here manifests as a hang rather than a failure, and nothing hung.
(`TestGarbageCollectForImageStore` fails identically before and after this change in my clone, for a missing `test/data/alpine` fixture.)

*Live.* Built from this branch and deployed to three replicas over one bucket with a shared valkey, behind a load balancer. The 24-way concurrent push returned 24/24 with zero lost tags on four consecutive runs, against 9 lost on
the first run of the same test before the change.

**Automation added to e2e**:

No. The unit test reproduces the race deterministically with two stores over one directory and needs no infrastructure, which seemed the more useful place for it. Happy to add an integration case if you would prefer one.

**Will this break upgrades or downgrades?**

No. No configuration changes, no schema changes, no wire changes. A deployment that does not use a shared cache behaves exactly as before. A deployment that does gains the lock automatically, and an older instance running alongside a newer one during a rolling upgrade is no worse off than it is today, since it simply does not take the lock.

**Does this PR introduce any user-facing change?**:

One: a manifest write that cannot obtain the repository lock now fails instead of proceeding. That is the intended behaviour, and it is reachable only when the shared cache is unavailable, which already breaks other operations.

Two questions I would rather you decide than assume:

- Gating is via a capability assertion on the cache driver, so it enables itself for redis users. If you would prefer an explicit config field, say so and I will add one.
- DynamoDB remote-cache users stay unprotected, since only the redis driver implements the interface. Dynamo could implement it later with conditional
  writes.

Worth stating plainly: this is mutual exclusion with a TTL, not fencing. A process stalled past the expiry can still lose a write. Closing that completely needs a conditional write on the index (`If-Match` on the ETag), which the storage driver interface cannot express today. This removes the failure that happens in ordinary operation; it does not make the index write atomic.

```release-note
Fixed concurrent pushes to the same repository from multiple instances sharing a storage backend silently dropping tags. Instances that share a cache driver capable of distributed locking now serialize writes to a repository's index.
```