### PR TITLE
fix(meta): don't mass-delete metaDB repos on a suspiciously empty sto…

### DIFF
--- a/pkg/meta/maybe_parse_test.go
+++ b/pkg/meta/maybe_parse_test.go
@@ -204,4 +204,26 @@ func TestMaybeParseStorageGate(t *testing.T) {
 		err := meta.MaybeParseStorage(mock, store, false, "v1", logger)
 		So(err, ShouldBeNil)
 	})
+
+	Convey("a suspiciously empty storage walk is not stamped (issue #4336)", t, func() {
+		// metaDB already knows about a repo, but the storage walk comes back empty - the guard
+		// in parseStorage should skip deleting it and MaybeParseStorage must not lock that state
+		// in via the fast-restart stamp, or the next restart would take the fast path and skip
+		// reparsing, permanently hiding the repo.
+		store := storage.StoreController{DefaultStore: mocks.MockedImageStore{
+			GetRepositoriesFn: func() ([]string, error) { return []string{}, nil },
+		}}
+
+		mock := mocks.MetaDBMock{
+			GetAllRepoNamesFn: func() ([]string, error) { return []string{repo}, nil },
+			SetFastRestartStampFn: func(string) error {
+				t.Fatal("must not stamp when the storage walk looked suspiciously empty")
+
+				return nil
+			},
+		}
+
+		err := meta.MaybeParseStorage(mock, store, false, "v1", logger)
+		So(err, ShouldBeNil)
+	})
 }

--- a/pkg/meta/parse.go
+++ b/pkg/meta/parse.go
@@ -26,13 +26,14 @@ const (
 
 // parseStats tracks per-repo outcomes of a storage walk.
 type parseStats struct {
-	failedRepos  int // skipped on a StatIndex or ParseRepo error
-	partialRepos int // parsed, but a manifest blob was missing
+	failedRepos      int  // skipped on a StatIndex or ParseRepo error
+	partialRepos     int  // parsed, but a manifest blob was missing
+	suspectEmptyWalk bool // storage walk returned no repos while metaDB had some; deletion pass was skipped
 }
 
 // complete reports whether the walk fully populated the metaDB.
 func (s parseStats) complete() bool {
-	return s.failedRepos == 0 && s.partialRepos == 0
+	return s.failedRepos == 0 && s.partialRepos == 0 && !s.suspectEmptyWalk
 }
 
 // ParseStorage will sync all repos found in the rootdirectory of the oci layout that zot was deployed on with the
@@ -65,13 +66,26 @@ func parseStorage(metaDB mTypes.MetaDB, storeController stypes.StoreController, 
 		return parseStats{}, err
 	}
 
-	for _, repo := range getReposToBeDeleted(allStorageRepos, allMetaDBRepos) {
-		err := metaDB.DeleteRepoMeta(repo)
-		if err != nil {
-			log.Error().Err(err).Str("rootDir", storeController.GetImageStore(repo).RootDir()).Str("component", "metadb").
-				Str("repo", repo).Msg("failed to delete repo meta")
+	// A storage walk that comes back empty while metaDB already has entries is far more likely to be
+	// a failed or partial walk (a storage backend error swallowed upstream, a scoped/misconfigured
+	// prefix, transient unavailability) than every previously-known repo disappearing from storage at
+	// once. Deleting metaDB's repos on that signal turns a storage hiccup into permanent data loss, so
+	// skip the deletion pass and leave metaDB untouched rather than trusting an empty walk here.
+	if len(allStorageRepos) == 0 && len(allMetaDBRepos) > 0 {
+		stats.suspectEmptyWalk = true
 
-			return parseStats{}, err
+		log.Warn().Str("component", "metadb").Int("metaDBRepos", len(allMetaDBRepos)).
+			Msg("storage walk returned no repositories while metaDB has existing entries; " +
+				"skipping repo deletion to avoid wiping metaDB on a possibly-failed walk")
+	} else {
+		for _, repo := range getReposToBeDeleted(allStorageRepos, allMetaDBRepos) {
+			err := metaDB.DeleteRepoMeta(repo)
+			if err != nil {
+				log.Error().Err(err).Str("rootDir", storeController.GetImageStore(repo).RootDir()).Str("component", "metadb").
+					Str("repo", repo).Msg("failed to delete repo meta")
+
+				return parseStats{}, err
+			}
 		}
 	}
 

--- a/pkg/meta/parse_internal_test.go
+++ b/pkg/meta/parse_internal_test.go
@@ -38,11 +38,32 @@ func indexBlobFor(digest godigest.Digest, tag string) []byte {
 }
 
 func TestParseStatsComplete(t *testing.T) {
-	Convey("parseStats.complete is true only with no failed or partial repos", t, func() {
+	Convey("parseStats.complete is true only with no failed or partial repos and no suspect empty walk", t, func() {
 		So(parseStats{}.complete(), ShouldBeTrue)
 		So(parseStats{failedRepos: 1}.complete(), ShouldBeFalse)
 		So(parseStats{partialRepos: 1}.complete(), ShouldBeFalse)
 		So(parseStats{failedRepos: 2, partialRepos: 3}.complete(), ShouldBeFalse)
+		So(parseStats{suspectEmptyWalk: true}.complete(), ShouldBeFalse)
+	})
+}
+
+func TestGetReposToBeDeleted(t *testing.T) {
+	Convey("getReposToBeDeleted returns metaDB repos absent from storage", t, func() {
+		Convey("no repos in either set", func() {
+			So(getReposToBeDeleted(nil, nil), ShouldBeEmpty)
+		})
+
+		Convey("metaDB repo present in storage is kept", func() {
+			So(getReposToBeDeleted([]string{"repo1"}, []string{"repo1"}), ShouldBeEmpty)
+		})
+
+		Convey("metaDB repo absent from storage is marked for deletion", func() {
+			So(getReposToBeDeleted([]string{"repo1"}, []string{"repo1", "repo2"}), ShouldResemble, []string{"repo2"})
+		})
+
+		Convey("empty storage marks every metaDB repo for deletion", func() {
+			So(getReposToBeDeleted(nil, []string{"repo1", "repo2"}), ShouldResemble, []string{"repo1", "repo2"})
+		})
 	})
 }
 
@@ -168,5 +189,53 @@ func TestParseStorageStats(t *testing.T) {
 		So(stats.failedRepos, ShouldEqual, 1)
 		So(stats.partialRepos, ShouldEqual, 1)
 		So(stats.complete(), ShouldBeFalse)
+	})
+
+	Convey("a storage walk that returns no repos while metaDB has entries skips deletion (issue #4336)", t, func() {
+		deleteCalled := false
+
+		metaDBWithRepos := mocks.MetaDBMock{
+			GetAllRepoNamesFn: func() ([]string, error) { return []string{"myorg/myapp", "otherrepo"}, nil },
+			DeleteRepoMetaFn: func(repo string) error {
+				deleteCalled = true
+
+				return nil
+			},
+		}
+
+		store := storage.StoreController{DefaultStore: mocks.MockedImageStore{
+			// simulates a failed/empty storage walk (e.g. a swallowed PathNotFoundError, or a
+			// scoped/misconfigured prefix) even though metaDB already knows about two repos.
+			GetRepositoriesFn: func() ([]string, error) { return []string{}, nil },
+		}}
+
+		stats, err := parseStorage(metaDBWithRepos, store, logger)
+		So(err, ShouldBeNil)
+		So(deleteCalled, ShouldBeFalse)
+		So(stats.suspectEmptyWalk, ShouldBeTrue)
+		So(stats.complete(), ShouldBeFalse)
+	})
+
+	Convey("an empty storage walk with an already-empty metaDB is not treated as suspect", t, func() {
+		deleteCalled := false
+
+		emptyMetaDB := mocks.MetaDBMock{
+			GetAllRepoNamesFn: func() ([]string, error) { return []string{}, nil },
+			DeleteRepoMetaFn: func(repo string) error {
+				deleteCalled = true
+
+				return nil
+			},
+		}
+
+		store := storage.StoreController{DefaultStore: mocks.MockedImageStore{
+			GetRepositoriesFn: func() ([]string, error) { return []string{}, nil },
+		}}
+
+		stats, err := parseStorage(emptyMetaDB, store, logger)
+		So(err, ShouldBeNil)
+		So(deleteCalled, ShouldBeFalse)
+		So(stats.suspectEmptyWalk, ShouldBeFalse)
+		So(stats.complete(), ShouldBeTrue)
 	})
 }

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -407,7 +407,7 @@ func (is *ImageStore) GetRepositories() ([]string, error) {
 	// if the root directory is not yet created then return an empty slice of repositories
 	var perr driver.PathNotFoundError
 	if errors.As(err, &perr) {
-		is.log.Debug().Msg("empty rootDir")
+		is.log.Debug().Err(err).Str("rootDir", dir).Msg("empty rootDir")
 
 		return stores, nil
 	}

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -407,6 +407,8 @@ func (is *ImageStore) GetRepositories() ([]string, error) {
 	// if the root directory is not yet created then return an empty slice of repositories
 	var perr driver.PathNotFoundError
 	if errors.As(err, &perr) {
+		is.log.Debug().Msg("empty rootDir")
+
 		return stores, nil
 	}
 


### PR DESCRIPTION
…rage walk

A storage walk that comes back empty while metaDB already has entries was treated as authoritative: parseStorage deleted every metaDB repo not in that (possibly wrong) result on every restart, and reported the wipe as a successful "complete" parse, which could lock the emptied state in via the fast-restart stamp on the next boot. Any transient or partial storage failure that made GetRepositories() come back empty (a swallowed PathNotFoundError, a scoped/misconfigured prefix, S3 unavailability) was therefore indistinguishable from a genuinely empty registry, and silently wiped out repos that were still present and reachable in storage.

Guard the deletion pass: when storage enumerates zero repos but metaDB has some, skip deleting and mark the parse incomplete instead, so the next restart retries rather than the wipe persisting. Also log the previously silent PathNotFoundError swallow in GetRepositories(), matching the existing log line in its sibling GetNextRepositories().

Fixes https://github.com/project-zot/zot/issues/4336

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
