### PR TITLE
ci: always run emulator teardown after job failures

### DIFF
--- a/.github/actions/teardown-localstack/action.yaml
+++ b/.github/actions/teardown-localstack/action.yaml
@@ -4,5 +4,4 @@ runs:
   using: "composite"
   steps:
     - shell: bash
-      if: always()
-      run: localstack stop
+      run: localstack stop || true

--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -164,3 +164,4 @@ jobs:
           name: zb-cloud-scale-out-functional-results-${{ github.sha }}
           path: ./zb-results/
       - uses: ./.github/actions/teardown-localstack
+        if: always()

--- a/.github/workflows/gc-stress-test.yaml
+++ b/.github/workflows/gc-stress-test.yaml
@@ -175,13 +175,14 @@ jobs:
           path: /tmp/gc-referrers-bench-s3.log
           if-no-files-found: error
 
+      - uses: ./.github/actions/teardown-localstack
+        if: always()
+
       - name: Check on failures
         if: steps.bench.outcome != 'success'
         run: |
           cat /tmp/gc-referrers-bench-s3.log
           exit 1
-
-      - uses: ./.github/actions/teardown-localstack
 
   gc-stress-s3:
     name: GC(without referrers) on S3(minio) with short interval
@@ -262,10 +263,11 @@ jobs:
           path: /tmp/gc-bench-s3.log
           if-no-files-found: error
 
+      - uses: ./.github/actions/teardown-localstack
+        if: always()
+
       - name: Check on failures
         if: steps.bench.outcome != 'success'
         run: |
           cat /tmp/gc-bench-s3.log
           exit 1
-
-      - uses: ./.github/actions/teardown-localstack

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -48,6 +48,7 @@ jobs:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
       - uses: ./.github/actions/teardown-localstack
+        if: always()
 
   sync:
     name: Sync harness
@@ -109,12 +110,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: fake
         continue-on-error: true
 
+      - uses: ./.github/actions/teardown-localstack
+        if: always()
       - name: Check on failures
         if: steps.bench.outcome != 'success'
         run: |
           cat /tmp/gc-referrers-bench-s3.log
           exit 1
-      - uses: ./.github/actions/teardown-localstack
 
   gc-stress-s3:
     name: GC(without referrers) on S3(localstack) with short interval
@@ -155,12 +157,13 @@ jobs:
           AWS_SECRET_ACCESS_KEY: fake
         continue-on-error: true
 
+      - uses: ./.github/actions/teardown-localstack
+        if: always()
       - name: Check on failures
         if: steps.bench.outcome != 'success'
         run: |
           cat /tmp/gc-bench-s3.log
           exit 1
-      - uses: ./.github/actions/teardown-localstack
 
   docker-image:
     name: Build docker image (for users still using Docker environments)
@@ -344,6 +347,8 @@ jobs:
       - name: clean up logs
         run: |
           rm -r /tmp/zot-ft-logs/dynamo-scale
+      - uses: ./.github/actions/teardown-localstack
+        if: always()
       - name: fail job if error
         if: ${{ steps.scale.outcome != 'success' || steps.multihop.outcome != 'success' }}
         run: |
@@ -354,7 +359,6 @@ jobs:
         with:
           name: zb-cloud-scale-out-perf-results-${{ github.sha }}
           path: ./zb-results/
-      - uses: ./.github/actions/teardown-localstack
 
   cloud-scale-out-redis:
     name: s3+redis scale-out
@@ -415,6 +419,8 @@ jobs:
       - name: clean up logs
         run: |
           rm -r /tmp/zot-ft-logs/redis-scale
+      - uses: ./.github/actions/teardown-localstack
+        if: always()
       - name: fail job if error
         if: ${{ steps.scale.outcome != 'success' || steps.multihop.outcome != 'success' }}
         run: |
@@ -425,4 +431,3 @@ jobs:
         with:
           name: zb-cloud-scale-out-redis-results-${{ github.sha }}
           path: ./zb-results/
-      - uses: ./.github/actions/teardown-localstack

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,9 @@ jobs:
           name: coverage-minimal
           path: coverage-minimal.txt
       - uses: ./.github/actions/teardown-localstack
+        if: always()
       - uses: ./.github/actions/teardown-azurite
+        if: always()
   test-run-extensions:
     name: Run zot with extensions tests
     runs-on: cncf-ubuntu-16-64-x86
@@ -102,7 +104,9 @@ jobs:
           name: coverage-extended
           path: coverage-extended.txt
       - uses: ./.github/actions/teardown-localstack
+        if: always()
       - uses: ./.github/actions/teardown-azurite
+        if: always()
   test-run-devmode:
     name: Running development-mode tests on Linux
     runs-on: ubuntu-latest
@@ -179,6 +183,7 @@ jobs:
           name: coverage-needprivileges
           path: coverage-needprivileges-*.txt
       - uses: ./.github/actions/teardown-gcs-storage-testbench
+        if: always()
   test-coverage:
     name: Collect all test coverage
     runs-on: ubuntu-latest


### PR DESCRIPTION
Composite teardown actions only run if the caller step runs. Add if: always() on teardown uses sites, and move teardown before intentional exit 1 checks so localstack/azurite/gcs cleanup still happens on shared runners.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
