### PR TITLE
Update link reference for project-zot repository

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -47,7 +47,7 @@ and the possible attack surface.
 
 [7] https://github.com/parabuzzle/craneoperator
 
-[8] https://github.com/project-zot/zot-ui
+[8] https://github.com/project-zot/zui
 
 [9] https://www.docker.com/blog/donating-docker-distribution-to-the-cncf/
 


### PR DESCRIPTION
Just a document change for renaming zot-ui to zui, previous link didn't work.