### PR TITLE
feat(search): support Trivy ignore files

### DIFF
--- a/examples/.trivyignore
+++ b/examples/.trivyignore
@@ -1,0 +1,2 @@
+# Add one reviewed vulnerability ID per line.
+GO-2026-5932

--- a/examples/README.md
+++ b/examples/README.md
@@ -1503,9 +1503,11 @@ A minimal configuration only sets how often the DB is refreshed; zot applies def
 
 To set those options explicitly (for example to mirror standalone Trivy’s `--vuln-severity-source` behavior), use a `trivy` object under `cve`:
 
-- [config-cve-trivy.json](config-cve-trivy.json) — shows optional `dbRepository`, `javaDBRepository`, `ignoreFile`, `vulnSeveritySources`, and `sbom`.
+- [config-cve-trivy.json](config-cve-trivy.json) — shows optional `dbRepository`, `javaDBRepository`, `vulnSeveritySources`, and `sbom`.
 
-`ignoreFile` specifies the path to a [Trivy ignore file](https://trivy.dev/docs/latest/configuration/filtering/#trivyignore) and supports the same plain-text and YAML formats as Trivy's `--ignorefile` option. The file must be accessible to the zot process.
+`ignoreFile` specifies the path to a [Trivy ignore file](https://trivy.dev/docs/latest/configuration/filtering/#trivyignore) and supports the same plain-text and YAML formats as Trivy's `--ignorefile` option. The file must exist and be readable when zot loads its configuration. Relative paths are resolved from zot's process working directory, not from the directory containing the zot configuration file, so use an absolute path in deployments, for example `"ignoreFile": "/etc/zot/.trivyignore"`. A sample [`.trivyignore`](.trivyignore) is included in this directory.
+
+Scan results are cached by manifest digest. Editing an ignore file does not invalidate existing cached results: newly ignored vulnerabilities can remain visible, and newly unignored vulnerabilities can remain hidden, until the CVE database refresh purges the scan cache or zot restarts. The minimum database `updateInterval` is two hours.
 
 `vulnSeveritySources` is a list of source names in priority order (for example `auto`, `nvd`, or vendor IDs such as `redhat`, `alpine`). If omitted, zot defaults it to `["auto"]`, consistent with the Trivy CLI. See [Trivy: severity selection](https://trivy.dev/docs/latest/scanner/vulnerability/#severity-selection).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1503,7 +1503,9 @@ A minimal configuration only sets how often the DB is refreshed; zot applies def
 
 To set those options explicitly (for example to mirror standalone Trivy’s `--vuln-severity-source` behavior), use a `trivy` object under `cve`:
 
-- [config-cve-trivy.json](config-cve-trivy.json) — shows optional `dbRepository`, `javaDBRepository`, `vulnSeveritySources`, and `sbom`.
+- [config-cve-trivy.json](config-cve-trivy.json) — shows optional `dbRepository`, `javaDBRepository`, `ignoreFile`, `vulnSeveritySources`, and `sbom`.
+
+`ignoreFile` specifies the path to a [Trivy ignore file](https://trivy.dev/docs/latest/configuration/filtering/#trivyignore) and supports the same plain-text and YAML formats as Trivy's `--ignorefile` option. The file must be accessible to the zot process.
 
 `vulnSeveritySources` is a list of source names in priority order (for example `auto`, `nvd`, or vendor IDs such as `redhat`, `alpine`). If omitted, zot defaults it to `["auto"]`, consistent with the Trivy CLI. See [Trivy: severity selection](https://trivy.dev/docs/latest/scanner/vulnerability/#severity-selection).
 

--- a/examples/config-cve-trivy.json
+++ b/examples/config-cve-trivy.json
@@ -18,7 +18,6 @@
         "trivy": {
           "dbRepository": "ghcr.io/aquasecurity/trivy-db",
           "javaDBRepository": "ghcr.io/aquasecurity/trivy-java-db",
-          "ignoreFile": "/etc/zot/.trivyignore.yaml",
           "vulnSeveritySources": ["auto"]
         }
       }

--- a/examples/config-cve-trivy.json
+++ b/examples/config-cve-trivy.json
@@ -18,6 +18,7 @@
         "trivy": {
           "dbRepository": "ghcr.io/aquasecurity/trivy-db",
           "javaDBRepository": "ghcr.io/aquasecurity/trivy-java-db",
+          "ignoreFile": "/etc/zot/.trivyignore.yaml",
           "vulnSeveritySources": ["auto"]
         }
       }

--- a/pkg/cli/server/extensions_test.go
+++ b/pkg/cli/server/extensions_test.go
@@ -873,6 +873,8 @@ func TestServeSearchEnabled(t *testing.T) {
 }
 
 func TestServeSearchEnabledDefaultCVEDB(t *testing.T) {
+	const ignoreFileContent = "# Add one reviewed vulnerability ID per line.\nGO-2026-5932\n"
+
 	oldArgs := os.Args
 
 	defer func() { os.Args = oldArgs }()
@@ -976,25 +978,72 @@ func TestServeSearchEnabledDefaultCVEDB(t *testing.T) {
 		So(cfg.Extensions.Search.CVE.Trivy.VulnSeveritySources, ShouldResemble, []string{"nvd", "ghsa"})
 	})
 
-	Convey("IgnoreFile respects an explicit path", t, func(c C) {
+	Convey("IgnoreFile accepts an existing readable file", t, func(c C) {
 		cfg := config.New()
+		ignoreFile := MakeTempFileWithContent(t, ".trivyignore", ignoreFileContent)
 
-		content := `{
+		content := fmt.Sprintf(`{
 				"storage": { "rootDirectory": "/tmp/zot" },
 				"http": { "address": "127.0.0.1", "port": "8080" },
 				"extensions": {
 					"search": {
 						"enable": true,
-						"cve": { "trivy": { "ignoreFile": "/etc/zot/.trivyignore.yaml" } }
+						"cve": { "trivy": { "ignoreFile": %q } }
 					}
 				}
-			}`
+			}`, ignoreFile)
 		configPath := MakeTempFileWithContent(t, "zot-test.json", content)
 
 		err := cli.LoadConfiguration(cfg, configPath)
 		So(err, ShouldBeNil)
 
-		So(cfg.Extensions.Search.CVE.Trivy.IgnoreFile, ShouldEqual, "/etc/zot/.trivyignore.yaml")
+		So(cfg.Extensions.Search.CVE.Trivy.IgnoreFile, ShouldEqual, ignoreFile)
+	})
+
+	Convey("IgnoreFile rejects a missing file", t, func(c C) {
+		cfg := config.New()
+		ignoreFile := MakeTempFilePath(t, ".trivyignore")
+
+		content := fmt.Sprintf(`{
+				"storage": { "rootDirectory": "/tmp/zot" },
+				"http": { "address": "127.0.0.1", "port": "8080" },
+				"extensions": {
+					"search": {
+						"enable": true,
+						"cve": { "trivy": { "ignoreFile": %q } }
+					}
+				}
+			}`, ignoreFile)
+		configPath := MakeTempFileWithContent(t, "zot-test.json", content)
+
+		err := cli.LoadConfiguration(cfg, configPath)
+		So(err, ShouldNotBeNil)
+		So(err, ShouldWrap, zerr.ErrBadConfig)
+	})
+
+	Convey("IgnoreFile rejects an unreadable file", t, func(c C) {
+		cfg := config.New()
+		ignoreFile := MakeTempFileWithContent(t, ".trivyignore", ignoreFileContent)
+		So(os.Chmod(ignoreFile, 0o000), ShouldBeNil)
+		defer func() {
+			So(os.Chmod(ignoreFile, 0o600), ShouldBeNil)
+		}()
+
+		content := fmt.Sprintf(`{
+				"storage": { "rootDirectory": "/tmp/zot" },
+				"http": { "address": "127.0.0.1", "port": "8080" },
+				"extensions": {
+					"search": {
+						"enable": true,
+						"cve": { "trivy": { "ignoreFile": %q } }
+					}
+				}
+			}`, ignoreFile)
+		configPath := MakeTempFileWithContent(t, "zot-test.json", content)
+
+		err := cli.LoadConfiguration(cfg, configPath)
+		So(err, ShouldNotBeNil)
+		So(err, ShouldWrap, zerr.ErrBadConfig)
 	})
 
 	Convey("CVE with only updateInterval (no trivy key) gets VulnSeveritySources [auto]", t, func(c C) {

--- a/pkg/cli/server/extensions_test.go
+++ b/pkg/cli/server/extensions_test.go
@@ -908,7 +908,7 @@ func TestServeSearchEnabledDefaultCVEDB(t *testing.T) {
 		// The default config handling logic will convert the 1h interval to a 2h interval
 		substring := "\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":7200000000000,\"Trivy\":" +
 			"{\"DBRepository\":\"ghcr.io/aquasecurity/trivy-db\",\"JavaDBRepository\":\"ghcr.io/aquasecurity/trivy-java-db\"," +
-			"\"VulnSeveritySources\":[\"auto\"],\"SBOM\":null}}}"
+			"\"IgnoreFile\":\"\",\"VulnSeveritySources\":[\"auto\"],\"SBOM\":null}}}"
 
 		found, err := ReadLogFileAndSearchString(logPath, substring, readLogFileTimeout)
 
@@ -974,6 +974,27 @@ func TestServeSearchEnabledDefaultCVEDB(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		So(cfg.Extensions.Search.CVE.Trivy.VulnSeveritySources, ShouldResemble, []string{"nvd", "ghsa"})
+	})
+
+	Convey("IgnoreFile respects an explicit path", t, func(c C) {
+		cfg := config.New()
+
+		content := `{
+				"storage": { "rootDirectory": "/tmp/zot" },
+				"http": { "address": "127.0.0.1", "port": "8080" },
+				"extensions": {
+					"search": {
+						"enable": true,
+						"cve": { "trivy": { "ignoreFile": "/etc/zot/.trivyignore.yaml" } }
+					}
+				}
+			}`
+		configPath := MakeTempFileWithContent(t, "zot-test.json", content)
+
+		err := cli.LoadConfiguration(cfg, configPath)
+		So(err, ShouldBeNil)
+
+		So(cfg.Extensions.Search.CVE.Trivy.IgnoreFile, ShouldEqual, "/etc/zot/.trivyignore.yaml")
 	})
 
 	Convey("CVE with only updateInterval (no trivy key) gets VulnSeveritySources [auto]", t, func(c C) {

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -610,6 +610,42 @@ func validateExtensionsConfig(cfg *config.Config, logger zlog.Logger) error {
 
 			return joinedErr
 		}
+
+		if extensionsConfig.Search != nil && extensionsConfig.Search.CVE != nil &&
+			extensionsConfig.Search.CVE.Trivy != nil && extensionsConfig.Search.CVE.Trivy.IgnoreFile != "" {
+			ignoreFile := extensionsConfig.Search.CVE.Trivy.IgnoreFile
+
+			file, err := os.Open(ignoreFile)
+			if err != nil {
+				wrappedErr := fmt.Errorf("%w: failed to open Trivy ignore file %q: %w", zerr.ErrBadConfig, ignoreFile, err)
+				logger.Error().Err(wrappedErr).Msg("invalid Trivy ignore file")
+
+				return wrappedErr
+			}
+
+			fileInfo, statErr := file.Stat()
+			closeErr := file.Close()
+			if statErr != nil {
+				wrappedErr := fmt.Errorf("%w: failed to stat Trivy ignore file %q: %w", zerr.ErrBadConfig, ignoreFile, statErr)
+				logger.Error().Err(wrappedErr).Msg("invalid Trivy ignore file")
+
+				return wrappedErr
+			}
+
+			if closeErr != nil {
+				wrappedErr := fmt.Errorf("%w: failed to close Trivy ignore file %q: %w", zerr.ErrBadConfig, ignoreFile, closeErr)
+				logger.Error().Err(wrappedErr).Msg("invalid Trivy ignore file")
+
+				return wrappedErr
+			}
+
+			if !fileInfo.Mode().IsRegular() {
+				wrappedErr := fmt.Errorf("%w: Trivy ignore file %q is not a regular file", zerr.ErrBadConfig, ignoreFile)
+				logger.Error().Err(wrappedErr).Msg("invalid Trivy ignore file")
+
+				return wrappedErr
+			}
+		}
 	}
 
 	if extensionsConfig.IsUIEnabled() {

--- a/pkg/extensions/config/config.go
+++ b/pkg/extensions/config/config.go
@@ -60,6 +60,8 @@ type CVEConfig struct {
 type TrivyConfig struct {
 	DBRepository     string // default is "ghcr.io/aquasecurity/trivy-db"
 	JavaDBRepository string // default is "ghcr.io/aquasecurity/trivy-java-db"
+	// IgnoreFile specifies the path to a Trivy ignore file (same as Trivy's --ignorefile).
+	IgnoreFile string
 	// VulnSeveritySources controls Trivy's severity source selection (same as Trivy's --vuln-severity-source).
 	// If empty, zot will default it to ["auto"].
 	VulnSeveritySources []string

--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -85,7 +85,7 @@ var newArtifactRunner = artifact.NewRunner //nolint:gochecknoglobals // test sea
 // getNewScanOptions sets trivy configuration values for our scans and returns them as
 // a trivy Options structure.
 func getNewScanOptions(dir string, dbRepositoryRef, javaDBRepositoryRef name.Reference,
-	vulnSeveritySources []dbTypes.SourceID, sbomEnabled bool,
+	vulnSeveritySources []dbTypes.SourceID, ignoreFile string, sbomEnabled bool,
 ) *flag.Options {
 	scanOptions := flag.Options{
 		GlobalOptions: flag.GlobalOptions{
@@ -111,7 +111,8 @@ func getNewScanOptions(dir string, dbRepositoryRef, javaDBRepositoryRef name.Ref
 			VulnSeveritySources: vulnSeveritySources,
 		},
 		ReportOptions: flag.ReportOptions{
-			Format: "table",
+			Format:     "table",
+			IgnoreFile: ignoreFile,
 			Severities: []dbTypes.Severity{
 				dbTypes.SeverityUnknown,
 				dbTypes.SeverityLow,
@@ -183,6 +184,7 @@ func NewScanner(storeController storage.StoreController,
 	dbRepository := trivyCfg.DBRepository
 	javaDBRepository := trivyCfg.JavaDBRepository
 	vulnSeveritySources := trivyCfg.VulnSeveritySources
+	ignoreFile := trivyCfg.IgnoreFile
 
 	// The logic to set defaults is similar to what trivy itself uses:
 	// https://github.com/aquasecurity/trivy/blob/v0.51.4/pkg/flag/db_flags.go#L152
@@ -226,7 +228,7 @@ func NewScanner(storeController storage.StoreController,
 		rootDir := imageStore.RootDir()
 
 		cacheDir := path.Join(rootDir, "_trivy")
-		opts := getNewScanOptions(cacheDir, dbRepositoryRef, javaDBRepositoryRef, sevSources, sbomOpts.enabled)
+		opts := getNewScanOptions(cacheDir, dbRepositoryRef, javaDBRepositoryRef, sevSources, ignoreFile, sbomOpts.enabled)
 
 		cveController.DefaultCveConfig = opts
 	}
@@ -236,7 +238,7 @@ func NewScanner(storeController storage.StoreController,
 			rootDir := storage.RootDir()
 
 			cacheDir := path.Join(rootDir, "_trivy")
-			opts := getNewScanOptions(cacheDir, dbRepositoryRef, javaDBRepositoryRef, sevSources, sbomOpts.enabled)
+			opts := getNewScanOptions(cacheDir, dbRepositoryRef, javaDBRepositoryRef, sevSources, ignoreFile, sbomOpts.enabled)
 
 			subCveConfig[route] = opts
 		}

--- a/pkg/extensions/search/cve/trivy/scanner_internal_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_internal_test.go
@@ -720,6 +720,16 @@ func TestVulnSeveritySourcesDefaulting(t *testing.T) {
 	})
 }
 
+func TestIgnoreFileConfiguration(t *testing.T) {
+	Convey("getNewScanOptions passes the configured ignore file to Trivy", t, func() {
+		const ignoreFile = "/etc/zot/.trivyignore.yaml"
+
+		opts := getNewScanOptions(t.TempDir(), nil, nil, []dbTypes.SourceID{"auto"}, ignoreFile, false)
+
+		So(opts.ReportOptions.IgnoreFile, ShouldEqual, ignoreFile)
+	})
+}
+
 func TestStoreSBOMAsOCIArtifact(t *testing.T) {
 	Convey("storeSBOMAsOCIArtifact stores SBOM once as OCI referrer", t, func() {
 		rootDir := t.TempDir()


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:

N/A — there is no existing issue for exposing Trivy's ignore-file option through zot configuration.

**What does this PR do / Why do we need it**:

Expose Trivy's native ignore-file filtering through the CVE scanner configuration. The new optional `extensions.search.cve.trivy.ignoreFile` setting is passed to Trivy's `ReportOptions.IgnoreFile` for both the default image store and every routed sub-store.

This lets operators suppress findings using Trivy's existing filtering semantics instead of maintaining zot-specific filtering logic. Both plain `.trivyignore` files and the experimental structured `.trivyignore.yaml`/`.yml` format are supported by the embedded Trivy version. The example configuration and documentation describe the option and note that the file must be accessible to the zot process.

**If an issue # is not available please add repro steps and logs showing the issue**:

Before this change, `TrivyConfig` has no ignore-file field, and `getNewScanOptions` leaves `flag.ReportOptions.IgnoreFile` empty. An operator therefore cannot apply an existing Trivy ignore file to CVE results returned by zot.

Reproduction:

1. Run zot with search and CVE scanning enabled.
2. Push an image with a Trivy finding that must be suppressed after external verification.
3. Add a `.trivyignore` file to the zot container.
4. Observe that there is no zot configuration setting that passes this file to the embedded Trivy scanner, so the finding remains in search results.

After this change, configure:

```json
{
  "extensions": {
    "search": {
      "enable": true,
      "cve": {
        "trivy": {
          "ignoreFile": "/etc/zot/.trivyignore.yaml"
        }
      }
    }
  }
}
```

Production startup output confirmed the configured value was loaded:

```text
"Trivy":{"DBRepository":"ghcr.io/aquasecurity/trivy-db","JavaDBRepository":"ghcr.io/aquasecurity/trivy-java-db","IgnoreFile":"/etc/zot/.trivyignore.yaml","VulnSeveritySources":["auto"],"SBOM":null}
```

**Testing done on this change**:

Automated tests:

```text
$ GOEXPERIMENT=jsonv2 go test github.com/aquasecurity/trivy/pkg/result -run 'TestParseIgnoreFile/happy_path_valid_(config|YAML_config)_file' -count=1
ok github.com/aquasecurity/trivy/pkg/result 0.032s

$ GOEXPERIMENT=jsonv2 go test -tags search ./pkg/extensions/search/cve/trivy -run '^TestIgnoreFileConfiguration$' -count=1
ok zotregistry.dev/zot/v2/pkg/extensions/search/cve/trivy 0.057s

$ GOEXPERIMENT=jsonv2 go test -tags 'sync,scrub,metrics,search,userprefs,mgmt,imagetrust,events' ./pkg/cli/server -run '^TestServeSearchEnabledDefaultCVEDB$' -count=1
ok zotregistry.dev/zot/v2/pkg/cli/server 28.313s

$ GOEXPERIMENT=jsonv2 go vet -tags search ./pkg/extensions/search/cve/trivy ./pkg/extensions/config

$ GOEXPERIMENT=jsonv2 golangci-lint run --build-tags 'sync,scrub,metrics,search,userprefs,mgmt,imagetrust,events' ./pkg/extensions/config/... ./pkg/extensions/search/cve/trivy/... ./pkg/cli/server/...
0 issues.
```

Manual integration testing used an amd64 image built from this commit and deployed to a production zot registry.

Plain ignore file test:

```text
/etc/zot/.trivyignore:
GO-2026-5932
```

The pod started cleanly, rescanned registry images, and the GraphQL `ImageListForCVE(id: "GO-2026-5932")` query returned:

```json
{"data":{"ImageListForCVE":{"Page":{"TotalCount":0,"ItemCount":0},"Results":[]}}}
```

Experimental YAML ignore file test:

```yaml
# /etc/zot/.trivyignore.yaml
vulnerabilities:
  - id: GO-2026-5932
```

The zot configuration was changed to `"ignoreFile": "/etc/zot/.trivyignore.yaml"`. The pod again started cleanly with zero restarts, rescanned images without ignore-file parse/filter errors, and the same GraphQL query returned:

```json
{"data":{"ImageListForCVE":{"Page":{"TotalCount":0,"ItemCount":0},"Results":[]}}}
```

The YAML form is additionally scoped to vulnerability findings, unlike the plain format which applies an ID across scanner categories.

**Automation added to e2e**:

No. Unit coverage verifies that zot passes the configured path to Trivy, configuration coverage verifies JSON decoding/default handling, and Trivy's parser tests cover both supported file formats. Manual integration testing covered the complete image scan and GraphQL result path for both formats.

**Will this break upgrades or downgrades?**

No. The field is optional and its zero value preserves existing behavior. Upgrading does not change scanning unless an operator configures `ignoreFile`. Before downgrading to a zot version without this field, operators should remove the setting from their configuration.

**Does this PR introduce any user-facing change?**:

Yes. Operators can configure Trivy ignore files for zot CVE scanning.

```release-note
The Trivy CVE scanner supports an optional `extensions.search.cve.trivy.ignoreFile` setting. The configured file is used for Trivy's native vulnerability filtering and may use either the plain `.trivyignore` format or the experimental structured `.trivyignore.yaml`/`.yml` format.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
