### PR TITLE
fix(sync): decouple on-demand requestStore cleanup from the original …

### DIFF
--- a/pkg/extensions/sync/on_demand.go
+++ b/pkg/extensions/sync/on_demand.go
@@ -62,7 +62,12 @@ func (onDemand *BaseOnDemand) SyncImage(ctx context.Context, repo, reference str
 		reference: reference,
 	}
 
-	syncResult := make(chan error)
+	// Keep result delivery and requestStore cleanup independent of this call's own receive
+	// below (see the syncImage() comment): today the caller always waits synchronously and
+	// this doesn't come into play, but a future caller that stops waiting some other way
+	// (an outer select/timeout, a leaked goroutine) must not be able to leave a stale
+	// requestStore entry or block the sync worker's result send.
+	syncResult := make(chan error, 1)
 	val, loaded := onDemand.requestStore.LoadOrStore(req, syncResult)
 
 	if loaded {
@@ -76,9 +81,7 @@ func (onDemand *BaseOnDemand) SyncImage(ctx context.Context, repo, reference str
 		return err
 	}
 
-	defer onDemand.requestStore.Delete(req)
-
-	go onDemand.syncImage(ctx, repo, reference, syncResult)
+	go onDemand.syncImage(ctx, repo, reference, req, syncResult)
 
 	err := <-syncResult
 
@@ -93,7 +96,12 @@ func (onDemand *BaseOnDemand) SyncReferrers(ctx context.Context, repo string,
 		reference: subjectDigestStr,
 	}
 
-	syncResult := make(chan error)
+	// Keep result delivery and requestStore cleanup independent of this call's own receive
+	// below (see the syncReferrers() comment): today the caller always waits synchronously
+	// and this doesn't come into play, but a future caller that stops waiting some other way
+	// (an outer select/timeout, a leaked goroutine) must not be able to leave a stale
+	// requestStore entry or block the sync worker's result send.
+	syncResult := make(chan error, 1)
 	val, loaded := onDemand.requestStore.LoadOrStore(req, syncResult)
 
 	if loaded {
@@ -107,9 +115,7 @@ func (onDemand *BaseOnDemand) SyncReferrers(ctx context.Context, repo string,
 		return err
 	}
 
-	defer onDemand.requestStore.Delete(req)
-
-	go onDemand.syncReferrers(ctx, repo, subjectDigestStr, referenceTypes, syncResult)
+	go onDemand.syncReferrers(ctx, repo, subjectDigestStr, referenceTypes, req, syncResult)
 
 	err := <-syncResult
 
@@ -117,8 +123,15 @@ func (onDemand *BaseOnDemand) SyncReferrers(ctx context.Context, repo string,
 }
 
 func (onDemand *BaseOnDemand) syncReferrers(ctx context.Context, repo, subjectDigestStr string,
-	referenceTypes []string, syncResult chan error,
+	referenceTypes []string, mainReq request, syncResult chan error,
 ) {
+	// Cleanup and result delivery are owned here, by the goroutine that knows the work is
+	// done, rather than in the original SyncImage()/SyncReferrers() caller's defer. Canceling
+	// that caller's context does not by itself stop its blocked `<-syncResult` receive, and
+	// today it always waits synchronously so this is defensive: it protects against a future
+	// caller that stops waiting some other way (an outer select/timeout, a leaked goroutine)
+	// without depending on that caller ever resuming.
+	defer onDemand.requestStore.Delete(mainReq)
 	defer close(syncResult)
 
 	var err error
@@ -196,7 +209,16 @@ func (onDemand *BaseOnDemand) syncReferrers(ctx context.Context, repo, subjectDi
 	syncResult <- err
 }
 
-func (onDemand *BaseOnDemand) syncImage(ctx context.Context, repo, reference string, syncResult chan error) {
+func (onDemand *BaseOnDemand) syncImage(ctx context.Context, repo, reference string,
+	mainReq request, syncResult chan error,
+) {
+	// Cleanup and result delivery are owned here, by the goroutine that knows the work is
+	// done, rather than in the original SyncImage()/SyncReferrers() caller's defer. Canceling
+	// that caller's context does not by itself stop its blocked `<-syncResult` receive, and
+	// today it always waits synchronously so this is defensive: it protects against a future
+	// caller that stops waiting some other way (an outer select/timeout, a leaked goroutine)
+	// without depending on that caller ever resuming.
+	defer onDemand.requestStore.Delete(mainReq)
 	defer close(syncResult)
 
 	var err error

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -753,6 +753,89 @@ func TestService(t *testing.T) {
 			So(err.Error(), ShouldEqual, "guaranteed referrer channel error")
 		})
 	})
+
+	Convey("test requestStore cleanup does not depend on the original caller reading the channel", t, func() {
+		// Defensive-hardening test: an original caller that never reaches the code after its
+		// blocking receive on syncResult must not permanently poison the requestStore entry
+		// for that (repo, reference). This test simulates that end state directly (a stored
+		// channel nobody will ever read) rather than reproducing how a caller ends up in it —
+		// with today's caller (a synchronous, non-canceling receive) it doesn't; context
+		// cancellation alone does not stop a goroutine blocked on a plain channel receive, so
+		// the caller would need to give up some other way (e.g. an outer select/timeout
+		// wrapped around the call, or its own goroutine leaking). Owning cleanup in the
+		// goroutine doing the sync work, rather than the caller's continued execution, means
+		// this failure mode can't happen regardless of how a future caller might be lost.
+
+		newAbandonedOnDemand := func(prefix string) *BaseOnDemand {
+			maxRetries := 0
+			conf := syncconf.RegistryConfig{
+				URLs:       []string{"http://localhost:32768"}, // unused port, no listener - fails fast
+				MaxRetries: &maxRetries,
+				Content:    []syncconf.Content{{Prefix: prefix}},
+			}
+
+			service, err := New(conf, "", nil, t.TempDir(), storage.StoreController{}, mocks.MetaDBMock{}, log.NewTestLogger())
+			So(err, ShouldBeNil)
+
+			onDemand := NewOnDemand(log.NewTestLogger())
+			onDemand.Add(service)
+
+			return onDemand
+		}
+
+		Convey("syncImage", func() {
+			onDemand := newAbandonedOnDemand("abandoned-repo")
+
+			req := request{repo: "abandoned-repo", reference: "abandoned-tag"}
+			syncResult := make(chan error, 1)
+
+			// Simulate the state left behind by an original SyncImage() caller that stored the
+			// channel but was abandoned before ever reading from it.
+			onDemand.requestStore.Store(req, syncResult)
+
+			done := make(chan struct{})
+			go func() {
+				onDemand.syncImage(context.Background(), "abandoned-repo", "abandoned-tag", req, syncResult)
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("syncImage blocked sending its result with no receiver present")
+			}
+
+			_, exists := onDemand.requestStore.Load(req)
+			So(exists, ShouldBeFalse)
+		})
+
+		Convey("syncReferrers", func() {
+			onDemand := newAbandonedOnDemand("abandoned-referrer-repo")
+
+			req := request{repo: "abandoned-referrer-repo", reference: "sha256:abandoned"}
+			syncResult := make(chan error, 1)
+
+			// Simulate the state left behind by an original SyncReferrers() caller that stored
+			// the channel but was abandoned before ever reading from it.
+			onDemand.requestStore.Store(req, syncResult)
+
+			done := make(chan struct{})
+			go func() {
+				onDemand.syncReferrers(context.Background(), "abandoned-referrer-repo", "sha256:abandoned",
+					[]string{"signature"}, req, syncResult)
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Fatal("syncReferrers blocked sending its result with no receiver present")
+			}
+
+			_, exists := onDemand.requestStore.Load(req)
+			So(exists, ShouldBeFalse)
+		})
+	})
 }
 
 func writeKeyFile(t *testing.T, content string) string {


### PR DESCRIPTION
Defensive fix. BaseOnDemand.SyncImage/SyncReferrers relied on the
original caller's own defer to delete its requestStore entry after
receiving from the result channel. If a caller ever stopped waiting
without reaching that code, the entry would stay forever, poisoning
all later requests for the same (repo, reference).

Move requestStore.Delete into syncImage()/syncReferrers()'s own defer
and make syncResult buffered, so cleanup and result delivery are owned
by the goroutine doing the sync work and never depend on the caller.

Relates to https://github.com/project-zot/zot/issues/4345

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
