### PR TITLE
perf: drop the index walk on blob Content-Type

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1448,6 +1448,7 @@ func normalizeBlobRedirectURL(rawURL string) (string, bool) {
 // @Summary Get image blob/layer
 // @Description Get an image's blob/layer given a digest
 // @Accept  json
+// @Produce json
 // @Produce application/octet-stream
 // @Param   name     path    string     true        "repository name"
 // @Param   digest   path    string     true        "blob/layer digest"

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -13,7 +13,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"mime"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -1051,36 +1050,6 @@ func canMount(userAc *reqCtx.UserAccessControl, imgStore storageTypes.ImageStore
 	return canMount, nil
 }
 
-// resolveBlobResponseMediaType resolves the OCI media type to advertise for a blob via
-// the repo's index/manifests. If the descriptor lookup fails (or the descriptor
-// has no media type), it falls back to application/octet-stream.
-//
-// Use this for Content-Type on HEAD/GET blob responses to satisfy OCI
-// distribution-spec conformance and consumers like stargz-snapshotter that
-// require a non-empty, well-formed media type.
-func resolveBlobResponseMediaType(
-	imgStore storageTypes.ImageStore,
-	repo string,
-	digest godigest.Digest,
-	logger log.Logger,
-) string {
-	desc, err := storageCommon.GetBlobDescriptorFromRepo(imgStore, repo, digest, logger)
-	if err == nil && desc.MediaType != "" {
-		// Descriptor media types originate from manifest JSON and are not
-		// necessarily validated. Ensure we only emit a header-safe, parseable
-		// media type; otherwise fall back to application/octet-stream.
-		//
-		// ParseMediaType also strips parameters so we only propagate the base
-		// type (e.g. "application/vnd.oci.image.layer.v1.tar+gzip").
-		mediaType, _, parseErr := mime.ParseMediaType(desc.MediaType)
-		if parseErr == nil && mediaType != "" {
-			return mediaType
-		}
-	}
-
-	return constants.BinaryMediaType
-}
-
 // CheckBlob godoc
 // @Summary Check image blob/layer
 // @Description Check an image's blob/layer given a digest
@@ -1175,7 +1144,7 @@ func (rh *RouteHandler) CheckBlob(response http.ResponseWriter, request *http.Re
 
 	response.Header().Set("Content-Length", strconv.FormatInt(blen, 10))
 	response.Header().Set("Accept-Ranges", "bytes")
-	response.Header().Set("Content-Type", resolveBlobResponseMediaType(imgStore, name, digest, rh.c.Log))
+	response.Header().Set("Content-Type", constants.BinaryMediaType)
 	response.Header().Set(constants.DistContentDigestKey, digest.String())
 	response.WriteHeader(http.StatusOK)
 }
@@ -1573,9 +1542,7 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 			return
 		}
 
-		// Resolve the response Content-Type from the blob's OCI descriptor (if
-		// any), with a fallback to application/octet-stream.
-		mediaType := resolveBlobResponseMediaType(imgStore, name, digest, rh.c.Log)
+		mediaType := constants.BinaryMediaType
 
 		ranges, err := parseRangeHeader(contentRange, bsize)
 		if err != nil {
@@ -1641,11 +1608,7 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 
 	var blen int64
 
-	// Resolve the response Content-Type from the blob's OCI descriptor
-	// (if any), with a fallback to application/octet-stream. This lookup
-	// may require an additional repo index/manifest walk before we read
-	// the blob, but preserves a more specific Content-Type when available.
-	mediaType := resolveBlobResponseMediaType(imgStore, name, digest, rh.c.Log)
+	mediaType := constants.BinaryMediaType
 
 	repo, blen, err := imgStore.GetBlob(name, digest, mediaType)
 	if err != nil {

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1054,6 +1054,7 @@ func canMount(userAc *reqCtx.UserAccessControl, imgStore storageTypes.ImageStore
 // @Summary Check image blob/layer
 // @Description Check an image's blob/layer given a digest
 // @Accept  json
+// @Produce json
 // @Produce application/octet-stream
 // @Param   name     path    string     true        "repository name"
 // @Param   digest   path    string     true        "blob/layer digest"

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1054,7 +1054,7 @@ func canMount(userAc *reqCtx.UserAccessControl, imgStore storageTypes.ImageStore
 // @Summary Check image blob/layer
 // @Description Check an image's blob/layer given a digest
 // @Accept  json
-// @Produce json
+// @Produce application/octet-stream
 // @Param   name     path    string     true        "repository name"
 // @Param   digest   path    string     true        "blob/layer digest"
 // @Success 200 {object} api.ImageManifest
@@ -1313,10 +1313,10 @@ func buildMultipartPartHeader(rng httpRange, mediaType string, size int64) textp
 	partHeader := textproto.MIMEHeader{}
 	partHeader.Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.start, rng.end, size))
 
-	// RFC 9110 §15.3.7 lets us omit per-part Content-Type, but when the
-	// caller has resolved a real media type (descriptor lookup succeeded
-	// or fell back to application/octet-stream) we propagate it so OCI
-	// clients don't have to re-derive it from the index for every part.
+	// RFC 9110 §15.3.7 lets us omit per-part Content-Type, but when the caller
+	// has a media type for the blob we propagate it to each part so clients do
+	// not have to derive one themselves. Blob responses always carry
+	// application/octet-stream.
 	if mediaType != "" {
 		partHeader.Set("Content-Type", mediaType)
 	}
@@ -1447,7 +1447,7 @@ func normalizeBlobRedirectURL(rawURL string) (string, bool) {
 // @Summary Get image blob/layer
 // @Description Get an image's blob/layer given a digest
 // @Accept  json
-// @Produce application/vnd.oci.image.layer.v1.tar+gzip
+// @Produce application/octet-stream
 // @Param   name     path    string     true        "repository name"
 // @Param   digest   path    string     true        "blob/layer digest"
 // @Header  200 {string} Docker-Content-Digest "Manifest digest of the content"

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -2341,12 +2341,9 @@ func TestWriteDataFromReader(t *testing.T) {
 
 // Content-Type tests for blob HEAD/GET.
 //
-// Blob responses always advertise application/octet-stream. They used to derive
-// the type from the blob's OCI descriptor by way of the repo's index and manifest
-// chain, which cost one storage read per manifest on every request
-// (project-zot/zot#4344). These tests use mock image stores that still serve that
-// chain, so they can assert both the constant header and that the blob path never
-// reads the index.
+// Blob responses always advertise application/octet-stream. These tests use mock
+// image stores that serve an index and manifest chain, so they can assert both the
+// constant header and that the blob path never reads the index.
 
 // descriptorTestDigests returns deterministic layer, manifest, and
 // config digests (in that order) used by the blob Content-Type tests.

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -2446,8 +2446,24 @@ func descriptorStore(t *testing.T) mocks.MockedImageStore {
 	}
 }
 
-func TestCheckBlobUsesDescriptorContentType(t *testing.T) {
+func TestCheckBlobAlwaysBinaryContentType(t *testing.T) {
 	store := descriptorStore(t)
+
+	// The blob path must not walk the repo index: that lookup was
+	// O(manifests) and cost minutes on remote storage with a large repo
+	// (project-zot/zot#4344).
+	var indexReads atomic.Int32
+
+	store.GetIndexContentFn = func(repo string) ([]byte, error) {
+		indexReads.Add(1)
+
+		return []byte("{}"), nil
+	}
+	store.GetBlobContentFn = func(repo string, digest godigest.Digest) ([]byte, error) {
+		indexReads.Add(1)
+
+		return []byte("{}"), nil
+	}
 	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 		return true, 42, nil
 	}
@@ -2475,9 +2491,11 @@ func TestCheckBlobUsesDescriptorContentType(t *testing.T) {
 	defer resp.Body.Close()
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, ispec.MediaTypeImageLayerGzip, resp.Header.Get("Content-Type"))
+	assert.Equal(t, constants.BinaryMediaType, resp.Header.Get("Content-Type"))
 	assert.Equal(t, "bytes", resp.Header.Get("Accept-Ranges"))
 	assert.Equal(t, layerDigest.String(), resp.Header.Get(constants.DistContentDigestKey))
+
+	assert.Zero(t, indexReads.Load(), "blob path must not walk the repo index")
 }
 
 func TestCheckBlobFallsBackToBinaryContentType(t *testing.T) {
@@ -2517,13 +2535,29 @@ func TestCheckBlobFallsBackToBinaryContentType(t *testing.T) {
 	assert.Equal(t, constants.BinaryMediaType, resp.Header.Get("Content-Type"))
 }
 
-func TestGetBlobUsesDescriptorContentType(t *testing.T) {
+func TestGetBlobAlwaysBinaryContentType(t *testing.T) {
 	store := descriptorStore(t)
+
+	// The blob path must not walk the repo index: that lookup was
+	// O(manifests) and cost minutes on remote storage with a large repo
+	// (project-zot/zot#4344).
+	var indexReads atomic.Int32
+
+	store.GetIndexContentFn = func(repo string) ([]byte, error) {
+		indexReads.Add(1)
+
+		return []byte("{}"), nil
+	}
+	store.GetBlobContentFn = func(repo string, digest godigest.Digest) ([]byte, error) {
+		indexReads.Add(1)
+
+		return []byte("{}"), nil
+	}
 	store.GetBlobFn = func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
 		// The mediaType argument forwarded to the storage layer is a
 		// hint and is currently ignored; we still feed it the resolved
 		// value so the surface stays consistent.
-		assert.Equal(t, ispec.MediaTypeImageLayerGzip, mediaType)
+		assert.Equal(t, constants.BinaryMediaType, mediaType)
 
 		return io.NopCloser(strings.NewReader("blob")), 4, nil
 	}
@@ -2552,58 +2586,9 @@ func TestGetBlobUsesDescriptorContentType(t *testing.T) {
 	defer resp.Body.Close()
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	assert.Equal(t, ispec.MediaTypeImageLayerGzip, resp.Header.Get("Content-Type"))
-}
-
-func TestGetBlobFallsBackOnInvalidDescriptorContentType(t *testing.T) {
-	// Descriptor media types are user-supplied and may be invalid as HTTP
-	// header values. resolveBlobResponseMediaType must sanitize/validate
-	// and fall back to application/octet-stream on parse failure.
-	store := descriptorStore(t)
-	store.GetBlobFn = func(repo string, digest godigest.Digest, mediaType string) (io.ReadCloser, int64, error) {
-		assert.Equal(t, constants.BinaryMediaType, mediaType)
-
-		return io.NopCloser(strings.NewReader("blob")), 4, nil
-	}
-
-	// Force descriptor lookup success but with an invalid media type string.
-	store.GetBlobContentFn = func(repo string, digest godigest.Digest) ([]byte, error) {
-		_, manifestJSON := descriptorFixture(t)
-
-		var manifest ispec.Manifest
-		require.NoError(t, json.Unmarshal(manifestJSON, &manifest))
-		require.Len(t, manifest.Layers, 1)
-		manifest.Layers[0].MediaType = "bad\r\nvalue"
-
-		out, err := json.Marshal(manifest)
-		require.NoError(t, err)
-
-		return out, nil
-	}
-
-	handler := newBlobTestRouteHandler(t, store)
-
-	layerDigest, _, _ := descriptorTestDigests()
-
-	req := httptest.NewRequestWithContext(
-		context.Background(),
-		http.MethodGet,
-		"http://example.com/v2/test/blobs/sha256:test",
-		http.NoBody,
-	)
-	req = mux.SetURLVars(req, map[string]string{
-		"name":   "test",
-		"digest": layerDigest.String(),
-	})
-
-	rec := httptest.NewRecorder()
-	handler.GetBlob(rec, req)
-
-	resp := rec.Result()
-	defer resp.Body.Close()
-
-	require.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Equal(t, constants.BinaryMediaType, resp.Header.Get("Content-Type"))
+
+	assert.Zero(t, indexReads.Load(), "blob path must not walk the repo index")
 }
 
 func TestGetBlobFallsBackToBinaryContentType(t *testing.T) {
@@ -2645,8 +2630,24 @@ func TestGetBlobFallsBackToBinaryContentType(t *testing.T) {
 	assert.Equal(t, constants.BinaryMediaType, resp.Header.Get("Content-Type"))
 }
 
-func TestGetBlobPartialUsesDescriptorContentType(t *testing.T) {
+func TestGetBlobPartialAlwaysBinaryContentType(t *testing.T) {
 	store := descriptorStore(t)
+
+	// The blob path must not walk the repo index: that lookup was
+	// O(manifests) and cost minutes on remote storage with a large repo
+	// (project-zot/zot#4344).
+	var indexReads atomic.Int32
+
+	store.GetIndexContentFn = func(repo string) ([]byte, error) {
+		indexReads.Add(1)
+
+		return []byte("{}"), nil
+	}
+	store.GetBlobContentFn = func(repo string, digest godigest.Digest) ([]byte, error) {
+		indexReads.Add(1)
+
+		return []byte("{}"), nil
+	}
 	store.GetBlobPartialFn = func(
 		repo string,
 		digest godigest.Digest,
@@ -2654,7 +2655,7 @@ func TestGetBlobPartialUsesDescriptorContentType(t *testing.T) {
 		from,
 		to int64,
 	) (io.ReadCloser, int64, int64, error) {
-		assert.Equal(t, ispec.MediaTypeImageLayerGzip, mediaType)
+		assert.Equal(t, constants.BinaryMediaType, mediaType)
 		assert.Equal(t, int64(0), from)
 		assert.Equal(t, int64(1), to)
 
@@ -2684,9 +2685,11 @@ func TestGetBlobPartialUsesDescriptorContentType(t *testing.T) {
 	defer resp.Body.Close()
 
 	require.Equal(t, http.StatusPartialContent, resp.StatusCode)
-	assert.Equal(t, ispec.MediaTypeImageLayerGzip, resp.Header.Get("Content-Type"))
+	assert.Equal(t, constants.BinaryMediaType, resp.Header.Get("Content-Type"))
 	assert.Equal(t, "bytes 0-1/4", resp.Header.Get("Content-Range"))
 	assert.Equal(t, layerDigest.String(), resp.Header.Get(constants.DistContentDigestKey))
+
+	assert.Zero(t, indexReads.Load(), "blob path must not walk the repo index")
 }
 
 func TestGetBlobPartialFallsBackToBinaryContentType(t *testing.T) {
@@ -2735,13 +2738,29 @@ func TestGetBlobPartialFallsBackToBinaryContentType(t *testing.T) {
 	assert.Equal(t, constants.BinaryMediaType, resp.Header.Get("Content-Type"))
 }
 
-// TestGetBlobMultipartPartHasDescriptorContentType verifies that each
-// part of a multipart/byteranges response carries the descriptor-
-// derived Content-Type alongside the per-part Content-Range.
-func TestGetBlobMultipartPartHasDescriptorContentType(t *testing.T) {
+// TestGetBlobMultipartPartBinaryContentType verifies that each part of a
+// multipart/byteranges response carries application/octet-stream
+// alongside the per-part Content-Range.
+func TestGetBlobMultipartPartBinaryContentType(t *testing.T) {
 	const blobBody = "0123456789"
 
 	store := descriptorStore(t)
+
+	// The blob path must not walk the repo index: that lookup was
+	// O(manifests) and cost minutes on remote storage with a large repo
+	// (project-zot/zot#4344).
+	var indexReads atomic.Int32
+
+	store.GetIndexContentFn = func(repo string) ([]byte, error) {
+		indexReads.Add(1)
+
+		return []byte("{}"), nil
+	}
+	store.GetBlobContentFn = func(repo string, digest godigest.Digest) ([]byte, error) {
+		indexReads.Add(1)
+
+		return []byte("{}"), nil
+	}
 	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
 		return true, int64(len(blobBody)), nil
 	}
@@ -2752,7 +2771,7 @@ func TestGetBlobMultipartPartHasDescriptorContentType(t *testing.T) {
 		from,
 		to int64,
 	) (io.ReadCloser, int64, int64, error) {
-		assert.Equal(t, ispec.MediaTypeImageLayerGzip, mediaType)
+		assert.Equal(t, constants.BinaryMediaType, mediaType)
 
 		return io.NopCloser(strings.NewReader(blobBody[from : to+1])), to - from + 1, int64(len(blobBody)), nil
 	}
@@ -2801,7 +2820,7 @@ func TestGetBlobMultipartPartHasDescriptorContentType(t *testing.T) {
 		require.NoError(t, err, "read part %d", i)
 
 		assert.Equal(t, want.contentRange, part.Header.Get("Content-Range"), "part %d content-range", i)
-		assert.Equal(t, ispec.MediaTypeImageLayerGzip, part.Header.Get("Content-Type"),
+		assert.Equal(t, constants.BinaryMediaType, part.Header.Get("Content-Type"),
 			"part %d content-type", i)
 
 		body, err := io.ReadAll(part)
@@ -2813,6 +2832,8 @@ func TestGetBlobMultipartPartHasDescriptorContentType(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 
 	assert.Equal(t, layerDigest.String(), resp.Header.Get(constants.DistContentDigestKey))
+
+	assert.Zero(t, indexReads.Load(), "blob path must not walk the repo index")
 }
 
 // Streaming-multipart tests for the lazy-fan-out path.

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -2339,17 +2339,17 @@ func TestWriteDataFromReader(t *testing.T) {
 	})
 }
 
-// Descriptor-aware Content-Type tests for blob HEAD/GET.
+// Content-Type tests for blob HEAD/GET.
 //
-// The blob endpoints derive the response Content-Type from the OCI
-// descriptor associated with the blob (via the repo's index/manifest
-// chain), and fall back to application/octet-stream when no such
-// descriptor is available. These tests use mock image stores to drive
-// both branches independently of the on-disk storage layer.
+// Blob responses always advertise application/octet-stream. They used to derive
+// the type from the blob's OCI descriptor by way of the repo's index and manifest
+// chain, which cost one storage read per manifest on every request
+// (project-zot/zot#4344). These tests use mock image stores that still serve that
+// chain, so they can assert both the constant header and that the blob path never
+// reads the index.
 
 // descriptorTestDigests returns deterministic layer, manifest, and
-// config digests (in that order) used by the descriptor-aware
-// Content-Type tests.
+// config digests (in that order) used by the blob Content-Type tests.
 func descriptorTestDigests() (godigest.Digest, godigest.Digest, godigest.Digest) {
 	return godigest.FromString("layer"), godigest.FromString("manifest"), godigest.FromString("config")
 }
@@ -2369,9 +2369,9 @@ func newBlobTestRouteHandler(t *testing.T, store mocks.MockedImageStore) *api.Ro
 	return api.NewRouteHandler(ctlr)
 }
 
-// descriptorFixture builds a minimal index -> manifest -> layer chain
-// that resolves the layer digest from descriptorTestDigests to
-// MediaTypeImageLayerGzip.
+// descriptorFixture builds a minimal index -> manifest -> layer chain that would
+// resolve the layer digest from descriptorTestDigests to MediaTypeImageLayerGzip.
+// It exists so the tests can prove the blob path leaves it untouched.
 func descriptorFixture(t *testing.T) ([]byte, []byte) {
 	t.Helper()
 
@@ -2416,10 +2416,11 @@ func descriptorFixture(t *testing.T) ([]byte, []byte) {
 	return indexJSON, manifestJSON
 }
 
-// descriptorStore returns a mock store backed by descriptorFixture.
-// Looking up the layer digest from descriptorTestDigests resolves to a
-// layer with media type MediaTypeImageLayerGzip via the index walk;
-// other digests fall through to the binary fallback.
+// descriptorStore returns a mock store backed by descriptorFixture, whose index
+// and manifest would resolve the layer digest from descriptorTestDigests to
+// MediaTypeImageLayerGzip. Blob responses no longer consult it: the tests below
+// keep the fixture so they can assert that the blob path never reads it, since
+// that lookup was O(manifests) per request (project-zot/zot#4344).
 func descriptorStore(t *testing.T) mocks.MockedImageStore {
 	t.Helper()
 
@@ -2449,9 +2450,6 @@ func descriptorStore(t *testing.T) mocks.MockedImageStore {
 func TestCheckBlobAlwaysBinaryContentType(t *testing.T) {
 	store := descriptorStore(t)
 
-	// The blob path must not walk the repo index: that lookup was
-	// O(manifests) and cost minutes on remote storage with a large repo
-	// (project-zot/zot#4344).
 	var indexReads atomic.Int32
 
 	store.GetIndexContentFn = func(repo string) ([]byte, error) {
@@ -2538,9 +2536,6 @@ func TestCheckBlobFallsBackToBinaryContentType(t *testing.T) {
 func TestGetBlobAlwaysBinaryContentType(t *testing.T) {
 	store := descriptorStore(t)
 
-	// The blob path must not walk the repo index: that lookup was
-	// O(manifests) and cost minutes on remote storage with a large repo
-	// (project-zot/zot#4344).
 	var indexReads atomic.Int32
 
 	store.GetIndexContentFn = func(repo string) ([]byte, error) {
@@ -2633,9 +2628,6 @@ func TestGetBlobFallsBackToBinaryContentType(t *testing.T) {
 func TestGetBlobPartialAlwaysBinaryContentType(t *testing.T) {
 	store := descriptorStore(t)
 
-	// The blob path must not walk the repo index: that lookup was
-	// O(manifests) and cost minutes on remote storage with a large repo
-	// (project-zot/zot#4344).
 	var indexReads atomic.Int32
 
 	store.GetIndexContentFn = func(repo string) ([]byte, error) {
@@ -2746,9 +2738,6 @@ func TestGetBlobMultipartPartBinaryContentType(t *testing.T) {
 
 	store := descriptorStore(t)
 
-	// The blob path must not walk the repo index: that lookup was
-	// O(manifests) and cost minutes on remote storage with a large repo
-	// (project-zot/zot#4344).
 	var indexReads atomic.Int32
 
 	store.GetIndexContentFn = func(repo string) ([]byte, error) {

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -698,6 +698,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "produces": [
+                    "application/json",
                     "application/octet-stream"
                 ],
                 "summary": "Check image blob/layer",

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -633,7 +633,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "produces": [
-                    "application/vnd.oci.image.layer.v1.tar+gzip"
+                    "application/octet-stream"
                 ],
                 "summary": "Get image blob/layer",
                 "parameters": [
@@ -698,7 +698,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "produces": [
-                    "application/json"
+                    "application/octet-stream"
                 ],
                 "summary": "Check image blob/layer",
                 "parameters": [

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -633,6 +633,7 @@ const docTemplate = `{
                     "application/json"
                 ],
                 "produces": [
+                    "application/json",
                     "application/octet-stream"
                 ],
                 "summary": "Get image blob/layer",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -690,6 +690,7 @@
                     "application/json"
                 ],
                 "produces": [
+                    "application/json",
                     "application/octet-stream"
                 ],
                 "summary": "Check image blob/layer",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -625,6 +625,7 @@
                     "application/json"
                 ],
                 "produces": [
+                    "application/json",
                     "application/octet-stream"
                 ],
                 "summary": "Get image blob/layer",

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -625,7 +625,7 @@
                     "application/json"
                 ],
                 "produces": [
-                    "application/vnd.oci.image.layer.v1.tar+gzip"
+                    "application/octet-stream"
                 ],
                 "summary": "Get image blob/layer",
                 "parameters": [
@@ -690,7 +690,7 @@
                     "application/json"
                 ],
                 "produces": [
-                    "application/json"
+                    "application/octet-stream"
                 ],
                 "summary": "Check image blob/layer",
                 "parameters": [

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -491,6 +491,7 @@ paths:
         required: true
         type: string
       produces:
+      - application/json
       - application/octet-stream
       responses:
         "200":

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -468,7 +468,7 @@ paths:
         required: true
         type: string
       produces:
-      - application/vnd.oci.image.layer.v1.tar+gzip
+      - application/octet-stream
       responses:
         "200":
           description: OK
@@ -491,7 +491,7 @@ paths:
         required: true
         type: string
       produces:
-      - application/json
+      - application/octet-stream
       responses:
         "200":
           description: OK

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -468,6 +468,7 @@ paths:
         required: true
         type: string
       produces:
+      - application/json
       - application/octet-stream
       responses:
         "200":


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

Partially fixes #4344. That issue describes two independent index walks per blob request; this
removes the second one (the `Content-Type` resolution). The first one, in `CheckBlob`, is
addressed by #4166, which is not mine and is complementary. #4344 should stay open until both
land.

**What does this PR do / Why do we need it**:

`HEAD`/`GET` on a blob resolved the response `Content-Type` through
`GetBlobDescriptorFromRepo`, which reads `index.json` and then fetches every manifest in the repo
from storage until it finds the digest. That is `O(manifests)` storage reads per request, and on a
remote driver it dominates the response: the reporter of #4344 measured roughly 0.145s per
manifest, so minutes on a repo with several hundred tags.

`Content-Type` is not specified for blob pulls. The dist-spec requires it for *manifest* pulls
only (`spec.md` "Pulling manifests"), and the helper already fell back to
`application/octet-stream` whenever the lookup failed, so the walk only ever upgraded a header
that nothing is entitled to depend on. Blob responses now always advertise
`application/octet-stream`, which stays non-empty and parseable for consumers such as
stargz-snapshotter. Manifest media-type resolution is untouched.

This is the approach @andaaron recommended in #4344:

> **Recommended:** stop calling `GetBlobDescriptorFromRepo` on the blob path. Set
> `Content-Type: application/octet-stream` (or keep the helper but skip the lookup).

It does revert the blob half of #4325. If descriptor-accurate types on blob responses are wanted
later, #4344 suggests a per-repo digest to descriptor map invalidated on index change, which would
be `O(1)` amortised rather than a walk per request.

**If an issue # is not available please add repro steps and logs showing the issue**:

n/a, see #4344.

**Testing done on this change**:

`go test -tags "sync,scrub,metrics,search,lint,mgmt" ./pkg/api/` passes, except
`TestRedisCookieStore`, which needs a Redis that is not present in my environment and fails
identically on an unmodified tree.

The four tests that pinned the descriptor-derived media type
(`TestCheckBlobUsesDescriptorContentType`, `TestGetBlobUsesDescriptorContentType`,
`TestGetBlobPartialUsesDescriptorContentType`,
`TestGetBlobMultipartPartHasDescriptorContentType`) now assert the constant, and each also fails
if the blob path reads the repo index or a manifest at all, so the walk cannot return unnoticed.
`TestGetBlobFallsBackOnInvalidDescriptorContentType` is removed along with the sanitising code
path it covered; the remaining `FallsBackToBinaryContentType` tests still assert the header.

Cross-driver corroboration from a live registry: Azure Blob storage driver, one repo at 114
manifests, blob `HEAD` measured at about 20s server-side, in line with the per-manifest figure in
#4344 from GCS.

**Automation added to e2e**:

No. The behaviour is covered by unit tests in `pkg/api/routes_test.go`, including the new
no-index-read assertions.

**Will this break upgrades or downgrades?**

No. No config, storage layout or API surface changes.

**Does this PR introduce any user-facing change?**:

Yes, the `Content-Type` on blob `HEAD`/`GET` responses.

```release-note
Blob HEAD/GET responses now always advertise Content-Type: application/octet-stream rather than
the manifest-declared layer media type, removing an O(manifests) index walk per blob request.
Content-Type is not specified for blob pulls; manifest responses are unchanged.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
