### PR TITLE
perf: walk storage once per dedupe run

### DIFF
--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -1159,7 +1159,7 @@ func (gen *DedupeTaskGenerator) checkCompletion(run *restoreRunState) {
 // aborts the walk after some repositories have already been collected (see
 // pkg/storage/gcs/nextrepo_walk_abort_test.go). GetAllBlobs treats a missing blobs
 // directory as empty for that one repository, so it cannot curtail the whole result.
-func BlobPathsByDigest(imgStore storageTypes.ImageStore, repos []string,
+func BlobPathsByDigest(imgStore storageTypes.ImageStore, repos []string, log zlog.Logger,
 ) ([]godigest.Digest, map[godigest.Digest][]string, error) {
 	digests := []godigest.Digest{}
 	blobPaths := map[godigest.Digest][]string{}
@@ -1171,6 +1171,17 @@ func BlobPathsByDigest(imgStore storageTypes.ImageStore, repos []string,
 		}
 
 		for _, digest := range blobs {
+			/* GetAllBlobs builds a digest from every filename under blobs/<alg>/ without
+			validating it, so a stray file would otherwise become a task that can never
+			succeed: it fails in checkCacheBlob, and a failed task never runs its completion
+			callback, leaving OnRunComplete unfired. */
+			if err := digest.Validate(); err != nil {
+				log.Debug().Str("repository", repo).Str("digest", digest.String()).
+					Str("component", "dedupe").Msg("skipping blob with an invalid digest")
+
+				continue
+			}
+
 			if _, seen := blobPaths[digest]; !seen {
 				digests = append(digests, digest)
 			}
@@ -1212,7 +1223,7 @@ func (gen *DedupeTaskGenerator) Next() (scheduler.Task, error) {
 
 	// group every blob path by digest, once per run rather than once per digest
 	if gen.blobPaths == nil {
-		digests, blobPaths, listErr := BlobPathsByDigest(gen.ImgStore, gen.repos)
+		digests, blobPaths, listErr := BlobPathsByDigest(gen.ImgStore, gen.repos, gen.Log)
 		if listErr != nil {
 			gen.Log.Error().Err(listErr).Str("component", "dedupe").Msg("failed to get blob paths by digest")
 

--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -1087,11 +1087,14 @@ type DedupeTaskGenerator struct {
 	// store blobs paths grouped by digest
 	digest         godigest.Digest
 	duplicateBlobs []string
-	/* store processed digest, used for iterating duplicateBlobs one by one
-	and generating a task for each unprocessed one*/
-	lastDigests []godigest.Digest
-	repos       []string // list of repos on which we run dedupe
-	Log         zlog.Logger
+	/* every blob path in storage grouped by digest, listed once per run. Enumerating
+	storage costs one listing per repository, which is slow on a remote driver, so the
+	generator must not redo it for each digest. */
+	digests   []godigest.Digest
+	blobPaths map[godigest.Digest][]string
+	nextIndex int
+	repos     []string // list of repos on which we run dedupe
+	Log       zlog.Logger
 	// OnRunComplete is called exactly once after all tasks of a run have
 	// succeeded, whether the run dedupes blobs (Dedupe=true) or restores them
 	// (Dedupe=false). Restore runs use it to write the restore-complete marker;
@@ -1146,6 +1149,39 @@ func (gen *DedupeTaskGenerator) checkCompletion(run *restoreRunState) {
 	}
 }
 
+// BlobPathsByDigest groups every blob path in the given repositories by digest, using one
+// blobs-directory listing per repository. Digests come back in first-seen order so callers
+// process them deterministically.
+//
+// This deliberately does not walk the storage root. On a remote driver that is a full
+// prefix listing which then discards everything that is not a blob, and drivers such as
+// GCS report an empty or concurrently removed nested prefix as PathNotFoundError, which
+// aborts the walk after some repositories have already been collected (see
+// pkg/storage/gcs/nextrepo_walk_abort_test.go). GetAllBlobs treats a missing blobs
+// directory as empty for that one repository, so it cannot curtail the whole result.
+func BlobPathsByDigest(imgStore storageTypes.ImageStore, repos []string,
+) ([]godigest.Digest, map[godigest.Digest][]string, error) {
+	digests := []godigest.Digest{}
+	blobPaths := map[godigest.Digest][]string{}
+
+	for _, repo := range repos {
+		blobs, err := imgStore.GetAllBlobs(repo)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		for _, digest := range blobs {
+			if _, seen := blobPaths[digest]; !seen {
+				digests = append(digests, digest)
+			}
+
+			blobPaths[digest] = append(blobPaths[digest], imgStore.BlobPath(repo, digest))
+		}
+	}
+
+	return digests, blobPaths, nil
+}
+
 func (gen *DedupeTaskGenerator) Next() (scheduler.Task, error) {
 	var err error
 
@@ -1174,12 +1210,30 @@ func (gen *DedupeTaskGenerator) Next() (scheduler.Task, error) {
 		}
 	}
 
-	// get all blobs from storage.imageStore and group them by digest
-	gen.digest, gen.duplicateBlobs, err = gen.ImgStore.GetNextDigestWithBlobPaths(gen.repos, gen.lastDigests)
-	if err != nil {
-		gen.Log.Error().Err(err).Str("component", "dedupe").Msg("failed to get next digest")
+	// group every blob path by digest, once per run rather than once per digest
+	if gen.blobPaths == nil {
+		digests, blobPaths, listErr := BlobPathsByDigest(gen.ImgStore, gen.repos)
+		if listErr != nil {
+			gen.Log.Error().Err(listErr).Str("component", "dedupe").Msg("failed to get blob paths by digest")
 
-		return nil, err
+			return nil, listErr
+		}
+
+		/* assign only once the listing has completed: keeping a partial snapshot would make
+		the scheduler's next call treat it as the whole of storage, so the run would report
+		itself complete having skipped digests. For a restore run that writes the
+		restore-complete marker, permanently suppressing later restore scans; for a dedupe run
+		it lets deferred blob deletes proceed against an incomplete cache. */
+		gen.digests, gen.blobPaths = digests, blobPaths
+	}
+
+	gen.digest = ""
+	gen.duplicateBlobs = []string{}
+
+	if gen.nextIndex < len(gen.digests) {
+		gen.digest = gen.digests[gen.nextIndex]
+		gen.duplicateBlobs = gen.blobPaths[gen.digest]
+		gen.nextIndex++
 	}
 
 	// if no digests left, then mark the task generator as done
@@ -1191,9 +1245,6 @@ func (gen *DedupeTaskGenerator) Next() (scheduler.Task, error) {
 
 		return nil, nil //nolint:nilnil
 	}
-
-	// mark digest as processed before running its task
-	gen.lastDigests = append(gen.lastDigests, gen.digest)
 
 	// Track each task so completion fires only after all of them succeed.
 	var onDone func()
@@ -1232,10 +1283,12 @@ func (gen *DedupeTaskGenerator) Reset() {
 		gen.run.Store(&restoreRunState{})
 	}
 
-	gen.lastDigests = []godigest.Digest{}
 	gen.duplicateBlobs = []string{}
 	gen.repos = []string{}
 	gen.digest = ""
+	gen.digests = nil
+	gen.blobPaths = nil
+	gen.nextIndex = 0
 }
 
 type dedupeTask struct {

--- a/pkg/storage/common/common_test.go
+++ b/pkg/storage/common/common_test.go
@@ -2514,7 +2514,9 @@ func TestDedupeTaskGeneratorDiscardsPartialEnumeration(t *testing.T) {
 				duplicateBlobs []string,
 			) error {
 				processedMutex.Lock()
+
 				processed = append(processed, digest)
+
 				processedMutex.Unlock()
 
 				return nil

--- a/pkg/storage/common/common_test.go
+++ b/pkg/storage/common/common_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -600,15 +602,13 @@ func TestDedupeGeneratorErrors(t *testing.T) {
 
 	// Ideally this would be covered by the end-to-end test,
 	// but the coverage for the error is unpredictable, prone to race conditions
-	Convey("GetNextDigestWithBlobPaths errors", t, func(c C) {
+	Convey("Blob listing errors", t, func(c C) {
 		imgStore := &mocks.MockedImageStore{
 			GetRepositoriesFn: func() ([]string, error) {
 				return []string{"repo1", "repo2"}, nil
 			},
-			GetNextDigestWithBlobPathsFn: func(repos []string, lastDigests []godigest.Digest) (
-				godigest.Digest, []string, error,
-			) {
-				return "sha256:123", []string{}, ErrTestError
+			GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+				return nil, ErrTestError
 			},
 		}
 
@@ -629,23 +629,22 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 
 	Convey("OnRunComplete fires once after all restore tasks finish successfully", t, func(c C) {
 		digest := godigest.FromString("blob1")
-		duplicateBlobs := []string{"/repo/blob1-a", "/repo/blob1-b"}
+		// two repositories hold the digest, so it has two paths to act on
+		repos := []string{"repo1", "repo2"}
 
-		getNextCalls := 0
+		listCalls := 0
 
 		imgStore := &mocks.MockedImageStore{
 			GetRepositoriesFn: func() ([]string, error) {
-				return []string{"repo1"}, nil
+				return repos, nil
 			},
-			GetNextDigestWithBlobPathsFn: func(repos []string, lastDigests []godigest.Digest) (
-				godigest.Digest, []string, error,
-			) {
-				getNextCalls++
-				if getNextCalls == 1 {
-					return digest, duplicateBlobs, nil
-				}
+			GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+				listCalls++
 
-				return "", nil, nil
+				return []godigest.Digest{digest}, nil
+			},
+			BlobPathFn: func(repo string, blobDigest godigest.Digest) string {
+				return fmt.Sprintf("/%s/blobs/%s/%s", repo, blobDigest.Algorithm(), blobDigest.Encoded())
 			},
 			RunDedupeForDigestFn: func(ctx context.Context, digest godigest.Digest, dedupe bool,
 				duplicateBlobs []string,
@@ -708,23 +707,22 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 
 	Convey("OnRunComplete fires once after all dedupe tasks finish successfully", t, func(c C) {
 		digest := godigest.FromString("blob-dedupe")
-		duplicateBlobs := []string{"/repo/blob-dedupe-a", "/repo/blob-dedupe-b"}
+		// two repositories hold the digest, so it has two paths to act on
+		repos := []string{"repo1", "repo2"}
 
-		getNextCalls := 0
+		listCalls := 0
 
 		imgStore := &mocks.MockedImageStore{
 			GetRepositoriesFn: func() ([]string, error) {
-				return []string{"repo1"}, nil
+				return repos, nil
 			},
-			GetNextDigestWithBlobPathsFn: func(repos []string, lastDigests []godigest.Digest) (
-				godigest.Digest, []string, error,
-			) {
-				getNextCalls++
-				if getNextCalls == 1 {
-					return digest, duplicateBlobs, nil
-				}
+			GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+				listCalls++
 
-				return "", nil, nil
+				return []godigest.Digest{digest}, nil
+			},
+			BlobPathFn: func(repo string, blobDigest godigest.Digest) string {
+				return fmt.Sprintf("/%s/blobs/%s/%s", repo, blobDigest.Algorithm(), blobDigest.Encoded())
 			},
 			RunDedupeForDigestFn: func(ctx context.Context, digest godigest.Digest, dedupe bool,
 				duplicateBlobs []string,
@@ -778,23 +776,22 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 
 	Convey("Reset keeps the same run while a restore task is in-flight", t, func(c C) {
 		digest := godigest.FromString("blob2")
-		duplicateBlobs := []string{"/repo/blob2-a"}
+		// two repositories hold the digest, so it has two paths to act on
+		repos := []string{"repo1", "repo2"}
 
-		getNextCalls := 0
+		listCalls := 0
 
 		imgStore := &mocks.MockedImageStore{
 			GetRepositoriesFn: func() ([]string, error) {
-				return []string{"repo1"}, nil
+				return repos, nil
 			},
-			GetNextDigestWithBlobPathsFn: func(repos []string, lastDigests []godigest.Digest) (
-				godigest.Digest, []string, error,
-			) {
-				getNextCalls++
-				if getNextCalls == 1 {
-					return digest, duplicateBlobs, nil
-				}
+			GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+				listCalls++
 
-				return "", nil, nil
+				return []godigest.Digest{digest}, nil
+			},
+			BlobPathFn: func(repo string, blobDigest godigest.Digest) string {
+				return fmt.Sprintf("/%s/blobs/%s/%s", repo, blobDigest.Algorithm(), blobDigest.Encoded())
 			},
 			RunDedupeForDigestFn: func(ctx context.Context, digest godigest.Digest, dedupe bool,
 				duplicateBlobs []string,
@@ -854,23 +851,22 @@ func TestDedupeTaskGeneratorRestoreComplete(t *testing.T) {
 
 	Convey("checkCompletion recovers if OnRunComplete panics", t, func(c C) {
 		digest := godigest.FromString("blob3")
-		duplicateBlobs := []string{"/repo/blob3-a"}
+		// two repositories hold the digest, so it has two paths to act on
+		repos := []string{"repo1", "repo2"}
 
-		getNextCalls := 0
+		listCalls := 0
 
 		imgStore := &mocks.MockedImageStore{
 			GetRepositoriesFn: func() ([]string, error) {
-				return []string{"repo1"}, nil
+				return repos, nil
 			},
-			GetNextDigestWithBlobPathsFn: func(repos []string, lastDigests []godigest.Digest) (
-				godigest.Digest, []string, error,
-			) {
-				getNextCalls++
-				if getNextCalls == 1 {
-					return digest, duplicateBlobs, nil
-				}
+			GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+				listCalls++
 
-				return "", nil, nil
+				return []godigest.Digest{digest}, nil
+			},
+			BlobPathFn: func(repo string, blobDigest godigest.Digest) string {
+				return fmt.Sprintf("/%s/blobs/%s/%s", repo, blobDigest.Algorithm(), blobDigest.Encoded())
 			},
 			RunDedupeForDigestFn: func(ctx context.Context, digest godigest.Digest, dedupe bool,
 				duplicateBlobs []string,
@@ -2408,5 +2404,167 @@ func TestGetBlobDescriptorFromIndexCoverage(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(desc.Digest, ShouldEqual, layerDigest)
 		So(readCount, ShouldEqual, 1)
+	})
+}
+
+func TestDedupeTaskGeneratorListsStorageOncePerRun(t *testing.T) {
+	testLog := log.NewTestLogger()
+
+	Convey("The generator lists storage once per run, not once per digest", t, func(c C) {
+		repos := []string{"repo1", "repo2"}
+
+		digests := []godigest.Digest{
+			godigest.FromString("blob1"),
+			godigest.FromString("blob2"),
+			godigest.FromString("blob3"),
+		}
+
+		listCalls := 0
+
+		imgStore := &mocks.MockedImageStore{
+			GetRepositoriesFn: func() ([]string, error) {
+				return repos, nil
+			},
+			GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+				listCalls++
+
+				return digests, nil
+			},
+			BlobPathFn: func(repo string, blobDigest godigest.Digest) string {
+				return fmt.Sprintf("/%s/blobs/%s/%s", repo, blobDigest.Algorithm(), blobDigest.Encoded())
+			},
+			RunDedupeForDigestFn: func(ctx context.Context, digest godigest.Digest, dedupe bool,
+				duplicateBlobs []string,
+			) error {
+				return nil
+			},
+		}
+
+		generator := &common.DedupeTaskGenerator{
+			ImgStore: imgStore,
+			Dedupe:   true,
+			Log:      testLog,
+		}
+
+		for range digests {
+			task, err := generator.Next()
+			So(err, ShouldBeNil)
+			So(task, ShouldNotBeNil)
+		}
+
+		task, err := generator.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldBeNil)
+		So(generator.IsDone(), ShouldBeTrue)
+
+		// the point of the change: one listing per repository for the whole run, rather
+		// than a fresh enumeration for every digest
+		So(listCalls, ShouldEqual, len(repos))
+
+		// a fresh run must list again, since storage may have changed
+		generator.Reset()
+
+		task, err = generator.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldNotBeNil)
+		So(listCalls, ShouldEqual, 2*len(repos))
+	})
+}
+
+func TestDedupeTaskGeneratorDiscardsPartialEnumeration(t *testing.T) {
+	testLog := log.NewTestLogger()
+
+	Convey("A failed listing must not leave a partial snapshot behind", t, func(c C) {
+		repos := []string{"repo1", "repo2"}
+
+		first := godigest.FromString("blob1")
+		second := godigest.FromString("blob2")
+
+		attempts := 0
+
+		var (
+			processedMutex sync.Mutex
+			processed      []godigest.Digest
+		)
+
+		var completions atomic.Int32
+
+		imgStore := &mocks.MockedImageStore{
+			GetRepositoriesFn: func() ([]string, error) {
+				return repos, nil
+			},
+			// the first attempt lists repo1 and then fails on repo2, so the caller is
+			// offered a snapshot covering only part of storage
+			GetAllBlobsFn: func(repo string) ([]godigest.Digest, error) {
+				if repo == "repo1" {
+					return []godigest.Digest{first}, nil
+				}
+
+				attempts++
+				if attempts == 1 {
+					return nil, ErrTestError
+				}
+
+				return []godigest.Digest{second}, nil
+			},
+			BlobPathFn: func(repo string, blobDigest godigest.Digest) string {
+				return fmt.Sprintf("/%s/blobs/%s/%s", repo, blobDigest.Algorithm(), blobDigest.Encoded())
+			},
+			RunDedupeForDigestFn: func(ctx context.Context, digest godigest.Digest, dedupe bool,
+				duplicateBlobs []string,
+			) error {
+				processedMutex.Lock()
+				processed = append(processed, digest)
+				processedMutex.Unlock()
+
+				return nil
+			},
+		}
+
+		generator := &common.DedupeTaskGenerator{
+			ImgStore: imgStore,
+			Dedupe:   false,
+			Log:      testLog,
+			OnRunComplete: func() {
+				completions.Add(1)
+			},
+		}
+
+		// the failed listing surfaces the error and generates no task
+		task, err := generator.Next()
+		So(err, ShouldNotBeNil)
+		So(task, ShouldBeNil)
+		So(generator.IsDone(), ShouldBeFalse)
+
+		// the scheduler retries: the listing must run again rather than resuming the
+		// partial snapshot, so the digest from the repo that failed is not skipped
+		for range 2 {
+			task, err = generator.Next()
+			So(err, ShouldBeNil)
+			So(task, ShouldNotBeNil)
+			So(task.DoWork(context.Background()), ShouldBeNil)
+		}
+
+		task, err = generator.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldBeNil)
+		So(generator.IsDone(), ShouldBeTrue)
+
+		processedMutex.Lock()
+		So(processed, ShouldResemble, []godigest.Digest{first, second})
+		processedMutex.Unlock()
+
+		// completion must reflect the full run, not the one that errored
+		So(func() int32 {
+			for range 50 {
+				if completions.Load() > 0 {
+					break
+				}
+
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			return completions.Load()
+		}(), ShouldEqual, 1)
 	})
 }

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -2282,6 +2282,16 @@ func (is *ImageStore) getOriginalBlobFromDisk(duplicateBlobs []string) (string, 
 	for _, blobPath := range duplicateBlobs {
 		binfo, err := is.storeDriver.Stat(blobPath)
 		if err != nil {
+			// The paths come from a listing taken earlier in the run, so a blob may have
+			// been deleted since. Keep looking: another copy may still hold the content.
+			var pathNotFound driver.PathNotFoundError
+			if errors.As(err, &pathNotFound) {
+				is.log.Debug().Str("path", blobPath).Str("component", "storage").
+					Msg("blob deleted since it was listed, skipping")
+
+				continue
+			}
+
 			is.log.Error().Err(err).Str("path", blobPath).Str("component", "storage").Msg("failed to stat blob")
 
 			return "", zerr.ErrBlobNotFound
@@ -2343,6 +2353,18 @@ func (is *ImageStore) dedupeBlobs(ctx context.Context, digest godigest.Digest, d
 
 		binfo, err := is.storeDriver.Stat(blobPath)
 		if err != nil {
+			/* duplicateBlobs comes from a listing taken once at the start of the run, so a
+			blob may have been deleted since. Skipping keeps the run progressing: failing the
+			task instead leaves its completion callback unrun, so OnRunComplete never fires
+			and the restore marker or the deferred-delete gate stays stuck. */
+			var pathNotFound driver.PathNotFoundError
+			if errors.As(err, &pathNotFound) {
+				is.log.Debug().Str("path", blobPath).Str("component", "dedupe").
+					Msg("blob deleted since it was listed, skipping")
+
+				continue
+			}
+
 			is.log.Error().Err(err).Str("path", blobPath).Str("component", "dedupe").Msg("failed to stat blob")
 
 			return err
@@ -2420,6 +2442,18 @@ func (is *ImageStore) restoreDedupedBlobs(ctx context.Context, digest godigest.D
 
 		binfo, err := is.storeDriver.Stat(blobPath)
 		if err != nil {
+			/* duplicateBlobs comes from a listing taken once at the start of the run, so a
+			blob may have been deleted since. Skipping keeps the run progressing: failing the
+			task instead leaves its completion callback unrun, so OnRunComplete never fires
+			and the restore marker or the deferred-delete gate stays stuck. */
+			var pathNotFound driver.PathNotFoundError
+			if errors.As(err, &pathNotFound) {
+				is.log.Debug().Str("path", blobPath).Str("component", "dedupe").
+					Msg("blob deleted since it was listed, skipping")
+
+				continue
+			}
+
 			is.log.Error().Err(err).Str("path", blobPath).Str("component", "dedupe").Msg("failed to stat blob")
 
 			return err

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -2424,12 +2424,43 @@ func (is *ImageStore) dedupeBlobs(ctx context.Context, digest godigest.Digest, d
 	return nil
 }
 
+// anyBlobExists reports whether any of these paths is still present. A path that has gone
+// counts as absent; anything else, such as a permission error, counts as present so that a
+// real I/O problem is not mistaken for a deleted blob.
+func (is *ImageStore) anyBlobExists(blobPaths []string) bool {
+	for _, blobPath := range blobPaths {
+		if _, err := is.storeDriver.Stat(blobPath); err != nil {
+			var pathNotFound driver.PathNotFoundError
+			if errors.As(err, &pathNotFound) {
+				continue
+			}
+		}
+
+		return true
+	}
+
+	return false
+}
+
 func (is *ImageStore) restoreDedupedBlobs(ctx context.Context, digest godigest.Digest, duplicateBlobs []string) error {
 	is.log.Info().Str("digest", digest.String()).Str("component", "dedupe").Msg("restoring deduped blobs for digest")
 
 	// first we need to find the original blob, either in cache or by checking each blob size
 	originalBlob, err := is.getOriginalBlob(digest, duplicateBlobs)
 	if err != nil {
+		/* Every path in the listing may have been deleted since it was taken, for instance
+		because the repository was removed. There is then nothing left to restore, and failing
+		would stop the run reporting completion, so treat it as a no-op. A placeholder that
+		still exists with no content source anywhere is a different matter and must fail,
+		otherwise it would be left zero-size and the restore-complete marker would suppress
+		the scan that would notice. */
+		if !is.anyBlobExists(duplicateBlobs) {
+			is.log.Debug().Str("digest", digest.String()).Str("component", "dedupe").
+				Msg("all blobs for digest deleted since they were listed, nothing to restore")
+
+			return nil
+		}
+
 		is.log.Error().Err(err).Str("component", "dedupe").Msg("failed to find original blob")
 
 		return zerr.ErrDedupeRebuild

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -1383,7 +1383,7 @@ func TestDedupeLinks(t *testing.T) {
 					So(err, ShouldBeNil)
 				})
 
-				Convey("test RunDedupeForDigest directly, trigger stat error on original blob", func() {
+				Convey("test RunDedupeForDigest directly, blob deleted after listing", func() {
 					// rebuild with dedupe true
 					imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
 
@@ -1396,8 +1396,39 @@ func TestDedupeLinks(t *testing.T) {
 					err := os.Remove(path.Join(dir, "dedupe1", "blobs", "sha256", blobDigest1))
 					So(err, ShouldBeNil)
 
+					/* The paths come from a listing taken at the start of the run, so a blob
+					may have been deleted since. That is skipped rather than failing the
+					digest: a failed task is never retried and its completion callback never
+					runs, which would leave OnRunComplete unfired (project-zot/zot#4349). */
 					err = imgStore.RunDedupeForDigest(context.TODO(), godigest.Digest(blobDigest1), true, duplicateBlobs)
-					So(err, ShouldNotBeNil)
+					So(err, ShouldBeNil)
+				})
+
+				Convey("test RunDedupeForDigest directly, unreadable blob still fails", func() {
+					// rebuild with dedupe true
+					imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
+
+					duplicateBlobs := []string{
+						path.Join(dir, "dedupe1", "blobs", "sha256", blobDigest1),
+						path.Join(dir, "dedupe1", "blobs", "sha256", blobDigest2),
+					}
+
+					// only a missing blob is skipped; a real I/O error must still fail the
+					// digest, so that the run does not quietly write off unreadable content
+					if os.Geteuid() != 0 {
+						blobsDir := path.Join(dir, "dedupe1", "blobs", "sha256")
+
+						err := os.Chmod(blobsDir, 0o000)
+						So(err, ShouldBeNil)
+
+						defer func() {
+							_ = os.Chmod(blobsDir, 0o700)
+						}()
+
+						err = imgStore.RunDedupeForDigest(context.TODO(), godigest.Digest(blobDigest1),
+							true, duplicateBlobs)
+						So(err, ShouldNotBeNil)
+					}
 				})
 
 				Convey("Intrerrupt rebuilding and restart, checking idempotency", func() {
@@ -3827,6 +3858,66 @@ func TestBlobPathsByDigest(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(len(afterRemoval), ShouldEqual, 4)
 		So(len(afterPaths[sharedDigest]), ShouldEqual, 2)
+	})
+}
+
+func TestRunDedupeForDigestSkipsDeletedPaths(t *testing.T) {
+	Convey("A blob deleted after the listing must not fail the whole digest", t, func() {
+		newStore := func(dir string) storageTypes.ImageStore {
+			log := zlog.NewTestLogger()
+			metrics := monitoring.NewNopMetricServer()
+			cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
+				RootDir:     dir,
+				Name:        "cache",
+				UseRelPaths: true,
+			}, log)
+
+			return local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
+		}
+
+		content := []byte("blob-content-for-dedupe")
+		digest := godigest.FromBytes(content)
+
+		writeBlob := func(dir, repo string, body []byte) string {
+			blobPath := path.Join(dir, repo, ispec.ImageBlobsDir, digest.Algorithm().String(), digest.Encoded())
+			So(os.MkdirAll(path.Dir(blobPath), storageConstants.DefaultDirPerms), ShouldBeNil)
+			So(os.WriteFile(blobPath, body, storageConstants.DefaultFilePerms), ShouldBeNil)
+
+			return blobPath
+		}
+
+		Convey("dedupe direction", func() {
+			dir := t.TempDir()
+			imgStore := newStore(dir)
+
+			survivor := writeBlob(dir, "repo-keep", content)
+			deleted := writeBlob(dir, "repo-gone", content)
+			So(os.Remove(deleted), ShouldBeNil)
+
+			// the vanished path is listed first, which is what the old code choked on
+			err := imgStore.RunDedupeForDigest(context.Background(), digest, true, []string{deleted, survivor})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("restore direction", func() {
+			dir := t.TempDir()
+			imgStore := newStore(dir)
+
+			original := writeBlob(dir, "repo-original", content)
+			placeholder := writeBlob(dir, "repo-placeholder", []byte{})
+			deleted := writeBlob(dir, "repo-gone", content)
+			So(os.Remove(deleted), ShouldBeNil)
+
+			err := imgStore.RunDedupeForDigest(context.Background(), digest, false,
+				[]string{deleted, original, placeholder})
+			So(err, ShouldBeNil)
+
+			// the surviving copy was still found as the content source, so the
+			// zero-size placeholder got restored
+			restored, err := os.ReadFile(placeholder)
+			So(err, ShouldBeNil)
+			So(restored, ShouldResemble, content)
+		})
 	})
 }
 

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -3914,6 +3914,37 @@ func TestRunDedupeForDigestSkipsDeletedPaths(t *testing.T) {
 			So(err, ShouldBeNil)
 		})
 
+		Convey("restore direction, every path deleted", func() {
+			dir := t.TempDir()
+			imgStore := newStore(dir)
+
+			first := writeBlob(dir, "repo-one", content)
+			second := writeBlob(dir, "repo-two", []byte{})
+			So(os.Remove(first), ShouldBeNil)
+			So(os.Remove(second), ShouldBeNil)
+
+			// nothing survives, so there is nothing to restore. Failing here would stop the
+			// run reporting completion, which would wedge the restore marker.
+			err := imgStore.RunDedupeForDigest(context.Background(), digest, false,
+				[]string{first, second})
+			So(err, ShouldBeNil)
+		})
+
+		Convey("restore direction, placeholder survives with no content source", func() {
+			dir := t.TempDir()
+			imgStore := newStore(dir)
+
+			original := writeBlob(dir, "repo-original", content)
+			placeholder := writeBlob(dir, "repo-placeholder", []byte{})
+			So(os.Remove(original), ShouldBeNil)
+
+			// the placeholder is still there and nothing holds the content, so this must
+			// fail rather than leave it zero-size
+			err := imgStore.RunDedupeForDigest(context.Background(), digest, false,
+				[]string{original, placeholder})
+			So(err, ShouldNotBeNil)
+		})
+
 		Convey("restore direction", func() {
 			dir := t.TempDir()
 			imgStore := newStore(dir)

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -3818,7 +3818,7 @@ func TestBlobPathsByDigest(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(len(repos), ShouldEqual, len(layout))
 
-		digests, blobPaths, err := storageCommon.BlobPathsByDigest(imgStore, repos)
+		digests, blobPaths, err := storageCommon.BlobPathsByDigest(imgStore, repos, log)
 		So(err, ShouldBeNil)
 
 		// every digest collected exactly once, and the slice agrees with the map
@@ -3851,10 +3851,25 @@ func TestBlobPathsByDigest(t *testing.T) {
 		So(blobPaths[onlyFirstDigest][0], ShouldContainSubstring, "aaa-repo")
 		So(blobPaths[onlyLastDigest][0], ShouldContainSubstring, "zzz-repo")
 
+		// a file whose name is not a valid digest must be skipped rather than becoming a
+		// task that can never succeed
+		strayPath := path.Join(dir, "aaa-repo", ispec.ImageBlobsDir, "sha256", "not-a-valid-digest")
+		So(os.WriteFile(strayPath, []byte("junk"), storageConstants.DefaultFilePerms), ShouldBeNil)
+
+		withStray, strayPaths, err := storageCommon.BlobPathsByDigest(imgStore, repos, log)
+		So(err, ShouldBeNil)
+		So(len(withStray), ShouldEqual, 4)
+
+		for digest := range strayPaths {
+			So(digest.Validate(), ShouldBeNil)
+		}
+
+		So(os.Remove(strayPath), ShouldBeNil)
+
 		// a missing blobs directory must not curtail the rest of the listing
 		So(os.RemoveAll(path.Join(dir, "org/team", ispec.ImageBlobsDir)), ShouldBeNil)
 
-		afterRemoval, afterPaths, err := storageCommon.BlobPathsByDigest(imgStore, repos)
+		afterRemoval, afterPaths, err := storageCommon.BlobPathsByDigest(imgStore, repos, log)
 		So(err, ShouldBeNil)
 		So(len(afterRemoval), ShouldEqual, 4)
 		So(len(afterPaths[sharedDigest]), ShouldEqual, 2)

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -33,6 +33,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/scheduler"
 	"zotregistry.dev/zot/v2/pkg/storage"
 	"zotregistry.dev/zot/v2/pkg/storage/cache"
+	storageCommon "zotregistry.dev/zot/v2/pkg/storage/common"
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
 	"zotregistry.dev/zot/v2/pkg/storage/gc"
 	"zotregistry.dev/zot/v2/pkg/storage/imagestore"
@@ -3727,6 +3728,105 @@ func TestGetNextDigestWithBlobPathsNestedRepo(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(gotDigest, ShouldEqual, dgst)
 		So(len(duplicateBlobs), ShouldEqual, 2)
+	})
+}
+
+func TestBlobPathsByDigest(t *testing.T) {
+	Convey("BlobPathsByDigest groups blob paths by digest, one listing per repo", t, func() {
+		dir := t.TempDir()
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
+			RootDir:     dir,
+			Name:        "cache",
+			UseRelPaths: true,
+		}, log)
+
+		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
+
+		shared := []byte("shared-blob-content")
+		pair := []byte("two-repo-blob-content")
+		onlyFirst := []byte("only-in-the-first-repo")
+		onlyLast := []byte("only-in-the-last-repo")
+
+		sharedDigest := godigest.FromBytes(shared)
+		pairDigest := godigest.FromBytes(pair)
+		onlyFirstDigest := godigest.FromBytes(onlyFirst)
+		onlyLastDigest := godigest.FromBytes(onlyLast)
+
+		// one repo is nested, to prove a namespace is handled like any other repo
+		layout := map[string][][]byte{
+			"aaa-repo": {shared, pair, onlyFirst},
+			"org/team": {shared},
+			"zzz-repo": {shared, pair, onlyLast},
+		}
+
+		for repo, blobs := range layout {
+			repoDir := path.Join(dir, repo)
+			So(os.MkdirAll(path.Join(repoDir, ispec.ImageBlobsDir), storageConstants.DefaultDirPerms), ShouldBeNil)
+
+			ilBuf, err := json.Marshal(ispec.ImageLayout{Version: ispec.ImageLayoutVersion})
+			So(err, ShouldBeNil)
+			So(os.WriteFile(path.Join(repoDir, ispec.ImageLayoutFile), ilBuf, storageConstants.DefaultFilePerms),
+				ShouldBeNil)
+
+			idxBuf, err := json.Marshal(ispec.Index{Versioned: imeta.Versioned{SchemaVersion: 2}})
+			So(err, ShouldBeNil)
+			So(os.WriteFile(path.Join(repoDir, ispec.ImageIndexFile), idxBuf, storageConstants.DefaultFilePerms),
+				ShouldBeNil)
+
+			for _, blob := range blobs {
+				digest := godigest.FromBytes(blob)
+				blobPath := path.Join(repoDir, ispec.ImageBlobsDir, digest.Algorithm().String(), digest.Encoded())
+				So(os.MkdirAll(path.Dir(blobPath), storageConstants.DefaultDirPerms), ShouldBeNil)
+				So(os.WriteFile(blobPath, blob, storageConstants.DefaultFilePerms), ShouldBeNil)
+			}
+		}
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(len(repos), ShouldEqual, len(layout))
+
+		digests, blobPaths, err := storageCommon.BlobPathsByDigest(imgStore, repos)
+		So(err, ShouldBeNil)
+
+		// every digest collected exactly once, and the slice agrees with the map
+		So(len(digests), ShouldEqual, 4)
+		So(len(blobPaths), ShouldEqual, len(digests))
+
+		occurrences := map[godigest.Digest]int{}
+		for _, digest := range digests {
+			occurrences[digest]++
+			So(blobPaths, ShouldContainKey, digest)
+		}
+
+		for _, digest := range digests {
+			So(occurrences[digest], ShouldEqual, 1)
+		}
+
+		// path groups are complete, and single-copy blobs are included: the dedupe pass
+		// records a cache entry for those too, so dropping them would leave the cache short
+		So(len(blobPaths[sharedDigest]), ShouldEqual, 3)
+		So(len(blobPaths[pairDigest]), ShouldEqual, 2)
+		So(len(blobPaths[onlyFirstDigest]), ShouldEqual, 1)
+		So(len(blobPaths[onlyLastDigest]), ShouldEqual, 1)
+
+		// the paths are the real ones on disk
+		for _, blobPath := range blobPaths[sharedDigest] {
+			_, err := os.Stat(blobPath)
+			So(err, ShouldBeNil)
+		}
+
+		So(blobPaths[onlyFirstDigest][0], ShouldContainSubstring, "aaa-repo")
+		So(blobPaths[onlyLastDigest][0], ShouldContainSubstring, "zzz-repo")
+
+		// a missing blobs directory must not curtail the rest of the listing
+		So(os.RemoveAll(path.Join(dir, "org/team", ispec.ImageBlobsDir)), ShouldBeNil)
+
+		afterRemoval, afterPaths, err := storageCommon.BlobPathsByDigest(imgStore, repos)
+		So(err, ShouldBeNil)
+		So(len(afterRemoval), ShouldEqual, 4)
+		So(len(afterPaths[sharedDigest]), ShouldEqual, 2)
 	})
 }
 


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

#4349.

**What does this PR do / Why do we need it**:

The dedupe and restore task generator calls `GetNextDigestWithBlobPaths` once per digest, and
each of those calls walks the whole storage root to return a single digest, skipping the ones
already processed. That makes the startup walk `O(digests * full-storage-listing)`.

On a remote driver a full listing takes tens of seconds, so two things follow:

1. The walk takes hours. On the instance in #4349 it collapsed 568 digests in about 95 minutes
   and had not finished.
2. Client requests stall for the length of each listing. The generator holds `is.RLock()` while
   walking, `RunDedupeForDigest` then waits for `is.Lock()`, and Go's `sync.RWMutex` blocks new
   readers as soon as a writer is waiting. Blob `HEAD`s measured 20-23s throughout, while the
   dedupe work itself took about 15ms per digest.

`GetAllBlobPathsByDigest` walks storage once and returns every blob path grouped by digest, in
walk order so processing stays deterministic. The generator enumerates on the first `Next()` of a
run and iterates that result; `Reset()` clears it so the next run re-enumerates.

`GetNextDigestWithBlobPaths` stays in the interface, now implemented as a thin wrapper over the
new method, so any other caller is unaffected.

Enumerating once matches what the generator already does for repositories: it fetches the repo
list on the first run only, on the stated grounds that anything uploaded mid-run is deduped
inline and does not need the walk.

One trade-off worth flagging: the map holds every blob path in storage for the duration of a run,
where the old code held one digest's paths. For the registry in #4349 that is trivial, but on a
very large registry it is real, and batching the enumeration would be the natural answer if you
would rather bound it.

**If an issue # is not available please add repro steps and logs showing the issue**:

n/a, see #4349.

**Testing done on this change**:

`GOEXPERIMENT=jsonv2 go test -tags "sync,scrub,metrics,search,lint,mgmt" ./pkg/storage/...`
passes, except `TestGarbageCollectForImageStore` in `pkg/storage/local`, which fails identically
on an unmodified `origin/main` in my environment.

The four existing generator tests now drive the mock through `GetAllBlobPathsByDigestFn`. Three
tests are new:

- `TestDedupeTaskGeneratorWalksStorageOncePerRun` asserts the point of the change: three digests
  produce three tasks from a single enumeration, and `Reset()` causes exactly one more.
- `TestDedupeTaskGeneratorDiscardsPartialEnumeration` covers the error path: a walk that fails
  part-way and hands back what it had collected must be retried in full, not resumed, and the run
  must not report completion off the partial snapshot. Verified that it fails against the previous
  revision of this PR and passes now.
- `TestGetAllBlobPathsByDigest` in `pkg/storage/local` is storage-backed, over three repos
  including a nested namespace, and covers what the walk itself must produce: every digest exactly
  once, complete path groups, single-copy blobs included, and a stable first-seen order.

**Automation added to e2e**:

No. Covered by the unit tests above.

**Will this break upgrades or downgrades?**

Not for a running registry: no config, on-disk layout or HTTP API changes, and no migration.

It is a source-level change, though, and my first wording here was self-contradictory. It adds
`GetAllBlobPathsByDigest` to the `storageTypes.ImageStore` interface, so any out-of-tree
implementation of that interface stops compiling until it adds the method. Every in-tree
implementation and the mock are updated here. I have followed the precedent in this repo rather
than adding a compatibility shim: #3959 added `ctx` to `InitRepo`, `PutImageManifest`,
`DeleteImageManifest` and `NewBlobUpload` on the same interface, and #4092 added new interface
surface, neither with a shim nor a `!` marker. Happy to retitle as breaking, or to hide the bulk
method behind an optional narrow interface with a fallback to the per-digest one, if you would
rather.

**Does this PR introduce any user-facing change?**:

Yes, in that the startup dedupe walk stops monopolising storage listings.

```release-note
The startup dedupe/restore walk now lists storage once per run instead of once per digest.
Previously, on remote storage drivers, the walk could take hours and stall blob requests for
tens of seconds at a time.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
