### PR TITLE
fix(compat): preserve Docker media types through MetaDB and search

### DIFF
--- a/pkg/cli/client/client.go
+++ b/pkg/cli/client/client.go
@@ -19,6 +19,7 @@ import (
 
 	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/common"
+	"zotregistry.dev/zot/v2/pkg/compat"
 )
 
 // HTTPClient manages HTTP clients with TLS support and caching.
@@ -247,9 +248,9 @@ func (p *requestsPool) doJob(ctx context.Context, job *httpJob) {
 
 	verbose := job.config.Verbose
 
-	switch header.Get("Content-Type") {
-	case ispec.MediaTypeImageManifest:
-		image, err := fetchImageManifestStruct(ctx, job)
+	switch contentType := header.Get("Content-Type"); {
+	case contentType == ispec.MediaTypeImageManifest || compat.IsCompatibleManifestMediaType(contentType):
+		image, err := fetchImageManifestStruct(ctx, job, contentType)
 		if err != nil {
 			if common.IsContextDone(ctx) {
 				return
@@ -275,8 +276,8 @@ func (p *requestsPool) doJob(ctx context.Context, job *httpJob) {
 		}
 
 		p.outputCh <- stringResult{str, nil}
-	case ispec.MediaTypeImageIndex:
-		image, err := fetchImageIndexStruct(ctx, job)
+	case contentType == ispec.MediaTypeImageIndex || compat.IsCompatibleManifestListMediaType(contentType):
+		image, err := fetchImageIndexStruct(ctx, job, contentType)
 		if err != nil {
 			if common.IsContextDone(ctx) {
 				return
@@ -308,7 +309,7 @@ func (p *requestsPool) doJob(ctx context.Context, job *httpJob) {
 	}
 }
 
-func fetchImageIndexStruct(ctx context.Context, job *httpJob) (*imageStruct, error) {
+func fetchImageIndexStruct(ctx context.Context, job *httpJob, mediaType string) (*imageStruct, error) {
 	var indexContent ispec.Index
 
 	httpClient := job.config.SearchService.getHTTPClient()
@@ -360,7 +361,7 @@ func fetchImageIndexStruct(ctx context.Context, job *httpJob) (*imageStruct, err
 		RepoName:  job.imageName,
 		Tag:       job.tagName,
 		Digest:    indexDigest,
-		MediaType: ispec.MediaTypeImageIndex,
+		MediaType: mediaType,
 		Manifests: manifestList,
 		Size:      strconv.FormatInt(imageSize, 10),
 		IsSigned:  isIndexSigned,
@@ -376,7 +377,7 @@ func atoiWithDefault(size string, defaultVal int) int {
 	return val
 }
 
-func fetchImageManifestStruct(ctx context.Context, job *httpJob) (*imageStruct, error) {
+func fetchImageManifestStruct(ctx context.Context, job *httpJob, mediaType string) (*imageStruct, error) {
 	manifest, err := fetchManifestStruct(ctx, job.imageName, job.tagName, job.config, job.username, job.password)
 	if err != nil {
 		return nil, err
@@ -386,7 +387,7 @@ func fetchImageManifestStruct(ctx context.Context, job *httpJob) (*imageStruct, 
 		RepoName:  job.imageName,
 		Tag:       job.tagName,
 		Digest:    manifest.Digest,
-		MediaType: ispec.MediaTypeImageManifest,
+		MediaType: mediaType,
 		Manifests: []common.ManifestSummary{
 			manifest,
 		},

--- a/pkg/cli/client/service.go
+++ b/pkg/cli/client/service.go
@@ -24,6 +24,7 @@ import (
 	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
 	"zotregistry.dev/zot/v2/pkg/common"
+	"zotregistry.dev/zot/v2/pkg/compat"
 )
 
 const (
@@ -1179,10 +1180,10 @@ func (img imageStruct) stringPlainText(maxImgNameLen, maxTagLen, maxPlatformLen 
 func addImageToTable(table *tablewriter.Table, img *imageStruct,
 	imageName, tagName string, verbose bool,
 ) error {
-	switch img.MediaType {
-	case ispec.MediaTypeImageManifest:
+	switch {
+	case img.MediaType == ispec.MediaTypeImageManifest || compat.IsCompatibleManifestMediaType(img.MediaType):
 		return addManifestToTable(table, imageName, tagName, &img.Manifests[0], verbose)
-	case ispec.MediaTypeImageIndex:
+	case img.MediaType == ispec.MediaTypeImageIndex || compat.IsCompatibleManifestListMediaType(img.MediaType):
 		return addImageIndexToTable(table, img, imageName, tagName, verbose)
 	}
 

--- a/pkg/cli/client/utils_internal_test.go
+++ b/pkg/cli/client/utils_internal_test.go
@@ -161,9 +161,50 @@ func TestDoHTTPRequest(t *testing.T) {
 			imageName: "repo",
 			tagName:   "tag",
 			config:    searchConf,
-		})
+		}, ispec.MediaTypeImageManifest)
 
 		So(err, ShouldNotBeNil)
+	})
+
+	Convey("fetchImageManifestStruct preserves docker Content-Type", t, func() {
+		server, baseURL := StartTestHTTPServer(HTTPRoutes{
+			{
+				Route: "/v2/{name}/manifests/{reference}",
+				HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Add("Docker-Content-Digest", godigest.FromString("manifest").String())
+					w.Header().Add("Content-Length", "64")
+					_, err := w.Write([]byte(`{"config":{"digest":"sha256:config","size":2},"layers":[]}`))
+					if err != nil {
+						return
+					}
+				},
+				AllowedMethods: []string{http.MethodGet},
+			},
+			{
+				Route: "/v2/{name}/blobs/{digest}",
+				HandlerFunc: func(w http.ResponseWriter, r *http.Request) {
+					_, err := w.Write([]byte(`{}`))
+					if err != nil {
+						return
+					}
+				},
+				AllowedMethods: []string{http.MethodGet},
+			},
+		})
+		defer server.Close()
+
+		searchConf := getDefaultSearchConf(baseURL)
+		image, err := fetchImageManifestStruct(context.Background(), &httpJob{
+			url:       baseURL + "/v2/repo/manifests/tag",
+			username:  "",
+			password:  "",
+			imageName: "repo",
+			tagName:   "tag",
+			config:    searchConf,
+		}, "application/vnd.docker.distribution.manifest.v2+json")
+		So(err, ShouldBeNil)
+		So(image, ShouldNotBeNil)
+		So(image.MediaType, ShouldEqual, "application/vnd.docker.distribution.manifest.v2+json")
 	})
 
 	Convey("fetchManifestStruct errors", t, func() {
@@ -340,7 +381,7 @@ func TestDoHTTPRequest(t *testing.T) {
 				imageName: "repo",
 				tagName:   "tag",
 				config:    searchConf,
-			})
+			}, ispec.MediaTypeImageIndex)
 			So(err, ShouldBeNil)
 			So(imageStruct, ShouldNotBeNil)
 		})
@@ -363,7 +404,7 @@ func TestDoHTTPRequest(t *testing.T) {
 				imageName: "repo",
 				tagName:   "tag",
 				config:    searchConf,
-			})
+			}, ispec.MediaTypeImageIndex)
 			So(err, ShouldNotBeNil)
 			So(imageStruct, ShouldBeNil)
 		})
@@ -382,7 +423,7 @@ func TestDoHTTPRequest(t *testing.T) {
 				imageName: "repo",
 				tagName:   "tag",
 				config:    searchConf,
-			})
+			}, ispec.MediaTypeImageIndex)
 			So(err, ShouldNotBeNil)
 			So(imageStruct, ShouldBeNil)
 		})

--- a/pkg/extensions/extension_image_trust_test.go
+++ b/pkg/extensions/extension_image_trust_test.go
@@ -30,6 +30,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	"zotregistry.dev/zot/v2/pkg/compat"
 	"zotregistry.dev/zot/v2/pkg/extensions"
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
@@ -207,7 +208,7 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 	imageQuery := `
 		{
 			Image(image:"%s:%s"){
-				RepoName Tag Digest IsSigned
+				RepoName Tag Digest MediaType IsSigned
 				Manifests {
 					Digest
 					SignatureInfo { Tool IsTrusted Author }
@@ -589,6 +590,264 @@ func RunSignatureUploadAndVerificationTests(t *testing.T, cacheDriverParams map[
 		resp, err = client.R().Post(baseURL + constants.FullNotation)
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusBadRequest)
+	})
+
+	Convey("Verify notation signatures on docker schema2 images", func() {
+		globalDir := t.TempDir()
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		conf.HTTP.Compat = []compat.MediaCompatibility{compat.DockerManifestV2SchemaV2}
+
+		if cacheDriverParams != nil {
+			conf.Storage.CacheDriver = cacheDriverParams
+		}
+		conf.Extensions = &extconf.ExtensionConfig{}
+		conf.Extensions.Search = &extconf.SearchConfig{}
+		conf.Extensions.Search.Enable = &defaultValue
+		conf.Extensions.Search.CVE = nil
+		conf.Extensions.Trust = &extconf.ImageTrustConfig{}
+		conf.Extensions.Trust.Enable = &defaultValue
+		conf.Extensions.Trust.Notation = defaultValue
+
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
+
+		writers := io.MultiWriter(os.Stdout, logFile)
+		logger := log.NewLoggerWithWriter("debug", writers)
+
+		imageStore := local.NewImageStore(globalDir, false, false,
+			logger, monitoring.NewNopMetricServer(), nil, nil, conf.HTTP.Compat, nil)
+
+		storeController := storage.StoreController{
+			DefaultStore: imageStore,
+		}
+
+		image := CreateRandomImage().AsDockerImage()
+		err := WriteImageToFileSystem(image, repo, tag, storeController)
+		So(err, ShouldBeNil)
+
+		ctlr := api.NewController(conf)
+		ctlr.Log = log.NewLoggerWithWriter("debug", writers)
+		ctlr.Config.Storage.RootDirectory = globalDir
+
+		ctlrManager := test.NewControllerManager(ctlr)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
+		defer ctlrManager.StopServer()
+
+		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, constants.FullSearchPrefix)
+
+		found, err := test.ReadLogFileAndSearchString(logFile.Name(), "setting up image trust routes", time.Second)
+		So(err, ShouldBeNil)
+		So(found, ShouldBeTrue)
+
+		strQuery := fmt.Sprintf(imageQuery, repo, tag)
+		gqlTargetURL := fmt.Sprintf("%s%s", gqlEndpoint, url.QueryEscape(strQuery))
+
+		resp, err := resty.R().Get(gqlTargetURL)
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+		So(resp.Body(), ShouldNotBeNil)
+
+		imgSummaryResponse := zcommon.ImageSummaryResult{}
+		err = json.Unmarshal(resp.Body(), &imgSummaryResponse)
+		So(err, ShouldBeNil)
+		So(imgSummaryResponse, ShouldNotBeNil)
+		So(imgSummaryResponse.ImageSummary, ShouldNotBeNil)
+		imgSummary := imgSummaryResponse.SingleImageSummary.ImageSummary
+		So(imgSummary.RepoName, ShouldContainSubstring, repo)
+		So(imgSummary.Tag, ShouldContainSubstring, tag)
+		So(imgSummary.Digest, ShouldContainSubstring, image.Digest().Encoded())
+		So(imgSummary.Manifests[0].Digest, ShouldContainSubstring, image.Digest().Encoded())
+		So(imgSummary.IsSigned, ShouldEqual, false)
+		So(imgSummary.SignatureInfo, ShouldNotBeNil)
+		So(len(imgSummary.SignatureInfo), ShouldEqual, 0)
+
+		rootDir := t.TempDir()
+
+		signature.NotationPathLock.Lock()
+		defer signature.NotationPathLock.Unlock()
+
+		signature.LoadNotationPath(rootDir)
+
+		err = signature.GenerateNotationCerts(rootDir, certName)
+		So(err, ShouldBeNil)
+
+		certificateContent, err := os.ReadFile(path.Join(rootDir, "notation/localkeys", certName+".crt"))
+		So(err, ShouldBeNil)
+		So(certificateContent, ShouldNotBeNil)
+
+		client := resty.New()
+		resp, err = client.R().SetHeader("Content-type", "application/octet-stream").
+			SetBody(certificateContent).Post(baseURL + constants.FullNotation)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		imageURL := fmt.Sprintf("localhost:%s/%s", port, fmt.Sprintf("%s:%s", repo, tag))
+
+		err = signature.SignWithNotation(certName, imageURL, rootDir, false)
+		So(err, ShouldBeNil)
+
+		found, err = test.ReadLogFileAndSearchString(logFile.Name(), "update signatures validity", 30*time.Second)
+		So(err, ShouldBeNil)
+		So(found, ShouldBeTrue)
+
+		found, err = test.ReadLogFileAndSearchString(logFile.Name(), "update signatures validity completed", time.Second)
+		So(err, ShouldBeNil)
+		So(found, ShouldBeTrue)
+
+		resp, err = resty.R().Get(gqlTargetURL)
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+		So(resp.Body(), ShouldNotBeNil)
+
+		imgSummaryResponse = zcommon.ImageSummaryResult{}
+		err = json.Unmarshal(resp.Body(), &imgSummaryResponse)
+		So(err, ShouldBeNil)
+		So(imgSummaryResponse, ShouldNotBeNil)
+		So(imgSummaryResponse.ImageSummary, ShouldNotBeNil)
+		imgSummary = imgSummaryResponse.SingleImageSummary.ImageSummary
+		So(imgSummary.RepoName, ShouldContainSubstring, repo)
+		So(imgSummary.Tag, ShouldContainSubstring, tag)
+		So(imgSummary.Digest, ShouldContainSubstring, image.Digest().Encoded())
+		So(imgSummary.Manifests[0].Digest, ShouldContainSubstring, image.Digest().Encoded())
+		So(imgSummary.MediaType, ShouldEqual, image.ManifestDescriptor.MediaType)
+		t.Log(imgSummary.SignatureInfo)
+		So(imgSummary.IsSigned, ShouldEqual, true)
+		So(imgSummary.SignatureInfo, ShouldNotBeNil)
+		So(len(imgSummary.SignatureInfo), ShouldEqual, 1)
+		So(imgSummary.SignatureInfo[0].IsTrusted, ShouldEqual, true)
+		So(imgSummary.SignatureInfo[0].Tool, ShouldEqual, "notation")
+		So(imgSummary.SignatureInfo[0].Author,
+			ShouldEqual, "CN=cert,O=Notary,L=Seattle,ST=WA,C=US")
+		So(imgSummary.Manifests[0].SignatureInfo, ShouldNotBeNil)
+		So(len(imgSummary.Manifests[0].SignatureInfo), ShouldEqual, 1)
+		So(imgSummary.Manifests[0].SignatureInfo[0].IsTrusted, ShouldEqual, true)
+		So(imgSummary.Manifests[0].SignatureInfo[0].Tool, ShouldEqual, "notation")
+		So(imgSummary.Manifests[0].SignatureInfo[0].Author,
+			ShouldEqual, "CN=cert,O=Notary,L=Seattle,ST=WA,C=US")
+	})
+
+	Convey("Verify notation signatures on docker schema2 manifest lists", func() {
+		globalDir := t.TempDir()
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		conf.HTTP.Compat = []compat.MediaCompatibility{compat.DockerManifestV2SchemaV2}
+
+		if cacheDriverParams != nil {
+			conf.Storage.CacheDriver = cacheDriverParams
+		}
+		conf.Extensions = &extconf.ExtensionConfig{}
+		conf.Extensions.Search = &extconf.SearchConfig{}
+		conf.Extensions.Search.Enable = &defaultValue
+		conf.Extensions.Search.CVE = nil
+		conf.Extensions.Trust = &extconf.ImageTrustConfig{}
+		conf.Extensions.Trust.Enable = &defaultValue
+		conf.Extensions.Trust.Notation = defaultValue
+
+		logFile := test.MakeTempFile(t, "zot-log.txt")
+		defer logFile.Close()
+
+		writers := io.MultiWriter(os.Stdout, logFile)
+		logger := log.NewLoggerWithWriter("debug", writers)
+
+		imageStore := local.NewImageStore(globalDir, false, false,
+			logger, monitoring.NewNopMetricServer(), nil, nil, conf.HTTP.Compat, nil)
+
+		storeController := storage.StoreController{
+			DefaultStore: imageStore,
+		}
+
+		multiarch := CreateRandomMultiarch().AsDockerImage()
+		err := WriteMultiArchImageToFileSystem(multiarch, repo, tag, storeController)
+		So(err, ShouldBeNil)
+
+		ctlr := api.NewController(conf)
+		ctlr.Log = log.NewLoggerWithWriter("debug", writers)
+		ctlr.Config.Storage.RootDirectory = globalDir
+
+		ctlrManager := test.NewControllerManager(ctlr)
+		baseURL := ctlrManager.StartAndWait()
+		port := strconv.Itoa(ctlrManager.Port())
+		defer ctlrManager.StopServer()
+
+		found, err := test.ReadLogFileAndSearchString(logFile.Name(), "setting up image trust routes", time.Second)
+		So(err, ShouldBeNil)
+		So(found, ShouldBeTrue)
+
+		rootDir := t.TempDir()
+
+		signature.NotationPathLock.Lock()
+		defer signature.NotationPathLock.Unlock()
+
+		signature.LoadNotationPath(rootDir)
+
+		err = signature.GenerateNotationCerts(rootDir, certName)
+		So(err, ShouldBeNil)
+
+		certificateContent, err := os.ReadFile(path.Join(rootDir, "notation/localkeys", certName+".crt"))
+		So(err, ShouldBeNil)
+		So(certificateContent, ShouldNotBeNil)
+
+		client := resty.New()
+		resp, err := client.R().SetHeader("Content-type", "application/octet-stream").
+			SetBody(certificateContent).Post(baseURL + constants.FullNotation)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		imageURL := fmt.Sprintf("localhost:%s/%s", port, fmt.Sprintf("%s:%s", repo, tag))
+
+		err = signature.SignWithNotation(certName, imageURL, rootDir, true)
+		So(err, ShouldBeNil)
+
+		found, err = test.ReadLogFileAndSearchString(logFile.Name(), "update signatures validity", 30*time.Second)
+		So(err, ShouldBeNil)
+		So(found, ShouldBeTrue)
+
+		found, err = test.ReadLogFileAndSearchString(logFile.Name(), "update signatures validity completed", time.Second)
+		So(err, ShouldBeNil)
+		So(found, ShouldBeTrue)
+
+		fullImageMeta, err := ctlr.MetaDB.GetFullImageMeta(context.Background(), repo, tag)
+		So(err, ShouldBeNil)
+		So(fullImageMeta.MediaType, ShouldEqual, multiarch.IndexDescriptor.MediaType)
+		So(fullImageMeta.Signatures, ShouldContainKey, zcommon.NotationSignature)
+
+		notationSignatures := fullImageMeta.Signatures[zcommon.NotationSignature]
+		So(len(notationSignatures), ShouldEqual, 1)
+		So(len(notationSignatures[0].LayersInfo), ShouldEqual, 1)
+		So(notationSignatures[0].LayersInfo[0].Signer,
+			ShouldEqual, "CN=cert,O=Notary,L=Seattle,ST=WA,C=US")
+
+		gqlEndpoint := fmt.Sprintf("%s%s?query=", baseURL, constants.FullSearchPrefix)
+		strQuery := fmt.Sprintf(imageQuery, repo, tag)
+		gqlTargetURL := fmt.Sprintf("%s%s", gqlEndpoint, url.QueryEscape(strQuery))
+
+		resp, err = resty.R().Get(gqlTargetURL)
+		So(resp, ShouldNotBeNil)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, 200)
+		So(resp.Body(), ShouldNotBeNil)
+
+		imgSummaryResponse := zcommon.ImageSummaryResult{}
+		err = json.Unmarshal(resp.Body(), &imgSummaryResponse)
+		So(err, ShouldBeNil)
+		So(imgSummaryResponse, ShouldNotBeNil)
+		So(imgSummaryResponse.ImageSummary, ShouldNotBeNil)
+		imgSummary := imgSummaryResponse.SingleImageSummary.ImageSummary
+		So(imgSummary.RepoName, ShouldContainSubstring, repo)
+		So(imgSummary.Tag, ShouldContainSubstring, tag)
+		So(imgSummary.Digest, ShouldContainSubstring, multiarch.Digest().Encoded())
+		So(imgSummary.MediaType, ShouldEqual, multiarch.IndexDescriptor.MediaType)
+		So(imgSummary.IsSigned, ShouldEqual, true)
+		So(imgSummary.SignatureInfo, ShouldNotBeNil)
+		So(len(imgSummary.SignatureInfo), ShouldEqual, 1)
+		So(imgSummary.SignatureInfo[0].IsTrusted, ShouldEqual, true)
+		So(imgSummary.SignatureInfo[0].Tool, ShouldEqual, "notation")
+		So(imgSummary.SignatureInfo[0].Author,
+			ShouldEqual, "CN=cert,O=Notary,L=Seattle,ST=WA,C=US")
 	})
 
 	Convey("Verify uploading cosign public keys", func() {

--- a/pkg/extensions/search/convert/convert_test.go
+++ b/pkg/extensions/search/convert/convert_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	dockerList "github.com/distribution/distribution/v3/manifest/manifestlist"
+	docker "github.com/distribution/distribution/v3/manifest/schema2"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
@@ -1370,5 +1372,92 @@ func TestConvertErrors(t *testing.T) {
 			)
 			So(len(imgSums), ShouldEqual, 0)
 		})
+	})
+}
+
+func TestDockerIndexMediaTypeConversion(t *testing.T) {
+	Convey("Docker manifest lists retain their media type in image summaries", t, func() {
+		digest := godigest.FromString("docker-index")
+		imageMeta := mTypes.ImageMeta{
+			MediaType: dockerList.MediaTypeManifestList,
+			Digest:    digest,
+			Index: &ispec.Index{
+				MediaType: dockerList.MediaTypeManifestList,
+			},
+		}
+		repoMeta := mTypes.RepoMeta{
+			Name: "repo",
+			Tags: map[string]mTypes.Descriptor{
+				"latest": {Digest: digest.String()},
+			},
+		}
+
+		fullImageMeta := convert.GetFullImageMeta("latest", repoMeta, imageMeta)
+		So(fullImageMeta.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+		So(fullImageMeta.Index.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+
+		summary, _, err := convert.FullImageMeta2ImageSummary(context.Background(), fullImageMeta)
+		So(err, ShouldBeNil)
+		So(summary, ShouldNotBeNil)
+		So(summary.MediaType, ShouldNotBeNil)
+		So(*summary.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+	})
+
+	Convey("Docker manifests prefer descriptor media type over empty nested JSON", t, func() {
+		digest := godigest.FromString("docker-manifest")
+		imageMeta := mTypes.ImageMeta{
+			MediaType: docker.MediaTypeManifest,
+			Digest:    digest,
+			Manifests: []mTypes.ManifestMeta{
+				{
+					Digest:   digest,
+					Manifest: ispec.Manifest{},
+					Config:   ispec.Image{},
+				},
+			},
+		}
+		repoMeta := mTypes.RepoMeta{
+			Name: "repo",
+			Tags: map[string]mTypes.Descriptor{
+				"latest": {Digest: digest.String()},
+			},
+		}
+
+		fullImageMeta := convert.GetFullImageMeta("latest", repoMeta, imageMeta)
+		summary, _, err := convert.FullImageMeta2ImageSummary(context.Background(), fullImageMeta)
+		So(err, ShouldBeNil)
+		So(summary, ShouldNotBeNil)
+		So(summary.MediaType, ShouldNotBeNil)
+		So(*summary.MediaType, ShouldEqual, docker.MediaTypeManifest)
+	})
+
+	Convey("empty top-level media type falls back to nested manifest JSON", t, func() {
+		digest := godigest.FromString("nested-media-type")
+		summary, _, err := convert.ImageManifest2ImageSummary(context.Background(), mTypes.FullImageMeta{
+			Repo:      "repo",
+			Tag:       "latest",
+			MediaType: "",
+			Digest:    digest,
+			Manifests: []mTypes.FullManifestMeta{
+				{
+					ManifestMeta: mTypes.ManifestMeta{
+						Digest: digest,
+						Size:   10,
+						Manifest: ispec.Manifest{
+							MediaType: docker.MediaTypeManifest,
+							Config: ispec.Descriptor{
+								Digest: godigest.FromString("config"),
+								Size:   2,
+							},
+						},
+						Config: ispec.Image{},
+					},
+				},
+			},
+		})
+		So(err, ShouldBeNil)
+		So(summary, ShouldNotBeNil)
+		So(summary.MediaType, ShouldNotBeNil)
+		So(*summary.MediaType, ShouldEqual, docker.MediaTypeManifest)
 	})
 }

--- a/pkg/extensions/search/convert/metadb.go
+++ b/pkg/extensions/search/convert/metadb.go
@@ -12,6 +12,7 @@ import (
 
 	zerr "zotregistry.dev/zot/v2/errors"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	"zotregistry.dev/zot/v2/pkg/compat"
 	cveinfo "zotregistry.dev/zot/v2/pkg/extensions/search/cve"
 	"zotregistry.dev/zot/v2/pkg/extensions/search/gql_generated"
 	"zotregistry.dev/zot/v2/pkg/extensions/search/pagination"
@@ -389,10 +390,12 @@ type (
 
 func FullImageMeta2ImageSummary(ctx context.Context, fullImageMeta mTypes.FullImageMeta,
 ) (*gql_generated.ImageSummary, map[BlobDigest]int64, error) {
-	switch fullImageMeta.MediaType {
-	case ispec.MediaTypeImageManifest:
+	switch {
+	case fullImageMeta.MediaType == ispec.MediaTypeImageManifest ||
+		compat.IsCompatibleManifestMediaType(fullImageMeta.MediaType):
 		return ImageManifest2ImageSummary(ctx, fullImageMeta)
-	case ispec.MediaTypeImageIndex:
+	case fullImageMeta.MediaType == ispec.MediaTypeImageIndex ||
+		compat.IsCompatibleManifestListMediaType(fullImageMeta.MediaType):
 		return ImageIndex2ImageSummary(ctx, fullImageMeta)
 	default:
 		return nil, nil, zerr.ErrMediaTypeNotSupported
@@ -412,7 +415,7 @@ func ImageIndex2ImageSummary(ctx context.Context, fullImageMeta mTypes.FullImage
 		indexBlobs          = map[string]int64{}
 
 		indexDigestStr    = fullImageMeta.Digest.String()
-		indexMediaType    = ispec.MediaTypeImageIndex
+		indexMediaType    = fullImageMeta.MediaType
 		lastPullTimestamp = fullImageMeta.Statistics.LastPullTimestamp
 		pushTimestamp     = fullImageMeta.Statistics.PushTimestamp
 		pushedBy          = fullImageMeta.Statistics.PushedBy
@@ -430,7 +433,7 @@ func ImageIndex2ImageSummary(ctx context.Context, fullImageMeta mTypes.FullImage
 		imageManifestSummary, manifestBlobs, err := ImageManifest2ImageSummary(ctx, mTypes.FullImageMeta{
 			Repo:            fullImageMeta.Repo,
 			Tag:             fullImageMeta.Tag,
-			MediaType:       ispec.MediaTypeImageManifest,
+			MediaType:       imageManifest.Manifest.MediaType,
 			Digest:          imageManifest.Digest,
 			Size:            imageManifest.Size,
 			Manifests:       []mTypes.FullManifestMeta{imageManifest},
@@ -529,7 +532,7 @@ func ImageManifest2ImageSummary(ctx context.Context, fullImageMeta mTypes.FullIm
 		configSize        = manifest.Manifest.Config.Size
 		manifestDigest    = manifest.Digest.String()
 		manifestSize      = manifest.Size
-		mediaType         = manifest.Manifest.MediaType
+		mediaType         = fullImageMeta.MediaType
 		artifactType      = zcommon.GetManifestArtifactType(fullImageMeta.Manifests[0].Manifest)
 		platform          = getPlatform(manifest.Config.Platform)
 		downloadCount     = fullImageMeta.Statistics.DownloadCount
@@ -539,6 +542,10 @@ func ImageManifest2ImageSummary(ctx context.Context, fullImageMeta mTypes.FullIm
 		pushedBy          = fullImageMeta.Statistics.PushedBy
 		taggedTimestamp   = fullImageMeta.TaggedTimestamp
 	)
+
+	if mediaType == "" {
+		mediaType = manifest.Manifest.MediaType
+	}
 
 	// Fallback to PushTimestamp if TaggedTimestamp is not available
 	if taggedTimestamp.IsZero() {

--- a/pkg/extensions/search/resolver.go
+++ b/pkg/extensions/search/resolver.go
@@ -17,6 +17,7 @@ import (
 
 	zerr "zotregistry.dev/zot/v2/errors"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	"zotregistry.dev/zot/v2/pkg/compat"
 	"zotregistry.dev/zot/v2/pkg/extensions/search/convert"
 	cveinfo "zotregistry.dev/zot/v2/pkg/extensions/search/cve"
 	cvemodel "zotregistry.dev/zot/v2/pkg/extensions/search/cve/model"
@@ -173,15 +174,23 @@ func getImageSummary(ctx context.Context, repo, tag string, digest *string, skip
 	imageDigest := manifestDescriptor.Digest
 	if digest != nil {
 		imageDigest = *digest
-		repoMeta.Tags[tag] = mTypes.Descriptor{
-			Digest:    imageDigest,
-			MediaType: ispec.MediaTypeImageManifest,
-		}
 	}
 
 	imageMetaMap, err := metaDB.FilterImageMeta(ctx, []string{imageDigest})
 	if err != nil {
 		return &gql_generated.ImageSummary{}, err
+	}
+
+	if digest != nil {
+		mediaType := ispec.MediaTypeImageManifest
+		if imageMeta, ok := imageMetaMap[imageDigest]; ok && imageMeta.MediaType != "" {
+			mediaType = imageMeta.MediaType
+		}
+
+		repoMeta.Tags[tag] = mTypes.Descriptor{
+			Digest:    imageDigest,
+			MediaType: mediaType,
+		}
 	}
 
 	imageSummaries := convert.RepoMeta2ImageSummaries(ctx, repoMeta, imageMetaMap, skipCVE, cveInfo)
@@ -497,12 +506,14 @@ func resolveImageData(ctx context.Context, imageInput gql_generated.ImageInput, 
 		return gql_generated.ImageInput{}, zerr.ErrImageNotFound
 	}
 
-	switch descriptor.MediaType {
-	case ispec.MediaTypeImageManifest:
+	switch {
+	case descriptor.MediaType == ispec.MediaTypeImageManifest ||
+		compat.IsCompatibleManifestMediaType(descriptor.MediaType):
 		imageInput.Digest = ref(descriptor.Digest)
 
 		return imageInput, nil
-	case ispec.MediaTypeImageIndex:
+	case descriptor.MediaType == ispec.MediaTypeImageIndex ||
+		compat.IsCompatibleManifestListMediaType(descriptor.MediaType):
 		if dderef(imageInput.Digest) == "" && !isPlatformSpecified(imageInput.Platform) {
 			return gql_generated.ImageInput{},
 				fmt.Errorf("%w: platform or specific manifest digest needed", zerr.ErrAmbiguousInput)
@@ -595,12 +606,14 @@ func FilterByTagInfo(tagsInfo []cvemodel.TagInfo) mTypes.FilterFunc {
 		manifestDigest := imageMeta.Manifests[0].Digest.String()
 
 		for _, tagInfo := range tagsInfo {
-			switch tagInfo.Descriptor.MediaType {
-			case ispec.MediaTypeImageManifest:
+			switch {
+			case tagInfo.Descriptor.MediaType == ispec.MediaTypeImageManifest ||
+				compat.IsCompatibleManifestMediaType(tagInfo.Descriptor.MediaType):
 				if tagInfo.Descriptor.Digest.String() == manifestDigest {
 					return true
 				}
-			case ispec.MediaTypeImageIndex:
+			case tagInfo.Descriptor.MediaType == ispec.MediaTypeImageIndex ||
+				compat.IsCompatibleManifestListMediaType(tagInfo.Descriptor.MediaType):
 				for _, manifestDesc := range tagInfo.Manifests {
 					if manifestDesc.Digest.String() == manifestDigest {
 						return true
@@ -622,12 +635,14 @@ func FilterByRepoAndTagInfo(repo string, tagsInfo []cvemodel.TagInfo) mTypes.Fil
 		manifestDigest := imageMeta.Manifests[0].Digest.String()
 
 		for _, tagInfo := range tagsInfo {
-			switch tagInfo.Descriptor.MediaType {
-			case ispec.MediaTypeImageManifest:
+			switch {
+			case tagInfo.Descriptor.MediaType == ispec.MediaTypeImageManifest ||
+				compat.IsCompatibleManifestMediaType(tagInfo.Descriptor.MediaType):
 				if tagInfo.Descriptor.Digest.String() == manifestDigest {
 					return true
 				}
-			case ispec.MediaTypeImageIndex:
+			case tagInfo.Descriptor.MediaType == ispec.MediaTypeImageIndex ||
+				compat.IsCompatibleManifestListMediaType(tagInfo.Descriptor.MediaType):
 				for _, manifestDesc := range tagInfo.Manifests {
 					if manifestDesc.Digest.String() == manifestDigest {
 						return true

--- a/pkg/extensions/search/resolver_test.go
+++ b/pkg/extensions/search/resolver_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/99designs/gqlgen/graphql"
+	dockerList "github.com/distribution/distribution/v3/manifest/manifestlist"
+	docker "github.com/distribution/distribution/v3/manifest/schema2"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
@@ -288,9 +290,9 @@ func TestRepoListWithNewestImage(t *testing.T) {
 				) (map[string]mTypes.ImageMeta, error) {
 					return map[string]mTypes.ImageMeta{
 						img1.DigestStr(): mConvert.GetImageManifestMeta(img1.Manifest, img1.Config,
-							img1.ManifestDescriptor.Size, img1.ManifestDescriptor.Digest),
+							img1.ManifestDescriptor.Size, img1.ManifestDescriptor.Digest, img1.Manifest.MediaType),
 						img2.DigestStr(): mConvert.GetImageManifestMeta(img2.Manifest, img2.Config,
-							img2.ManifestDescriptor.Size, img2.ManifestDescriptor.Digest),
+							img2.ManifestDescriptor.Size, img2.ManifestDescriptor.Digest, img2.Manifest.MediaType),
 					}, nil
 				},
 			}
@@ -3228,4 +3230,47 @@ func getGQLPageInput(limit int, offset int) *gql_generated.PageInput {
 		Offset: &offset,
 		SortBy: &sortCriteria,
 	}
+}
+
+func TestFilterByTagInfoDockerMediaTypes(t *testing.T) {
+	Convey("FilterByTagInfo accepts Docker schema2 media types", t, func() {
+		childDigest := godigest.FromString("docker-child")
+		indexDigest := godigest.FromString("docker-list")
+		imageMeta := mTypes.ImageMeta{
+			Manifests: []mTypes.ManifestMeta{
+				{Digest: childDigest},
+			},
+		}
+
+		Convey("Docker manifest list matches child digests", func() {
+			filter := FilterByTagInfo([]cvemodel.TagInfo{
+				{
+					Tag: "latest",
+					Descriptor: cvemodel.Descriptor{
+						Digest:    indexDigest,
+						MediaType: dockerList.MediaTypeManifestList,
+					},
+					Manifests: []cvemodel.DescriptorInfo{
+						{Descriptor: cvemodel.Descriptor{Digest: childDigest}},
+					},
+				},
+			})
+
+			So(filter(mTypes.RepoMeta{}, imageMeta), ShouldBeTrue)
+		})
+
+		Convey("Docker schema2 manifest matches descriptor digest", func() {
+			filter := FilterByTagInfo([]cvemodel.TagInfo{
+				{
+					Tag: "v1",
+					Descriptor: cvemodel.Descriptor{
+						Digest:    childDigest,
+						MediaType: docker.MediaTypeManifest,
+					},
+				},
+			})
+
+			So(filter(mTypes.RepoMeta{}, imageMeta), ShouldBeTrue)
+		})
+	})
 }

--- a/pkg/meta/boltdb/boltdb.go
+++ b/pkg/meta/boltdb/boltdb.go
@@ -160,10 +160,11 @@ func (bdw *BoltDB) SetImageMeta(digest godigest.Digest, imageMeta mTypes.ImageMe
 			compat.IsCompatibleManifestMediaType(imageMeta.MediaType) {
 			manifest := imageMeta.Manifests[0]
 			protoImageMeta = mConvert.GetProtoImageManifestData(manifest.Manifest, manifest.Config,
-				manifest.Size, manifest.Digest.String())
+				manifest.Size, manifest.Digest.String(), imageMeta.MediaType)
 		} else if imageMeta.MediaType == ispec.MediaTypeImageIndex ||
 			compat.IsCompatibleManifestListMediaType(imageMeta.MediaType) {
-			protoImageMeta = mConvert.GetProtoImageIndexMeta(*imageMeta.Index, imageMeta.Size, imageMeta.Digest.String())
+			protoImageMeta = mConvert.GetProtoImageIndexMeta(*imageMeta.Index, imageMeta.Size, imageMeta.Digest.String(),
+				imageMeta.MediaType)
 		}
 
 		pImageMetaBlob, err := proto.Marshal(protoImageMeta)
@@ -1370,6 +1371,8 @@ func (bdw *BoltDB) UpdateSignaturesValidity(ctx context.Context, repo string, ma
 			return err
 		}
 
+		verifyImageMeta := mConvert.GetImageMeta(&protoImageMeta)
+
 		// update signatures with details about validity and author
 		repoBuck := transaction.Bucket([]byte(RepoMetaBuck))
 
@@ -1396,8 +1399,14 @@ func (bdw *BoltDB) UpdateSignaturesValidity(ctx context.Context, repo string, ma
 				layersInfo := []*proto_go.LayersInfo{}
 
 				for _, layerInfo := range sigInfo.LayersInfo {
-					author, date, isTrusted, _ := imgTrustStore.VerifySignature(sigType, layerInfo.LayerContent,
-						layerInfo.SignatureKey, manifestDigest, mConvert.GetImageMeta(&protoImageMeta), repo)
+					author, date, isTrusted, err := imgTrustStore.VerifySignature(sigType, layerInfo.LayerContent,
+						layerInfo.SignatureKey, manifestDigest, verifyImageMeta, repo)
+					if err != nil {
+						bdw.Log.Error().Err(err).Str("repo", repo).Str("signatureType", sigType).
+							Str("manifestDigest", manifestDigest.String()).
+							Str("mediaType", verifyImageMeta.MediaType).
+							Msg("failed to verify signature validity")
+					}
 
 					if isTrusted {
 						layerInfo.Signer = author

--- a/pkg/meta/common/common.go
+++ b/pkg/meta/common/common.go
@@ -10,6 +10,7 @@ import (
 
 	zerr "zotregistry.dev/zot/v2/errors"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	"zotregistry.dev/zot/v2/pkg/compat"
 	mConvert "zotregistry.dev/zot/v2/pkg/meta/convert"
 	proto_go "zotregistry.dev/zot/v2/pkg/meta/proto/gen"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
@@ -176,8 +177,8 @@ func CheckImageLastUpdated(repoLastUpdated time.Time, isSigned bool, noImageChec
 func AddImageMetaToRepoMeta(repoMeta *proto_go.RepoMeta, repoBlobs *proto_go.RepoBlobs, reference string,
 	imageMeta mTypes.ImageMeta,
 ) (*proto_go.RepoMeta, *proto_go.RepoBlobs) {
-	switch imageMeta.MediaType {
-	case ispec.MediaTypeImageManifest:
+	switch {
+	case imageMeta.MediaType == ispec.MediaTypeImageManifest || compat.IsCompatibleManifestMediaType(imageMeta.MediaType):
 		if len(imageMeta.Manifests) == 0 {
 			// Empty manifests is an invalid state for ImageManifest, but we still add basic blob info
 			// to avoid skipping all metadata processing (e.g., LastUpdatedImage update)
@@ -224,7 +225,7 @@ func AddImageMetaToRepoMeta(repoMeta *proto_go.RepoMeta, repoBlobs *proto_go.Rep
 			SubBlobs:    subBlobs,
 			LastUpdated: mConvert.GetProtoTime(&lastUpdated),
 		}
-	case ispec.MediaTypeImageIndex:
+	case imageMeta.MediaType == ispec.MediaTypeImageIndex || compat.IsCompatibleManifestListMediaType(imageMeta.MediaType):
 		subBlobs := []string{}
 		lastUpdated := time.Time{}
 

--- a/pkg/meta/common/common_test.go
+++ b/pkg/meta/common/common_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	dockerList "github.com/distribution/distribution/v3/manifest/manifestlist"
+	docker "github.com/distribution/distribution/v3/manifest/schema2"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
@@ -611,6 +613,96 @@ func TestUtils(t *testing.T) {
 			So(len(resultBlobs.Blobs[digestStr].SubBlobs), ShouldEqual, 2) // config + layer
 			So(resultBlobs.Blobs[configDigest.String()], ShouldNotBeNil)
 			So(resultBlobs.Blobs[layerDigest.String()], ShouldNotBeNil)
+		})
+
+		Convey("should handle Docker schema2 ImageManifest media type", func() {
+			repoMeta := &proto_go.RepoMeta{
+				Name: "test-repo",
+				Tags: map[string]*proto_go.TagDescriptor{},
+			}
+
+			repoBlobs := &proto_go.RepoBlobs{
+				Blobs: map[string]*proto_go.BlobInfo{},
+			}
+
+			testDigest := godigest.FromString("sha256:dockertestdigest")
+			configDigest := godigest.FromString("sha256:dockerconfigdigest")
+			layerDigest := godigest.FromString("sha256:dockerlayerdigest")
+
+			imageMeta := mTypes.ImageMeta{
+				MediaType: docker.MediaTypeManifest,
+				Digest:    testDigest,
+				Size:      1000,
+				Manifests: []mTypes.ManifestMeta{
+					{
+						Digest: testDigest,
+						Size:   1000,
+						Manifest: ispec.Manifest{
+							Config: ispec.Descriptor{
+								Digest: configDigest,
+								Size:   500,
+							},
+							Layers: []ispec.Descriptor{
+								{
+									Digest: layerDigest,
+									Size:   300,
+								},
+							},
+						},
+						Config: ispec.Image{},
+					},
+				},
+			}
+
+			resultMeta, resultBlobs := common.AddImageMetaToRepoMeta(repoMeta, repoBlobs, "tag1", imageMeta)
+			So(resultMeta, ShouldNotBeNil)
+			So(resultBlobs, ShouldNotBeNil)
+
+			digestStr := testDigest.String()
+			So(resultBlobs.Blobs[digestStr], ShouldNotBeNil)
+			So(resultBlobs.Blobs[digestStr].Size, ShouldEqual, 1000)
+			So(len(resultBlobs.Blobs[digestStr].SubBlobs), ShouldEqual, 2)
+			So(resultBlobs.Blobs[configDigest.String()], ShouldNotBeNil)
+			So(resultBlobs.Blobs[layerDigest.String()], ShouldNotBeNil)
+		})
+
+		Convey("should handle Docker schema2 manifest list media type", func() {
+			repoMeta := &proto_go.RepoMeta{
+				Name: "test-repo",
+				Tags: map[string]*proto_go.TagDescriptor{},
+			}
+
+			repoBlobs := &proto_go.RepoBlobs{
+				Blobs: map[string]*proto_go.BlobInfo{},
+			}
+
+			indexDigest := godigest.FromString("sha256:dockerindexdigest")
+			childDigest := godigest.FromString("sha256:dockerchilddigest")
+
+			imageMeta := mTypes.ImageMeta{
+				MediaType: dockerList.MediaTypeManifestList,
+				Digest:    indexDigest,
+				Size:      2000,
+				Index: &ispec.Index{
+					MediaType: dockerList.MediaTypeManifestList,
+					Manifests: []ispec.Descriptor{
+						{
+							MediaType: docker.MediaTypeManifest,
+							Digest:    childDigest,
+							Size:      1000,
+						},
+					},
+				},
+			}
+
+			resultMeta, resultBlobs := common.AddImageMetaToRepoMeta(repoMeta, repoBlobs, "tag1", imageMeta)
+			So(resultMeta, ShouldNotBeNil)
+			So(resultBlobs, ShouldNotBeNil)
+
+			digestStr := indexDigest.String()
+			So(resultBlobs.Blobs[digestStr], ShouldNotBeNil)
+			So(resultBlobs.Blobs[digestStr].Size, ShouldEqual, 2000)
+			So(resultBlobs.Blobs[digestStr].SubBlobs, ShouldContain, childDigest.String())
 		})
 	})
 }

--- a/pkg/meta/convert/convert.go
+++ b/pkg/meta/convert/convert.go
@@ -331,10 +331,14 @@ func GetImageStatistics(stats *proto_go.DescriptorStatistics) mTypes.DescriptorS
 }
 
 func GetImageManifestMeta(manifestContent ispec.Manifest, configContent ispec.Image, size int64,
-	digest godigest.Digest,
+	digest godigest.Digest, mediaType string,
 ) mTypes.ImageMeta {
+	if mediaType == "" {
+		mediaType = ispec.MediaTypeImageManifest
+	}
+
 	return mTypes.ImageMeta{
-		MediaType: ispec.MediaTypeImageManifest,
+		MediaType: mediaType,
 		Digest:    digest,
 		Size:      size,
 		Manifests: []mTypes.ManifestMeta{
@@ -348,9 +352,14 @@ func GetImageManifestMeta(manifestContent ispec.Manifest, configContent ispec.Im
 	}
 }
 
-func GetImageIndexMeta(indexContent ispec.Index, size int64, digest godigest.Digest) mTypes.ImageMeta {
+func GetImageIndexMeta(indexContent ispec.Index, size int64, digest godigest.Digest, mediaType string,
+) mTypes.ImageMeta {
+	if mediaType == "" {
+		mediaType = ispec.MediaTypeImageIndex
+	}
+
 	return mTypes.ImageMeta{
-		MediaType: ispec.MediaTypeImageIndex,
+		MediaType: mediaType,
 		Index:     &indexContent,
 		Manifests: GetManifests(indexContent.Manifests),
 		Size:      size,
@@ -569,9 +578,15 @@ func GetImageMeta(dbImageMeta *proto_go.ImageMeta) mTypes.ImageMeta {
 			manifests = append(manifests, desc)
 		}
 
+		// Prefer nested index JSON media type; fall back to the top-level descriptor type.
+		indexMediaType := dbImageMeta.GetIndex().GetIndex().GetMediaType()
+		if indexMediaType == "" {
+			indexMediaType = dbImageMeta.GetMediaType()
+		}
+
 		imageMeta.Index = &ispec.Index{
 			Versioned:    specs.Versioned{SchemaVersion: int(dbImageMeta.GetIndex().GetIndex().Versioned.GetSchemaVersion())},
-			MediaType:    ispec.MediaTypeImageIndex,
+			MediaType:    indexMediaType,
 			Manifests:    manifests,
 			Subject:      GetImageSubject(dbImageMeta),
 			ArtifactType: GetImageArtifactType(dbImageMeta),

--- a/pkg/meta/convert/convert_proto.go
+++ b/pkg/meta/convert/convert_proto.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"zotregistry.dev/zot/v2/pkg/common"
+	"zotregistry.dev/zot/v2/pkg/compat"
 	proto_go "zotregistry.dev/zot/v2/pkg/meta/proto/gen"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 )
@@ -29,8 +30,9 @@ func GetProtoRepoMeta(repo mTypes.RepoMeta) *proto_go.RepoMeta {
 }
 
 func GetProtoImageMeta(imageMeta mTypes.ImageMeta) *proto_go.ImageMeta {
-	switch imageMeta.MediaType {
-	case ispec.MediaTypeImageManifest:
+	switch {
+	case imageMeta.MediaType == ispec.MediaTypeImageManifest ||
+		compat.IsCompatibleManifestMediaType(imageMeta.MediaType):
 		if len(imageMeta.Manifests) == 0 {
 			return nil
 		}
@@ -38,29 +40,40 @@ func GetProtoImageMeta(imageMeta mTypes.ImageMeta) *proto_go.ImageMeta {
 		manifestData := imageMeta.Manifests[0]
 
 		return GetProtoImageManifestData(manifestData.Manifest, manifestData.Config, manifestData.Size,
-			manifestData.Digest.String())
-	case ispec.MediaTypeImageIndex:
+			manifestData.Digest.String(), imageMeta.MediaType)
+	case imageMeta.MediaType == ispec.MediaTypeImageIndex ||
+		compat.IsCompatibleManifestListMediaType(imageMeta.MediaType):
 		if imageMeta.Index == nil {
 			return nil
 		}
 
-		return GetProtoImageIndexMeta(*imageMeta.Index, imageMeta.Size, imageMeta.Digest.String())
+		return GetProtoImageIndexMeta(*imageMeta.Index, imageMeta.Size, imageMeta.Digest.String(), imageMeta.MediaType)
 	default:
 		return nil
 	}
 }
 
 func GetProtoImageManifestData(manifestContent ispec.Manifest, configContent ispec.Image, size int64, digest string,
+	mediaType string,
 ) *proto_go.ImageMeta {
 	return &proto_go.ImageMeta{
-		MediaType: ispec.MediaTypeImageManifest,
-		Manifests: []*proto_go.ManifestMeta{GetProtoManifestMeta(manifestContent, configContent, size, digest)},
-		Index:     nil,
+		MediaType: mediaType,
+		Manifests: []*proto_go.ManifestMeta{
+			GetProtoManifestMeta(manifestContent, configContent, size, digest, mediaType),
+		},
+		Index: nil,
 	}
 }
 
 func GetProtoManifestMeta(manifestContent ispec.Manifest, configContent ispec.Image, size int64, digest string,
+	mediaType string,
 ) *proto_go.ManifestMeta {
+	// Prefer the media type from the manifest JSON; fall back to the descriptor/wire type when omitted.
+	nestedMediaType := manifestContent.MediaType
+	if nestedMediaType == "" {
+		nestedMediaType = mediaType
+	}
+
 	return &proto_go.ManifestMeta{
 		Digest: digest,
 		Size:   size,
@@ -71,7 +84,7 @@ func GetProtoManifestMeta(manifestContent ispec.Manifest, configContent ispec.Im
 				Size:      manifestContent.Config.Size,
 				MediaType: manifestContent.Config.MediaType,
 			},
-			MediaType:    ref(ispec.MediaTypeImageManifest),
+			MediaType:    ref(nestedMediaType),
 			ArtifactType: &manifestContent.ArtifactType,
 			Layers:       getProtoManifestLayers(manifestContent.Layers),
 			Subject:      getProtoDesc(manifestContent.Subject),
@@ -101,15 +114,22 @@ func GetProtoManifestMeta(manifestContent ispec.Manifest, configContent ispec.Im
 	}
 }
 
-func GetProtoImageIndexMeta(indexContent ispec.Index, size int64, digest string) *proto_go.ImageMeta {
+func GetProtoImageIndexMeta(indexContent ispec.Index, size int64, digest string, mediaType string,
+) *proto_go.ImageMeta {
+	// Prefer the media type from the index JSON; fall back to the descriptor/wire type when omitted.
+	nestedMediaType := indexContent.MediaType
+	if nestedMediaType == "" {
+		nestedMediaType = mediaType
+	}
+
 	return &proto_go.ImageMeta{
-		MediaType: ispec.MediaTypeImageIndex,
+		MediaType: mediaType,
 		Index: &proto_go.IndexMeta{
 			Size:   size,
 			Digest: digest,
 			Index: &proto_go.Index{
 				Versioned:    &proto_go.Versioned{SchemaVersion: int32(indexContent.Versioned.SchemaVersion)}, //nolint:gosec,lll // ignore overflow
-				MediaType:    ref(ispec.MediaTypeImageIndex),
+				MediaType:    ref(nestedMediaType),
 				ArtifactType: ref(common.GetIndexArtifactType(indexContent)),
 				Manifests:    getProtoManifestList(indexContent.Manifests),
 				Subject:      getProtoDesc(indexContent.Subject),

--- a/pkg/meta/convert/convert_test.go
+++ b/pkg/meta/convert/convert_test.go
@@ -4,6 +4,9 @@ import (
 	"testing"
 	"time"
 
+	dockerList "github.com/distribution/distribution/v3/manifest/manifestlist"
+	docker "github.com/distribution/distribution/v3/manifest/schema2"
+	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
 
@@ -97,5 +100,107 @@ func TestGetProtoEarlierUpdatedImage(t *testing.T) {
 		repoLastUpdatedImage = convert.GetProtoEarlierUpdatedImage(&repoLastImage, &lastImage)
 		So(repoLastUpdatedImage, ShouldNotBeNil)
 		So(repoLastUpdatedImage.LastUpdated, ShouldNotBeNil)
+	})
+}
+
+func TestPreserveCompatMediaTypes(t *testing.T) {
+	Convey("Docker schema2 manifest media types are preserved through proto conversion", t, func() {
+		digest := godigest.FromString("docker-manifest")
+		imageMeta := convert.GetImageManifestMeta(ispec.Manifest{}, ispec.Image{}, 10, digest, docker.MediaTypeManifest)
+		So(imageMeta.MediaType, ShouldEqual, docker.MediaTypeManifest)
+		So(imageMeta.Manifests[0].Manifest.MediaType, ShouldEqual, "")
+
+		protoMeta := convert.GetProtoImageMeta(imageMeta)
+		So(protoMeta, ShouldNotBeNil)
+		So(protoMeta.GetMediaType(), ShouldEqual, docker.MediaTypeManifest)
+
+		roundTrip := convert.GetImageMeta(protoMeta)
+		So(roundTrip.MediaType, ShouldEqual, docker.MediaTypeManifest)
+		So(roundTrip.Manifests[0].Manifest.MediaType, ShouldEqual, docker.MediaTypeManifest)
+		So(roundTrip.Digest, ShouldEqual, digest)
+		So(roundTrip.Size, ShouldEqual, int64(10))
+	})
+
+	Convey("Docker manifest JSON media type is preferred over descriptor when both are set", t, func() {
+		digest := godigest.FromString("docker-manifest-json")
+		manifest := ispec.Manifest{MediaType: docker.MediaTypeManifest}
+		imageMeta := convert.GetImageManifestMeta(manifest, ispec.Image{}, 10, digest, docker.MediaTypeManifest)
+		So(imageMeta.Manifests[0].Manifest.MediaType, ShouldEqual, docker.MediaTypeManifest)
+
+		protoMeta := convert.GetProtoImageMeta(imageMeta)
+		So(protoMeta.GetManifests()[0].GetManifest().GetMediaType(), ShouldEqual, docker.MediaTypeManifest)
+	})
+
+	Convey("Docker manifest list media types are preserved through proto conversion", t, func() {
+		digest := godigest.FromString("docker-index")
+		index := ispec.Index{MediaType: dockerList.MediaTypeManifestList}
+		imageMeta := convert.GetImageIndexMeta(index, 20, digest, dockerList.MediaTypeManifestList)
+		So(imageMeta.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+
+		protoMeta := convert.GetProtoImageMeta(imageMeta)
+		So(protoMeta, ShouldNotBeNil)
+		So(protoMeta.GetMediaType(), ShouldEqual, dockerList.MediaTypeManifestList)
+
+		roundTrip := convert.GetImageMeta(protoMeta)
+		So(roundTrip.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+		So(roundTrip.Index, ShouldNotBeNil)
+		So(roundTrip.Index.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+		So(roundTrip.Digest, ShouldEqual, digest)
+		So(roundTrip.Size, ShouldEqual, int64(20))
+	})
+
+	Convey("empty nested index media type is filled from descriptor on proto write", t, func() {
+		digest := godigest.FromString("docker-index-empty-nested")
+		imageMeta := convert.GetImageIndexMeta(ispec.Index{}, 20, digest, dockerList.MediaTypeManifestList)
+		So(imageMeta.Index.MediaType, ShouldEqual, "")
+
+		protoMeta := convert.GetProtoImageMeta(imageMeta)
+		So(protoMeta.GetIndex().GetIndex().GetMediaType(), ShouldEqual, dockerList.MediaTypeManifestList)
+
+		roundTrip := convert.GetImageMeta(protoMeta)
+		So(roundTrip.Index.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+	})
+
+	Convey("nested index media type is preferred over top-level on read", t, func() {
+		digest := godigest.FromString("index-nested-prefers-json")
+		index := ispec.Index{MediaType: ispec.MediaTypeImageIndex}
+		imageMeta := convert.GetImageIndexMeta(index, 20, digest, dockerList.MediaTypeManifestList)
+		protoMeta := convert.GetProtoImageMeta(imageMeta)
+		So(protoMeta.GetMediaType(), ShouldEqual, dockerList.MediaTypeManifestList)
+		So(protoMeta.GetIndex().GetIndex().GetMediaType(), ShouldEqual, ispec.MediaTypeImageIndex)
+
+		roundTrip := convert.GetImageMeta(protoMeta)
+		So(roundTrip.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+		So(roundTrip.Index.MediaType, ShouldEqual, ispec.MediaTypeImageIndex)
+	})
+
+	Convey("empty nested index media type falls back to top-level on read", t, func() {
+		digest := godigest.FromString("index-empty-nested-fallback")
+		// Simulate a legacy MetaDB row: top-level descriptor type set, nested JSON media type omitted.
+		protoMeta := &gen.ImageMeta{
+			MediaType: dockerList.MediaTypeManifestList,
+			Index: &gen.IndexMeta{
+				Size:   20,
+				Digest: digest.String(),
+				Index: &gen.Index{
+					Versioned: &gen.Versioned{SchemaVersion: 2},
+				},
+			},
+		}
+
+		imageMeta := convert.GetImageMeta(protoMeta)
+		So(imageMeta.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+		So(imageMeta.Index, ShouldNotBeNil)
+		So(imageMeta.Index.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+		So(imageMeta.Digest, ShouldEqual, digest)
+		So(imageMeta.Size, ShouldEqual, int64(20))
+	})
+
+	Convey("empty media type defaults to OCI", t, func() {
+		manifestMeta := convert.GetImageManifestMeta(ispec.Manifest{}, ispec.Image{}, 1, godigest.FromString("m"), "")
+		So(manifestMeta.MediaType, ShouldEqual, ispec.MediaTypeImageManifest)
+
+		indexMeta := convert.GetImageIndexMeta(ispec.Index{}, 1, godigest.FromString("i"), "")
+		So(indexMeta.MediaType, ShouldEqual, ispec.MediaTypeImageIndex)
 	})
 }

--- a/pkg/meta/dynamodb/dynamodb.go
+++ b/pkg/meta/dynamodb/dynamodb.go
@@ -1292,6 +1292,8 @@ func (dwr *DynamoDB) UpdateSignaturesValidity(ctx context.Context, repo string, 
 		return err
 	}
 
+	verifyImageMeta := mConvert.GetImageMeta(protoImageMeta)
+
 	// update signatures with details about validity and author
 	protoRepoMeta, err := dwr.getProtoRepoMeta(ctx, repo)
 	if err != nil {
@@ -1311,8 +1313,14 @@ func (dwr *DynamoDB) UpdateSignaturesValidity(ctx context.Context, repo string, 
 			layersInfo := []*proto_go.LayersInfo{}
 
 			for _, layerInfo := range sigInfo.LayersInfo {
-				author, date, isTrusted, _ := imgTrustStore.VerifySignature(sigType, layerInfo.LayerContent,
-					layerInfo.SignatureKey, manifestDigest, mConvert.GetImageMeta(protoImageMeta), repo)
+				author, date, isTrusted, err := imgTrustStore.VerifySignature(sigType, layerInfo.LayerContent,
+					layerInfo.SignatureKey, manifestDigest, verifyImageMeta, repo)
+				if err != nil {
+					dwr.Log.Error().Err(err).Str("repo", repo).Str("signatureType", sigType).
+						Str("manifestDigest", manifestDigest.String()).
+						Str("mediaType", verifyImageMeta.MediaType).
+						Msg("failed to verify signature validity")
+				}
 
 				if isTrusted {
 					layerInfo.Signer = author

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	dockerList "github.com/distribution/distribution/v3/manifest/manifestlist"
+	docker "github.com/distribution/distribution/v3/manifest/schema2"
 	guuid "github.com/gofrs/uuid"
 	"github.com/notaryproject/notation-core-go/signature/jws"
 	"github.com/notaryproject/notation-go"
@@ -556,6 +558,30 @@ func RunMetaDBTests(t *testing.T, metaDB mTypes.MetaDB, preparationFuncs ...func
 			retrievedImgMultiData, err := metaDB.GetImageMeta(imgMulti.Digest())
 			So(err, ShouldBeNil)
 			So(imgMulti.AsImageMeta(), ShouldEqual, retrievedImgMultiData)
+
+			dockerImage := CreateRandomImage().AsDockerImage()
+			err = metaDB.SetImageMeta(dockerImage.Digest(), dockerImage.AsImageMeta())
+			So(err, ShouldBeNil)
+
+			retrievedDockerImage, err := metaDB.GetImageMeta(dockerImage.Digest())
+			So(err, ShouldBeNil)
+			So(retrievedDockerImage.MediaType, ShouldEqual, docker.MediaTypeManifest)
+			So(retrievedDockerImage.Manifests[0].Manifest.MediaType, ShouldEqual, docker.MediaTypeManifest)
+
+			dockerMultiarch := CreateRandomMultiarch().AsDockerImage()
+
+			for i := range dockerMultiarch.Images {
+				err = metaDB.SetImageMeta(dockerMultiarch.Images[i].Digest(), dockerMultiarch.Images[i].AsImageMeta())
+				So(err, ShouldBeNil)
+			}
+
+			err = metaDB.SetImageMeta(dockerMultiarch.Digest(), dockerMultiarch.AsImageMeta())
+			So(err, ShouldBeNil)
+
+			retrievedDockerMultiarch, err := metaDB.GetImageMeta(dockerMultiarch.Digest())
+			So(err, ShouldBeNil)
+			So(retrievedDockerMultiarch.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+			So(retrievedDockerMultiarch.Index.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
 		})
 
 		Convey("GetFullImageMeta", func() {

--- a/pkg/meta/parse.go
+++ b/pkg/meta/parse.go
@@ -533,7 +533,7 @@ func SetImageMetaFromInput(ctx context.Context, repo, reference, mediaType strin
 			return nil
 		}
 
-		imageMeta = convert.GetImageManifestMeta(manifestContent, configContent, int64(len(blob)), digest)
+		imageMeta = convert.GetImageManifestMeta(manifestContent, configContent, int64(len(blob)), digest, mediaType)
 	} else if mediaType == ispec.MediaTypeImageIndex || compat.IsCompatibleManifestListMediaType(mediaType) {
 		indexContent := ispec.Index{}
 
@@ -542,7 +542,7 @@ func SetImageMetaFromInput(ctx context.Context, repo, reference, mediaType strin
 			return err
 		}
 
-		imageMeta = convert.GetImageIndexMeta(indexContent, int64(len(blob)), digest)
+		imageMeta = convert.GetImageIndexMeta(indexContent, int64(len(blob)), digest, mediaType)
 	} else {
 		return nil
 	}

--- a/pkg/meta/parse_test.go
+++ b/pkg/meta/parse_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	dockerList "github.com/distribution/distribution/v3/manifest/manifestlist"
+	docker "github.com/distribution/distribution/v3/manifest/schema2"
 	godigest "github.com/opencontainers/go-digest"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
 	. "github.com/smartystreets/goconvey/convey"
@@ -344,6 +346,57 @@ func TestParseStorageErrors(t *testing.T) {
 				So(err, ShouldNotBeNil)
 			})
 		})
+	})
+}
+
+func TestSetImageMetaFromInputPreservesDescriptorMediaType(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewTestLogger()
+
+	Convey("Docker manifest media type", t, func() {
+		image := CreateRandomImage().AsDockerImage()
+		configBlob, err := json.Marshal(image.Config)
+		So(err, ShouldBeNil)
+
+		var storedImageMeta mTypes.ImageMeta
+
+		imageStore := mocks.MockedImageStore{
+			GetBlobContentFn: func(string, godigest.Digest) ([]byte, error) {
+				return configBlob, nil
+			},
+		}
+		metaDB := mocks.MetaDBMock{
+			SetRepoReferenceFn: func(_ context.Context, _, _ string, imageMeta mTypes.ImageMeta) error {
+				storedImageMeta = imageMeta
+
+				return nil
+			},
+		}
+
+		err = meta.SetImageMetaFromInput(ctx, "repo", "tag", docker.MediaTypeManifest, image.Digest(),
+			image.ManifestDescriptor.Data, imageStore, metaDB, logger)
+		So(err, ShouldBeNil)
+		So(storedImageMeta.MediaType, ShouldEqual, docker.MediaTypeManifest)
+	})
+
+	Convey("Docker manifest-list media type", t, func() {
+		multiarch := CreateRandomMultiarch().AsDockerImage()
+
+		var storedImageMeta mTypes.ImageMeta
+
+		metaDB := mocks.MetaDBMock{
+			SetRepoReferenceFn: func(_ context.Context, _, _ string, imageMeta mTypes.ImageMeta) error {
+				storedImageMeta = imageMeta
+
+				return nil
+			},
+		}
+
+		err := meta.SetImageMetaFromInput(ctx, "repo", "tag", dockerList.MediaTypeManifestList,
+			multiarch.Digest(), multiarch.IndexDescriptor.Data, mocks.MockedImageStore{}, metaDB, logger)
+		So(err, ShouldBeNil)
+		So(storedImageMeta.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
+		So(storedImageMeta.Index.MediaType, ShouldEqual, dockerList.MediaTypeManifestList)
 	})
 }
 

--- a/pkg/meta/redis/redis.go
+++ b/pkg/meta/redis/redis.go
@@ -703,10 +703,11 @@ func (rc *RedisDB) SetImageMeta(digest godigest.Digest, imageMeta mTypes.ImageMe
 		compat.IsCompatibleManifestMediaType(imageMeta.MediaType) {
 		manifest := imageMeta.Manifests[0]
 		protoImageMeta = mConvert.GetProtoImageManifestData(manifest.Manifest, manifest.Config,
-			manifest.Size, manifest.Digest.String())
+			manifest.Size, manifest.Digest.String(), imageMeta.MediaType)
 	} else if imageMeta.MediaType == ispec.MediaTypeImageIndex ||
 		compat.IsCompatibleManifestListMediaType(imageMeta.MediaType) {
-		protoImageMeta = mConvert.GetProtoImageIndexMeta(*imageMeta.Index, imageMeta.Size, imageMeta.Digest.String())
+		protoImageMeta = mConvert.GetProtoImageIndexMeta(*imageMeta.Index, imageMeta.Size, imageMeta.Digest.String(),
+			imageMeta.MediaType)
 	}
 
 	pImageMetaBlob, err := proto.Marshal(protoImageMeta)
@@ -1510,6 +1511,8 @@ func (rc *RedisDB) UpdateSignaturesValidity(ctx context.Context, repo string, ma
 			return err
 		}
 
+		verifyImageMeta := mConvert.GetImageMeta(protoImageMeta)
+
 		// update signatures with details about validity and author
 		protoRepoMeta, err := rc.getProtoRepoMeta(ctx, repo)
 		if err != nil {
@@ -1529,8 +1532,14 @@ func (rc *RedisDB) UpdateSignaturesValidity(ctx context.Context, repo string, ma
 				layersInfo := []*proto_go.LayersInfo{}
 
 				for _, layerInfo := range sigInfo.LayersInfo {
-					author, date, isTrusted, _ := imgTrustStore.VerifySignature(sigType, layerInfo.LayerContent,
-						layerInfo.SignatureKey, manifestDigest, mConvert.GetImageMeta(protoImageMeta), repo)
+					author, date, isTrusted, err := imgTrustStore.VerifySignature(sigType, layerInfo.LayerContent,
+						layerInfo.SignatureKey, manifestDigest, verifyImageMeta, repo)
+					if err != nil {
+						rc.Log.Error().Err(err).Str("repo", repo).Str("signatureType", sigType).
+							Str("manifestDigest", manifestDigest.String()).
+							Str("mediaType", verifyImageMeta.MediaType).
+							Msg("failed to verify signature validity")
+					}
 
 					if isTrusted {
 						layerInfo.Signer = author

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -634,7 +634,7 @@ func (is *ImageStore) PutImageManifest(ctx context.Context, repo, reference, med
 
 	artifactType := ""
 
-	if mediaType == ispec.MediaTypeImageManifest {
+	if mediaType == ispec.MediaTypeImageManifest || compat.IsCompatibleManifestMediaType(mediaType) {
 		var manifest ispec.Manifest
 
 		err := json.Unmarshal(body, &manifest)
@@ -647,7 +647,7 @@ func (is *ImageStore) PutImageManifest(ctx context.Context, repo, reference, med
 		}
 
 		artifactType = zcommon.GetManifestArtifactType(manifest)
-	} else if mediaType == ispec.MediaTypeImageIndex {
+	} else if mediaType == ispec.MediaTypeImageIndex || compat.IsCompatibleManifestListMediaType(mediaType) {
 		var imgIndex ispec.Index
 
 		err := json.Unmarshal(body, &imgIndex)

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -2417,6 +2417,34 @@ func TestDeleteImageManifestDockerCompatReferenced(t *testing.T) {
 	})
 }
 
+func TestPutImageManifestDockerCompatSubject(t *testing.T) {
+	Convey("docker schema2 manifest with subject returns subject digest", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		rootDir := t.TempDir()
+
+		compatMediaTypes := []compat.MediaCompatibility{compat.DockerManifestV2SchemaV2}
+		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, compatMediaTypes, nil)
+
+		storeController := storage.StoreController{DefaultStore: imgStore}
+		repoName := "docker-compat-subject"
+
+		subject := CreateRandomImage().AsDockerImage()
+		err := WriteImageToFileSystem(subject, repoName, "subject", storeController)
+		So(err, ShouldBeNil)
+
+		referrer := CreateImageWith().RandomLayers(1, 10).DefaultConfig().
+			Subject(subject.DescriptorRef()).Build().AsDockerImage()
+		err = WriteImageToFileSystem(referrer, repoName, "referrer", storeController)
+		So(err, ShouldBeNil)
+
+		_, subjectDigest, err := imgStore.PutImageManifest(context.Background(), repoName, "referrer-again",
+			referrer.ManifestDescriptor.MediaType, referrer.ManifestDescriptor.Data, nil)
+		So(err, ShouldBeNil)
+		So(subjectDigest, ShouldEqual, subject.Digest())
+	})
+}
+
 func TestReuploadCorruptedBlob(t *testing.T) {
 	for _, testcase := range testCases {
 		t.Run(testcase.testCaseName, func(t *testing.T) {

--- a/pkg/test/image-utils/multiarch.go
+++ b/pkg/test/image-utils/multiarch.go
@@ -68,7 +68,7 @@ func (mi MultiarchImage) AsImageMeta() mTypes.ImageMeta {
 	}
 
 	return mTypes.ImageMeta{
-		MediaType: ispec.MediaTypeImageIndex,
+		MediaType: mi.IndexDescriptor.MediaType,
 		Digest:    mi.IndexDescriptor.Digest,
 		Size:      mi.IndexDescriptor.Size,
 		Index:     &index,


### PR DESCRIPTION
Docker schema2 manifest and manifest-list Content-Types were rewritten to OCI during metadata conversion and several OCI-only switches, so docker2s2 images lost their wire type in MetaDB, GraphQL, CLI, and signature validity checks (including Notation trust).

- Persist ingest/wire mediaType on ImageMeta and through proto conversion
- Prefer nested JSON mediaType when set; fill empty nested from descriptor
- Accept Docker types alongside OCI in MetaDB, search, CLI, and imagestore
- Log VerifySignature errors during signature validity updates

Closes #4355 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
