### PR TITLE
fix: don't lock storage before reading blob upload bodies

### DIFF
--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -139,9 +139,7 @@ func (is *ImageStore) Unlock(lockStart *time.Time) {
 	monitoring.ObserveStorageLockLatency(is.metrics, latency, is.RootDir(), storageConstants.RWLOCK) // histogram
 }
 
-func (is *ImageStore) initRepo(ctx context.Context, name string) error {
-	repoDir := path.Join(is.rootDir, name)
-
+func (is *ImageStore) validateRepoName(name string) error {
 	if !utf8.ValidString(name) {
 		is.log.Error().Msg("invalid UTF-8 input")
 
@@ -152,6 +150,16 @@ func (is *ImageStore) initRepo(ctx context.Context, name string) error {
 		is.log.Error().Str("repository", name).Msg("invalid repository name")
 
 		return zerr.ErrInvalidRepositoryName
+	}
+
+	return nil
+}
+
+func (is *ImageStore) initRepo(ctx context.Context, name string) error {
+	repoDir := path.Join(is.rootDir, name)
+
+	if err := is.validateRepoName(name); err != nil {
+		return err
 	}
 
 	// create "blobs" subdir
@@ -1009,23 +1017,43 @@ func (is *ImageStore) GetBlobUpload(repo, uuid string) (int64, error) {
 	return writer.Size(), nil
 }
 
-// PutBlobChunkStreamed appends another chunk of data to the specified blob. It returns
-// the number of actual bytes to the blob.
-func (is *ImageStore) PutBlobChunkStreamed(ctx context.Context, repo, uuid string, body io.Reader) (int64, error) {
-	if err := is.InitRepo(ctx, repo); err != nil {
-		return -1, err
+func (is *ImageStore) openBlobUploadWriter(ctx context.Context, repo, uuid string) (driver.FileWriter, error) {
+	// NewBlobUpload already created the repo. Avoid InitRepo: it takes the store write
+	// lock before the request body is read, which races http.Server.ReadTimeout.
+	if err := ctx.Err(); err != nil {
+		return nil, err
 	}
 
-	blobUploadPath := is.BlobUploadPath(repo, uuid)
+	if err := is.validateRepoName(repo); err != nil {
+		return nil, err
+	}
 
-	file, err := is.storeDriver.Writer(blobUploadPath, true)
+	if err := is.storeDriver.EnsureDir(path.Join(is.rootDir, repo, storageConstants.BlobUploadDir)); err != nil {
+		is.log.Error().Err(err).Msg("failed to create blob upload subdir")
+
+		return nil, err
+	}
+
+	file, err := is.storeDriver.Writer(is.BlobUploadPath(repo, uuid), true)
 	if err != nil {
 		if errors.As(err, &driver.PathNotFoundError{}) {
-			return -1, zerr.ErrUploadNotFound
+			return nil, zerr.ErrUploadNotFound
 		}
 
 		is.log.Error().Err(err).Msg("failed to continue multipart upload")
 
+		return nil, err
+	}
+
+	return file, nil
+}
+
+// PutBlobChunkStreamed appends another chunk of data to the specified blob. It returns
+// the number of actual bytes to the blob.
+func (is *ImageStore) PutBlobChunkStreamed(ctx context.Context, repo, uuid string, body io.Reader) (int64, error) {
+	// Validates the repo name and ensures .uploads exists without InitRepo's store lock.
+	file, err := is.openBlobUploadWriter(ctx, repo, uuid)
+	if err != nil {
 		return -1, err
 	}
 
@@ -1045,20 +1073,9 @@ func (is *ImageStore) PutBlobChunkStreamed(ctx context.Context, repo, uuid strin
 func (is *ImageStore) PutBlobChunk(ctx context.Context, repo, uuid string, from, to int64,
 	body io.Reader,
 ) (int64, error) {
-	if err := is.InitRepo(ctx, repo); err != nil {
-		return -1, err
-	}
-
-	blobUploadPath := is.BlobUploadPath(repo, uuid)
-
-	file, err := is.storeDriver.Writer(blobUploadPath, true)
+	// Validates the repo name and ensures .uploads exists without InitRepo's store lock.
+	file, err := is.openBlobUploadWriter(ctx, repo, uuid)
 	if err != nil {
-		if errors.As(err, &driver.PathNotFoundError{}) {
-			return -1, zerr.ErrUploadNotFound
-		}
-
-		is.log.Error().Err(err).Msg("failed to continue multipart upload")
-
 		return -1, err
 	}
 

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -1017,20 +1017,29 @@ func (is *ImageStore) GetBlobUpload(repo, uuid string) (int64, error) {
 	return writer.Size(), nil
 }
 
-func (is *ImageStore) openBlobUploadWriter(ctx context.Context, repo, uuid string) (driver.FileWriter, error) {
-	// NewBlobUpload already created the repo. Avoid InitRepo: it takes the store write
-	// lock before the request body is read, which races http.Server.ReadTimeout.
+func (is *ImageStore) prepareBlobUploadDir(ctx context.Context, repo string) error {
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := is.validateRepoName(repo); err != nil {
-		return nil, err
+		return err
 	}
 
 	if err := is.storeDriver.EnsureDir(path.Join(is.rootDir, repo, storageConstants.BlobUploadDir)); err != nil {
 		is.log.Error().Err(err).Msg("failed to create blob upload subdir")
 
+		return err
+	}
+
+	return nil
+}
+
+func (is *ImageStore) openBlobUploadWriter(ctx context.Context, repo, uuid string) (driver.FileWriter, error) {
+	// NewBlobUpload already created the repo. Avoid InitRepo: it takes the store write
+	// lock before the request body is read, which races http.Server.ReadTimeout.
+	// FinishBlobUpload and FullBlobUpload restore oci-layout/index.json under the lock after the copy.
+	if err := is.prepareBlobUploadDir(ctx, repo); err != nil {
 		return nil, err
 	}
 
@@ -1155,6 +1164,21 @@ func (is *ImageStore) FinishBlobUpload(repo, uuid string, body io.Reader, dstDig
 		return zerr.ErrBadBlobDigest
 	}
 
+	dst := is.BlobPath(repo, dstDigest)
+
+	var lockLatency time.Time
+
+	is.Lock(&lockLatency)
+	defer is.Unlock(&lockLatency)
+
+	// Chunk PUT/PATCH no longer call InitRepo (that lock stalled unread bodies vs GC).
+	// Recreate the OCI layout here, while we already hold the store lock for the move,
+	// so a blob finished after GC deleted the repo is still a walkable repository.
+	// Use initRepo, not InitRepo: InitRepo takes this same lock and would deadlock.
+	if err := is.initRepo(context.Background(), repo); err != nil {
+		return err
+	}
+
 	dir := path.Join(is.rootDir, repo, ispec.ImageBlobsDir, dstDigest.Algorithm().String())
 
 	err = is.storeDriver.EnsureDir(dir)
@@ -1163,13 +1187,6 @@ func (is *ImageStore) FinishBlobUpload(repo, uuid string, body io.Reader, dstDig
 
 		return err
 	}
-
-	dst := is.BlobPath(repo, dstDigest)
-
-	var lockLatency time.Time
-
-	is.Lock(&lockLatency)
-	defer is.Unlock(&lockLatency)
 
 	if is.dedupe && fmt.Sprintf("%v", is.cache) != fmt.Sprintf("%v", nil) {
 		err = is.DedupeBlob(src, dstDigest, repo, dst)
@@ -1199,10 +1216,6 @@ func (is *ImageStore) FullBlobUpload(ctx context.Context, repo string, body io.R
 		return "", -1, err
 	}
 
-	if err := is.InitRepo(ctx, repo); err != nil {
-		return "", -1, err
-	}
-
 	u, err := guuid.NewV4()
 	if err != nil {
 		return "", -1, err
@@ -1210,6 +1223,12 @@ func (is *ImageStore) FullBlobUpload(ctx context.Context, repo string, body io.R
 
 	uuid := u.String()
 	src := is.BlobUploadPath(repo, uuid)
+
+	// Do not InitRepo before reading the body: that store write lock races GC vs ReadTimeout.
+	// Create .uploads without the lock; initRepo runs after the copy, under the move lock.
+	if err := is.prepareBlobUploadDir(ctx, repo); err != nil {
+		return "", -1, err
+	}
 
 	dstDigestAlgorithm := dstDigest.Algorithm()
 
@@ -1259,15 +1278,23 @@ func (is *ImageStore) FullBlobUpload(ctx context.Context, repo string, body io.R
 		return "", -1, zerr.ErrBadBlobDigest
 	}
 
-	dir := path.Join(is.rootDir, repo, ispec.ImageBlobsDir, dstDigestAlgorithm.String())
-	_ = is.storeDriver.EnsureDir(dir)
+	dst := is.BlobPath(repo, dstDigest)
 
 	var lockLatency time.Time
 
 	is.Lock(&lockLatency)
 	defer is.Unlock(&lockLatency)
 
-	dst := is.BlobPath(repo, dstDigest)
+	if err := is.initRepo(ctx, repo); err != nil {
+		return "", -1, err
+	}
+
+	dir := path.Join(is.rootDir, repo, ispec.ImageBlobsDir, dstDigestAlgorithm.String())
+	if err := is.storeDriver.EnsureDir(dir); err != nil {
+		is.log.Error().Str("directory", dir).Err(err).Msg("failed to create dir")
+
+		return "", -1, err
+	}
 
 	if is.dedupe && fmt.Sprintf("%v", is.cache) != fmt.Sprintf("%v", nil) {
 		if err := is.DedupeBlob(src, dstDigest, repo, dst); err != nil {

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -3485,6 +3485,279 @@ func TestPutBlobChunkStreamed(t *testing.T) {
 	})
 }
 
+func TestBlobChunkUploadDoesNotBlockOnStoreLock(t *testing.T) {
+	Convey("chunk PUT/PATCH copy the body while the store write lock is held", t, func() {
+		dir := t.TempDir()
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		imgStore := local.NewImageStore(dir, false, false, log, metrics, nil, nil, nil, nil)
+		ctx := context.Background()
+		repo := "chunk-under-lock"
+
+		assertCopyWhileLocked := func(put func() (int64, error)) {
+			var lockLatency time.Time
+			imgStore.Lock(&lockLatency)
+
+			done := make(chan error, 1)
+
+			go func() {
+				_, err := put()
+				done <- err
+			}()
+
+			blocked := true
+
+			select {
+			case err := <-done:
+				imgStore.Unlock(&lockLatency)
+				blocked = false
+				So(err, ShouldBeNil)
+			case <-time.After(5 * time.Second):
+				imgStore.Unlock(&lockLatency)
+			}
+
+			So(blocked, ShouldBeFalse)
+		}
+
+		Convey("PutBlobChunkStreamed", func() {
+			uuid, err := imgStore.NewBlobUpload(ctx, repo)
+			So(err, ShouldBeNil)
+
+			content := []byte("streamed-under-lock")
+			assertCopyWhileLocked(func() (int64, error) {
+				return imgStore.PutBlobChunkStreamed(ctx, repo, uuid, bytes.NewReader(content))
+			})
+		})
+
+		Convey("PutBlobChunk", func() {
+			uuid, err := imgStore.NewBlobUpload(ctx, repo)
+			So(err, ShouldBeNil)
+
+			content := []byte("chunk-under-lock")
+			assertCopyWhileLocked(func() (int64, error) {
+				return imgStore.PutBlobChunk(ctx, repo, uuid, 0, int64(len(content)), bytes.NewReader(content))
+			})
+		})
+	})
+}
+
+func TestFinishBlobUploadRecreatesRepoLayout(t *testing.T) {
+	Convey("FinishBlobUpload restores oci-layout and index.json if GC removed them", t, func() {
+		dir := t.TempDir()
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		imgStore := local.NewImageStore(dir, false, false, log, metrics, nil, nil, nil, nil)
+		ctx := context.Background()
+		repo := "finish-after-gc"
+
+		uuid, err := imgStore.NewBlobUpload(ctx, repo)
+		So(err, ShouldBeNil)
+
+		content := []byte("blob-survives-gc-layout-delete")
+		digest := godigest.FromBytes(content)
+		n, err := imgStore.PutBlobChunk(ctx, repo, uuid, 0, int64(len(content)), bytes.NewReader(content))
+		So(err, ShouldBeNil)
+		So(n, ShouldEqual, len(content))
+
+		So(os.Remove(path.Join(dir, repo, ispec.ImageIndexFile)), ShouldBeNil)
+		So(os.Remove(path.Join(dir, repo, ispec.ImageLayoutFile)), ShouldBeNil)
+		So(os.RemoveAll(path.Join(dir, repo, ispec.ImageBlobsDir)), ShouldBeNil)
+
+		ok, _ := imgStore.ValidateRepo(repo)
+		So(ok, ShouldBeFalse)
+
+		err = imgStore.FinishBlobUpload(repo, uuid, bytes.NewReader(nil), digest)
+		So(err, ShouldBeNil)
+
+		ok, err = imgStore.ValidateRepo(repo)
+		So(err, ShouldBeNil)
+		So(ok, ShouldBeTrue)
+
+		hasBlob, size, err := imgStore.CheckBlob(ctx, repo, digest)
+		So(err, ShouldBeNil)
+		So(hasBlob, ShouldBeTrue)
+		So(size, ShouldEqual, int64(len(content)))
+	})
+}
+
+func TestFullBlobUploadDoesNotBlockOnStoreLock(t *testing.T) {
+	Convey("FullBlobUpload reads the body while the store write lock is held", t, func() {
+		dir := t.TempDir()
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		imgStore := local.NewImageStore(dir, false, false, log, metrics, nil, nil, nil, nil)
+		ctx := context.Background()
+		repo := "full-under-lock"
+		content := []byte("full-blob-under-lock")
+		digest := godigest.FromBytes(content)
+
+		pipeReader, pipeWriter := io.Pipe()
+
+		var lockLatency time.Time
+		imgStore.Lock(&lockLatency)
+
+		errCh := make(chan error, 1)
+
+		go func() {
+			_, _, err := imgStore.FullBlobUpload(ctx, repo, pipeReader, digest)
+			errCh <- err
+		}()
+
+		wrote := make(chan error, 1)
+
+		go func() {
+			_, err := pipeWriter.Write(content)
+			_ = pipeWriter.Close()
+			wrote <- err
+		}()
+
+		blocked := true
+
+		select {
+		case err := <-wrote:
+			blocked = false
+			So(err, ShouldBeNil)
+		case <-time.After(5 * time.Second):
+			_ = pipeWriter.Close()
+		}
+
+		imgStore.Unlock(&lockLatency)
+		So(blocked, ShouldBeFalse)
+		So(<-errCh, ShouldBeNil)
+	})
+}
+
+func TestFullBlobUploadCreatesRepoLayout(t *testing.T) {
+	Convey("FullBlobUpload creates the OCI layout after copying, including if GC removed it", t, func() {
+		dir := t.TempDir()
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		imgStore := local.NewImageStore(dir, false, false, log, metrics, nil, nil, nil, nil)
+		ctx := context.Background()
+		repo := "full-creates-layout"
+
+		content := []byte("monolith-first-push")
+		digest := godigest.FromBytes(content)
+
+		_, nbytes, err := imgStore.FullBlobUpload(ctx, repo, bytes.NewReader(content), digest)
+		So(err, ShouldBeNil)
+		So(nbytes, ShouldEqual, int64(len(content)))
+
+		ok, err := imgStore.ValidateRepo(repo)
+		So(err, ShouldBeNil)
+		So(ok, ShouldBeTrue)
+
+		So(os.Remove(path.Join(dir, repo, ispec.ImageIndexFile)), ShouldBeNil)
+		So(os.Remove(path.Join(dir, repo, ispec.ImageLayoutFile)), ShouldBeNil)
+		So(os.RemoveAll(path.Join(dir, repo, ispec.ImageBlobsDir)), ShouldBeNil)
+
+		content2 := []byte("monolith-after-gc")
+		digest2 := godigest.FromBytes(content2)
+		_, nbytes, err = imgStore.FullBlobUpload(ctx, repo, bytes.NewReader(content2), digest2)
+		So(err, ShouldBeNil)
+		So(nbytes, ShouldEqual, int64(len(content2)))
+
+		ok, err = imgStore.ValidateRepo(repo)
+		So(err, ShouldBeNil)
+		So(ok, ShouldBeTrue)
+
+		hasBlob, size, err := imgStore.CheckBlob(ctx, repo, digest2)
+		So(err, ShouldBeNil)
+		So(hasBlob, ShouldBeTrue)
+		So(size, ShouldEqual, int64(len(content2)))
+	})
+}
+
+func TestBlobUploadPrepareAndInitRepoErrors(t *testing.T) {
+	Convey("prepareBlobUploadDir and post-copy initRepo error paths", t, func() {
+		dir := t.TempDir()
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		imgStore := local.NewImageStore(dir, false, false, log, metrics, nil, nil, nil, nil)
+		content := []byte("upload-error-path")
+		digest := godigest.FromBytes(content)
+
+		Convey("canceled context fails before opening the upload writer", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			_, err := imgStore.PutBlobChunkStreamed(ctx, "canceled-chunk", "unused-uuid", bytes.NewReader(content))
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, context.Canceled), ShouldBeTrue)
+
+			_, _, err = imgStore.FullBlobUpload(ctx, "canceled-full", bytes.NewReader(content), digest)
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, context.Canceled), ShouldBeTrue)
+		})
+
+		Convey("invalid repository name fails prepareBlobUploadDir", func() {
+			ctx := context.Background()
+
+			_, err := imgStore.PutBlobChunk(ctx, "_badname", "unused-uuid", 0, int64(len(content)), bytes.NewReader(content))
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
+
+			_, _, err = imgStore.FullBlobUpload(ctx, "_badname", bytes.NewReader(content), digest)
+			So(err, ShouldNotBeNil)
+			So(errors.Is(err, zerr.ErrInvalidRepositoryName), ShouldBeTrue)
+		})
+
+		Convey("EnsureDir for .uploads fails when .uploads is a file", func() {
+			ctx := context.Background()
+			repoChunk := "ensure-uploads-fail"
+			repoFull := "ensure-uploads-fail-full"
+
+			for _, repo := range []string{repoChunk, repoFull} {
+				So(os.MkdirAll(path.Join(dir, repo), 0o755), ShouldBeNil)
+				So(os.WriteFile(path.Join(dir, repo, storageConstants.BlobUploadDir), []byte("not-a-dir"), 0o600), ShouldBeNil)
+			}
+
+			_, err := imgStore.PutBlobChunkStreamed(ctx, repoChunk, "unused-uuid", bytes.NewReader(content))
+			So(err, ShouldNotBeNil)
+
+			_, _, err = imgStore.FullBlobUpload(ctx, repoFull, bytes.NewReader(content), digest)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("FinishBlobUpload returns initRepo errors under the move lock", func() {
+			ctx := context.Background()
+			repo := "finish-init-fail"
+
+			uuid, err := imgStore.NewBlobUpload(ctx, repo)
+			So(err, ShouldBeNil)
+
+			n, err := imgStore.PutBlobChunk(ctx, repo, uuid, 0, int64(len(content)), bytes.NewReader(content))
+			So(err, ShouldBeNil)
+			So(n, ShouldEqual, len(content))
+
+			So(os.RemoveAll(path.Join(dir, repo, ispec.ImageBlobsDir)), ShouldBeNil)
+			So(os.WriteFile(path.Join(dir, repo, ispec.ImageBlobsDir), []byte("not-a-dir"), 0o600), ShouldBeNil)
+
+			err = imgStore.FinishBlobUpload(repo, uuid, bytes.NewReader(nil), digest)
+			So(err, ShouldNotBeNil)
+		})
+
+		Convey("FullBlobUpload returns initRepo errors after the body is copied", func() {
+			ctx := context.Background()
+			repo := "full-init-fail"
+
+			_, nbytes, err := imgStore.FullBlobUpload(ctx, repo, bytes.NewReader(content), digest)
+			So(err, ShouldBeNil)
+			So(nbytes, ShouldEqual, int64(len(content)))
+
+			So(os.Remove(path.Join(dir, repo, ispec.ImageIndexFile)), ShouldBeNil)
+			So(os.Remove(path.Join(dir, repo, ispec.ImageLayoutFile)), ShouldBeNil)
+			So(os.RemoveAll(path.Join(dir, repo, ispec.ImageBlobsDir)), ShouldBeNil)
+			So(os.WriteFile(path.Join(dir, repo, ispec.ImageBlobsDir), []byte("not-a-dir"), 0o600), ShouldBeNil)
+
+			content2 := []byte("full-init-fail-second")
+			digest2 := godigest.FromBytes(content2)
+			_, _, err = imgStore.FullBlobUpload(ctx, repo, bytes.NewReader(content2), digest2)
+			So(err, ShouldNotBeNil)
+		})
+	})
+}
+
 func TestPullRange(t *testing.T) {
 	Convey("Repo layout", t, func(c C) {
 		dir := t.TempDir()


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
N/A (zb GC stress flake)

**What does this PR do / Why do we need it**:
`PutBlobChunk`, `PutBlobChunkStreamed`, and `FullBlobUpload` called `InitRepo` *before* reading the request body. `InitRepo` takes the store write lock, which GC also holds for long stretches. A chunk PUT/PATCH that arrived while GC ran never started consuming the body, so `http.Server.ReadTimeout` fired and the zb GC stress job failed:

https://github.com/project-zot/zot/actions/runs/32948879069/job/98120616173

Copy the upload body without that lock. Validate the repo name and ensure `.uploads` exists via `prepareBlobUploadDir`. `NewBlobUpload` still creates the repo. After the copy, `FinishBlobUpload` and `FullBlobUpload` call `initRepo` (not `InitRepo`, which would deadlock) while they already hold the store lock for the move, so a blob finished after GC deleted `oci-layout` / `index.json` is still a walkable repository.

**Testing done on this change**:
- `TestBlobChunkUploadDoesNotBlockOnStoreLock` — chunk PUT/PATCH copy the body while the store write lock is held
- `TestFullBlobUploadDoesNotBlockOnStoreLock` — same for monolithic upload
- `TestFinishBlobUploadRecreatesRepoLayout` — finish restores layout if GC removed it
- `TestFullBlobUploadCreatesRepoLayout` — monolithic upload creates layout after the copy, including after a simulated GC wipe

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
