### PR TITLE
fix(api)!: make blob HEAD/range reads repo-local by default

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -35,6 +35,7 @@ Examples of working configurations for various use cases are available [here](..
   - [Top-level Configuration Map](#top-level-configuration-map)
   - [Network](#network)
   - [Storage](#storage)
+    - [Hydrate blob on read](#hydrate-blob-on-read)
     - [Fast restart](#fast-restart)
   - [Authentication](#authentication)
     - [TLS Mutual Authentication](#tls-mutual-authentication)
@@ -69,7 +70,7 @@ includes supported field aliases where the config loader accepts them.
 | Key | Type | Purpose |
 | --- | --- | --- |
 | `distSpecVersion` | string | Distribution spec version declared by the config. zot warns if it differs from the supported version and then uses the supported version. |
-| `storage` | object | Registry storage root, dedupe, garbage collection, retention, storage drivers, cache drivers, and repository subpaths. |
+| `storage` | object | Registry storage root, dedupe, hydrate blob on read, garbage collection, retention, storage drivers, cache drivers, and repository subpaths. |
 | `http` | object | Listener address and port, TLS, authentication, authorization, CORS, rate limits, realm, and client compatibility settings. |
 | `log` | object | Log level, primary log output, and audit log output. |
 | `extensions` | object | Optional sync, search, UI, metrics, scrub, lint, image trust, API key, management, and event-recorder settings. |
@@ -122,6 +123,32 @@ support hard links, inline deduplication can be enabled with:
 ```
         "dedupe": true,
 ```
+
+### Hydrate blob on read
+
+With `dedupe` enabled, `POST /v2/<name>/blobs/uploads/?mount=<digest>` can still
+link a blob from this store's dedupe cache into another repository. By default,
+blob **reads** (`HEAD` and ranged `GET`) only look at the repository-local blob
+path, so a digest deleted from one repository stays missing there even if the
+same digest remains in another repository or in the cache (OCI distribution-spec
+AtomicDelete behavior).
+
+To restore the older behavior where `HEAD` / ranged `GET` may materialize a
+cached digest into the target repository when it is not present locally, set:
+
+```
+        "hydrateBlobOnRead": true,
+```
+
+The default is `false` (omit the field or set it explicitly). The setting is
+per store: it can be set under top-level `storage` or under a `subPaths` entry,
+and it only applies within that store (not across different `subPaths` /
+storage drivers). Explicit mounts via `POST ...?mount=` are unchanged.
+When `accessControl` is enabled, both hydration and explicit mounts also require
+`create` on the destination repository and `read` on at least one repository that
+already holds the digest; otherwise `HEAD` / ranged `GET` stay repo-local
+(`StatBlob`) and can still return 404 for digests missing from the destination.
+A complete example is in [config-hydrate-blob-on-read.json](config-hydrate-blob-on-read.json).
 
 When an image is deleted (either by tag or reference), orphaned blobs can lead
 to wasted storage, and background garbage collection can be enabled with:
@@ -177,7 +204,8 @@ their own repository paths, dedupe and garbage collection settings with:
             },
             "/b": {
                 "rootDirectory": "/tmp/zot2",
-                "dedupe": true
+                "dedupe": true,
+                "hydrateBlobOnRead": true
             },
             "/c": {
                 "rootDirectory": "/tmp/zot3",

--- a/examples/config-boltdb.json
+++ b/examples/config-boltdb.json
@@ -3,6 +3,7 @@
     "storage": {
         "rootDirectory": "/tmp/zot",
         "dedupe": true,
+        "hydrateBlobOnRead": false,
         "remoteCache": false
     },
     "http": {

--- a/examples/config-conformance.json
+++ b/examples/config-conformance.json
@@ -3,7 +3,7 @@
   "storage": {
     "rootDirectory": "/tmp/zot",
     "gc": true,
-    "dedupe": false
+    "dedupe": true
   },
   "http": {
     "address": "0.0.0.0",

--- a/examples/config-example.json
+++ b/examples/config-example.json
@@ -1,7 +1,9 @@
 {
   "distSpecVersion": "1.1.1",
   "storage": {
-    "rootDirectory": "/tmp/zot"
+    "rootDirectory": "/tmp/zot",
+    "dedupe": true,
+    "hydrateBlobOnRead": false
   },
   "http": {
     "address": "127.0.0.1",

--- a/examples/config-hydrate-blob-on-read.json
+++ b/examples/config-hydrate-blob-on-read.json
@@ -3,26 +3,23 @@
     "storage": {
         "rootDirectory": "/tmp/zot",
         "dedupe": true,
-        "gc": true,
+        "hydrateBlobOnRead": true,
         "subPaths": {
             "/a": {
-                "rootDirectory": "/tmp/zot1",
-                "dedupe": true
+                "rootDirectory": "/tmp/zot-a",
+                "dedupe": true,
+                "hydrateBlobOnRead": false
             },
             "/b": {
-                "rootDirectory": "/tmp/zot2",
+                "rootDirectory": "/tmp/zot-b",
                 "dedupe": true,
                 "hydrateBlobOnRead": true
-            },
-            "/c": {
-                "rootDirectory": "/tmp/zot3",
-                "dedupe": false
             }
         }
     },
     "http": {
         "address": "127.0.0.1",
-        "port": "5000"
+        "port": "8080"
     },
     "log": {
         "level": "debug"

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -32,10 +32,17 @@ type StorageConfig struct {
 	Dedupe          bool
 	RemoteCache     bool
 	RedirectBlobURL bool
-	GC              bool
-	Commit          bool
-	GCDelay         time.Duration // applied for blobs
-	GCInterval      time.Duration
+	// HydrateBlobOnRead restores the pre-conformance behavior where HEAD and ranged
+	// GET may call CheckBlob and hard-link a digest from this store's dedupe cache
+	// into the destination repository. The zero value (false) keeps blob reads
+	// repo-local via StatBlob (OCI AtomicDelete / distribution-spec). Explicit
+	// mounts via POST .../blobs/uploads/?mount= are unaffected. Only applies within
+	// a single store/substore (not across SubPaths).
+	HydrateBlobOnRead bool
+	GC                bool
+	Commit            bool
+	GCDelay           time.Duration // applied for blobs
+	GCInterval        time.Duration
 	// GCTimeWindow restricts periodic garbage-collection runs to a daily time-of-day
 	// window, e.g. "01:00-08:00". The zero value means GC can run at any time.
 	GCTimeWindow  GCTimeWindow
@@ -838,7 +845,9 @@ func New() *Config {
 
 func (expConfig StorageConfig) ParamsEqual(actConfig StorageConfig) bool {
 	return expConfig.GC == actConfig.GC && expConfig.Dedupe == actConfig.Dedupe &&
-		expConfig.RedirectBlobURL == actConfig.RedirectBlobURL && expConfig.GCDelay == actConfig.GCDelay &&
+		expConfig.RedirectBlobURL == actConfig.RedirectBlobURL &&
+		expConfig.HydrateBlobOnRead == actConfig.HydrateBlobOnRead &&
+		expConfig.GCDelay == actConfig.GCDelay &&
 		expConfig.GCInterval == actConfig.GCInterval && expConfig.GCTimeWindow == actConfig.GCTimeWindow
 }
 
@@ -1073,6 +1082,7 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 	c.Storage.GC = newConfig.Storage.GC
 	c.Storage.Dedupe = newConfig.Storage.Dedupe
 	c.Storage.RedirectBlobURL = newConfig.Storage.RedirectBlobURL
+	c.Storage.HydrateBlobOnRead = newConfig.Storage.HydrateBlobOnRead
 	c.Storage.GCDelay = newConfig.Storage.GCDelay
 	c.Storage.GCInterval = newConfig.Storage.GCInterval
 	c.Storage.GCTimeWindow = newConfig.Storage.GCTimeWindow
@@ -1092,6 +1102,7 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 		subPathConfig.GC = storageConfig.GC
 		subPathConfig.Dedupe = storageConfig.Dedupe
 		subPathConfig.RedirectBlobURL = storageConfig.RedirectBlobURL
+		subPathConfig.HydrateBlobOnRead = storageConfig.HydrateBlobOnRead
 		subPathConfig.GCDelay = storageConfig.GCDelay
 		subPathConfig.GCInterval = storageConfig.GCInterval
 		subPathConfig.GCTimeWindow = storageConfig.GCTimeWindow
@@ -1240,6 +1251,26 @@ func (c *Config) IsBlobRedirectEnabled(storePath string) bool {
 	}
 
 	return c.Storage.RedirectBlobURL
+}
+
+// IsHydrateBlobOnReadEnabled returns whether HEAD / ranged GET may hydrate blobs
+// from this store's dedupe cache into the destination repository. If a matching
+// subpath exists, its setting takes precedence over the global one.
+func (c *Config) IsHydrateBlobOnReadEnabled(storePath string) bool {
+	if c == nil {
+		return false
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if storePath != "/" {
+		if subPathConfig, ok := c.Storage.SubPaths[storePath]; ok {
+			return subPathConfig.HydrateBlobOnRead
+		}
+	}
+
+	return c.Storage.HydrateBlobOnRead
 }
 
 // CopyExtensionsConfig returns a copy of the extensions config if it exists.

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -126,6 +126,14 @@ func TestConfig(t *testing.T) {
 
 		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
 
+		firstStorageConfig.HydrateBlobOnRead = true
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeFalse)
+
+		firstStorageConfig.HydrateBlobOnRead = false
+
+		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeTrue)
+
 		So(firstStorageConfig.GCTimeWindow.UnmarshalJSON([]byte(`"01:00-08:00"`)), ShouldBeNil)
 
 		So(firstStorageConfig.ParamsEqual(secondStorageConfig), ShouldBeFalse)
@@ -1804,6 +1812,38 @@ func TestConfig(t *testing.T) {
 			})
 		})
 
+		Convey("Test IsHydrateBlobOnReadEnabled()", func() {
+			Convey("returns global setting for default store path", func() {
+				cfg := &config.Config{
+					Storage: config.GlobalStorageConfig{
+						StorageConfig: config.StorageConfig{HydrateBlobOnRead: true},
+					},
+				}
+
+				So(cfg.IsHydrateBlobOnReadEnabled("/"), ShouldBeTrue)
+			})
+
+			Convey("returns subpath setting when subpath exists", func() {
+				cfg := &config.Config{
+					Storage: config.GlobalStorageConfig{
+						StorageConfig: config.StorageConfig{HydrateBlobOnRead: false},
+						SubPaths: map[string]config.StorageConfig{
+							"/a": {HydrateBlobOnRead: true},
+						},
+					},
+				}
+
+				So(cfg.IsHydrateBlobOnReadEnabled("/a"), ShouldBeTrue)
+				So(cfg.IsHydrateBlobOnReadEnabled("/b"), ShouldBeFalse)
+			})
+
+			Convey("nil config returns false", func() {
+				var nilCfg *config.Config
+
+				So(nilCfg.IsHydrateBlobOnReadEnabled("/"), ShouldBeFalse)
+			})
+		})
+
 		Convey("Test CopyLogConfig()", func() {
 			Convey("Test with non-nil Log", func() {
 				cfg := &config.Config{
@@ -2515,22 +2555,24 @@ func TestConfig(t *testing.T) {
 			cfg := &config.Config{
 				Storage: config.GlobalStorageConfig{
 					StorageConfig: config.StorageConfig{
-						GC:              true,
-						Dedupe:          false,
-						RedirectBlobURL: false,
-						GCDelay:         time.Hour,
-						GCInterval:      2 * time.Hour,
+						GC:                true,
+						Dedupe:            false,
+						RedirectBlobURL:   false,
+						HydrateBlobOnRead: false,
+						GCDelay:           time.Hour,
+						GCInterval:        2 * time.Hour,
 					},
 				},
 			}
 			newConfig := &config.Config{
 				Storage: config.GlobalStorageConfig{
 					StorageConfig: config.StorageConfig{
-						GC:              false,
-						Dedupe:          true,
-						RedirectBlobURL: true,
-						GCDelay:         3 * time.Hour,
-						GCInterval:      4 * time.Hour,
+						GC:                false,
+						Dedupe:            true,
+						RedirectBlobURL:   true,
+						HydrateBlobOnRead: true,
+						GCDelay:           3 * time.Hour,
+						GCInterval:        4 * time.Hour,
 					},
 				},
 			}
@@ -2540,6 +2582,7 @@ func TestConfig(t *testing.T) {
 			So(cfg.Storage.GC, ShouldBeFalse)
 			So(cfg.Storage.Dedupe, ShouldBeTrue)
 			So(cfg.Storage.RedirectBlobURL, ShouldBeTrue)
+			So(cfg.Storage.HydrateBlobOnRead, ShouldBeTrue)
 			So(cfg.Storage.GCDelay, ShouldEqual, 3*time.Hour)
 			So(cfg.Storage.GCInterval, ShouldEqual, 4*time.Hour)
 		})
@@ -3475,18 +3518,20 @@ func TestConfig(t *testing.T) {
 					},
 					SubPaths: map[string]config.StorageConfig{
 						"/path1": {
-							GC:              true,
-							Dedupe:          false,
-							RedirectBlobURL: false,
-							GCDelay:         time.Hour,
-							GCInterval:      time.Hour * 24,
+							GC:                true,
+							Dedupe:            false,
+							RedirectBlobURL:   false,
+							HydrateBlobOnRead: false,
+							GCDelay:           time.Hour,
+							GCInterval:        time.Hour * 24,
 						},
 						"/path2": {
-							GC:              false,
-							Dedupe:          true,
-							RedirectBlobURL: true,
-							GCDelay:         time.Hour * 2,
-							GCInterval:      time.Hour * 48,
+							GC:                false,
+							Dedupe:            true,
+							RedirectBlobURL:   true,
+							HydrateBlobOnRead: true,
+							GCDelay:           time.Hour * 2,
+							GCInterval:        time.Hour * 48,
 						},
 					},
 				},
@@ -3496,24 +3541,27 @@ func TestConfig(t *testing.T) {
 			newConfig := &config.Config{
 				Storage: config.GlobalStorageConfig{
 					StorageConfig: config.StorageConfig{
-						GC:              true,
-						Dedupe:          false,
-						RedirectBlobURL: true,
+						GC:                true,
+						Dedupe:            false,
+						RedirectBlobURL:   true,
+						HydrateBlobOnRead: true,
 					},
 					SubPaths: map[string]config.StorageConfig{
 						"/path1": {
-							GC:              false,          // Changed
-							Dedupe:          true,           // Changed
-							RedirectBlobURL: true,           // Changed
-							GCDelay:         time.Hour * 2,  // Changed
-							GCInterval:      time.Hour * 12, // Changed
+							GC:                false,          // Changed
+							Dedupe:            true,           // Changed
+							RedirectBlobURL:   true,           // Changed
+							HydrateBlobOnRead: true,           // Changed
+							GCDelay:           time.Hour * 2,  // Changed
+							GCInterval:        time.Hour * 12, // Changed
 						},
 						"/path2": {
-							GC:              true,           // Changed
-							Dedupe:          false,          // Changed
-							RedirectBlobURL: false,          // Changed
-							GCDelay:         time.Hour * 3,  // Changed
-							GCInterval:      time.Hour * 36, // Changed
+							GC:                true,           // Changed
+							Dedupe:            false,          // Changed
+							RedirectBlobURL:   false,          // Changed
+							HydrateBlobOnRead: false,          // Changed
+							GCDelay:           time.Hour * 3,  // Changed
+							GCInterval:        time.Hour * 36, // Changed
 						},
 					},
 				},
@@ -3530,6 +3578,7 @@ func TestConfig(t *testing.T) {
 			So(path1Config.GC, ShouldBeFalse)
 			So(path1Config.Dedupe, ShouldBeTrue)
 			So(path1Config.RedirectBlobURL, ShouldBeTrue)
+			So(path1Config.HydrateBlobOnRead, ShouldBeTrue)
 			So(path1Config.GCDelay, ShouldEqual, time.Hour*2)
 			So(path1Config.GCInterval, ShouldEqual, time.Hour*12)
 
@@ -3538,6 +3587,7 @@ func TestConfig(t *testing.T) {
 			So(path2Config.GC, ShouldBeTrue)
 			So(path2Config.Dedupe, ShouldBeFalse)
 			So(path2Config.RedirectBlobURL, ShouldBeFalse)
+			So(path2Config.HydrateBlobOnRead, ShouldBeFalse)
 			So(path2Config.GCDelay, ShouldEqual, time.Hour*3)
 			So(path2Config.GCInterval, ShouldEqual, time.Hour*36)
 		})

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -5686,6 +5686,13 @@ func TestAuthorizationMountBlob(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
 
+		/* ranged GET must not mount from the global cache either */
+		resp, err = userClient2.R().
+			SetHeader("Range", "bytes=0-7").
+			Get(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", repoName2, blobDigest))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
 		params := make(map[string]string)
 		params["mount"] = blobDigest.String()
 
@@ -5695,11 +5702,16 @@ func TestAuthorizationMountBlob(t *testing.T) {
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
 
-		/* a HEAD request by user1 on blob digest (found in user1Repo) should return 200
-		because user1 has permission to read user1Repo */
-		resp, err = userClient1.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", username1+"/"+"mysecondrepo", blobDigest))
+		/* a HEAD request by user1 on the blob in repoName1 should return 200;
+		blob reads are repo-local (StatBlob), not satisfied via cross-repo cache */
+		resp, err = userClient1.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", repoName1, blobDigest))
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		/* the same digest is not known to a different repository until mounted there */
+		resp, err = userClient1.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", username1+"/"+"mysecondrepo", blobDigest))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
 
 		// user2 can upload without dedupe
 		err = UploadImageWithBasicAuth(img, baseURL, repoName2, tag, username2, password2)
@@ -5709,6 +5721,388 @@ func TestAuthorizationMountBlob(t *testing.T) {
 		resp, err = userClient2.R().SetQueryParams(params).Post(baseURL + "/v2/" + repoName2 + "/blobs/uploads/")
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+	})
+}
+
+func TestAuthorizationMountBlobRematerializeOnRead(t *testing.T) {
+	Convey("With hydrateBlobOnRead, HEAD/range may rematerialize when permitted", t, func() {
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		username1, _ := test.GenerateRandomString()
+		password1, _ := test.GenerateRandomString()
+		username1 = strings.ToLower(username1)
+
+		content := test.GetBcryptCredString(username1, password1)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, content)
+
+		conf.HTTP.Auth = &config.AuthConfig{
+			HTPasswd: config.AuthHTPasswd{
+				Path: htpasswdPath,
+			},
+		}
+
+		user1Repo := username1 + "/**"
+		conf.HTTP.AccessControl = &config.AccessControlConfig{
+			Repositories: config.Repositories{
+				user1Repo: config.PolicyGroup{
+					Policies: []config.Policy{
+						{
+							Users: []string{username1},
+							Actions: []string{
+								constants.ReadPermission,
+								constants.CreatePermission,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		dir := t.TempDir()
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.Dedupe = true
+		ctlr.Config.Storage.HydrateBlobOnRead = true
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+		defer cm.StopServer()
+
+		userClient1 := resty.New()
+		userClient1.SetBasicAuth(username1, password1)
+
+		img := CreateImageWith().RandomLayers(1, 2).DefaultConfig().Build()
+		repoName1 := username1 + "/" + "myrepo"
+		err := UploadImageWithBasicAuth(img, baseURL, repoName1, "1.0", username1, password1)
+		So(err, ShouldBeNil)
+
+		blobDigest := img.Manifest.Layers[0].Digest
+		secondRepo := username1 + "/" + "mysecondrepo"
+
+		resp, err := userClient1.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", secondRepo, blobDigest))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		thirdRepo := username1 + "/" + "mythirdrepo"
+		resp, err = userClient1.R().
+			SetHeader("Range", "bytes=0-0").
+			Get(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", thirdRepo, blobDigest))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusPartialContent)
+	})
+}
+
+func TestAuthorizationReadOnlyCannotMaterializeBlob(t *testing.T) {
+	Convey("defaultPolicy read alone does not materialize blobs on HEAD or ranged GET", t, func() {
+		conf := config.New()
+		conf.HTTP.Port = "0"
+
+		writerUser, _ := test.GenerateRandomString()
+		writerPass, _ := test.GenerateRandomString()
+		readerUser, _ := test.GenerateRandomString()
+		readerPass, _ := test.GenerateRandomString()
+		writerUser = strings.ToLower(writerUser)
+		readerUser = strings.ToLower(readerUser)
+
+		content := test.GetBcryptCredString(writerUser, writerPass) +
+			test.GetBcryptCredString(readerUser, readerPass)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, content)
+
+		conf.HTTP.Auth = &config.AuthConfig{
+			HTPasswd: config.AuthHTPasswd{
+				Path: htpasswdPath,
+			},
+		}
+
+		conf.HTTP.AccessControl = &config.AccessControlConfig{
+			Repositories: config.Repositories{
+				"**": config.PolicyGroup{
+					DefaultPolicy: []string{constants.ReadPermission},
+					Policies: []config.Policy{
+						{
+							Users: []string{writerUser},
+							Actions: []string{
+								constants.ReadPermission,
+								constants.CreatePermission,
+								constants.UpdatePermission,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		dir := t.TempDir()
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.Dedupe = true
+		ctlr.Config.Storage.HydrateBlobOnRead = true
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+		defer cm.StopServer()
+
+		img := CreateImageWith().RandomLayers(1, 2).DefaultConfig().Build()
+		writerRepo := "writer/repo"
+		err := UploadImageWithBasicAuth(img, baseURL, writerRepo, "1.0", writerUser, writerPass)
+		So(err, ShouldBeNil)
+
+		blobDigest := img.Manifest.Layers[0].Digest
+		junkRepo := "reader-junk"
+
+		readerClient := resty.New()
+		readerClient.SetBasicAuth(readerUser, readerPass)
+
+		resp, err := readerClient.R().Post(baseURL + "/v2/" + junkRepo + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
+
+		resp, err = readerClient.R().Head(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", junkRepo, blobDigest))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+		_, err = os.Stat(filepath.Join(dir, junkRepo))
+		So(os.IsNotExist(err), ShouldBeTrue)
+
+		resp, err = readerClient.R().
+			SetHeader("Range", "bytes=0-7").
+			Get(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", junkRepo, blobDigest))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+		_, err = os.Stat(filepath.Join(dir, junkRepo))
+		So(os.IsNotExist(err), ShouldBeTrue)
+
+		// Missing local blob: ranged GET returns 404.
+		resp, err = readerClient.R().
+			SetHeader("Range", "bytes=0-64").
+			Get(baseURL + fmt.Sprintf("/v2/%s/blobs/%s", "other/empty", blobDigest))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+		_, err = os.Stat(filepath.Join(dir, "other"))
+		So(os.IsNotExist(err), ShouldBeTrue)
+	})
+}
+
+func TestAuthorizationMountBlobCELConditions(t *testing.T) {
+	Convey("canMount evaluates CEL policy conditions", t, func() {
+		conf := config.New()
+		conf.HTTP.Port = "0"
+
+		writer, _ := test.GenerateRandomString()
+		writerPass, _ := test.GenerateRandomString()
+		limited, _ := test.GenerateRandomString()
+		limitedPass, _ := test.GenerateRandomString()
+		writer = strings.ToLower(writer)
+		limited = strings.ToLower(limited)
+
+		content := test.GetBcryptCredString(writer, writerPass) +
+			test.GetBcryptCredString(limited, limitedPass)
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, content)
+
+		conf.HTTP.Auth = &config.AuthConfig{
+			HTPasswd: config.AuthHTPasswd{
+				Path: htpasswdPath,
+			},
+		}
+
+		// Writer seeds private/; limited has CEL limits on blocked/ and private/.
+		conf.HTTP.AccessControl = &config.AccessControlConfig{
+			Repositories: config.Repositories{
+				"**": config.PolicyGroup{
+					Policies: []config.Policy{
+						{
+							Users: []string{writer},
+							Actions: []string{
+								constants.ReadPermission,
+								constants.CreatePermission,
+							},
+						},
+						{
+							Users: []string{limited},
+							Actions: []string{
+								constants.ReadPermission,
+								constants.CreatePermission,
+							},
+							Conditions: []config.Condition{
+								{
+									Expression: `req.action != "create" || !req.repository.startsWith("blocked/")`,
+									Message:    "create under blocked/ not permitted",
+								},
+								{
+									Expression: `req.action != "read" || !req.repository.startsWith("private/")`,
+									Message:    "read under private/ not permitted",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		dir := t.TempDir()
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.Dedupe = true
+		ctlr.Config.Storage.HydrateBlobOnRead = true
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+		defer cm.StopServer()
+
+		limitedClient := resty.New()
+		limitedClient.SetBasicAuth(limited, limitedPass)
+
+		img := CreateImageWith().RandomLayers(1, 2).DefaultConfig().Build()
+		err := UploadImageWithBasicAuth(img, baseURL, "allowed/src", "1.0", writer, writerPass)
+		So(err, ShouldBeNil)
+
+		privateImg := CreateImageWith().RandomLayers(1, 2).DefaultConfig().Build()
+		err = UploadImageWithBasicAuth(privateImg, baseURL, "private/src", "1.0", writer, writerPass)
+		So(err, ShouldBeNil)
+
+		allowedDigest := img.Manifest.Layers[0].Digest
+		privateDigest := privateImg.Manifest.Layers[0].Digest
+
+		// Middleware already denies POST create under blocked/ (403). HEAD only
+		// requires read, so rematerialize is gated by canMount's CEL create check.
+		resp, err := limitedClient.R().
+			SetQueryParam("mount", allowedDigest.String()).
+			Post(baseURL + "/v2/blocked/dest/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusForbidden)
+
+		resp, err = limitedClient.R().Head(baseURL + fmt.Sprintf("/v2/blocked/dest/blobs/%s", allowedDigest))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+		// Middleware allows create on allowed/dest; canMount applies CEL source-read.
+		resp, err = limitedClient.R().
+			SetQueryParam("mount", privateDigest.String()).
+			Post(baseURL + "/v2/allowed/dest/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+		resp, err = limitedClient.R().Head(baseURL + fmt.Sprintf("/v2/allowed/dest/blobs/%s", privateDigest))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+		// Control: limited can mount allowed → allowed when CEL permits create+read.
+		resp, err = limitedClient.R().
+			SetQueryParam("mount", allowedDigest.String()).
+			Post(baseURL + "/v2/allowed/dest2/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+	})
+}
+
+func TestBearerAuthMountBlobWithAccessControl(t *testing.T) {
+	Convey("traditional bearer can mount/rematerialize when accessControl is also set", t, func() {
+		serverCertPath, serverKeyPath, _, _ := setupBearerAuthServerCerts(t, tlsutils.KeyTypeRSA)
+
+		authTestServer := authutils.MakeAuthTestServer(serverKeyPath, "RS256", UnauthorizedNamespace)
+		defer authTestServer.Close()
+
+		conf := config.New()
+		conf.HTTP.Port = "0"
+
+		aurl, err := url.Parse(authTestServer.URL)
+		So(err, ShouldBeNil)
+
+		conf.HTTP.Auth = &config.AuthConfig{
+			Bearer: &config.BearerConfig{
+				Cert:    serverCertPath,
+				Realm:   authTestServer.URL + "/auth/token",
+				Service: aurl.Host,
+			},
+		}
+		conf.HTTP.AccessControl = &config.AccessControlConfig{
+			Repositories: config.Repositories{
+				"**": config.PolicyGroup{
+					Policies: []config.Policy{
+						{
+							Users: []string{"alice"},
+							Actions: []string{
+								constants.ReadPermission,
+								constants.CreatePermission,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		ctlr := makeController(conf, t.TempDir())
+		ctlr.Config.Storage.Dedupe = true
+		ctlr.Config.Storage.HydrateBlobOnRead = true
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+		defer cm.StopServer()
+
+		getToken := func(method, challengeURL string) string {
+			resp, err := resty.R().Execute(method, challengeURL)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+
+			authorizationHeader := authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
+			resp, err = resty.R().
+				SetQueryParam("service", authorizationHeader.Service).
+				SetQueryParam("scope", authorizationHeader.Scope).
+				Get(authorizationHeader.Realm)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			var token authutils.AccessTokenResponse
+			err = json.Unmarshal(resp.Body(), &token)
+			So(err, ShouldBeNil)
+
+			return token.AccessToken
+		}
+
+		blob := []byte("bearer-mount-with-ac")
+		digest := godigest.FromBytes(blob)
+		srcRepo := "bearer/src"
+		destRepo := "bearer/dest"
+		rematRepo := "bearer/remat"
+
+		token := getToken(http.MethodPost, baseURL+"/v2/"+srcRepo+"/blobs/uploads/")
+		resp, err := resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			Post(baseURL + "/v2/" + srcRepo + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+		loc := resp.Header().Get("Location")
+
+		putURL := baseURL + loc + "?digest=" + digest.String()
+		token = getToken(http.MethodPut, putURL)
+		resp, err = resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			SetHeader("Content-Length", strconv.Itoa(len(blob))).
+			SetHeader("Content-Type", "application/octet-stream").
+			SetQueryParam("digest", digest.String()).
+			SetBody(blob).
+			Put(baseURL + loc)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		mountURL := baseURL + "/v2/" + destRepo + "/blobs/uploads/?mount=" + digest.String()
+		token = getToken(http.MethodPost, mountURL)
+		resp, err = resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			SetQueryParam("mount", digest.String()).
+			Post(baseURL + "/v2/" + destRepo + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		headURL := baseURL + fmt.Sprintf("/v2/%s/blobs/%s", rematRepo, digest)
+		token = getToken(http.MethodHead, headURL)
+		resp, err = resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			Head(headURL)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 	})
 }
 
@@ -7366,10 +7760,16 @@ func TestCrossRepoMount(t *testing.T) {
 
 		So(os.SameFile(cacheFi, linkFi), ShouldEqual, true)
 
+		// Blob reads are repo-local: HEAD succeeds only where the blob was mounted.
+		headResponse, err = client.R().SetBasicAuth(username, password).
+			Head(fmt.Sprintf("%s/v2/zot-mount-test/blobs/%s", baseURL, manifestDigest))
+		So(err, ShouldBeNil)
+		So(headResponse.StatusCode(), ShouldEqual, http.StatusOK)
+
 		headResponse, err = client.R().SetBasicAuth(username, password).
 			Head(fmt.Sprintf("%s/v2/zot-cv-test/blobs/%s", baseURL, manifestDigest))
 		So(err, ShouldBeNil)
-		So(headResponse.StatusCode(), ShouldEqual, http.StatusOK)
+		So(headResponse.StatusCode(), ShouldEqual, http.StatusNotFound)
 
 		// Invalid request
 		params = make(map[string]string)
@@ -7426,6 +7826,154 @@ func TestCrossRepoMount(t *testing.T) {
 			Head(fmt.Sprintf("%s/v2/%s/blobs/%s", baseURL, name, digest))
 		So(err, ShouldBeNil)
 		So(headResponse.StatusCode(), ShouldEqual, http.StatusNotFound)
+	})
+}
+
+func TestBlobReadRepoLocalAfterMountDelete(t *testing.T) {
+	Convey("blob HEAD and GET are repo-local after cross-repo mount and delete", t, func() {
+		conf := config.New()
+		conf.HTTP.Port = "0"
+
+		dir := t.TempDir()
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.Dedupe = true
+		ctlr.Config.Storage.GC = false
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+
+		defer cm.StopServer()
+
+		client := resty.New()
+
+		const (
+			repoDest = "oci-conformance/distribution-test"
+			repoSrc  = "oci-conformance/crossmount-test"
+		)
+
+		blob := []byte("mount-atomic-delete-test")
+		digest := godigest.FromBytes(blob).String()
+
+		resp, err := client.R().
+			SetHeader("Content-Type", "application/octet-stream").
+			SetHeader("Content-Length", strconv.Itoa(len(blob))).
+			SetQueryParam("digest", digest).
+			SetBody(blob).
+			Post(baseURL + "/v2/" + repoSrc + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		resp, err = client.R().
+			SetQueryParam("mount", digest).
+			Post(baseURL + "/v2/" + repoDest + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		headBlob := func(repo string) int {
+			head, headErr := client.R().Head(baseURL + "/v2/" + repo + "/blobs/" + digest)
+			So(headErr, ShouldBeNil)
+
+			return head.StatusCode()
+		}
+
+		getBlob := func(repo string, rangeHeader string) (int, []byte) {
+			req := client.R()
+			if rangeHeader != "" {
+				req.SetHeader("Range", rangeHeader)
+			}
+
+			get, getErr := req.Get(baseURL + "/v2/" + repo + "/blobs/" + digest)
+			So(getErr, ShouldBeNil)
+
+			return get.StatusCode(), get.Body()
+		}
+
+		So(headBlob(repoDest), ShouldEqual, http.StatusOK)
+
+		status, body := getBlob(repoDest, "")
+		So(status, ShouldEqual, http.StatusOK)
+		So(body, ShouldResemble, blob)
+
+		status, body = getBlob(repoDest, "bytes=0-4")
+		So(status, ShouldEqual, http.StatusPartialContent)
+		So(body, ShouldResemble, blob[:5])
+
+		resp, err = client.R().Delete(baseURL + "/v2/" + repoDest + "/blobs/" + digest)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+		So(headBlob(repoDest), ShouldEqual, http.StatusNotFound)
+		So(headBlob(repoSrc), ShouldEqual, http.StatusOK)
+
+		status, _ = getBlob(repoDest, "")
+		So(status, ShouldEqual, http.StatusNotFound)
+
+		status, _ = getBlob(repoDest, "bytes=0-4")
+		So(status, ShouldEqual, http.StatusNotFound)
+
+		status, body = getBlob(repoSrc, "")
+		So(status, ShouldEqual, http.StatusOK)
+		So(body, ShouldResemble, blob)
+	})
+}
+
+func TestBlobReadRematerializeAfterMountDelete(t *testing.T) {
+	Convey("with hydrateBlobOnRead, HEAD rematerializes after delete", t, func() {
+		conf := config.New()
+		conf.HTTP.Port = "0"
+
+		dir := t.TempDir()
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = dir
+		ctlr.Config.Storage.Dedupe = true
+		ctlr.Config.Storage.GC = false
+		ctlr.Config.Storage.HydrateBlobOnRead = true
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+		defer cm.StopServer()
+
+		client := resty.New()
+
+		const (
+			repoDest = "oci-conformance/distribution-test"
+			repoSrc  = "oci-conformance/crossmount-test"
+		)
+
+		blob := []byte("mount-rematerialize-on-read-test")
+		digest := godigest.FromBytes(blob).String()
+
+		resp, err := client.R().
+			SetHeader("Content-Type", "application/octet-stream").
+			SetHeader("Content-Length", strconv.Itoa(len(blob))).
+			SetQueryParam("digest", digest).
+			SetBody(blob).
+			Post(baseURL + "/v2/" + repoSrc + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		resp, err = client.R().
+			SetQueryParam("mount", digest).
+			Post(baseURL + "/v2/" + repoDest + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		resp, err = client.R().Delete(baseURL + "/v2/" + repoDest + "/blobs/" + digest)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+		// Legacy path: HEAD rematerializes from the dedupe cache into dest.
+		head, err := client.R().Head(baseURL + "/v2/" + repoDest + "/blobs/" + digest)
+		So(err, ShouldBeNil)
+		So(head.StatusCode(), ShouldEqual, http.StatusOK)
+
+		get, err := client.R().
+			SetHeader("Range", "bytes=0-4").
+			Get(baseURL + "/v2/" + repoDest + "/blobs/" + digest)
+		So(err, ShouldBeNil)
+		So(get.StatusCode(), ShouldEqual, http.StatusPartialContent)
+		So(get.Body(), ShouldResemble, blob[:5])
 	})
 }
 
@@ -12582,7 +13130,7 @@ func TestPeriodicGC(t *testing.T) {
 
 		// periodic GC is enabled for sub store
 		So(string(data), ShouldContainSubstring,
-			fmt.Sprintf("\"SubPaths\":{\"/a\":{\"RootDirectory\":\"%s\",\"MaxRepos\":0,\"Dedupe\":false,\"RemoteCache\":false,\"RedirectBlobURL\":false,\"GC\":true,\"Commit\":false,\"GCDelay\":1000000000,\"GCInterval\":86400000000000", subDir)) //nolint:lll // gofumpt conflicts with lll
+			fmt.Sprintf("\"SubPaths\":{\"/a\":{\"RootDirectory\":\"%s\",\"MaxRepos\":0,\"Dedupe\":false,\"RemoteCache\":false,\"RedirectBlobURL\":false,\"HydrateBlobOnRead\":false,\"GC\":true,\"Commit\":false,\"GCDelay\":1000000000,\"GCInterval\":86400000000000", subDir)) //nolint:lll // gofumpt conflicts with lll
 	})
 
 	Convey("Periodic gc error", t, func() {

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1021,33 +1021,133 @@ func (rh *RouteHandler) DeleteManifest(response http.ResponseWriter, request *ht
 	response.WriteHeader(http.StatusAccepted)
 }
 
-// canMount checks if a user has read permission on cached blobs with this specific digest.
-// returns true if the user have permission to copy blob from cache.
-func canMount(userAc *reqCtx.UserAccessControl, imgStore storageTypes.ImageStore, digest godigest.Digest,
+// canMount reports whether the caller may materialize digest into destRepo from
+// the dedupe cache. That requires create on destRepo and read on at least
+// one repository that already holds the digest. Permissions are evaluated with
+// AccessController.can so policy CEL conditions apply. Call only when authz is
+// enabled.
+func (rh *RouteHandler) canMount(
+	request *http.Request, userAc *reqCtx.UserAccessControl, imgStore storageTypes.ImageStore,
+	digest godigest.Digest, destRepo string,
 ) (bool, error) {
-	canMount := true
+	authnMwCtx, err := reqCtx.GetAuthnMiddlewareContext(request.Context())
+	if err == nil && authnMwCtx != nil && authnMwCtx.AuthnType == BEARER {
+		return true, nil
+	}
 
-	if userAc != nil {
-		canMount = false
+	// Snapshot AC config and reuse the controller logger (avoid opening Log.Output per call).
+	accessControlConfig := rh.c.Config.CopyAccessControlConfig()
+	if accessControlConfig == nil {
+		accessControlConfig = &config.AccessControlConfig{}
+	}
 
-		repos, err := imgStore.GetAllDedupeReposCandidates(digest)
-		if err != nil {
-			return false, err
-		}
+	acCtrlr := &AccessController{
+		Config: accessControlConfig,
+		Log:    rh.c.Log,
+	}
 
-		if len(repos) == 0 {
-			canMount = false
-		}
+	digestRef := digest.String()
 
-		// check if user can read any repo which contain this blob
-		for _, repo := range repos {
-			if userAc.Can(constants.ReadPermission, repo) {
-				canMount = true
-			}
+	if ok, _ := acCtrlr.can(request, userAc, constants.CreatePermission, destRepo, digestRef); !ok {
+		return false, nil
+	}
+
+	repos, err := imgStore.GetAllDedupeReposCandidates(digest)
+	if err != nil {
+		return false, err
+	}
+
+	for _, repo := range repos {
+		if ok, _ := acCtrlr.can(request, userAc, constants.ReadPermission, repo, digestRef); ok {
+			return true, nil
 		}
 	}
 
-	return canMount, nil
+	return false, nil
+}
+
+func (rh *RouteHandler) isHydrateBlobOnReadEnabled(repo string) bool {
+	storePath := rh.c.StoreController.GetStorePath(repo)
+
+	return rh.c.Config.IsHydrateBlobOnReadEnabled(storePath)
+}
+
+// userMayMountBlob reports whether request may rematerialize digest into destRepo
+// via CheckBlob. canMount lookup failures are logged and treated as "not allowed"
+// (repo-local fallback).
+func (rh *RouteHandler) userMayMountBlob(
+	request *http.Request, imgStore storageTypes.ImageStore, digest godigest.Digest, destRepo string,
+) (bool, error) {
+	userAc, err := reqCtx.UserAcFromContext(request.Context())
+	if err != nil {
+		return false, err
+	}
+
+	accessControlConfig := rh.c.Config.CopyAccessControlConfig()
+	if !accessControlConfig.IsAuthzEnabled() {
+		return true, nil
+	}
+
+	allowed, err := rh.canMount(request, userAc, imgStore, digest, destRepo)
+	if err != nil {
+		rh.c.Log.Error().Err(err).Msg("unexpected error")
+
+		return false, nil
+	}
+
+	return allowed, nil
+}
+
+// resolveBlobPresence returns whether digest exists for repo. By default this is
+// repo-local (StatBlob). When hydrateBlobOnRead is enabled and the caller
+// may mount, CheckBlob may hard-link from the dedupe cache into repo.
+func (rh *RouteHandler) resolveBlobPresence(
+	request *http.Request, imgStore storageTypes.ImageStore, repo string, digest godigest.Digest,
+) (bool, int64, error) {
+	if rh.isHydrateBlobOnReadEnabled(repo) {
+		userCanMount, err := rh.userMayMountBlob(request, imgStore, digest, repo)
+		if err != nil {
+			return false, -1, err
+		}
+
+		if userCanMount {
+			ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
+
+			return imgStore.CheckBlob(ctx, repo, digest)
+		}
+		// Mount not allowed: fall through to repo-local StatBlob.
+	}
+
+	var lockLatency time.Time
+
+	imgStore.RLock(&lockLatency)
+	ok, size, _, err := imgStore.StatBlob(repo, digest)
+	imgStore.RUnlock(&lockLatency)
+
+	return ok, size, err
+}
+
+// writeBlobReadError maps storage errors for blob HEAD/GET to OCI error responses.
+func (rh *RouteHandler) writeBlobReadError(
+	response http.ResponseWriter, name string, digest godigest.Digest, err error,
+) {
+	details := zerr.GetDetails(err)
+	if errors.Is(err, zerr.ErrBadBlobDigest) { //nolint:gocritic // errorslint conflicts with gocritic:IfElseChain
+		details["digest"] = digest.String()
+		e := apiErr.NewError(apiErr.DIGEST_INVALID).AddDetail(details)
+		zcommon.WriteJSON(response, http.StatusBadRequest, apiErr.NewErrorList(e))
+	} else if errors.Is(err, zerr.ErrRepoNotFound) {
+		details["name"] = name
+		e := apiErr.NewError(apiErr.NAME_UNKNOWN).AddDetail(details)
+		zcommon.WriteJSON(response, http.StatusNotFound, apiErr.NewErrorList(e))
+	} else if errors.Is(err, zerr.ErrBlobNotFound) {
+		details["digest"] = digest.String()
+		e := apiErr.NewError(apiErr.BLOB_UNKNOWN).AddDetail(details)
+		zcommon.WriteJSON(response, http.StatusNotFound, apiErr.NewErrorList(e))
+	} else {
+		rh.c.Log.Error().Err(err).Msg("unexpected error")
+		response.WriteHeader(http.StatusInternalServerError)
+	}
 }
 
 // CheckBlob godoc
@@ -1083,55 +1183,15 @@ func (rh *RouteHandler) CheckBlob(response http.ResponseWriter, request *http.Re
 
 	digest := godigest.Digest(digestStr)
 
-	userAc, err := reqCtx.UserAcFromContext(request.Context())
-	if err != nil {
-		response.WriteHeader(http.StatusInternalServerError)
+	if err := digest.Validate(); err != nil {
+		rh.writeBlobReadError(response, name, digest, zerr.ErrBadBlobDigest)
 
 		return
 	}
 
-	userCanMount := true
-	accessControlConfig := rh.c.Config.CopyAccessControlConfig()
-
-	if accessControlConfig.IsAuthzEnabled() {
-		userCanMount, err = canMount(userAc, imgStore, digest)
-		if err != nil {
-			rh.c.Log.Error().Err(err).Msg("unexpected error")
-		}
-	}
-
-	var blen int64
-
-	if userCanMount {
-		ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
-		ok, blen, err = imgStore.CheckBlob(ctx, name, digest)
-	} else {
-		var lockLatency time.Time
-
-		imgStore.RLock(&lockLatency)
-		defer imgStore.RUnlock(&lockLatency)
-
-		ok, blen, _, err = imgStore.StatBlob(name, digest)
-	}
-
+	ok, blen, err := rh.resolveBlobPresence(request, imgStore, name, digest)
 	if err != nil {
-		details := zerr.GetDetails(err)
-		if errors.Is(err, zerr.ErrBadBlobDigest) { //nolint:gocritic,dupl // errorslint conflicts with gocritic:IfElseChain
-			details["digest"] = digest.String()
-			e := apiErr.NewError(apiErr.DIGEST_INVALID).AddDetail(details)
-			zcommon.WriteJSON(response, http.StatusBadRequest, apiErr.NewErrorList(e))
-		} else if errors.Is(err, zerr.ErrRepoNotFound) {
-			details["name"] = name
-			e := apiErr.NewError(apiErr.NAME_UNKNOWN).AddDetail(details)
-			zcommon.WriteJSON(response, http.StatusNotFound, apiErr.NewErrorList(e))
-		} else if errors.Is(err, zerr.ErrBlobNotFound) {
-			details["digest"] = digest.String()
-			e := apiErr.NewError(apiErr.BLOB_UNKNOWN).AddDetail(details)
-			zcommon.WriteJSON(response, http.StatusNotFound, apiErr.NewErrorList(e))
-		} else {
-			rh.c.Log.Error().Err(err).Msg("unexpected error")
-			response.WriteHeader(http.StatusInternalServerError)
-		}
+		rh.writeBlobReadError(response, name, digest, err)
 
 		return
 	}
@@ -1349,8 +1409,9 @@ func (c *byteCountingWriter) Write(p []byte) (int, error) {
 // layer's metadata path (e.g. a deleted blob) would historically have
 // produced a 4xx; under this design they too truncate. The 16-range
 // cap and coalesceRanges already bound the worst case, and the eager
-// CheckBlob earlier in GetBlob still rejects the obvious "blob does
-// not exist" case before we get here.
+// existence check in GetBlob (resolveBlobPresence — StatBlob by default,
+// or CheckBlob when hydrateBlobOnRead permits rematerialization) still
+// rejects the obvious "blob does not exist" case before we get here.
 func writeMultipartRanges(
 	response http.ResponseWriter,
 	ranges []httpRange,
@@ -1480,28 +1541,8 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 	contentRange := request.Header.Get("Range")
 	_, rangeHeaderPresent := request.Header["Range"]
 
-	writeBlobError := func(err error) {
-		details := zerr.GetDetails(err)
-		if errors.Is(err, zerr.ErrBadBlobDigest) { //nolint:gocritic // errorslint conflicts with gocritic:IfElseChain
-			details["digest"] = digest.String()
-			e := apiErr.NewError(apiErr.DIGEST_INVALID).AddDetail(details)
-			zcommon.WriteJSON(response, http.StatusBadRequest, apiErr.NewErrorList(e))
-		} else if errors.Is(err, zerr.ErrRepoNotFound) {
-			details["name"] = name
-			e := apiErr.NewError(apiErr.NAME_UNKNOWN).AddDetail(details)
-			zcommon.WriteJSON(response, http.StatusNotFound, apiErr.NewErrorList(e))
-		} else if errors.Is(err, zerr.ErrBlobNotFound) {
-			details["digest"] = digest.String()
-			e := apiErr.NewError(apiErr.BLOB_UNKNOWN).AddDetail(details)
-			zcommon.WriteJSON(response, http.StatusNotFound, apiErr.NewErrorList(e))
-		} else {
-			rh.c.Log.Error().Err(err).Msg("unexpected error")
-			response.WriteHeader(http.StatusInternalServerError)
-		}
-	}
-
 	if err := digest.Validate(); err != nil {
-		writeBlobError(zerr.ErrBadBlobDigest)
+		rh.writeBlobReadError(response, name, digest, zerr.ErrBadBlobDigest)
 
 		return
 	}
@@ -1510,7 +1551,7 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 	if !rangeHeaderPresent && rh.isBlobRedirectEnabled(name) {
 		redirectURL, err := imgStore.GetBlobRedirectURL(request, name, digest)
 		if err != nil {
-			writeBlobError(err)
+			rh.writeBlobReadError(response, name, digest, err)
 
 			return
 		} else if redirectURL != "" {
@@ -1529,10 +1570,9 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 	}
 
 	if rangeHeaderPresent {
-		ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
-		ok, bsize, err := imgStore.CheckBlob(ctx, name, digest)
+		ok, bsize, err := rh.resolveBlobPresence(request, imgStore, name, digest)
 		if err != nil {
-			writeBlobError(err)
+			rh.writeBlobReadError(response, name, digest, err)
 
 			return
 		}
@@ -1581,7 +1621,7 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 
 		reader, blen, _, err := imgStore.GetBlobPartial(name, digest, mediaType, rng.start, rng.end)
 		if err != nil {
-			writeBlobError(err)
+			rh.writeBlobReadError(response, name, digest, err)
 
 			return
 		}
@@ -1614,7 +1654,7 @@ func (rh *RouteHandler) GetBlob(response http.ResponseWriter, request *http.Requ
 
 	repo, blen, err := imgStore.GetBlob(name, digest, mediaType)
 	if err != nil {
-		writeBlobError(err)
+		rh.writeBlobReadError(response, name, digest, err)
 
 		return
 	}
@@ -1724,7 +1764,7 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 
 	ctx := events.WithEventContext(request.Context(), eventContextFromRequest(request))
 
-	// currently zot does not support cross-repository mounting, following dist-spec and returning 202
+	// Cross-repository mount: CheckBlob hard-links from the store dedupe cache when allowed.
 	if mountDigests, ok := request.URL.Query()["mount"]; ok {
 		if len(mountDigests) != 1 {
 			response.WriteHeader(http.StatusBadRequest)
@@ -1745,15 +1785,15 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 		accessControlConfig := rh.c.Config.CopyAccessControlConfig()
 
 		if accessControlConfig.IsAuthzEnabled() {
-			userCanMount, err = canMount(userAc, imgStore, mountDigest)
+			userCanMount, err = rh.canMount(request, userAc, imgStore, mountDigest, name)
 			if err != nil {
 				rh.c.Log.Error().Err(err).Msg("unexpected error")
 			}
 		}
 
-		// zot does not support cross mounting directly and do a workaround creating using hard link.
-		// check blob looks for actual path (name+mountDigests[0]) first then look for cache and
-		// if found in cache, will do hard link and if fails we will start new upload.
+		// CheckBlob looks for the digest under dest first, then the dedupe cache; on a
+		// cache hit it hard-links into dest. On failure (or if canMount denied), fall
+		// through to a new blob upload.
 		if userCanMount {
 			_, _, err = imgStore.CheckBlob(ctx, name, mountDigest)
 		}

--- a/pkg/api/routes_internal_test.go
+++ b/pkg/api/routes_internal_test.go
@@ -1,13 +1,24 @@
 package api
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
 
+	godigest "github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+
 	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/api/constants"
+	"zotregistry.dev/zot/v2/pkg/log"
+	reqCtx "zotregistry.dev/zot/v2/pkg/requestcontext"
 	"zotregistry.dev/zot/v2/pkg/storage"
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
 )
 
 func TestParseRangeHeader(t *testing.T) {
@@ -201,4 +212,181 @@ func TestIsBlobRedirectEnabled(t *testing.T) {
 	if routeHandler.isBlobRedirectEnabled("b/repo") {
 		t.Fatal("expected redirect to be disabled for default storage")
 	}
+}
+
+func TestCanMountTraditionalBearer(t *testing.T) {
+	t.Parallel()
+
+	conf := config.New()
+	conf.HTTP.AccessControl = &config.AccessControlConfig{
+		Repositories: config.Repositories{
+			"**": config.PolicyGroup{
+				Policies: []config.Policy{
+					{
+						Users: []string{"alice"},
+						Actions: []string{
+							constants.ReadPermission,
+							constants.CreatePermission,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rh := &RouteHandler{c: &Controller{Config: conf, Log: log.NewTestLogger()}}
+	imgStore := mocks.MockedImageStore{
+		GetAllDedupeReposCandidatesFn: func(_ godigest.Digest) ([]string, error) {
+			return []string{"src/repo"}, nil
+		},
+	}
+	digest := godigest.FromString("bearer-mount-test")
+	emptyUser := reqCtx.NewUserAccessControl()
+
+	req := httptest.NewRequest(http.MethodPost, "/v2/dest/blobs/uploads/", nil)
+	ok, err := rh.canMount(req, emptyUser, imgStore, digest, "dest")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	acCtrlr := NewAccessController(conf)
+	bearerReq := req.WithContext(acCtrlr.getAuthnMiddlewareContext(BEARER, req))
+	ok, err = rh.canMount(bearerReq, emptyUser, imgStore, digest, "dest")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	oidcReq := req.WithContext(acCtrlr.getAuthnMiddlewareContext(BEARER_OIDC, req))
+	ok, err = rh.canMount(oidcReq, emptyUser, imgStore, digest, "dest")
+	require.NoError(t, err)
+	require.False(t, ok)
+}
+
+func TestCanMountDedupeCandidatesError(t *testing.T) {
+	t.Parallel()
+
+	conf := config.New()
+	conf.HTTP.AccessControl = &config.AccessControlConfig{
+		Repositories: config.Repositories{
+			"**": config.PolicyGroup{
+				Policies: []config.Policy{
+					{
+						Users: []string{"alice"},
+						Actions: []string{
+							constants.ReadPermission,
+							constants.CreatePermission,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	candidatesErr := errors.New("candidates failed")
+	rh := &RouteHandler{c: &Controller{Config: conf, Log: log.NewTestLogger()}}
+	imgStore := mocks.MockedImageStore{
+		GetAllDedupeReposCandidatesFn: func(_ godigest.Digest) ([]string, error) {
+			return nil, candidatesErr
+		},
+	}
+
+	userAc := reqCtx.NewUserAccessControl()
+	userAc.SetUsername("alice")
+	req := httptest.NewRequest(http.MethodPost, "/v2/dest/blobs/uploads/", nil)
+
+	ok, err := rh.canMount(req, userAc, imgStore, godigest.FromString("candidates-err"), "dest")
+	require.ErrorIs(t, err, candidatesErr)
+	require.False(t, ok)
+}
+
+func TestUserMayMountBlobErrorPaths(t *testing.T) {
+	t.Parallel()
+
+	conf := config.New()
+	conf.HTTP.AccessControl = &config.AccessControlConfig{
+		Repositories: config.Repositories{
+			"**": config.PolicyGroup{
+				Policies: []config.Policy{
+					{
+						Users: []string{"alice"},
+						Actions: []string{
+							constants.ReadPermission,
+							constants.CreatePermission,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rh := &RouteHandler{c: &Controller{Config: conf, Log: log.NewTestLogger()}}
+	digest := godigest.FromString("user-may-mount-err")
+
+	t.Run("bad user access control type", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.WithValue(context.Background(), reqCtx.GetContextKey(), "not-a-user-ac")
+		req := httptest.NewRequestWithContext(ctx, http.MethodHead, "/v2/dest/blobs/"+digest.String(), nil)
+
+		ok, err := rh.userMayMountBlob(req, mocks.MockedImageStore{}, digest, "dest")
+		require.Error(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("canMount candidates error is denied", func(t *testing.T) {
+		t.Parallel()
+
+		userAc := reqCtx.NewUserAccessControl()
+		userAc.SetUsername("alice")
+		req := httptest.NewRequest(http.MethodHead, "/v2/dest/blobs/"+digest.String(), nil)
+		userAc.SaveOnRequest(req)
+
+		candidatesErr := errors.New("candidates failed")
+		imgStore := mocks.MockedImageStore{
+			GetAllDedupeReposCandidatesFn: func(_ godigest.Digest) ([]string, error) {
+				return nil, candidatesErr
+			},
+		}
+
+		ok, err := rh.userMayMountBlob(req, imgStore, digest, "dest")
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+}
+
+func TestResolveBlobPresenceUserMayMountError(t *testing.T) {
+	t.Parallel()
+
+	conf := config.New()
+	conf.Storage.HydrateBlobOnRead = true
+	conf.HTTP.AccessControl = &config.AccessControlConfig{
+		Repositories: config.Repositories{
+			"**": config.PolicyGroup{
+				Policies: []config.Policy{
+					{
+						Users: []string{"alice"},
+						Actions: []string{
+							constants.ReadPermission,
+							constants.CreatePermission,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	rh := &RouteHandler{
+		c: &Controller{
+			Config:          conf,
+			Log:             log.NewTestLogger(),
+			StoreController: storage.StoreController{},
+		},
+	}
+
+	digest := godigest.FromString("resolve-presence-err")
+	ctx := context.WithValue(context.Background(), reqCtx.GetContextKey(), "not-a-user-ac")
+	req := httptest.NewRequestWithContext(ctx, http.MethodHead, "/v2/dest/blobs/"+digest.String(), nil)
+
+	ok, size, err := rh.resolveBlobPresence(req, mocks.MockedImageStore{}, "dest", digest)
+	require.Error(t, err)
+	require.False(t, ok)
+	require.Equal(t, int64(-1), size)
 }

--- a/pkg/api/routes_test.go
+++ b/pkg/api/routes_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
@@ -826,6 +827,8 @@ func TestRoutes(t *testing.T) {
 
 		// Check Blob
 		Convey("CheckBlob", func() {
+			const validDigest = "sha256:7b8437f04f83f084b7ed68ad8c4a4947e12fc4e1b006b38129bac89114ec3621"
+
 			testCheckBlob := func(urlVars map[string]string, ism *mocks.MockedImageStore) int {
 				ctlr.StoreController.DefaultStore = ism
 				request, _ := http.NewRequestWithContext(context.TODO(), http.MethodHead, baseURL, nil)
@@ -840,15 +843,28 @@ func TestRoutes(t *testing.T) {
 				return resp.StatusCode
 			}
 
-			// ErrBadBlobDigest
+			// invalid digest format is rejected before StatBlob
 			statusCode := testCheckBlob(
 				map[string]string{
 					"name":   "ErrBadBlobDigest",
 					"digest": "1234",
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, zerr.ErrBadBlobDigest
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						panic("StatBlob must not be called for invalid digest format")
+					},
+				})
+			So(statusCode, ShouldEqual, http.StatusBadRequest)
+
+			// ErrBadBlobDigest from storage
+			statusCode = testCheckBlob(
+				map[string]string{
+					"name":   "ErrBadBlobDigest",
+					"digest": validDigest,
+				},
+				&mocks.MockedImageStore{
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, zerr.ErrBadBlobDigest
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusBadRequest)
@@ -857,11 +873,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrRepoNotFound",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, zerr.ErrRepoNotFound
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, zerr.ErrRepoNotFound
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusNotFound)
@@ -870,11 +886,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrBlobNotFound",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, zerr.ErrBlobNotFound
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, zerr.ErrBlobNotFound
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusNotFound)
@@ -883,11 +899,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "ErrUnexpectedError",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 0, ErrUnexpectedError
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 0, time.Time{}, ErrUnexpectedError
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusInternalServerError)
@@ -896,11 +912,11 @@ func TestRoutes(t *testing.T) {
 			statusCode = testCheckBlob(
 				map[string]string{
 					"name":   "Check Blob Not Ok",
-					"digest": "1234",
+					"digest": validDigest,
 				},
 				&mocks.MockedImageStore{
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return false, 0, nil
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return false, 0, time.Time{}, nil
 					},
 				})
 			So(statusCode, ShouldEqual, http.StatusNotFound)
@@ -1037,8 +1053,8 @@ func TestRoutes(t *testing.T) {
 
 						return "https://storage.example.com/zot/repo/blobs/sha256/layer", nil
 					},
-					CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-						return true, 4, nil
+					StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+						return true, 4, time.Time{}, nil
 					},
 					GetBlobPartialFn: func(repo string, digest godigest.Digest, mediaType string,
 						from, to int64,
@@ -2426,12 +2442,12 @@ func descriptorStore(t *testing.T) mocks.MockedImageStore {
 
 	return mocks.MockedImageStore{
 		RootDirFn: func() string { return t.TempDir() },
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
 			if digest == layerDigest {
-				return true, 4, nil
+				return true, 4, time.Time{}, nil
 			}
 
-			return true, 0, nil
+			return true, 0, time.Time{}, nil
 		},
 		GetIndexContentFn: func(repo string) ([]byte, error) {
 			return indexJSON, nil
@@ -2459,8 +2475,8 @@ func TestCheckBlobAlwaysBinaryContentType(t *testing.T) {
 
 		return []byte("{}"), nil
 	}
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, 42, nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, 42, time.Time{}, nil
 	}
 
 	handler := newBlobTestRouteHandler(t, store)
@@ -2498,8 +2514,8 @@ func TestCheckBlobFallsBackToBinaryContentType(t *testing.T) {
 	// must fall back to application/octet-stream so OCI clients get a
 	// well-formed Content-Type.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 1024, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 1024, time.Time{}, nil
 		},
 		GetIndexContentFn: func(repo string) ([]byte, error) {
 			return nil, zerr.ErrManifestNotFound
@@ -2685,8 +2701,8 @@ func TestGetBlobPartialFallsBackToBinaryContentType(t *testing.T) {
 	// Single-range request for a blob whose repo has no index — same
 	// fallback behaviour as the full-GET case.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -2747,8 +2763,8 @@ func TestGetBlobMultipartPartBinaryContentType(t *testing.T) {
 
 		return []byte("{}"), nil
 	}
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -2910,8 +2926,8 @@ func TestGetBlobMultipartContentLengthMatchesBody(t *testing.T) {
 	const blobBody = "0123456789abcdef" // 16 bytes
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -2983,8 +2999,8 @@ func TestGetBlobMultipartOpensOneReaderAtATime(t *testing.T) {
 	var opens partialReaderOpenTracker
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -3041,8 +3057,8 @@ func TestGetBlobMultipartTruncatesOnReaderError(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -3102,8 +3118,8 @@ func TestGetBlobRangeUnsatisfiable(t *testing.T) {
 	// retry with a valid range. parseRangeHeader rejects the header
 	// before the handler reaches GetBlobPartial.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetIndexContentFn: func(repo string) ([]byte, error) {
 			return nil, zerr.ErrManifestNotFound
@@ -3133,11 +3149,11 @@ func TestGetBlobRangeUnsatisfiable(t *testing.T) {
 }
 
 func TestGetBlobRangeCheckBlobError(t *testing.T) {
-	// CheckBlob returning a non-zerr error must surface as 500 via
+	// StatBlob returning a non-zerr error must surface as 500 via
 	// writeBlobError's default branch.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return false, 0, ErrUnexpectedError
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return false, 0, time.Time{}, ErrUnexpectedError
 		},
 	})
 
@@ -3163,12 +3179,12 @@ func TestGetBlobRangeCheckBlobError(t *testing.T) {
 }
 
 func TestGetBlobRangeCheckBlobMissing(t *testing.T) {
-	// CheckBlob succeeding with ok=false (e.g. a deleted blob whose
+	// StatBlob succeeding with ok=false (e.g. a deleted blob whose
 	// repo still exists) must short-circuit to 404 BLOB_UNKNOWN before
 	// any range parsing or descriptor lookup.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return false, 0, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return false, 0, time.Time{}, nil
 		},
 	})
 
@@ -3201,14 +3217,14 @@ func TestGetBlobRangeCheckBlobMissing(t *testing.T) {
 
 func TestGetBlobSingleRangePartialBlobNotFound(t *testing.T) {
 	// Single-range path: GetBlobPartial returning ErrBlobNotFound after
-	// a successful CheckBlob (a blob deleted between the two calls)
-	// must surface as 404 with the BLOB_UNKNOWN error body. CheckBlob
+	// a successful StatBlob (a blob deleted between the two calls)
+	// must surface as 404 with the BLOB_UNKNOWN error body. StatBlob
 	// has already returned ok=true so we get past the length check;
 	// the response is still recoverable because no body bytes have
 	// been written yet.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -3255,8 +3271,8 @@ func TestGetBlobSingleRangePartialUnexpectedError(t *testing.T) {
 	// Single-range path: GetBlobPartial returning a non-zerr error
 	// hits writeBlobError's default branch and produces a 500.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -3302,8 +3318,8 @@ func TestGetBlobSingleRangeLengthMismatch(t *testing.T) {
 	// since on the single-range path the headers haven't been flushed
 	// yet and 5xx is still possible.
 	handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-		CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-			return true, 4, nil
+		StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+			return true, 4, time.Time{}, nil
 		},
 		GetBlobPartialFn: func(
 			repo string,
@@ -3355,8 +3371,8 @@ func TestGetBlobMultipartShortReaderTruncates(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,
@@ -3407,7 +3423,7 @@ func TestGetBlobMultipartShortReaderTruncates(t *testing.T) {
 }
 
 func TestGetBlobRangeCheckBlobNamedErrors(t *testing.T) {
-	// CheckBlob is the first storage call on the range branch and the
+	// StatBlob is the first storage call on the range branch and the
 	// only place where named storage errors can be turned into proper
 	// 4xx OCI error responses (once the 206 is in flight on the
 	// multipart path it's too late). Each case in the table maps a
@@ -3439,8 +3455,8 @@ func TestGetBlobRangeCheckBlobNamedErrors(t *testing.T) {
 	for name, testCase := range cases {
 		t.Run(name, func(t *testing.T) {
 			handler := newBlobTestRouteHandler(t, mocks.MockedImageStore{
-				CheckBlobFn: func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-					return false, 0, testCase.err
+				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+					return false, 0, time.Time{}, testCase.err
 				},
 			})
 
@@ -3495,8 +3511,8 @@ func TestGetBlobMultipartReaderCloseError(t *testing.T) {
 	var calls atomic.Int32
 
 	store := descriptorStore(t)
-	store.CheckBlobFn = func(ctx context.Context, repo string, digest godigest.Digest) (bool, int64, error) {
-		return true, int64(len(blobBody)), nil
+	store.StatBlobFn = func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
+		return true, int64(len(blobBody)), time.Time{}, nil
 	}
 	store.GetBlobPartialFn = func(
 		repo string,

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -475,7 +475,7 @@ func (is MockedImageStore) VerifyBlobDigestValue(repo string, digest godigest.Di
 }
 
 func (is MockedImageStore) GetAllDedupeReposCandidates(digest godigest.Digest) ([]string, error) {
-	if is.GetAllBlobsFn != nil {
+	if is.GetAllDedupeReposCandidatesFn != nil {
 		return is.GetAllDedupeReposCandidatesFn(digest)
 	}
 


### PR DESCRIPTION
BREAKING CHANGE: with dedupe enabled, HEAD and ranged GET no longer
rematerialize digests from the store dedupe cache into the target
repository. Clients that depended on that HEAD side effect must use
POST `/v2/<name>/blobs/uploads/?mount=<digest>`, or set
storage.hydrateBlobOnRead to true (per store/subpath).

Default blob reads use StatBlob so OCI AtomicDelete (DELETE then HEAD → 404)
holds. POST `?mount=` still uses CheckBlob. When access control is enabled,
mount and opt-in hydrate paths require create on the destination and read on
a cache source via AccessController.can. Share writeBlobReadError for
HEAD/GET; document the flag; cover default, opt-in, and authz paths in
tests; run conformance with dedupe enabled.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
