### PR TITLE
fix(api): only apply failDelay when credentials are sent

### DIFF
--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -817,7 +817,10 @@ func getRelyingPartyArgs(cfg *config.Config, provider string, hashKey, encryptKe
 }
 
 func authFail(w http.ResponseWriter, r *http.Request, realm string, delay int) {
-	if !isAuthorizationHeaderEmpty(r) || hasSessionHeader(r) {
+	// Only delay when credentials were supplied. UI probes (X-ZOT-API-CLIENT without
+	// Authorization) and expired-session checks must not sleep, or a stale 401 can race
+	// with a later successful login
+	if !isAuthorizationHeaderEmpty(r) {
 		time.Sleep(time.Duration(delay) * time.Second)
 	}
 

--- a/pkg/api/authn_internal_test.go
+++ b/pkg/api/authn_internal_test.go
@@ -1,13 +1,17 @@
 package api
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"slices"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/zitadel/oidc/v3/pkg/oidc"
 
 	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/api/constants"
 	"zotregistry.dev/zot/v2/pkg/log"
 )
 
@@ -333,4 +337,40 @@ func TestAppendOpenIDGroups(t *testing.T) {
 			assert.Equal(t, test.expected, groups)
 		})
 	}
+}
+
+func TestAuthFailDelay(t *testing.T) {
+	t.Parallel()
+
+	const failDelay = 1
+
+	t.Run("no delay for UI probe without credentials", func(t *testing.T) {
+		t.Parallel()
+
+		request := httptest.NewRequest(http.MethodGet, "/v2/", nil)
+		request.Header.Set(constants.SessionClientHeaderName, constants.SessionClientHeaderValue)
+
+		recorder := httptest.NewRecorder()
+		start := time.Now()
+		authFail(recorder, request, "zot", failDelay)
+		elapsed := time.Since(start)
+
+		assert.Less(t, elapsed, 200*time.Millisecond)
+		assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+	})
+
+	t.Run("delay for failed credential attempt", func(t *testing.T) {
+		t.Parallel()
+
+		request := httptest.NewRequest(http.MethodGet, "/v2/", nil)
+		request.Header.Set("Authorization", "Basic dXNlcjp3cm9uZw==")
+
+		recorder := httptest.NewRecorder()
+		start := time.Now()
+		authFail(recorder, request, "zot", failDelay)
+		elapsed := time.Since(start)
+
+		assert.GreaterOrEqual(t, elapsed, 900*time.Millisecond)
+		assert.Equal(t, http.StatusUnauthorized, recorder.Code)
+	})
 }


### PR DESCRIPTION
UI login probes GET /v2/ with X-ZOT-API-CLIENT but no Authorization header. Delaying those 401s widened a race with a later successful login: the stale response could trigger logout after navigation.

Limit authFail sleep to requests that actually supplied credentials, preserving brute-force protection for failed basic auth.

Fixes project-zot/zot#4361

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
