### PR TITLE
fix(cve): stop SBOM generation from widening CVE results

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1531,12 +1531,17 @@ A minimal configuration only sets how often the DB is refreshed; zot applies def
 
 To set those options explicitly (for example to mirror standalone Trivy’s `--vuln-severity-source` behavior), use a `trivy` object under `cve`:
 
-- [config-cve-trivy.json](config-cve-trivy.json) — shows optional `dbRepository`, `javaDBRepository`, `vulnSeveritySources`, and `sbom`.
+- [config-cve-trivy.json](config-cve-trivy.json) — shows optional `dbRepository`, `javaDBRepository`, `vulnSeveritySources`, `detectionPriority`, `scanRemovedPkgs`, and `includeDevDeps`.
+- [config-sbom-trivy.json](config-sbom-trivy.json) — adds `sbom` to generate SBOMs during scanning.
 
 `ignoreFile` specifies the path to a [Trivy ignore file](https://trivy.dev/docs/latest/configuration/filtering/#trivyignore) and supports the same plain-text and YAML formats as Trivy's `--ignorefile` option. The file must exist and be readable when zot loads its configuration. Relative paths are resolved from zot's process working directory, not from the directory containing the zot configuration file, so use an absolute path in deployments, for example `"ignoreFile": "/etc/zot/.trivyignore"`. A sample [`.trivyignore`](.trivyignore) is included in this directory.
 
 Scan results are cached by manifest digest. Editing an ignore file does not invalidate existing cached results: newly ignored vulnerabilities can remain visible, and newly unignored vulnerabilities can remain hidden, until the CVE database refresh purges the scan cache or zot restarts. The minimum database `updateInterval` is two hours.
 
 `vulnSeveritySources` is a list of source names in priority order (for example `auto`, `nvd`, or vendor IDs such as `redhat`, `alpine`). If omitted, zot defaults it to `["auto"]`, consistent with the Trivy CLI. See [Trivy: severity selection](https://trivy.dev/docs/latest/scanner/vulnerability/#severity-selection).
+
+`detectionPriority` mirrors Trivy's [`--detection-priority`](https://trivy.dev/docs/latest/scanner/vulnerability/#detection-priority) and accepts `precise` (default) or `comprehensive`. `comprehensive` stops Trivy filtering files owned by the OS package manager, so those files are reported a second time as language packages matched against NVD. On distributions that backport security fixes (RHEL, SLES) this typically results in reported vulnerabilities that the vendor has already patched.
+
+`scanRemovedPkgs` mirrors Trivy's `--removed-pkgs` and reports vulnerabilities for packages deleted in later image layers. `includeDevDeps` mirrors Trivy's `--include-dev-deps` and reports development dependencies. Both default to `false`.
 
 `sbom.enable` lets zot generate SBOMs while scanning and store them as OCI artifacts attached to the scanned image. `sbom.format` supports `spdx-json` (default) and `cyclonedx`.

--- a/examples/config-cve-trivy.json
+++ b/examples/config-cve-trivy.json
@@ -18,7 +18,10 @@
         "trivy": {
           "dbRepository": "ghcr.io/aquasecurity/trivy-db",
           "javaDBRepository": "ghcr.io/aquasecurity/trivy-java-db",
-          "vulnSeveritySources": ["auto"]
+          "vulnSeveritySources": ["auto"],
+          "detectionPriority": "precise",
+          "scanRemovedPkgs": false,
+          "includeDevDeps": false
         }
       }
     }

--- a/pkg/cli/server/extensions_test.go
+++ b/pkg/cli/server/extensions_test.go
@@ -910,7 +910,8 @@ func TestServeSearchEnabledDefaultCVEDB(t *testing.T) {
 		// The default config handling logic will convert the 1h interval to a 2h interval
 		substring := "\"Search\":{\"Enable\":true,\"CVE\":{\"UpdateInterval\":7200000000000,\"Trivy\":" +
 			"{\"DBRepository\":\"ghcr.io/aquasecurity/trivy-db\",\"JavaDBRepository\":\"ghcr.io/aquasecurity/trivy-java-db\"," +
-			"\"IgnoreFile\":\"\",\"VulnSeveritySources\":[\"auto\"],\"SBOM\":null}}}"
+			"\"IgnoreFile\":\"\",\"VulnSeveritySources\":[\"auto\"],\"DetectionPriority\":\"precise\"," +
+			"\"ScanRemovedPkgs\":false,\"IncludeDevDeps\":false,\"SBOM\":null}}}"
 
 		found, err := ReadLogFileAndSearchString(logPath, substring, readLogFileTimeout)
 

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -1077,6 +1077,13 @@ func applyDefaultValues(config *config.Config, viperInstance *viper.Viper, logge
 
 					config.Extensions.Search.CVE.Trivy.VulnSeveritySources = defaultVulnSeveritySources
 				}
+
+				if config.Extensions.Search.CVE.Trivy.DetectionPriority == "" {
+					defaultDetectionPriority := "precise"
+					logger.Info().Str("detectionPriority", defaultDetectionPriority).Str("component", "config").
+						Msg("using default trivy detection priority.")
+					config.Extensions.Search.CVE.Trivy.DetectionPriority = defaultDetectionPriority
+				}
 			}
 		}
 

--- a/pkg/extensions/config/config.go
+++ b/pkg/extensions/config/config.go
@@ -65,6 +65,9 @@ type TrivyConfig struct {
 	// VulnSeveritySources controls Trivy's severity source selection (same as Trivy's --vuln-severity-source).
 	// If empty, zot will default it to ["auto"].
 	VulnSeveritySources []string
+	DetectionPriority   string // default is "precise", same as Trivy's --detection-priority flag
+	ScanRemovedPkgs     bool   // default is false, same as Trivy's --removed-pkgs flag
+	IncludeDevDeps      bool   // default is false, same as Trivy's --include-dev-deps flag
 	SBOM                *SBOMConfig
 }
 

--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -85,7 +85,7 @@ var newArtifactRunner = artifact.NewRunner //nolint:gochecknoglobals // test sea
 // getNewScanOptions sets trivy configuration values for our scans and returns them as
 // a trivy Options structure.
 func getNewScanOptions(dir string, dbRepositoryRef, javaDBRepositoryRef name.Reference,
-	vulnSeveritySources []dbTypes.SourceID, ignoreFile string, sbomEnabled bool,
+	vulnSeveritySources []dbTypes.SourceID, ignoreFile string, sbomEnabled bool, tuning trivyScanTuning,
 ) *flag.Options {
 	scanOptions := flag.Options{
 		GlobalOptions: flag.GlobalOptions{
@@ -123,15 +123,43 @@ func getNewScanOptions(dir string, dbRepositoryRef, javaDBRepositoryRef name.Ref
 		},
 	}
 
+	scanOptions.ImageOptions.ScanRemovedPkgs = tuning.scanRemovedPkgs
+	scanOptions.PackageOptions.IncludeDevDeps = tuning.includeDevDeps
+	scanOptions.ScanOptions.DetectionPriority = tuning.detectionPriority
+
+	// trivy report feeds SBOM and CVE API, so sbomEnabled alone should not set detectionPriority,
+	// scanRemovedPkgs, and includeDevDeps. Blindly setting those to "true" will usually result in
+	// false positive CVEs on RHEL images. We set those above separately as configurable options.
 	if sbomEnabled {
 		scanOptions.ScanOptions.Scanners = types.Scanners{types.VulnerabilityScanner, types.LicenseScanner}
-		scanOptions.ScanOptions.DetectionPriority = fanalTypes.PriorityComprehensive
-		scanOptions.ImageOptions.ScanRemovedPkgs = true
 		scanOptions.LicenseOptions.LicenseFull = true
-		scanOptions.PackageOptions.IncludeDevDeps = true
 	}
 
 	return &scanOptions
+}
+
+type trivyScanTuning struct {
+	scanRemovedPkgs   bool
+	includeDevDeps    bool
+	detectionPriority fanalTypes.DetectionPriority
+}
+
+func getTrivyScanTuning(trivyCfg *extconf.TrivyConfig, logger log.Logger) trivyScanTuning {
+	var scanTuning trivyScanTuning
+	scanTuning.scanRemovedPkgs = trivyCfg.ScanRemovedPkgs
+	scanTuning.includeDevDeps = trivyCfg.IncludeDevDeps
+	scanTuning.detectionPriority = fanalTypes.PriorityPrecise
+
+	switch strings.ToLower(trivyCfg.DetectionPriority) {
+	case "", string(fanalTypes.PriorityPrecise):
+	case string(fanalTypes.PriorityComprehensive):
+		scanTuning.detectionPriority = fanalTypes.PriorityComprehensive
+	default:
+		logger.Warn().Str("detectionPriority", trivyCfg.DetectionPriority).
+			Msg("unsupported trivy detection priority, defaulting to precise")
+	}
+
+	return scanTuning
 }
 
 type cveTrivyController struct {
@@ -186,6 +214,8 @@ func NewScanner(storeController storage.StoreController,
 	vulnSeveritySources := trivyCfg.VulnSeveritySources
 	ignoreFile := trivyCfg.IgnoreFile
 
+	scanTuning := getTrivyScanTuning(trivyCfg, log)
+
 	// The logic to set defaults is similar to what trivy itself uses:
 	// https://github.com/aquasecurity/trivy/blob/v0.51.4/pkg/flag/db_flags.go#L152
 	var dbRepositoryRef name.Reference
@@ -228,7 +258,8 @@ func NewScanner(storeController storage.StoreController,
 		rootDir := imageStore.RootDir()
 
 		cacheDir := path.Join(rootDir, "_trivy")
-		opts := getNewScanOptions(cacheDir, dbRepositoryRef, javaDBRepositoryRef, sevSources, ignoreFile, sbomOpts.enabled)
+		opts := getNewScanOptions(cacheDir, dbRepositoryRef, javaDBRepositoryRef, sevSources,
+			ignoreFile, sbomOpts.enabled, scanTuning)
 
 		cveController.DefaultCveConfig = opts
 	}
@@ -238,7 +269,8 @@ func NewScanner(storeController storage.StoreController,
 			rootDir := storage.RootDir()
 
 			cacheDir := path.Join(rootDir, "_trivy")
-			opts := getNewScanOptions(cacheDir, dbRepositoryRef, javaDBRepositoryRef, sevSources, ignoreFile, sbomOpts.enabled)
+			opts := getNewScanOptions(cacheDir, dbRepositoryRef, javaDBRepositoryRef, sevSources,
+				ignoreFile, sbomOpts.enabled, scanTuning)
 
 			subCveConfig[route] = opts
 		}

--- a/pkg/extensions/search/cve/trivy/scanner_internal_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/aquasecurity/trivy-db/pkg/metadata"
 	dbTypes "github.com/aquasecurity/trivy-db/pkg/types"
 	"github.com/aquasecurity/trivy/pkg/commands/artifact"
+	fanalTypes "github.com/aquasecurity/trivy/pkg/fanal/types"
 	"github.com/aquasecurity/trivy/pkg/flag"
 	trivyTypes "github.com/aquasecurity/trivy/pkg/types"
 	godigest "github.com/opencontainers/go-digest"
@@ -724,9 +725,88 @@ func TestIgnoreFileConfiguration(t *testing.T) {
 	Convey("getNewScanOptions passes the configured ignore file to Trivy", t, func() {
 		const ignoreFile = "/etc/zot/.trivyignore.yaml"
 
-		opts := getNewScanOptions(t.TempDir(), nil, nil, []dbTypes.SourceID{"auto"}, ignoreFile, false)
+		opts := getNewScanOptions(t.TempDir(), nil, nil, []dbTypes.SourceID{"auto"}, ignoreFile, false, trivyScanTuning{})
 
 		So(opts.ReportOptions.IgnoreFile, ShouldEqual, ignoreFile)
+	})
+}
+
+func TestScanTuningConfiguration(t *testing.T) {
+	// Regression test: enabling SBOM generation used to imply comprehensive CVE detection, which stops
+	// Trivy filtering OS-owned files and re-reports them as language packages matched against NVD.
+	Convey("enabling SBOM generation does not widen vulnerability detection", t, func() {
+		tuning := getTrivyScanTuning(&extconf.TrivyConfig{
+			SBOM: &extconf.SBOMConfig{Enable: true},
+		}, log.NewTestLogger())
+
+		opts := getNewScanOptions(t.TempDir(), nil, nil, []dbTypes.SourceID{"auto"}, "", true, tuning)
+
+		So(opts.ScanOptions.DetectionPriority, ShouldEqual, fanalTypes.PriorityPrecise)
+		So(opts.ImageOptions.ScanRemovedPkgs, ShouldBeFalse)
+		So(opts.PackageOptions.IncludeDevDeps, ShouldBeFalse)
+
+		So(opts.LicenseOptions.LicenseFull, ShouldBeTrue)
+		So(opts.ScanOptions.Scanners, ShouldContain, trivyTypes.LicenseScanner)
+	})
+
+	Convey("scan tuning defaults to precise detection", t, func() {
+		tuning := getTrivyScanTuning(&extconf.TrivyConfig{}, log.NewTestLogger())
+
+		So(tuning.detectionPriority, ShouldEqual, fanalTypes.PriorityPrecise)
+		So(tuning.scanRemovedPkgs, ShouldBeFalse)
+		So(tuning.includeDevDeps, ShouldBeFalse)
+	})
+
+	Convey("scan tuning honors explicit configuration", t, func() {
+		tuning := getTrivyScanTuning(&extconf.TrivyConfig{
+			DetectionPriority: string(fanalTypes.PriorityComprehensive),
+			ScanRemovedPkgs:   true,
+			IncludeDevDeps:    true,
+		}, log.NewTestLogger())
+
+		opts := getNewScanOptions(t.TempDir(), nil, nil, []dbTypes.SourceID{"auto"}, "", false, tuning)
+
+		So(opts.ScanOptions.DetectionPriority, ShouldEqual, fanalTypes.PriorityComprehensive)
+		So(opts.ImageOptions.ScanRemovedPkgs, ShouldBeTrue)
+		So(opts.PackageOptions.IncludeDevDeps, ShouldBeTrue)
+	})
+
+	Convey("detection priority is case insensitive", t, func() {
+		tuning := getTrivyScanTuning(&extconf.TrivyConfig{
+			DetectionPriority: "COMPREHENSIVE",
+		}, log.NewTestLogger())
+
+		So(tuning.detectionPriority, ShouldEqual, fanalTypes.PriorityComprehensive)
+	})
+
+	Convey("unsupported detection priority falls back to precise", t, func() {
+		tuning := getTrivyScanTuning(&extconf.TrivyConfig{
+			DetectionPriority: "aggressive",
+		}, log.NewTestLogger())
+
+		So(tuning.detectionPriority, ShouldEqual, fanalTypes.PriorityPrecise)
+	})
+
+	Convey("NewScanner propagates scan tuning to the store scan options", t, func() {
+		logger := log.NewTestLogger()
+		store := local.NewImageStore(t.TempDir(), false, false, logger,
+			monitoring.NewNopMetricServer(), nil, nil, nil, nil)
+
+		scanner := NewScanner(storage.StoreController{DefaultStore: store}, nil, &extconf.CVEConfig{
+			Trivy: &extconf.TrivyConfig{
+				DBRepository:      "ghcr.io/project-zot/trivy-db",
+				DetectionPriority: string(fanalTypes.PriorityComprehensive),
+				ScanRemovedPkgs:   true,
+				IncludeDevDeps:    true,
+			},
+		}, logger)
+		So(scanner, ShouldNotBeNil)
+
+		opts := scanner.cveController.DefaultCveConfig
+		So(opts, ShouldNotBeNil)
+		So(opts.ScanOptions.DetectionPriority, ShouldEqual, fanalTypes.PriorityComprehensive)
+		So(opts.ImageOptions.ScanRemovedPkgs, ShouldBeTrue)
+		So(opts.PackageOptions.IncludeDevDeps, ShouldBeTrue)
 	})
 }
 


### PR DESCRIPTION
Turning on the trivy sbom generation also turns on trivy's comprehensive detection priority, --removed-pkgs and --include-dev-deps flags (see [here](https://github.com/project-zot/zot/pull/4088)). One Trivy report feeds both the SBOM and the CVE API, so enabling SBOMs quietly changed which CVEs are reported by zot/trivy.

Comprehensive detection is the main problem. It stops Trivy filtering files owned by the OS package manager, so those files get scanned a second time as language packages and matched against NVD. Distros that backport fixes then look vulnerable when they are not.

Scanning redhat/ubi9 this way adds 14 CVEs that Red Hat has already patched, such as CVE-2022-40897 and CVE-2023-32681. redhat/ubi10 goes from 0 to 7, since Trivy ships no Red Hat advisory data for RHEL 10 at all.

This PR moves the three above-mentioned settings to separate config options:

  detectionPriority  (--detection-priority, defaults to "precise")
  scanRemovedPkgs    (--removed-pkgs, defaults to OFF)
  includeDevDeps     (--include-dev-deps, defaults to OFF)

detectionPriority also gets its default applied in applyDefaultValues, so the effective value shows up in the logged configuration. An unsupported value falls back to "precise" with a warning.

SBOM generation now only adds license collection by default, which does not change vulnerability results.

**What type of PR is this?**
bug

**Which issue does this PR fix**:
Fixes #4356

**Testing done on this change**:
Unit tests (`pkg/extensions/search/cve/trivy/scanner_internal_test.go`):

- `TestScanTuningConfiguration` - new. Asserts that enabling `sbom` leaves `DetectionPriority`, `ScanRemovedPkgs` and `IncludeDevDeps` untouched while still enabling license collection; that defaults resolve to `precise`/`false`/`false`; that explicit values reach the Trivy options; that `detectionPriority` is case-insensitive; that an unsupported value falls back to `precise`; and that `NewScanner` propagates the values through to `cveController.DefaultCveConfig`.
- `TestIgnoreFileConfiguration` - updated for the new `getNewScanOptions` signature
- `TestServeSearchEnabledDefaultCVEDB` — updated for the serialized `TrivyConfig`

Local verification (`GOEXPERIMENT=jsonv2`, extension build tags):

- `go build ./...` - OK
- `golangci-lint` v2.12.2 - 0 issues
- `go test ./pkg/extensions/search/cve/trivy/... ./pkg/extensions/config/...` - pass
- `go test -run TestServeSearchEnabledDefaultCVEDB ./pkg/cli/server/...` - pass

Behavioral reproduction with the Trivy CLI v0.74.0 (the version currently vendored), comparing zot's non-SBOM option set against its SBOM option set (this is also shown in the linked issue)

```bash
trivy image --quiet --scanners vuln --pkg-types os,library --offline-scan \
  --format json -o baseline.json redhat/ubi9:latest

trivy image --quiet --scanners vuln --pkg-types os,library --offline-scan \
  --detection-priority comprehensive --removed-pkgs \
  --format json -o sbom-mode.json redhat/ubi9:latest
```

| image | SBOM off | SBOM on | delta |
|---|---|---|---|
| `redhat/ubi9` | 310 CVEs, all `os-pkgs/redhat` | 324 | +14, all `lang-pkgs/python-pkg` |
| `redhat/ubi10` | 0 | 7 | +7, all `lang-pkgs/python-pkg` |

The extra findings are false positives against RPM-owned files carrying backported fixes:

```
$ rpm -qf /usr/lib/python3.9/site-packages/urllib3-1.26.5-py3.9.egg-info
python3-urllib3-1.26.5-8.el9_8.noarch
```

**Automation added to e2e**:
No. The change is confined to how Trivy scan options are constructed, which the unit tests cover directly without needing a server round-trip. Happy to add a blackbox case alongside `test/blackbox/sbom.bats` if maintainers would prefer coverage at that level.

**Will this break upgrades or downgrades?**
Upgrades: no config migration needed. The three keys are optional and existing configs remain valid.

Upgrades do change CVE output for anyone currently running with `sbom.enable: true`: those deployments were implicitly getting comprehensive detection, so their reported CVE counts will drop. That is the intent of the fix: the removed findings are false positives, but it is visible. Setting `"detectionPriority": "comprehensive"`, `"scanRemovedPkgs": true` and `"includeDevDeps": true` restores the previous behavior exactly.

Downgrades: if any of the three new keys are present in the configuration file, an older zot will fail to start with `failed to load config due to unknown keys`, since `LoadConfiguration` rejects unknown keys rather than ignoring them. Remove the keys before downgrading.

**Does this PR introduce any user-facing change?**:
Yes. Three new optional configuration keys, and a change in reported CVEs when SBOM generation is enabled.

**Release Notes**
```release-note
Enabling `extensions.search.cve.trivy.sbom` no longer necessarily changes vulnerability detection. Previously it implicitly enabled Trivy's comprehensive detection priority, `--removed-pkgs` and `--include-dev-deps`, which caused false positive CVEs on distributions that backport security fixes (for example RHEL).

These 3 trivy flags are now independent configuration options under `extensions.search.cve.trivy`, disabled by default:

  detectionPriority  "precise" (default) or "comprehensive"
  scanRemovedPkgs    false (default)
  includeDevDeps     false (default)

Deployments that relied on the previous behavior can restore it by setting all three explicitly.
```

### Does this degrade SBOM quality?

Not on my tests, but it's *possible* - see below. Measured on `redhat/ubi9:latest` with Trivy v0.73.0, comparing SPDX output generated with and without the trio of `detectionPriority`, `scanRemovedPkgs`, and `includeDevDeps`.

```bash
trivy image --quiet --scanners vuln --pkg-types os,library --offline-scan --list-all-pkgs --format spdx-json -o sbom-precise.json redhat/ubi9:latest

trivy image --quiet --scanners vuln --pkg-types os,library --offline-scan --list-all-pkgs --detection-priority comprehensive --removed-pkgs --format spdx-json -o sbom-comprehensive.json redhat/ubi9:latest
```

| | precise (new default) | comprehensive (previous implicit behavior) |
|---|---|---|
| total packages | 190 | 208 |
| `pkg:rpm/...` | 188 | 188 |
| `pkg:pypi/...` | 0 | 18 |
| `pkg:oci/...` | 1 | 1 |

No component is lost: the set difference `precise \ comprehensive` is empty, and the RPM inventory is identical at 188 entries either way.

All 18 extra components are duplicates of RPMs already in the SBOM, emitted with a second PURL whose version drops the distribution release suffix:

```
pkg:rpm/redhat/python3-urllib3@1.26.5-8.el9_8   (precise and comprehensive)
pkg:pypi/urllib3@1.26.5                         (comprehensive only)
```

All 18 map to an RPM already present: `requests`→`python3-requests`, `setuptools`→`python3-setuptools`, `PyGObject`→`python3-gobject-base`, and so on. The `-8.el9_8` suffix is what records Red Hat's backported fixes, so the duplicate PURL misrepresents the patch state of the same bytes on disk anyway. That is the same root cause as the CVE false positives, surfaced in the SBOM.

Note that `comprehensive` does have a legitimate SBOM use case: dependencies bundled inside OS packages (a fat JAR shipped in an RPM, vendored modules in an RPM-owned Go binary) are invisible to the OS-package view and only appear when the system-file filter is disabled. `ubi9` is a minimal base with no such content, which is why the diff here is pure duplication. But in that case, we now have the option to turn on these flags!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
