### PR TITLE
feat(mgmt): expose allowAnonymousAccess in auth config

### DIFF
--- a/pkg/extensions/README_mgmt.md
+++ b/pkg/extensions/README_mgmt.md
@@ -31,12 +31,15 @@ curl http://localhost:8080/v2/_zot/ext/mgmt | jq
       "bearer": {
         "realm": "https://auth.myreg.io/auth/token",
         "service": "myauth"
-      }
+      },
+      "allowAnonymousAccess": true
     }
   }
 }
 ```
 
-If ldap or htpasswd are enabled mgmt will return `{"htpasswd": {}}` indicating that clients can authenticate with basic auth credentials.
+If ldap or htpasswd are enabled mgmt will return `{"htpasswd": {}}` indicating that clients can authenticate with basic auth credentials. An empty `htpasswd` object from a disabled (pathless) htpasswd config is omitted.
+
+If `accessControl` contains any repository `anonymousPolicy`, mgmt sets `allowAnonymousAccess: true` so clients can offer guest login without probing `GET /v2/`.
 
 If any key is present under `'auth'` key, in the mgmt response, it means that particular authentication method is enabled.

--- a/pkg/extensions/extension_mgmt.go
+++ b/pkg/extensions/extension_mgmt.go
@@ -36,9 +36,10 @@ type Auth struct {
 	Bearer   *BearerConfig `json:"bearer,omitempty"   mapstructure:"bearer"`
 	LDAP     *struct {
 		Address string `json:"address,omitempty" mapstructure:"address"`
-	} `json:"ldap,omitempty"   mapstructure:"ldap"`
-	OpenID *OpenIDConfig `json:"openid,omitempty" mapstructure:"openid"`
-	APIKey bool          `json:"apikey,omitempty" mapstructure:"apikey"`
+	} `json:"ldap,omitempty"                 mapstructure:"ldap"`
+	OpenID               *OpenIDConfig `json:"openid,omitempty"               mapstructure:"openid"`
+	APIKey               bool          `json:"apikey,omitempty"               mapstructure:"apikey"`
+	AllowAnonymousAccess bool          `json:"allowAnonymousAccess,omitempty" mapstructure:"allowAnonymousAccess"`
 }
 
 type StrippedConfig struct {
@@ -60,7 +61,7 @@ func (auth Auth) MarshalJSON() ([]byte, error) {
 	type localAuth Auth
 
 	if auth.Bearer == nil && auth.LDAP == nil &&
-		auth.HTPasswd.Path == "" &&
+		(auth.HTPasswd == nil || auth.HTPasswd.Path == "") &&
 		(auth.OpenID == nil || len(auth.OpenID.Providers) == 0) {
 		auth.HTPasswd = nil
 		auth.OpenID = nil
@@ -68,10 +69,12 @@ func (auth Auth) MarshalJSON() ([]byte, error) {
 		return json.Marshal((localAuth)(auth))
 	}
 
-	if auth.HTPasswd.Path == "" && auth.LDAP == nil {
-		auth.HTPasswd = nil
+	// HTPasswd is a value on AuthConfig, so MarshalThroughStruct always yields a
+	// non-nil pointer. Only advertise basic auth when LDAP is set or a path exists.
+	if auth.LDAP != nil || (auth.HTPasswd != nil && auth.HTPasswd.Path != "") {
+		auth.HTPasswd = &HTPasswd{}
 	} else {
-		auth.HTPasswd.Path = ""
+		auth.HTPasswd = nil
 	}
 
 	if auth.OpenID != nil && len(auth.OpenID.Providers) == 0 {
@@ -122,12 +125,29 @@ type Mgmt struct {
 // @Success 200 {object}   extensions.StrippedConfig
 // @Failure 500 {string}   string   "internal server error"
 func (mgmt *Mgmt) HandleGetConfig(w http.ResponseWriter, r *http.Request) {
+	var stripped StrippedConfig
+
 	sanitizedConfig := mgmt.Conf.Sanitize()
 
-	buf, err := zcommon.MarshalThroughStruct(sanitizedConfig, &StrippedConfig{})
+	if _, err := zcommon.MarshalThroughStruct(sanitizedConfig, &stripped); err != nil {
+		mgmt.Log.Error().Err(err).Str("component", "mgmt").Msg("failed to marshal config response")
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	if stripped.HTTP.Auth != nil &&
+		sanitizedConfig.HTTP.AccessControl != nil &&
+		sanitizedConfig.HTTP.AccessControl.AnonymousPolicyExists() {
+		stripped.HTTP.Auth.AllowAnonymousAccess = true
+	}
+
+	buf, err := json.Marshal(stripped)
 	if err != nil {
 		mgmt.Log.Error().Err(err).Str("component", "mgmt").Msg("failed to marshal config response")
 		w.WriteHeader(http.StatusInternalServerError)
+
+		return
 	}
 
 	_, _ = w.Write(buf)

--- a/pkg/extensions/extension_mgmt_internal_test.go
+++ b/pkg/extensions/extension_mgmt_internal_test.go
@@ -1,0 +1,89 @@
+//go:build mgmt
+
+package extensions
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuthMarshalJSONNilHTPasswd(t *testing.T) {
+	t.Parallel()
+
+	buf, err := json.Marshal(Auth{APIKey: true})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf, &decoded))
+	assert.True(t, decoded["apikey"].(bool))
+	assert.NotContains(t, decoded, "htpasswd")
+}
+
+func TestAuthMarshalJSONLDAPOnly(t *testing.T) {
+	t.Parallel()
+
+	buf, err := json.Marshal(Auth{
+		LDAP: &struct {
+			Address string `json:"address,omitempty" mapstructure:"address"`
+		}{Address: "ldap.example.com"},
+	})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf, &decoded))
+	assert.NotContains(t, decoded, "ldap")
+
+	htpasswd, ok := decoded["htpasswd"].(map[string]any)
+	require.True(t, ok)
+	assert.Empty(t, htpasswd)
+}
+
+func TestAuthMarshalJSONBearerOnlyEmptyHTPasswd(t *testing.T) {
+	t.Parallel()
+
+	buf, err := json.Marshal(Auth{
+		HTPasswd: &HTPasswd{},
+		Bearer: &BearerConfig{
+			Realm:   "https://auth.example.com/token",
+			Service: "zot",
+		},
+	})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf, &decoded))
+	assert.NotContains(t, decoded, "htpasswd")
+	assert.NotContains(t, decoded, "ldap")
+
+	bearer, ok := decoded["bearer"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "https://auth.example.com/token", bearer["realm"])
+	assert.Equal(t, "zot", bearer["service"])
+}
+
+func TestAuthMarshalJSONOpenIDOnlyEmptyHTPasswd(t *testing.T) {
+	t.Parallel()
+
+	buf, err := json.Marshal(Auth{
+		HTPasswd: &HTPasswd{},
+		OpenID: &OpenIDConfig{
+			Providers: map[string]OpenIDProviderConfig{
+				"oidc": {Name: "Example"},
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	var decoded map[string]any
+	require.NoError(t, json.Unmarshal(buf, &decoded))
+	assert.NotContains(t, decoded, "htpasswd")
+
+	openid, ok := decoded["openid"].(map[string]any)
+	require.True(t, ok)
+	providers, ok := openid["providers"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, providers, "oidc")
+}

--- a/pkg/extensions/extensions_test.go
+++ b/pkg/extensions/extensions_test.go
@@ -1052,3 +1052,74 @@ func TestAllowedMethodsHeaderMgmt(t *testing.T) {
 		So(resp.StatusCode(), ShouldEqual, http.StatusNoContent)
 	})
 }
+
+func TestMgmtAllowAnonymousAccess(t *testing.T) {
+	defaultValue := true
+
+	setupMgmtController := func(t *testing.T, accessControl *config.AccessControlConfig) (string, func()) {
+		t.Helper()
+
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		conf.HTTP.Auth = &config.AuthConfig{APIKey: true}
+		conf.HTTP.AccessControl = accessControl
+
+		conf.Extensions = &extconf.ExtensionConfig{}
+		conf.Extensions.Search = &extconf.SearchConfig{}
+		conf.Extensions.Search.Enable = &defaultValue
+		conf.Extensions.Search.CVE = nil
+		conf.Extensions.UI = &extconf.UIConfig{}
+		conf.Extensions.UI.Enable = &defaultValue
+
+		ctlr := api.NewController(conf)
+		ctlr.Config.Storage.RootDirectory = t.TempDir()
+
+		ctrlManager := test.NewControllerManager(ctlr)
+		baseURL := ctrlManager.StartAndWait()
+
+		return baseURL, ctrlManager.StopServer
+	}
+
+	Convey("mgmt reports allowAnonymousAccess when anonymous policies exist", t, func() {
+		baseURL, stop := setupMgmtController(t, &config.AccessControlConfig{
+			Repositories: config.Repositories{
+				"repo": config.PolicyGroup{
+					AnonymousPolicy: []string{"read"},
+				},
+			},
+		})
+		defer stop()
+
+		resp, err := resty.R().Get(baseURL + constants.FullMgmt)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		mgmtResp := extensions.StrippedConfig{}
+		err = json.Unmarshal(resp.Body(), &mgmtResp)
+		So(err, ShouldBeNil)
+		So(mgmtResp.HTTP.Auth, ShouldNotBeNil)
+		So(mgmtResp.HTTP.Auth.AllowAnonymousAccess, ShouldBeTrue)
+	})
+
+	Convey("mgmt omits allowAnonymousAccess without anonymous policies", t, func() {
+		baseURL, stop := setupMgmtController(t, &config.AccessControlConfig{
+			Repositories: config.Repositories{
+				"repo": config.PolicyGroup{
+					DefaultPolicy: []string{"read"},
+				},
+			},
+		})
+		defer stop()
+
+		resp, err := resty.R().Get(baseURL + constants.FullMgmt)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		mgmtResp := extensions.StrippedConfig{}
+		err = json.Unmarshal(resp.Body(), &mgmtResp)
+		So(err, ShouldBeNil)
+		So(mgmtResp.HTTP.Auth, ShouldNotBeNil)
+		So(mgmtResp.HTTP.Auth.AllowAnonymousAccess, ShouldBeFalse)
+		So(string(resp.Body()), ShouldNotContainSubstring, "allowAnonymousAccess")
+	})
+}

--- a/swagger/docs.go
+++ b/swagger/docs.go
@@ -1406,6 +1406,9 @@ const docTemplate = `{
         "extensions.Auth": {
             "type": "object",
             "properties": {
+                "allowAnonymousAccess": {
+                    "type": "boolean"
+                },
                 "apikey": {
                     "type": "boolean"
                 },

--- a/swagger/swagger.json
+++ b/swagger/swagger.json
@@ -1398,6 +1398,9 @@
         "extensions.Auth": {
             "type": "object",
             "properties": {
+                "allowAnonymousAccess": {
+                    "type": "boolean"
+                },
                 "apikey": {
                     "type": "boolean"
                 },

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -106,6 +106,8 @@ definitions:
     type: object
   extensions.Auth:
     properties:
+      allowAnonymousAccess:
+        type: boolean
       apikey:
         type: boolean
       bearer:

--- a/test/blackbox/metadata.bats
+++ b/test/blackbox/metadata.bats
@@ -170,3 +170,22 @@ function teardown_file() {
     [ "$status" -eq 0 ]
     [ $(echo "${lines[-1]}" | jq -r '.data.BookmarkedRepos.Results') = '[]' ]
 }
+
+@test "mgmt reports allowAnonymousAccess and basic auth methods" {
+    zot_port=`cat ${BATS_FILE_TMPDIR}/zot.port`
+
+    run curl -s -w "\n%{http_code}" "http://127.0.0.1:${zot_port}/v2/_zot/ext/mgmt"
+    [ "$status" -eq 0 ]
+    http_code=$(echo "${output}" | tail -n1)
+    body=$(echo "${output}" | sed '$d')
+    [ "${http_code}" = "200" ]
+
+    # htpasswd is exposed as an empty object (path stripped); LDAP details are never returned
+    [ $(echo "${body}" | jq -r 'has("http")') = "true" ]
+    [ $(echo "${body}" | jq -r '.http.auth | has("htpasswd")') = "true" ]
+    [ $(echo "${body}" | jq -c '.http.auth.htpasswd') = '{}' ]
+    [ $(echo "${body}" | jq -r '.http.auth | has("ldap")') = "false" ]
+
+    # anonymousPolicy is configured in this suite, so guest login is advertised
+    [ $(echo "${body}" | jq -r '.http.auth.allowAnonymousAccess') = "true" ]
+}


### PR DESCRIPTION
Add http.auth.allowAnonymousAccess to the mgmt API so the UI can offer guest login without probing GET /v2/, avoiding a race with delayed 401 responses (project-zot/zot#4361).

Also harden Auth.MarshalJSON: nil-safe htpasswd checks, emit htpasswd {} when LDAP or htpasswd is enabled, and simplify HandleGetConfig by enriching the stripped struct in place after MarshalThroughStruct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
