### PR TITLE
fix(gc): treat missing blobs as GC-eligible instead of aborting repo GC

### DIFF
--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -1099,10 +1099,20 @@ func isBlobOlderThan(imgStore types.ImageStore, repo string,
 ) (bool, error) {
 	_, _, modtime, err := imgStore.StatBlob(repo, digest)
 	if err != nil {
-		// Fail closed: ImageStore.StatBlob maps any underlying Stat failure (including
-		// transient S3/network errors) to ErrBlobNotFound, so treating "missing" as
-		// GC-eligible would risk deleting live index rows during storage blips.
-		// Stale prune can still remove truly absent blobs later when CleanRepo succeeds.
+		var pathNotFoundErr driver.PathNotFoundError
+		if errors.As(err, &pathNotFoundErr) {
+			// Blob is missing from storage but referenced in index.json - treat as
+			// GC-eligible so the stale index entry gets removed.
+			log.Warn().Err(err).Str("module", "gc").Str("repository", repo).Str("digest", digest.String()).
+				Msg("blob missing from storage, treating as GC-eligible to clean up stale index entry")
+
+			return true, nil
+		}
+
+		// Fail closed for other errors (transient S3/network issues): we can't
+		// distinguish them from permanently missing blobs, so don't risk deleting
+		// live index rows during storage blips. Stale prune can still remove truly
+		// absent blobs later when CleanRepo succeeds.
 		log.Error().Err(err).Str("module", "gc").Str("repository", repo).Str("digest", digest.String()).
 			Msg("failed to stat blob")
 

--- a/pkg/storage/gc/gc_internal_test.go
+++ b/pkg/storage/gc/gc_internal_test.go
@@ -1565,20 +1565,31 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			So(hasTag, ShouldBeFalse)
 		})
 
-		Convey("removeReferrersWithMissingSubject aborts when StatBlob reports missing", func() {
-			// Match main: StatBlob errors (including ErrBlobNotFound from ImageStore's
-			// error collapsing) fail closed in isBlobOlderThan.
+		Convey("removeReferrersWithMissingSubject treats missing referrer blob as GC-eligible", func() {
+			// When a referrer's blob is missing from storage, isBlobOlderThan returns (true, nil)
+			// so the stale referrer entry gets removed.
 			missingSubject := godigest.FromString("missing-subject")
 			cosignTag := "sha256-" + missingSubject.Encoded() + ".sig"
-			missingDigest := godigest.FromString("missing-cosign-blob")
+			referrerDigest := godigest.FromString("referrer-blob")
+
+			cosignManifest := ispec.Manifest{
+				MediaType: ispec.MediaTypeImageManifest,
+				Subject: &ispec.Descriptor{
+					MediaType: ispec.MediaTypeImageManifest,
+					Digest:    missingSubject,
+					Size:      100,
+				},
+				ArtifactType: zcommon.ArtifactTypeCosign,
+			}
+			cosignManifestBlob, _ := json.Marshal(cosignManifest)
 
 			parentIndex := ispec.Index{
 				MediaType: ispec.MediaTypeImageIndex,
 				Manifests: []ispec.Descriptor{
 					{
 						MediaType: ispec.MediaTypeImageManifest,
-						Digest:    missingDigest,
-						Size:      10,
+						Digest:    referrerDigest,
+						Size:      int64(len(cosignManifestBlob)),
 						Annotations: map[string]string{
 							ispec.AnnotationRefName: cosignTag,
 						},
@@ -1588,10 +1599,16 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 
 			imgStore := mocks.MockedImageStore{
 				GetBlobContentFn: func(repo string, digest godigest.Digest) ([]byte, error) {
+					if digest == referrerDigest {
+						return cosignManifestBlob, nil
+					}
 					return nil, driver.PathNotFoundError{Path: digest.String(), DriverName: "local"}
 				},
 				StatBlobFn: func(repo string, digest godigest.Digest) (bool, int64, time.Time, error) {
-					return false, -1, time.Time{}, driver.PathNotFoundError{Path: digest.String(), DriverName: "local"}
+					if digest == referrerDigest {
+						return false, -1, time.Time{}, driver.PathNotFoundError{Path: digest.String(), DriverName: "local"}
+					}
+					return true, 100, time.Now(), nil
 				},
 			}
 
@@ -1609,9 +1626,13 @@ func TestGarbageCollectWithMockedImageStore(t *testing.T) {
 			gc := NewGarbageCollect(imgStore, mocks.MetaDBMock{}, gcOptions, audit, log, metrics)
 
 			gced, err := gc.removeReferrersWithMissingSubject(repoName, &parentIndex)
-			So(err, ShouldNotBeNil)
-			So(gced, ShouldBeFalse)
+			So(err, ShouldBeNil)
+			So(gced, ShouldBeTrue)
+			// Last-tag delete re-adds an untagged row (RemoveManifestDescByReference semantics);
+			// the outer removeManifestsPerRepoPolicy loop clears it on a later pass.
 			So(len(parentIndex.Manifests), ShouldEqual, 1)
+			_, hasTag := parentIndex.Manifests[0].Annotations[ispec.AnnotationRefName]
+			So(hasTag, ShouldBeFalse)
 		})
 
 		Convey("identifyManifestsReferencedInIndex walks a diamond DAG once per node", func() {

--- a/pkg/storage/gcs/gcs_test.go
+++ b/pkg/storage/gcs/gcs_test.go
@@ -3118,7 +3118,7 @@ func RunGCSCheckAllBlobsIntegrityTests( //nolint: thelper
 			// get content of layer
 			imageRes := storage.CheckLayers(repoName, "1.0", []ispec.Descriptor{{Digest: digest}}, imgStore)
 			So(imageRes.Status, ShouldEqual, "affected")
-			So(imageRes.Error, ShouldEqual, "blob not found")
+			So(imageRes.Error, ShouldContainSubstring, "blob not found")
 
 			buff := bytes.NewBufferString("")
 

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -1639,7 +1639,7 @@ func (is *ImageStore) checkCacheBlob(digest godigest.Digest) (string, error) {
 			return "", err
 		}
 
-		return "", zerr.ErrBlobNotFound
+		return "", fmt.Errorf("%w: %w", zerr.ErrBlobNotFound, err)
 	}
 
 	is.log.Debug().Str("digest", digest.String()).Str("dstRecord", dstRecord).Str("component", "cache").
@@ -1731,11 +1731,15 @@ func (is *ImageStore) originalBlobInfo(repo string, digest godigest.Digest) (dri
 
 		if errors.As(err, &pathNotFoundErr) {
 			is.log.Debug().Err(err).Str("blob", blobPath).Str("digest", digest.String()).Msg("blob not found")
-		} else {
-			is.log.Error().Err(err).Str("blob", blobPath).Msg("failed to stat blob")
+
+			// Wrap to preserve error chain for callers that need to distinguish
+			// genuine "not found" from transient errors.
+			return nil, fmt.Errorf("%w: %w", zerr.ErrBlobNotFound, err)
 		}
 
-		return nil, zerr.ErrBlobNotFound
+		is.log.Error().Err(err).Str("blob", blobPath).Msg("failed to stat blob")
+
+		return nil, fmt.Errorf("%w: %w", zerr.ErrBlobNotFound, err)
 	}
 
 	if binfo.Size() == 0 {
@@ -1753,14 +1757,14 @@ func (is *ImageStore) originalBlobInfo(repo string, digest godigest.Digest) (dri
 		if err != nil {
 			is.log.Debug().Err(err).Str("digest", digest.String()).Msg("not found in cache")
 
-			return nil, zerr.ErrBlobNotFound
+			return nil, fmt.Errorf("%w: %w", zerr.ErrBlobNotFound, err)
 		}
 
 		binfo, err = is.storeDriver.Stat(dstRecord)
 		if err != nil {
 			is.log.Error().Err(err).Str("blob", dstRecord).Msg("failed to stat blob")
 
-			return nil, zerr.ErrBlobNotFound
+			return nil, fmt.Errorf("%w: %w", zerr.ErrBlobNotFound, err)
 		}
 	}
 

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -2958,18 +2958,19 @@ func TestGarbageCollectErrors(t *testing.T) {
 			So(err, ShouldNotBeNil)
 		})
 
-		Convey("Missing untagged manifest blob aborts GC on StatBlob", func() {
+		Convey("Missing untagged manifest blob is treated as GC-eligible", func() {
 			digest = putUntaggedManifestForGCErrors(imgStore, repoName, bdgst1, bsize1)
 
 			// Identify soft-continues on Get miss, but untagged removal still Stats the digest
-			// for the retention delay; StatBlob miss fails closed (same as main).
+			// for the retention delay; StatBlob miss treats missing blobs as GC-eligible so
+			// the stale index entry gets cleaned up instead of aborting GC.
 			err = os.Remove(imgStore.BlobPath(repoName, digest))
 			So(err, ShouldBeNil)
 
 			time.Sleep(500 * time.Millisecond)
 
 			err = gc.CleanRepo(ctx, repoName)
-			So(err, ShouldNotBeNil)
+			So(err, ShouldBeNil)
 		})
 
 		Convey("Corrupt untagged manifest blob aborts GC", func() {

--- a/pkg/storage/scrub_test.go
+++ b/pkg/storage/scrub_test.go
@@ -491,7 +491,7 @@ func RunCheckAllBlobsIntegrityTests( //nolint: thelper
 			// get content of layer
 			imageRes := storage.CheckLayers(repoName, tag, []ispec.Descriptor{{Digest: digest}}, imgStore)
 			So(imageRes.Status, ShouldEqual, "affected")
-			So(imageRes.Error, ShouldEqual, "blob not found")
+			So(imageRes.Error, ShouldContainSubstring, "blob not found")
 
 			buff := bytes.NewBufferString("")
 

--- a/pkg/test/oci-utils/oci_layout_test.go
+++ b/pkg/test/oci-utils/oci_layout_test.go
@@ -492,7 +492,7 @@ func TestExtractImageDetails(t *testing.T) {
 
 		olu := ociutils.NewBaseOciLayoutUtils(storeController, testLogger)
 		resDigest, resManifest, resIspecImage, resErr := olu.ExtractImageDetails("zot-test", "latest", testLogger)
-		So(resErr, ShouldEqual, zerr.ErrBlobNotFound)
+		So(errors.Is(resErr, zerr.ErrBlobNotFound), ShouldBeTrue)
 		So(string(resDigest), ShouldEqual, "")
 		So(resManifest, ShouldBeNil)
 		So(resIspecImage, ShouldBeNil)


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

Fixes #4271

**What does this PR do / Why do we need it**:

When a repo's `index.json` references a blob digest that no longer exists in storage, `isBlobOlderThan()` in `pkg/storage/gc/gc.go` propagates the `StatBlob` error all the way up through `gcManifest()` and `cleanRepo()`, aborting GC for that entire repo.

This PR changes `isBlobOlderThan()` to distinguish between a genuine "not found" error (the referenced blob truly doesn't exist, so it is treated as GC-eligible), and any other error (e.g. transient S3/network errors) that still fails closed as before, since we can't safely tell those apart from a real "missing" blob, and we don't want to risk deleting live index rows during transient storage issues.

To make the `PathNotFoundError` detection possible with `errors.As`, `pkg/storage/imagestore/imagestore.go` was also updated so that `ErrBlobNotFound` is wrapped together with the underlying driver error instead of discarding it. Previously the underlying error was swallowed, which made it impossible for callers to check whether the root cause was specifically a missing path.

As a side effect of this richer error wrapping, a few existing tests that asserted on the exact error string/value (`ShouldEqual "blob not found"` / `ShouldEqual zerr.ErrBlobNotFound`) were relaxed to `ShouldContainSubstring` / `errors.Is(...)` checks, since the error message now includes the wrapped underlying error.

**If an issue # is not available please add repro steps and logs showing the issue**:

N/A, see #4271.

**Testing done on this change**:

Unit tests updated/added:
- `pkg/storage/gc/gc_internal_test.go`: `TestGarbageCollectWithMockedImageStore` — updated the "removeReferrersWithMissingSubject" case to reflect that a missing referrer blob is now treated as GC-eligible (stale referrer entry gets removed) instead of aborting.
- `pkg/storage/local/local_test.go`: `TestGarbageCollectErrors` — updated the "Missing untagged manifest blob" case to assert `CleanRepo` now succeeds instead of erroring when the underlying blob file was removed from disk.
- `pkg/storage/gcs/gcs_test.go`, `pkg/storage/scrub_test.go`, `pkg/test/oci-utils/oci_layout_test.go`: relaxed exact-string/exact-value error assertions to account for the richer wrapped error message.

Manual test runs:
```
$ make test-extended
...
ok      zotregistry.dev/zot/v2/pkg/storage      (cached)        coverage: 7.2% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/storage/azure        (cached)        coverage: 0.5% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/storage/cache        (cached)        coverage: 1.2% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/storage/common       (cached)        coverage: 3.1% of statements in ./...
?       zotregistry.dev/zot/v2/pkg/storage/constants    [no test files]
ok      zotregistry.dev/zot/v2/pkg/storage/gc   57.674s coverage: 8.9% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/storage/gcs  (cached)        coverage: 0.7% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/storage/imagestore   (cached)        coverage: 0.8% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/storage/local        59.307s coverage: 7.0% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/storage/s3   (cached)        coverage: 2.7% of statements in ./...
?       zotregistry.dev/zot/v2/pkg/storage/types        [no test files]
ok      zotregistry.dev/zot/v2/pkg/test/auth    (cached)        coverage: 0.4% of statements in ./...
        zotregistry.dev/zot/v2/pkg/test/azurite         coverage: 0.0% of statements
ok      zotregistry.dev/zot/v2/pkg/test/common  2.871s  coverage: 4.2% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/test/image-utils     (cached)        coverage: 9.1% of statements in ./...
        zotregistry.dev/zot/v2/pkg/test/inject          coverage: 0.0% of statements
        zotregistry.dev/zot/v2/pkg/test/mocks           coverage: 0.0% of statements
ok      zotregistry.dev/zot/v2/pkg/test/oci-utils       (cached)        coverage: 10.8% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/test/signature       (cached)        coverage: 6.1% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/test/skip    (cached)        coverage: 0.0% of statements in ./...
ok      zotregistry.dev/zot/v2/pkg/test/tls     (cached)        coverage: 0.6% of statements in ./...
ok      zotregistry.dev/zot/v2/swagger  (cached)        coverage: 0.0% of statements in ./...
...

$ go test ./pkg/storage/gc/... -run "TestGarbageCollectWithMockedImageStore" -v
...
188 total assertions
--- PASS: TestGarbageCollectWithMockedImageStore (0.02s)
PASS
ok      zotregistry.dev/zot/v2/pkg/storage/gc   0.042s

$ go test ./pkg/storage/local/... -run "TestGarbageCollectErrors" -v
...
104 total assertions
--- PASS: TestGarbageCollectErrors (2.10s)
PASS
ok      zotregistry.dev/zot/v2/pkg/storage/local        2.137s
```
**Automation added to e2e**:

No. The fix should be fully covered by the unit tests listed above.

**Will this break upgrades or downgrades?**

No. This only changes in-process GC error handling.

**Does this PR introduce any user-facing change?**:

Yes — GC behavior changes for repos with dangling index entries.

```release-note
Garbage collection no longer aborts an entire repository's cleanup when `index.json` references a blob that is missing from storage. Such entries are now treated as GC-eligible and removed, while transient stat errors still fail closed as before to avoid risking deletion of live data.
```

Assisted-by opencode (claude-sonnet)