### PR TITLE
fix(scanner): synchronize trivy scans

### DIFF
--- a/pkg/extensions/search/cve/trivy/scanner.go
+++ b/pkg/extensions/search/cve/trivy/scanner.go
@@ -32,6 +32,7 @@ import (
 	godigest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"golang.org/x/sync/singleflight"
 	_ "modernc.org/sqlite"
 
 	zerr "zotregistry.dev/zot/v2/errors"
@@ -178,6 +179,10 @@ type Scanner struct {
 	javaDBRepositoryRef name.Reference
 	vulnSeveritySources []dbTypes.SourceID
 	sbomOptions         sbomOptions
+
+	// SingleFlightGroup is used to prevent multiple requests
+	// running a trivy scan for the same digest repeatedly.
+	scanSingleFlightGroup *singleflight.Group
 }
 
 type sbomOptions struct {
@@ -279,16 +284,17 @@ func NewScanner(storeController storage.StoreController,
 	cveController.SubCveConfig = subCveConfig
 
 	return &Scanner{
-		log:                 log,
-		metaDB:              metaDB,
-		cveController:       cveController,
-		storeController:     storeController,
-		dbLock:              &sync.Mutex{},
-		cache:               cvecache.NewCveCache(cacheSize, log),
-		dbRepositoryRef:     dbRepositoryRef,
-		javaDBRepositoryRef: javaDBRepositoryRef,
-		vulnSeveritySources: sevSources,
-		sbomOptions:         sbomOpts,
+		log:                   log,
+		metaDB:                metaDB,
+		cveController:         cveController,
+		storeController:       storeController,
+		dbLock:                &sync.Mutex{},
+		cache:                 cvecache.NewCveCache(cacheSize, log),
+		dbRepositoryRef:       dbRepositoryRef,
+		javaDBRepositoryRef:   javaDBRepositoryRef,
+		vulnSeveritySources:   sevSources,
+		sbomOptions:           sbomOpts,
+		scanSingleFlightGroup: &singleflight.Group{},
 	}
 }
 
@@ -673,98 +679,119 @@ func (scanner Scanner) scanManifest(ctx context.Context, repo, digest string) (m
 		return cachedMap, true, nil
 	}
 
-	cveidMap := map[string]zcommon.CVE{}
-	image := repo + "@" + digest
+	// prevent multiple requests running trivy multiple times
+	result, err, _ := scanner.scanSingleFlightGroup.Do(digest, func() (any, error) {
+		// Double check the cache under flight group lock to prevent a race
+		// where a caller just sees a cache miss before the cache is updated.
+		// In this case, the caller initiates a fresh flight even though a scan just finished up.
+		// This avoids a double scan of the image.
+		if cachedMap := scanner.cache.Get(digest); cachedMap != nil {
+			return cacheableScanResult{cachedMap, true}, nil
+		}
 
-	scanner.dbLock.Lock()
-	opts := scanner.getTrivyOptions(image)
-	report, sbom, err := scanner.runTrivy(ctx, opts)
-	scanner.dbLock.Unlock()
-	if sbom != nil && sbom.filePath != "" {
-		defer os.Remove(sbom.filePath)
-	}
+		cveidMap := map[string]zcommon.CVE{}
+		image := repo + "@" + digest
 
-	if err != nil { //nolint: wsl
-		return cveidMap, false, err
-	}
+		// Use separate context without cancellation for scanning
+		scanCtx := context.WithoutCancel(ctx)
+		scanner.dbLock.Lock()
+		opts := scanner.getTrivyOptions(image)
+		report, sbom, err := scanner.runTrivy(scanCtx, opts)
+		scanner.dbLock.Unlock()
+		if sbom != nil && sbom.filePath != "" {
+			defer os.Remove(sbom.filePath)
+		}
 
-	// SBOM persistence is best-effort: CVE scanning should still complete even if
-	// SBOM artifact upload fails.
-	if err = scanner.storeSBOMAsOCIArtifact(ctx, repo, digest, sbom); err != nil {
-		scanner.log.Warn().Err(err).Str("image", image).Msg("failed to store generated sbom as OCI artifact")
-	}
+		if err != nil {
+			return cveidMap, err
+		}
 
-	for _, result := range report.Results {
-		for _, vulnerability := range result.Vulnerabilities {
-			pkgName := vulnerability.PkgName
+		// SBOM persistence is best-effort: CVE scanning should still complete even if
+		// SBOM artifact upload fails.
+		if err = scanner.storeSBOMAsOCIArtifact(scanCtx, repo, digest, sbom); err != nil {
+			scanner.log.Warn().Err(err).Str("image", image).Msg("failed to store generated sbom as OCI artifact")
+		}
 
-			installedVersion := vulnerability.InstalledVersion
+		for _, result := range report.Results {
+			for _, vulnerability := range result.Vulnerabilities {
+				pkgName := vulnerability.PkgName
 
-			var fixedVersion string
-			if vulnerability.FixedVersion != "" {
-				fixedVersion = vulnerability.FixedVersion
-			} else {
-				fixedVersion = cvemodel.NotSpecified
-			}
+				installedVersion := vulnerability.InstalledVersion
 
-			var packagePath string
-			if vulnerability.PkgPath != "" {
-				packagePath = vulnerability.PkgPath
-			} else {
-				packagePath = cvemodel.NotSpecified
-			}
+				var fixedVersion string
+				if vulnerability.FixedVersion != "" {
+					fixedVersion = vulnerability.FixedVersion
+				} else {
+					fixedVersion = cvemodel.NotSpecified
+				}
 
-			_, ok := cveidMap[vulnerability.VulnerabilityID]
-			if ok {
-				cveDetailStruct := cveidMap[vulnerability.VulnerabilityID]
+				var packagePath string
+				if vulnerability.PkgPath != "" {
+					packagePath = vulnerability.PkgPath
+				} else {
+					packagePath = cvemodel.NotSpecified
+				}
 
-				pkgList := cveDetailStruct.PackageList
+				_, ok := cveidMap[vulnerability.VulnerabilityID]
+				if ok {
+					cveDetailStruct := cveidMap[vulnerability.VulnerabilityID]
 
-				pkgList = append(
-					pkgList,
-					zcommon.Package{
-						Name:             pkgName,
-						PackagePath:      packagePath,
-						InstalledVersion: installedVersion,
-						FixedVersion:     fixedVersion,
-					},
-				)
+					pkgList := cveDetailStruct.PackageList
 
-				cveDetailStruct.PackageList = pkgList
+					pkgList = append(
+						pkgList,
+						zcommon.Package{
+							Name:             pkgName,
+							PackagePath:      packagePath,
+							InstalledVersion: installedVersion,
+							FixedVersion:     fixedVersion,
+						},
+					)
 
-				cveidMap[vulnerability.VulnerabilityID] = cveDetailStruct
-			} else {
-				newPkgList := make([]zcommon.Package, 0)
+					cveDetailStruct.PackageList = pkgList
 
-				newPkgList = append(
-					newPkgList,
-					zcommon.Package{
-						Name:             pkgName,
-						PackagePath:      packagePath,
-						InstalledVersion: installedVersion,
-						FixedVersion:     fixedVersion,
-					},
-				)
+					cveidMap[vulnerability.VulnerabilityID] = cveDetailStruct
+				} else {
+					newPkgList := make([]zcommon.Package, 0)
 
-				cveidMap[vulnerability.VulnerabilityID] = zcommon.CVE{
-					ID:          vulnerability.VulnerabilityID,
-					Title:       vulnerability.Title,
-					Description: vulnerability.Description,
-					Reference: getCVEReference(
-						vulnerability.VulnerabilityID,
-						vulnerability.PrimaryURL,
-						vulnerability.References,
-					),
-					Severity:    convertSeverity(vulnerability.Severity),
-					PackageList: newPkgList,
+					newPkgList = append(
+						newPkgList,
+						zcommon.Package{
+							Name:             pkgName,
+							PackagePath:      packagePath,
+							InstalledVersion: installedVersion,
+							FixedVersion:     fixedVersion,
+						},
+					)
+
+					cveidMap[vulnerability.VulnerabilityID] = zcommon.CVE{
+						ID:          vulnerability.VulnerabilityID,
+						Title:       vulnerability.Title,
+						Description: vulnerability.Description,
+						Reference: getCVEReference(
+							vulnerability.VulnerabilityID,
+							vulnerability.PrimaryURL,
+							vulnerability.References,
+						),
+						Severity:    convertSeverity(vulnerability.Severity),
+						PackageList: newPkgList,
+					}
 				}
 			}
 		}
+
+		scanner.cache.Add(digest, cveidMap)
+
+		return cacheableScanResult{cveidMap, false}, nil
+	})
+	if err != nil {
+		return map[string]zcommon.CVE{}, false, err
 	}
 
-	scanner.cache.Add(digest, cveidMap)
+	scanResult, _ := result.(cacheableScanResult)
+	resultingMap := scanResult.cachedMap
 
-	return cveidMap, false, nil
+	return resultingMap, scanResult.wasCached, nil
 }
 
 func (scanner Scanner) storeSBOMAsOCIArtifact(ctx context.Context,
@@ -949,38 +976,65 @@ func getNVDReference(references []string) (string, bool) {
 	return "", false
 }
 
+type cacheableScanResult struct {
+	cachedMap map[string]zcommon.CVE
+	wasCached bool
+}
+
 func (scanner Scanner) scanIndex(ctx context.Context, repo, digest string) (map[string]zcommon.CVE, bool, error) {
 	if cachedMap := scanner.cache.Get(digest); cachedMap != nil {
 		return cachedMap, true, nil
 	}
 
-	indexData, err := scanner.metaDB.GetImageMeta(godigest.Digest(digest))
+	// prevent multiple requests running trivy multiple times
+	result, err, _ := scanner.scanSingleFlightGroup.Do(digest, func() (any, error) {
+		// Double check the cache under flight group lock to prevent a race
+		// where a caller just sees a cache miss before the cache is updated.
+		// In this case, the caller initiates a fresh flight even though a scan just finished up.
+		// This avoids a double scan of the index.
+		if cachedMap := scanner.cache.Get(digest); cachedMap != nil {
+			return cacheableScanResult{cachedMap, true}, nil
+		}
+
+		indexData, err := scanner.metaDB.GetImageMeta(godigest.Digest(digest))
+		if err != nil {
+			return nil, err
+		}
+
+		if indexData.Index == nil {
+			return nil, zerr.ErrUnexpectedMediaType
+		}
+
+		indexCveIDMap := map[string]zcommon.CVE{}
+		// use a separate context for scanning the index
+		// so that request cancellation still completes the scan.
+		indexScanCtx := context.WithoutCancel(ctx)
+
+		for _, manifest := range indexData.Index.Manifests {
+			if isScannable, err := scanner.isManifestScannable(manifest.Digest.String()); isScannable && err == nil {
+				// the per-manifest cache status doesn't matter here: it's the aggregate index-level
+				// cache check above that determines whether this ScanImage call is a cache hit
+				manifestCveIDMap, _, err := scanner.scanManifest(indexScanCtx, repo, manifest.Digest.String())
+				if err != nil {
+					return nil, err
+				}
+
+				maps.Copy(indexCveIDMap, manifestCveIDMap)
+			}
+		}
+
+		scanner.cache.Add(digest, indexCveIDMap)
+
+		return indexCveIDMap, nil
+	})
 	if err != nil {
 		return map[string]zcommon.CVE{}, false, err
 	}
 
-	if indexData.Index == nil {
-		return map[string]zcommon.CVE{}, false, zerr.ErrUnexpectedMediaType
-	}
+	scanResult, _ := result.(cacheableScanResult)
+	resultingMap := scanResult.cachedMap
 
-	indexCveIDMap := map[string]zcommon.CVE{}
-
-	for _, manifest := range indexData.Index.Manifests {
-		if isScannable, err := scanner.isManifestScannable(manifest.Digest.String()); isScannable && err == nil {
-			// the per-manifest cache status doesn't matter here: it's the aggregate index-level
-			// cache check above that determines whether this ScanImage call is a cache hit
-			manifestCveIDMap, _, err := scanner.scanManifest(ctx, repo, manifest.Digest.String())
-			if err != nil {
-				return nil, false, err
-			}
-
-			maps.Copy(indexCveIDMap, manifestCveIDMap)
-		}
-	}
-
-	scanner.cache.Add(digest, indexCveIDMap)
-
-	return indexCveIDMap, false, nil
+	return resultingMap, scanResult.wasCached, nil
 }
 
 // UpdateDB downloads the Trivy DB / Cache under the store root directory.

--- a/pkg/extensions/search/cve/trivy/scanner_internal_test.go
+++ b/pkg/extensions/search/cve/trivy/scanner_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"os"
 	"path"
+	"sync"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
 	cvecache "zotregistry.dev/zot/v2/pkg/extensions/search/cve/cache"
+	"zotregistry.dev/zot/v2/pkg/extensions/search/cve/model"
 	"zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/meta"
 	"zotregistry.dev/zot/v2/pkg/meta/boltdb"
@@ -40,10 +42,15 @@ import (
 )
 
 type fakeArtifactRunner struct {
-	reportFn func(ctx context.Context, opts flag.Options, report trivyTypes.Report) error
+	reportFn    func(ctx context.Context, opts flag.Options, report trivyTypes.Report) error
+	scanImageFn func(ctx context.Context, opts flag.Options) (trivyTypes.Report, error)
 }
 
 func (f fakeArtifactRunner) ScanImage(ctx context.Context, opts flag.Options) (trivyTypes.Report, error) {
+	if f.scanImageFn != nil {
+		return f.scanImageFn(ctx, opts)
+	}
+
 	return trivyTypes.Report{}, nil
 }
 
@@ -85,7 +92,7 @@ func (f fakeArtifactRunner) Close(ctx context.Context) error {
 
 var _ artifact.Runner = fakeArtifactRunner{}
 
-func generateTestImage(storeController storage.StoreController, imageName string) {
+func generateTestImage(storeController storage.StoreController, imageName string) Image {
 	repoName, tag := zcommon.GetImageDirAndTag(imageName)
 
 	image := CreateRandomImage()
@@ -93,6 +100,8 @@ func generateTestImage(storeController storage.StoreController, imageName string
 	err := WriteImageToFileSystem(
 		image, repoName, tag, storeController)
 	So(err, ShouldBeNil)
+
+	return image
 }
 
 func TestGenerateSBOM(t *testing.T) {
@@ -923,5 +932,507 @@ func TestGetCVEReference(t *testing.T) {
 
 		ref = getCVEReference("GHSA-abcd-1234", "https://avd.aquasec.com/nvd/cve-2026-42496", []string{})
 		So(ref, ShouldResemble, "https://avd.aquasec.com/nvd/cve-2026-42496")
+	})
+}
+
+func initMockStoreWithFakeScannerDB(tempDir string) (storage.StoreController, error) {
+	storeController := storage.StoreController{}
+	store := mocks.MockedImageStore{}
+	store.RootDirFn = func() string {
+		return tempDir
+	}
+	storeController.DefaultStore = store
+
+	err := os.MkdirAll(path.Join(tempDir, "_trivy", "db"), 0o755)
+	if err != nil {
+		return storeController, err
+	}
+
+	err = os.WriteFile(path.Join(tempDir, "_trivy", "db", "metadata.json"), []byte{1}, 0o644)
+
+	return storeController, err
+}
+
+func TestScannerCacheMissWithMultipleCallersSynchronization(t *testing.T) {
+	Convey("Multiple concurrent scans for the same uncached digest should trigger only one scan", t, func() {
+		tempDir := t.TempDir()
+		logger := log.NewTestLogger()
+
+		storeController, err := initMockStoreWithFakeScannerDB(tempDir)
+		So(err, ShouldBeNil)
+
+		metaDB := mocks.MetaDBMock{}
+
+		img1 := CreateRandomImage()
+
+		metaDB.GetImageMetaFn = func(digest godigest.Digest) (types.ImageMeta, error) {
+			return map[string]types.ImageMeta{
+				img1.DigestStr(): img1.AsImageMeta(),
+			}[digest.String()], nil
+		}
+
+		metaDB.GetRepoMetaFn = func(ctx context.Context, repo string) (types.RepoMeta, error) {
+			imgDesc := types.Descriptor{
+				Digest:          img1.DigestStr(),
+				MediaType:       img1.Manifest.MediaType,
+				TaggedTimestamp: time.Now(),
+			}
+			return types.RepoMeta{
+				Name: repo,
+				Tags: map[types.Tag]types.Descriptor{
+					"1.0": imgDesc,
+				},
+			}, nil
+		}
+
+		scanner := NewScanner(storeController, metaDB, &extconf.CVEConfig{
+			Trivy: &extconf.TrivyConfig{
+				DBRepository: "ghcr.io/project-zot/trivy-db",
+			},
+		}, logger)
+
+		scanCallMap := map[string]int{}
+
+		oldNewArtifactRunner := newArtifactRunner
+		newArtifactRunner = func(ctx context.Context, opts flag.Options, target artifact.TargetKind,
+			runnerOpts ...artifact.RunnerOption,
+		) (artifact.Runner, error) {
+			return fakeArtifactRunner{
+				scanImageFn: func(ctx context.Context, opts flag.Options) (trivyTypes.Report, error) {
+					if _, ok := scanCallMap[opts.Target]; !ok {
+						scanCallMap[opts.Target] = 0
+					}
+					scanCallMap[opts.Target] += 1
+					time.Sleep(1 * time.Second)
+
+					return trivyTypes.Report{}, nil
+				},
+			}, nil
+		}
+		defer func() {
+			newArtifactRunner = oldNewArtifactRunner
+		}()
+
+		var wg sync.WaitGroup
+		numRoutines := 50
+		results := make(chan model.ScanResult, numRoutines)
+		errs := make(chan error, numRoutines)
+
+		for range 50 {
+			wg.Go(func() {
+				res, err := scanner.ScanImage(context.Background(), "repo:1.0")
+				results <- res
+				errs <- err
+			})
+		}
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for scanErr := range errs {
+			So(scanErr, ShouldBeNil)
+		}
+
+		for r := range results {
+			So(r.Digest, ShouldNotBeEmpty)
+		}
+
+		So(len(scanCallMap), ShouldEqual, 1)
+		scanPath := path.Join(tempDir, "repo@"+img1.DigestStr())
+		So(scanCallMap[scanPath], ShouldEqual, 1)
+
+		// Purging the cache should allow it to run again
+		scanner.cache.Purge()
+
+		results = make(chan model.ScanResult, numRoutines)
+		errs = make(chan error, numRoutines)
+
+		for range 50 {
+			wg.Go(func() {
+				res, err := scanner.ScanImage(context.Background(), "repo:1.0")
+				results <- res
+				errs <- err
+			})
+		}
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for scanErr := range errs {
+			So(scanErr, ShouldBeNil)
+		}
+
+		for r := range results {
+			So(r.Digest, ShouldNotBeEmpty)
+		}
+
+		So(len(scanCallMap), ShouldEqual, 1)
+		// Should be called a second time since the cache was purged
+		So(scanCallMap[scanPath], ShouldEqual, 2)
+	})
+
+	Convey("Multiple concurrent scans for the same uncached index should trigger only one scan", t, func() {
+		tempDir := t.TempDir()
+		logger := log.NewTestLogger()
+
+		storeController, err := initMockStoreWithFakeScannerDB(tempDir)
+		So(err, ShouldBeNil)
+
+		metaDB := mocks.MetaDBMock{}
+
+		img1 := CreateRandomImage()
+		img2 := CreateRandomImage()
+		multiarch := CreateMultiarchWith().Images([]Image{img1, img2}).Build()
+
+		metaDB.GetImageMetaFn = func(digest godigest.Digest) (types.ImageMeta, error) {
+			return map[string]types.ImageMeta{
+				img1.DigestStr():      img1.AsImageMeta(),
+				img2.DigestStr():      img2.AsImageMeta(),
+				multiarch.DigestStr(): multiarch.AsImageMeta(),
+			}[digest.String()], nil
+		}
+
+		metaDB.GetRepoMetaFn = func(ctx context.Context, repo string) (types.RepoMeta, error) {
+			multiDesc := types.Descriptor{
+				Digest:          multiarch.DigestStr(),
+				MediaType:       multiarch.Index.MediaType,
+				TaggedTimestamp: time.Now(),
+			}
+			return types.RepoMeta{
+				Name: repo,
+				Tags: map[types.Tag]types.Descriptor{
+					"3.0": multiDesc,
+				},
+			}, nil
+		}
+
+		scanner := NewScanner(storeController, metaDB, &extconf.CVEConfig{
+			Trivy: &extconf.TrivyConfig{
+				DBRepository: "ghcr.io/project-zot/trivy-db",
+			},
+		}, logger)
+
+		scanCallMap := map[string]int{}
+
+		oldNewArtifactRunner := newArtifactRunner
+		newArtifactRunner = func(ctx context.Context, opts flag.Options, target artifact.TargetKind,
+			runnerOpts ...artifact.RunnerOption,
+		) (artifact.Runner, error) {
+			return fakeArtifactRunner{
+				scanImageFn: func(ctx context.Context, opts flag.Options) (trivyTypes.Report, error) {
+					if _, ok := scanCallMap[opts.Target]; !ok {
+						scanCallMap[opts.Target] = 0
+					}
+					scanCallMap[opts.Target] += 1
+					time.Sleep(1 * time.Second)
+
+					return trivyTypes.Report{}, nil
+				},
+			}, nil
+		}
+		defer func() {
+			newArtifactRunner = oldNewArtifactRunner
+		}()
+
+		var wg sync.WaitGroup
+		numRoutines := 50
+		results := make(chan model.ScanResult, numRoutines)
+		errs := make(chan error, numRoutines)
+
+		for range 50 {
+			wg.Go(func() {
+				res, err := scanner.ScanImage(context.Background(), "repo:3.0")
+				results <- res
+				errs <- err
+			})
+		}
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for scanErr := range errs {
+			So(scanErr, ShouldBeNil)
+		}
+
+		for r := range results {
+			So(r.Digest, ShouldNotBeEmpty)
+		}
+
+		So(len(scanCallMap), ShouldEqual, 2)
+		scanPath := path.Join(tempDir, "repo@"+img1.DigestStr())
+		So(scanCallMap[scanPath], ShouldEqual, 1)
+		scanPath2 := path.Join(tempDir, "repo@"+img2.DigestStr())
+		So(scanCallMap[scanPath2], ShouldEqual, 1)
+
+		// Purging the cache should allow it to run again
+		scanner.cache.Purge()
+
+		results = make(chan model.ScanResult, numRoutines)
+		errs = make(chan error, numRoutines)
+
+		for range 50 {
+			wg.Go(func() {
+				res, err := scanner.ScanImage(context.Background(), "repo:3.0")
+				results <- res
+				errs <- err
+			})
+		}
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for scanErr := range errs {
+			So(scanErr, ShouldBeNil)
+		}
+
+		for r := range results {
+			So(r.Digest, ShouldNotBeEmpty)
+		}
+
+		So(len(scanCallMap), ShouldEqual, 2)
+
+		// Should be called a second time since the cache was purged
+		So(scanCallMap[scanPath], ShouldEqual, 2)
+		So(scanCallMap[scanPath2], ShouldEqual, 2)
+	})
+
+	Convey("Concurrent scans on an index resulting in an error should return the error for all callers", t, func() {
+		tempDir := t.TempDir()
+		logger := log.NewTestLogger()
+
+		storeController, err := initMockStoreWithFakeScannerDB(tempDir)
+		So(err, ShouldBeNil)
+
+		metaDB := mocks.MetaDBMock{}
+
+		img1 := CreateRandomImage()
+		img2 := CreateRandomImage()
+		multiarch := CreateMultiarchWith().Images([]Image{img1, img2}).Build()
+
+		metaDB.GetImageMetaFn = func(digest godigest.Digest) (types.ImageMeta, error) {
+			return map[string]types.ImageMeta{
+				img1.DigestStr():      img1.AsImageMeta(),
+				img2.DigestStr():      img2.AsImageMeta(),
+				multiarch.DigestStr(): multiarch.AsImageMeta(),
+			}[digest.String()], nil
+		}
+
+		metaDB.GetRepoMetaFn = func(ctx context.Context, repo string) (types.RepoMeta, error) {
+			multiDesc := types.Descriptor{
+				Digest:          multiarch.DigestStr(),
+				MediaType:       multiarch.Index.MediaType,
+				TaggedTimestamp: time.Now(),
+			}
+			return types.RepoMeta{
+				Name: repo,
+				Tags: map[types.Tag]types.Descriptor{
+					"3.0": multiDesc,
+				},
+			}, nil
+		}
+
+		scanner := NewScanner(storeController, metaDB, &extconf.CVEConfig{
+			Trivy: &extconf.TrivyConfig{
+				DBRepository: "ghcr.io/project-zot/trivy-db",
+			},
+		}, logger)
+
+		scanCallMap := map[string]int{}
+
+		oldNewArtifactRunner := newArtifactRunner
+		newArtifactRunner = func(ctx context.Context, opts flag.Options, target artifact.TargetKind,
+			runnerOpts ...artifact.RunnerOption,
+		) (artifact.Runner, error) {
+			return fakeArtifactRunner{
+				scanImageFn: func(ctx context.Context, opts flag.Options) (trivyTypes.Report, error) {
+					if _, ok := scanCallMap[opts.Target]; !ok {
+						scanCallMap[opts.Target] = 0
+					}
+					scanCallMap[opts.Target] += 1
+					time.Sleep(1 * time.Second)
+
+					return trivyTypes.Report{}, errors.New("fake scan error")
+				},
+			}, nil
+		}
+		defer func() {
+			newArtifactRunner = oldNewArtifactRunner
+		}()
+
+		var wg sync.WaitGroup
+		numRoutines := 50
+		results := make(chan model.ScanResult, numRoutines)
+		errs := make(chan error, numRoutines)
+
+		for range 50 {
+			wg.Go(func() {
+				res, err := scanner.ScanImage(context.Background(), "repo:3.0")
+				results <- res
+				errs <- err
+			})
+		}
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for scanErr := range errs {
+			So(scanErr, ShouldNotBeNil)
+		}
+
+		for r := range results {
+			So(r.Digest, ShouldBeEmpty)
+		}
+
+		// Since the first manifest errors out, the scan doesn't continue.
+		So(len(scanCallMap), ShouldEqual, 1)
+		scanPath := path.Join(tempDir, "repo@"+img1.DigestStr())
+		So(scanCallMap[scanPath], ShouldEqual, 1)
+
+		// Purging the cache should allow it to run again
+		scanner.cache.Purge()
+
+		results = make(chan model.ScanResult, numRoutines)
+		errs = make(chan error, numRoutines)
+
+		for range 50 {
+			wg.Go(func() {
+				res, err := scanner.ScanImage(context.Background(), "repo:3.0")
+				results <- res
+				errs <- err
+			})
+		}
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for scanErr := range errs {
+			So(scanErr, ShouldNotBeNil)
+		}
+
+		for r := range results {
+			So(r.Digest, ShouldBeEmpty)
+		}
+
+		So(len(scanCallMap), ShouldEqual, 1)
+
+		// Should be called a second time since the cache was purged
+		So(scanCallMap[scanPath], ShouldEqual, 2)
+	})
+
+	Convey("Concurrent scans for a manifest with an error should return error for all waiting callers", t, func() {
+		tempDir := t.TempDir()
+		logger := log.NewTestLogger()
+
+		storeController, err := initMockStoreWithFakeScannerDB(tempDir)
+		So(err, ShouldBeNil)
+
+		metaDB := mocks.MetaDBMock{}
+
+		img1 := CreateRandomImage()
+
+		metaDB.GetImageMetaFn = func(digest godigest.Digest) (types.ImageMeta, error) {
+			return map[string]types.ImageMeta{
+				img1.DigestStr(): img1.AsImageMeta(),
+			}[digest.String()], nil
+		}
+
+		metaDB.GetRepoMetaFn = func(ctx context.Context, repo string) (types.RepoMeta, error) {
+			imgDesc := types.Descriptor{
+				Digest:          img1.DigestStr(),
+				MediaType:       img1.Manifest.MediaType,
+				TaggedTimestamp: time.Now(),
+			}
+			return types.RepoMeta{
+				Name: repo,
+				Tags: map[types.Tag]types.Descriptor{
+					"1.0": imgDesc,
+				},
+			}, nil
+		}
+
+		scanner := NewScanner(storeController, metaDB, &extconf.CVEConfig{
+			Trivy: &extconf.TrivyConfig{
+				DBRepository: "ghcr.io/project-zot/trivy-db",
+			},
+		}, logger)
+
+		scanCallMap := map[string]int{}
+
+		oldNewArtifactRunner := newArtifactRunner
+		newArtifactRunner = func(ctx context.Context, opts flag.Options, target artifact.TargetKind,
+			runnerOpts ...artifact.RunnerOption,
+		) (artifact.Runner, error) {
+			return fakeArtifactRunner{
+				scanImageFn: func(ctx context.Context, opts flag.Options) (trivyTypes.Report, error) {
+					if _, ok := scanCallMap[opts.Target]; !ok {
+						scanCallMap[opts.Target] = 0
+					}
+					scanCallMap[opts.Target] += 1
+					time.Sleep(1 * time.Second)
+
+					return trivyTypes.Report{}, errors.New("fake scan error")
+				},
+			}, nil
+		}
+		defer func() {
+			newArtifactRunner = oldNewArtifactRunner
+		}()
+
+		var wg sync.WaitGroup
+		numRoutines := 50
+		results := make(chan model.ScanResult, numRoutines)
+		errs := make(chan error, numRoutines)
+
+		for range 50 {
+			wg.Go(func() {
+				res, err := scanner.ScanImage(context.Background(), "repo:1.0")
+				results <- res
+				errs <- err
+			})
+		}
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for scanErr := range errs {
+			So(scanErr, ShouldNotBeNil)
+		}
+
+		for r := range results {
+			So(r.Digest, ShouldBeEmpty)
+		}
+
+		So(len(scanCallMap), ShouldEqual, 1)
+		scanPath := path.Join(tempDir, "repo@"+img1.DigestStr())
+		So(scanCallMap[scanPath], ShouldEqual, 1)
+
+		// Purging the cache should allow it to run again
+		scanner.cache.Purge()
+
+		results = make(chan model.ScanResult, numRoutines)
+		errs = make(chan error, numRoutines)
+
+		for range 50 {
+			wg.Go(func() {
+				res, err := scanner.ScanImage(context.Background(), "repo:1.0")
+				results <- res
+				errs <- err
+			})
+		}
+		wg.Wait()
+		close(results)
+		close(errs)
+
+		for scanErr := range errs {
+			So(scanErr, ShouldNotBeNil)
+		}
+
+		for r := range results {
+			So(r.Digest, ShouldBeEmpty)
+		}
+
+		So(len(scanCallMap), ShouldEqual, 1)
+		// Should be called a second time since the cache was purged
+		So(scanCallMap[scanPath], ShouldEqual, 2)
 	})
 }


### PR DESCRIPTION
**What type of PR is this?**
bug

**Which issue does this PR fix**:
- Multiple callers could trigger multiple scans of the same image.

**What does this PR do / Why do we need it**:
- Synchronizes trivy scans to prevent multiple simultaneous requests for an uncached digest's CVEList from triggering multiple re-scans of the same digest. Only 1 caller runs the scan while others wait for the result.

**Testing done on this change**:
Unit Tests

**Automation added to e2e**:
N/A

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
