### PR TITLE
fix(sync): dedupe on-demand sync with singleflight

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -84,6 +84,7 @@ require (
 	go.etcd.io/bbolt v1.5.0
 	golang.org/x/crypto v0.55.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	google.golang.org/protobuf v1.36.12
 	gopkg.in/resty.v1 v1.12.0
@@ -531,7 +532,6 @@ require (
 	golang.org/x/exp v0.0.0-20260603202125-055de637280b // indirect
 	golang.org/x/mod v0.40.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
-	golang.org/x/sync v0.22.0 // indirect
 	golang.org/x/term v0.45.0 // indirect
 	golang.org/x/text v0.41.0 // indirect
 	golang.org/x/time v0.15.0 // indirect

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -49,7 +49,7 @@ type Controller struct {
 	Metrics         monitoring.MetricServer
 	EventRecorder   events.Recorder
 	CveScanner      ext.CveScanner
-	SyncOnDemand    SyncOnDemand
+	SyncOnDemand    ext.SyncOnDemand
 	RelyingParties  map[string]rp.RelyingParty
 	CookieStore     *CookieStore
 	HTPasswd        *HTPasswd
@@ -594,8 +594,9 @@ func (c *Controller) StartBackgroundTasks() {
 		c.Log.Error().Err(err).Msg("failed to start sync extension")
 	}
 
-	// Only set SyncOnDemand if sync is actually enabled
-	if extensionsConfig.IsSyncEnabled() {
+	// EnableSyncExtension returns ext.SyncOnDemand (an interface), so failure/disabled
+	// paths yield a true nil interface — safe for isSyncOnDemandEnabled's != nil check.
+	if extensionsConfig.IsSyncEnabled() && syncOnDemand != nil {
 		c.SyncOnDemand = syncOnDemand
 	}
 
@@ -641,10 +642,4 @@ func RunGCTasks(conf *config.Config, storeController storage.StoreController, me
 			}
 		}
 	}
-}
-
-type SyncOnDemand interface {
-	SyncImage(ctx context.Context, repo, reference string) error
-	SyncReferrers(ctx context.Context, repo string, subjectDigestStr string, referenceTypes []string) error
-	ShouldCheckUpstreamManifest(repo, reference string) bool
 }

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -3015,12 +3015,8 @@ func isSyncOnDemandEnabled(ctlr *Controller) bool {
 	}
 
 	extensionsConfig := ctlr.Config.CopyExtensionsConfig()
-	if extensionsConfig.IsSyncEnabled() &&
-		fmt.Sprintf("%v", ctlr.SyncOnDemand) != fmt.Sprintf("%v", nil) {
-		return true
-	}
 
-	return false
+	return extensionsConfig.IsSyncEnabled() && ctlr.SyncOnDemand != nil
 }
 
 func eventContextFromRequest(r *http.Request) *events.EventContext {

--- a/pkg/api/routes_manifest_test.go
+++ b/pkg/api/routes_manifest_test.go
@@ -18,6 +18,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api"
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
+	ext "zotregistry.dev/zot/v2/pkg/extensions"
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
 	syncconf "zotregistry.dev/zot/v2/pkg/extensions/config/sync"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
@@ -51,7 +52,7 @@ func (m *mockSyncOnDemand) ShouldCheckUpstreamManifest(repo, reference string) b
 func newSyncTestRouteHandler(
 	t *testing.T,
 	store mocks.MockedImageStore,
-	syncOnDemand api.SyncOnDemand,
+	syncOnDemand ext.SyncOnDemand,
 ) *api.RouteHandler {
 	t.Helper()
 

--- a/pkg/extensions/extension_sync.go
+++ b/pkg/extensions/extension_sync.go
@@ -20,7 +20,7 @@ import (
 
 func EnableSyncExtension(config *config.Config, metaDB mTypes.MetaDB,
 	storeController storage.StoreController, sch *scheduler.Scheduler, log log.Logger,
-) (*sync.BaseOnDemand, error) {
+) (SyncOnDemand, error) {
 	// Get extensions config safely
 	extensionsConfig := config.CopyExtensionsConfig()
 	httpAddress := config.GetHTTPAddress()

--- a/pkg/extensions/extension_sync_disabled.go
+++ b/pkg/extensions/extension_sync_disabled.go
@@ -4,7 +4,6 @@ package extensions
 
 import (
 	"zotregistry.dev/zot/v2/pkg/api/config"
-	"zotregistry.dev/zot/v2/pkg/extensions/sync"
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/scheduler"
@@ -14,7 +13,7 @@ import (
 // EnableSyncExtension ...
 func EnableSyncExtension(config *config.Config, metaDB mTypes.MetaDB,
 	storeController storage.StoreController, sch *scheduler.Scheduler, log log.Logger,
-) (*sync.BaseOnDemand, error) {
+) (SyncOnDemand, error) {
 	log.Warn().Msg("skipping enabling sync extension because given zot binary doesn't include this feature," +
 		"please build a binary that does so")
 

--- a/pkg/extensions/get_extensions.go
+++ b/pkg/extensions/get_extensions.go
@@ -6,10 +6,14 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
 	"zotregistry.dev/zot/v2/pkg/buildinfo"
+	"zotregistry.dev/zot/v2/pkg/extensions/sync"
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/scheduler"
 )
+
+// SyncOnDemand is the on-demand sync handler exposed to the API layer.
+type SyncOnDemand sync.OnDemand
 
 func GetExtensions(config *config.Config) distext.ExtensionList {
 	extensionList := distext.ExtensionList{}

--- a/pkg/extensions/sync/common.go
+++ b/pkg/extensions/sync/common.go
@@ -1,0 +1,13 @@
+package sync
+
+import "context"
+
+// OnDemand pulls images and referrers from upstream registries on client request.
+type OnDemand interface {
+	// SyncImage syncs a single image (repo:tag or repo:digest) into local storage.
+	SyncImage(ctx context.Context, repo, reference string) error
+	// SyncReferrers syncs referrers for the given subject digest into local storage.
+	SyncReferrers(ctx context.Context, repo string, subjectDigestStr string, referenceTypes []string) error
+	// ShouldCheckUpstreamManifest reports whether repo:reference still needs an upstream check.
+	ShouldCheckUpstreamManifest(repo, reference string) bool
+}

--- a/pkg/extensions/sync/on_demand.go
+++ b/pkg/extensions/sync/on_demand.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/singleflight"
+
 	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/common"
 	"zotregistry.dev/zot/v2/pkg/log"
@@ -22,16 +24,19 @@ type request struct {
 }
 
 /*
-BaseOnDemand tracks requests that can be an image/signature/sbom.
+BaseOnDemand tracks on-demand image/referrer sync requests.
 
-It keeps track of all parallel requests, if two requests of same image/signature/sbom comes at the same time,
-process just the first one, also keep track of all background retrying routines.
+Concurrent SyncImage/SyncReferrers calls for the same key are deduplicated with
+singleflight (one upstream sync, shared result). requestStore tracks in-flight
+background retry goroutines so at most one retry runs per service/key.
 */
 type BaseOnDemand struct {
 	services []Service
-	// map[request]chan err
-	requestStore *sync.Map
-	log          log.Logger
+	// background retry dedup: map[request]struct{}
+	requestStore   *sync.Map
+	imageFlight    singleflight.Group
+	referrerFlight singleflight.Group
+	log            log.Logger
 }
 
 func NewOnDemand(log log.Logger) *BaseOnDemand {
@@ -56,31 +61,27 @@ func (onDemand *BaseOnDemand) ShouldCheckUpstreamManifest(repo, reference string
 	return true
 }
 
+func onDemandKey(repo, reference string) string {
+	return repo + "\x00" + reference
+}
+
 func (onDemand *BaseOnDemand) SyncImage(ctx context.Context, repo, reference string) error {
-	req := request{
-		repo:      repo,
-		reference: reference,
-	}
+	key := onDemandKey(repo, reference)
 
-	syncResult := make(chan error)
-	val, loaded := onDemand.requestStore.LoadOrStore(req, syncResult)
+	// leader is set only in the closure that actually runs; waiters never execute it.
+	leader := false
 
-	if loaded {
+	_, err, shared := onDemand.imageFlight.Do(key, func() (any, error) {
+		leader = true
+
+		return nil, onDemand.syncImage(ctx, repo, reference)
+	})
+
+	// singleflight sets shared for every participant when dups > 0, including the leader.
+	if shared && !leader {
 		onDemand.log.Info().Str("repo", repo).Str("reference", reference).
-			Msg("image already demanded, waiting on channel")
-
-		syncResult, _ := val.(chan error)
-
-		err := <-syncResult
-
-		return err
+			Msg("image already demanded, on-demand sync result was shared")
 	}
-
-	defer onDemand.requestStore.Delete(req)
-
-	go onDemand.syncImage(ctx, repo, reference, syncResult)
-
-	err := <-syncResult
 
 	return err
 }
@@ -88,39 +89,29 @@ func (onDemand *BaseOnDemand) SyncImage(ctx context.Context, repo, reference str
 func (onDemand *BaseOnDemand) SyncReferrers(ctx context.Context, repo string,
 	subjectDigestStr string, referenceTypes []string,
 ) error {
-	req := request{
-		repo:      repo,
-		reference: subjectDigestStr,
-	}
+	key := onDemandKey(repo, subjectDigestStr)
 
-	syncResult := make(chan error)
-	val, loaded := onDemand.requestStore.LoadOrStore(req, syncResult)
+	// leader is set only in the closure that actually runs; waiters never execute it.
+	leader := false
 
-	if loaded {
+	_, err, shared := onDemand.referrerFlight.Do(key, func() (any, error) {
+		leader = true
+
+		return nil, onDemand.syncReferrers(ctx, repo, subjectDigestStr, referenceTypes)
+	})
+
+	// singleflight sets shared for every participant when dups > 0, including the leader.
+	if shared && !leader {
 		onDemand.log.Info().Str("repo", repo).Str("reference", subjectDigestStr).
-			Msg("referrers for image already demanded, waiting on channel")
-
-		syncResult, _ := val.(chan error)
-
-		err := <-syncResult
-
-		return err
+			Msg("referrers for image already demanded, on-demand sync result was shared")
 	}
-
-	defer onDemand.requestStore.Delete(req)
-
-	go onDemand.syncReferrers(ctx, repo, subjectDigestStr, referenceTypes, syncResult)
-
-	err := <-syncResult
 
 	return err
 }
 
 func (onDemand *BaseOnDemand) syncReferrers(ctx context.Context, repo, subjectDigestStr string,
-	referenceTypes []string, syncResult chan error,
-) {
-	defer close(syncResult)
-
+	referenceTypes []string,
+) error {
 	var err error
 
 	for serviceID, service := range onDemand.services {
@@ -193,12 +184,10 @@ func (onDemand *BaseOnDemand) syncReferrers(ctx context.Context, repo, subjectDi
 		}
 	}
 
-	syncResult <- err
+	return err
 }
 
-func (onDemand *BaseOnDemand) syncImage(ctx context.Context, repo, reference string, syncResult chan error) {
-	defer close(syncResult)
-
+func (onDemand *BaseOnDemand) syncImage(ctx context.Context, repo, reference string) error {
 	var err error
 
 	for serviceID, service := range onDemand.services {
@@ -271,5 +260,5 @@ func (onDemand *BaseOnDemand) syncImage(ctx context.Context, repo, reference str
 		}
 	}
 
-	syncResult <- err
+	return err
 }

--- a/pkg/extensions/sync/sync_internal_test.go
+++ b/pkg/extensions/sync/sync_internal_test.go
@@ -681,76 +681,99 @@ func TestService(t *testing.T) {
 		})
 	})
 
-	Convey("test assured channel waiting path", t, func() {
-		// Strategy: Pre-populate requestStore with a channel to GUARANTEE the channel waiting code path
-		// This ensures the "waiting on channel" message is logged and the channel receive happens
+	Convey("test singleflight deduplicates concurrent on-demand sync calls", t, func() {
+		runConcurrentDedup := func(t *testing.T, syncFn func(*BaseOnDemand) error, syncCalls *atomic.Int32, wantErr error) {
+			t.Helper()
 
-		Convey("SyncImage assured channel waiting", func() {
+			entered := make(chan struct{})
+			release := make(chan struct{})
 			onDemand := NewOnDemand(log.NewTestLogger())
+			onDemand.Add(&countingOnDemandService{
+				syncCalls: syncCalls,
+				entered:   entered,
+				release:   release,
+				retErr:    wantErr,
+			})
 
-			// Create request and pre-populate with a channel that we control
-			req := request{
-				repo:         "test-guaranteed-channel-image",
-				reference:    "guaranteed-image-tag",
-				serviceID:    0,
-				isBackground: false,
+			const numCallers = 4
+			errCh := make(chan error, numCallers)
+
+			run := func() {
+				errCh <- syncFn(onDemand)
 			}
 
-			// Create a channel that we control completely
-			pendingChannel := make(chan error, 1)
-			onDemand.requestStore.Store(req, pendingChannel)
+			// Start the leader first; it registers the in-flight singleflight entry and
+			// blocks in the mock service until release.
+			go run()
 
-			// Start request that will wait on our channel
-			requestCompleted := make(chan error)
-			go func() {
-				err := onDemand.SyncImage(context.Background(), "test-guaranteed-channel-image", "guaranteed-image-tag")
-				requestCompleted <- err
-			}()
+			select {
+			case <-entered:
+			case <-time.After(5 * time.Second):
+				t.Fatal("timed out waiting for in-flight sync to start")
+			}
 
-			// Wait a moment for the request to reach the channel waiting code
-			time.Sleep(50 * time.Millisecond)
+			var waitersStarted sync.WaitGroup
+			waitersStarted.Add(numCallers - 1)
 
-			// Send error through our controlled channel - this proves channel waiting worked
-			pendingChannel <- errors.New("guaranteed channel error")
+			for range numCallers - 1 {
+				go func() {
+					waitersStarted.Done()
+					run()
+				}()
+			}
 
-			// Verify the request got our controlled error
-			err := <-requestCompleted
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "guaranteed channel error")
+			// Wait until every waiter goroutine is running; the leader still holds the flight open.
+			waitersStarted.Wait()
+			close(release)
+
+			for range numCallers {
+				select {
+				case err := <-errCh:
+					if wantErr == nil {
+						So(err, ShouldBeNil)
+					} else {
+						So(err, ShouldEqual, wantErr)
+					}
+				case <-time.After(5 * time.Second):
+					t.Fatal("timed out waiting for concurrent on-demand sync")
+				}
+			}
+
+			So(syncCalls.Load(), ShouldEqual, 1)
+		}
+
+		Convey("SyncImage success", func() {
+			var syncCalls atomic.Int32
+
+			runConcurrentDedup(t, func(onDemand *BaseOnDemand) error {
+				return onDemand.SyncImage(context.Background(), "dedup-repo", "dedup-tag")
+			}, &syncCalls, nil)
 		})
 
-		Convey("SyncReferrers assured channel waiting", func() {
-			onDemand := NewOnDemand(log.NewTestLogger())
+		Convey("SyncReferrers success", func() {
+			var syncCalls atomic.Int32
 
-			// Create request and pre-populate with a channel that we control
-			req := request{
-				repo:         "test-guaranteed-channel-referrers",
-				reference:    "sha256:guaranteed",
-				serviceID:    0,
-				isBackground: false,
-			}
+			runConcurrentDedup(t, func(onDemand *BaseOnDemand) error {
+				return onDemand.SyncReferrers(context.Background(), "dedup-referrer-repo", "sha256:dedup", nil)
+			}, &syncCalls, nil)
+		})
 
-			// Create a channel that we control completely
-			pendingChannel := make(chan error, 1)
-			onDemand.requestStore.Store(req, pendingChannel)
+		Convey("SyncImage shares leader error", func() {
+			var syncCalls atomic.Int32
+			wantErr := errors.New("sentinel sync image error")
 
-			// Start request that will wait on our channel
-			requestCompleted := make(chan error)
-			go func() {
-				err := onDemand.SyncReferrers(context.Background(), "test-guaranteed-channel-referrers", "sha256:guaranteed", []string{"signature"})
-				requestCompleted <- err
-			}()
+			runConcurrentDedup(t, func(onDemand *BaseOnDemand) error {
+				return onDemand.SyncImage(context.Background(), "dedup-repo-err", "dedup-tag")
+			}, &syncCalls, wantErr)
+		})
 
-			// Wait a moment for the request to reach the channel waiting code
-			time.Sleep(50 * time.Millisecond)
+		Convey("SyncReferrers shares leader error", func() {
+			var syncCalls atomic.Int32
+			wantErr := errors.New("sentinel sync referrers error")
 
-			// Send error through our controlled channel - this proves channel waiting worked
-			pendingChannel <- errors.New("guaranteed referrer channel error")
-
-			// Verify the request got our controlled error
-			err := <-requestCompleted
-			So(err, ShouldNotBeNil)
-			So(err.Error(), ShouldEqual, "guaranteed referrer channel error")
+			runConcurrentDedup(t, func(onDemand *BaseOnDemand) error {
+				return onDemand.SyncReferrers(context.Background(), "dedup-referrer-repo-err", "sha256:dedup", nil)
+			}, &syncCalls, wantErr)
 		})
 	})
 }
@@ -2718,6 +2741,44 @@ func TestCredentialRefreshOnEverySyncEntryPoint(t *testing.T) {
 		})
 	})
 }
+
+// countingOnDemandService is a minimal Service that counts SyncImage/SyncReferrers calls.
+type countingOnDemandService struct {
+	syncCalls *atomic.Int32
+	entered   chan struct{}
+	release   chan struct{}
+	retErr    error
+}
+
+func (s *countingOnDemandService) GetNextRepo(_ string) (string, error) { return "", nil }
+
+func (s *countingOnDemandService) SyncRepo(_ context.Context, _ string) error { return nil }
+
+func (s *countingOnDemandService) waitUntilReleased() {
+	s.syncCalls.Add(1)
+	s.entered <- struct{}{}
+	<-s.release
+}
+
+func (s *countingOnDemandService) SyncImage(_ context.Context, _, _ string) error {
+	s.waitUntilReleased()
+
+	return s.retErr
+}
+
+func (s *countingOnDemandService) SyncReferrers(_ context.Context, _, _ string, _ []string) error {
+	s.waitUntilReleased()
+
+	return s.retErr
+}
+
+func (s *countingOnDemandService) ResetCatalog() {}
+
+func (s *countingOnDemandService) CanRetryOnError() bool { return false }
+
+func (s *countingOnDemandService) GetSyncTimeout() time.Duration { return time.Minute }
+
+func (s *countingOnDemandService) ShouldCheckUpstream(_, _ string) bool { return true }
 
 // mockCheckService is a minimal Service implementation for exercising
 // BaseOnDemand.ShouldCheckUpstreamManifest.


### PR DESCRIPTION
Replace hand-rolled sync.Map + channel coordination in BaseOnDemand with
golang.org/x/sync/singleflight for SyncImage and SyncReferrers.

Fixes #4345. When the original HTTP caller disconnected before reading the
result channel, the worker could block on send and leave a stale
requestStore entry, causing later pulls for the same digest to hang on
"already demanded". singleflight dedupes in-flight work by key, ties
cleanup to sync completion (not channel receive), and returns the same
error to all waiters.

Expose on-demand sync through ext.SyncOnDemand (sync.OnDemand in
common.go) instead of *BaseOnDemand. EnableSyncExtension returns the
interface so failure paths yield a true nil; guard assignment and
isSyncOnDemandEnabled with != nil instead of fmt.Sprintf.

requestStore is kept only for background-retry dedup. Add tests for
concurrent SyncImage/SyncReferrers performing a single upstream sync.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
