### PR TITLE
fix(api): enforce dedupe mount auth for bearer and unify via UserAc

### DIFF
--- a/pkg/api/authz.go
+++ b/pkg/api/authz.go
@@ -253,6 +253,16 @@ func (ac *AccessController) updateUserAccessControl(httpReq *http.Request, userA
 		ac.getGlobPatterns(mkER(constants.DetectManifestCollisionPermission)))
 }
 
+// attachPermissionEvaluator wires config-based policy evaluation into userAc so
+// handlers can use CanOnResource without constructing AccessController.
+func (ac *AccessController) attachPermissionEvaluator(httpReq *http.Request, userAc *reqCtx.UserAccessControl) {
+	userAc.SetPermissionEvaluator(func(action, repository, reference string) bool {
+		ok, _ := ac.can(httpReq, userAc, action, repository, reference)
+
+		return ok
+	})
+}
+
 // getAuthnMiddlewareContext builds ac context(allowed to read repos and if user is admin) and returns it.
 func (ac *AccessController) getAuthnMiddlewareContext(authnType string, request *http.Request) context.Context {
 	amwCtx := reqCtx.AuthnMiddlewareContext{
@@ -644,6 +654,7 @@ func BaseAuthzHandler(ctlr *Controller) mux.MiddlewareFunc {
 			}
 
 			aCtlr.updateUserAccessControl(request, userAc)
+			aCtlr.attachPermissionEvaluator(request, userAc)
 			userAc.SaveOnRequest(request)
 
 			next.ServeHTTP(response, request) //nolint:contextcheck

--- a/pkg/api/authz_internal_test.go
+++ b/pkg/api/authz_internal_test.go
@@ -651,6 +651,47 @@ func TestSetGlobPatternsOrderIndependence(t *testing.T) {
 	assert.True(t, uac2.IsAdmin())
 }
 
+func TestCanOnResourceUsesPermissionEvaluator(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.AccessControlConfig{
+		Repositories: config.Repositories{
+			"**": config.PolicyGroup{
+				Policies: []config.Policy{
+					{
+						Users:   []string{"limited"},
+						Actions: []string{constants.ReadPermission, constants.CreatePermission},
+						Conditions: []config.Condition{
+							{
+								Expression: `req.action != "read" || !req.repository.startsWith("private/")`,
+								Message:    "read under private/ not permitted",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	programs, err := CompileAccessControl(cfg)
+	assert.NoError(t, err)
+	cfg.StoreCompiledConditions(programs)
+
+	uac := reqCtx.NewUserAccessControl()
+	uac.SetUsername("limited")
+	uac.SetIsAdmin(false)
+	uac.SetGlobPatterns(constants.ReadPermission, map[string]bool{"**": true})
+
+	// Optimistic glob patterns allow read on private/src.
+	assert.True(t, uac.Can(constants.ReadPermission, "private/src"))
+
+	ac := &AccessController{Config: cfg, Log: log.NewLogger("debug", "")}
+	req := httptest.NewRequest(http.MethodHead, "/v2/private/src/blobs/sha256:abc", nil)
+	ac.attachPermissionEvaluator(req, uac)
+
+	assert.False(t, uac.CanOnResource(constants.ReadPermission, "private/src", "sha256:abc"))
+	assert.True(t, uac.CanOnResource(constants.ReadPermission, "public/src", "sha256:abc"))
+}
+
 func TestPolicyConditionsAnonymousAndAdminFlags(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/api/bearer.go
+++ b/pkg/api/bearer.go
@@ -10,6 +10,9 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	zerr "zotregistry.dev/zot/v2/errors"
+	"zotregistry.dev/zot/v2/pkg/api/constants"
+	zreg "zotregistry.dev/zot/v2/pkg/regexp"
+	reqCtx "zotregistry.dev/zot/v2/pkg/requestcontext"
 )
 
 var bearerTokenMatch = regexp.MustCompile("(?i)bearer (.*)")
@@ -85,10 +88,84 @@ func NewBearerAuthorizer(realm string, service string, keyFunc BearerAuthorizerK
 	}
 }
 
-// Authorize verifies whether the bearer token in the given Authorization header is valid, and whether it has sufficient
-// scope for the requested resource action. If an authorization error occurs (e.g. no token is given or the token has
-// insufficient scope), an AuthChallengeError is returned as the error.
-func (a *BearerAuthorizer) Authorize(ctx context.Context, header string, requested *ResourceAction) error {
+// UserAccessControlFromBearerAccess maps distribution token access entries to
+// UserAccessControl glob patterns so secondary authorization checks (e.g. dedupe
+// mount source-repo read) can reuse the same permission model as config-based authz.
+//
+// Authenticate matches access names exactly; only map OCI-valid repository names
+// here so glob-based Can() cannot widen scope (e.g. a "**" entry must not imply
+// read on every repository). Catalog uses repository::pull and registry:catalog:*
+// scopes whose names are not valid repository paths and are skipped.
+func UserAccessControlFromBearerAccess(access []ResourceAccess) *reqCtx.UserAccessControl {
+	userAc := reqCtx.NewUserAccessControl()
+
+	readPatterns := map[string]bool{}
+	createPatterns := map[string]bool{}
+	updatePatterns := map[string]bool{}
+	deletePatterns := map[string]bool{}
+
+	now := time.Now()
+
+	for _, resourceAccess := range access {
+		if resourceAccess.Type != "repository" {
+			continue
+		}
+
+		if !zreg.FullNameRegexp.MatchString(resourceAccess.Name) {
+			continue
+		}
+
+		if resourceAccess.ExpiresAt != nil && resourceAccess.ExpiresAt.Time.Before(now) {
+			continue
+		}
+
+		for _, action := range resourceAccess.Actions {
+			switch action {
+			case "pull":
+				readPatterns[resourceAccess.Name] = true
+			case "push":
+				createPatterns[resourceAccess.Name] = true
+				updatePatterns[resourceAccess.Name] = true
+			case "delete":
+				deletePatterns[resourceAccess.Name] = true
+			}
+		}
+	}
+
+	// Token has no valid repository names (common for catalog-only scopes such as
+	// repository::pull on /v2/_catalog). Skip installing permissions: empty glob
+	// maps would list no repos in _catalog and still mark the caller as scoped.
+	if !hasNonEmptyGlobPatterns(readPatterns, createPatterns, updatePatterns, deletePatterns) {
+		return userAc
+	}
+
+	userAc.SetIsAdmin(false)
+	userAc.SetGlobPatterns(constants.ReadPermission, readPatterns)
+	userAc.SetGlobPatterns(constants.CreatePermission, createPatterns)
+	userAc.SetGlobPatterns(constants.UpdatePermission, updatePatterns)
+	userAc.SetGlobPatterns(constants.DeletePermission, deletePatterns)
+
+	return userAc
+}
+
+// hasNonEmptyGlobPatterns reports whether any action map contains at least one
+// repository pattern (used to distinguish scoped repo grants from catalog-only tokens).
+func hasNonEmptyGlobPatterns(patterns ...map[string]bool) bool {
+	for _, patternMap := range patterns {
+		if len(patternMap) > 0 {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Authenticate verifies the bearer token and, when requested is non-nil, that
+// the token scope covers the requested resource action. On success it returns
+// the parsed access claims.
+func (a *BearerAuthorizer) Authenticate(
+	ctx context.Context, header string, requested *ResourceAction,
+) (*ClaimsWithAccess, error) {
 	challenge := &AuthChallengeError{
 		realm:          a.realm,
 		service:        a.service,
@@ -99,7 +176,7 @@ func (a *BearerAuthorizer) Authorize(ctx context.Context, header string, request
 		// if no bearer token is set in the authorization header, return the authentication challenge
 		challenge.err = zerr.ErrNoBearerToken
 
-		return challenge
+		return nil, challenge
 	}
 
 	signedString := bearerTokenMatch.ReplaceAllString(header, "$1")
@@ -108,17 +185,17 @@ func (a *BearerAuthorizer) Authorize(ctx context.Context, header string, request
 		return a.keyFunc(ctx, token)
 	}, jwt.WithValidMethods(a.allowedSigningAlgorithms()), jwt.WithIssuedAt())
 	if err != nil {
-		return fmt.Errorf("%w: %w", zerr.ErrInvalidBearerToken, err)
-	}
-
-	if requested == nil {
-		// the token is valid and no access is requested, so we do not have to validate the access claim
-		return nil
+		return nil, fmt.Errorf("%w: %w", zerr.ErrInvalidBearerToken, err)
 	}
 
 	claims, ok := token.Claims.(*ClaimsWithAccess)
 	if !ok {
-		return fmt.Errorf("%w: invalid claims type", zerr.ErrInvalidBearerToken)
+		return nil, fmt.Errorf("%w: invalid claims type", zerr.ErrInvalidBearerToken)
+	}
+
+	if requested == nil {
+		// the token is valid and no access is requested, so we do not have to validate the access claim
+		return claims, nil
 	}
 
 	// check whether the requested access is allowed by the scope of the token
@@ -140,12 +217,21 @@ func (a *BearerAuthorizer) Authorize(ctx context.Context, header string, request
 		}
 
 		// requested action is allowed, so don't return an error
-		return nil
+		return claims, nil
 	}
 
 	challenge.err = zerr.ErrInsufficientScope
 
-	return challenge
+	return nil, challenge
+}
+
+// Authorize verifies whether the bearer token in the given Authorization header is valid, and whether it has sufficient
+// scope for the requested resource action. If an authorization error occurs (e.g. no token is given or the token has
+// insufficient scope), an AuthChallengeError is returned as the error.
+func (a *BearerAuthorizer) Authorize(ctx context.Context, header string, requested *ResourceAction) error {
+	_, err := a.Authenticate(ctx, header, requested)
+
+	return err
 }
 
 func (a *BearerAuthorizer) allowedSigningAlgorithms() []string {

--- a/pkg/api/bearer_auth.go
+++ b/pkg/api/bearer_auth.go
@@ -202,7 +202,7 @@ func (b *BearerAuth) Middleware(ctlr *Controller) mux.MiddlewareFunc {
 
 			// Fall back to traditional bearer token auth if OIDC didn't succeed.
 			if b.traditional != nil {
-				err := b.traditional.Authorize(request.Context(), header, requestedAccess)
+				claims, err := b.traditional.Authenticate(request.Context(), header, requestedAccess)
 				if err != nil {
 					var challenge *AuthChallengeError
 					if errors.As(err, &challenge) {
@@ -219,6 +219,11 @@ func (b *BearerAuth) Middleware(ctlr *Controller) mux.MiddlewareFunc {
 					zcommon.WriteJSON(response, http.StatusUnauthorized, apiErr.NewError(apiErr.UNSUPPORTED))
 
 					return
+				}
+
+				if claims != nil {
+					userAc := UserAccessControlFromBearerAccess(claims.Access)
+					userAc.SaveOnRequest(request)
 				}
 
 				amCtx := acCtrlr.getAuthnMiddlewareContext(BEARER, request)

--- a/pkg/api/bearer_test.go
+++ b/pkg/api/bearer_test.go
@@ -16,6 +16,7 @@ import (
 
 	zerr "zotregistry.dev/zot/v2/errors"
 	"zotregistry.dev/zot/v2/pkg/api"
+	"zotregistry.dev/zot/v2/pkg/api/constants"
 )
 
 func TestBearerAuthorizer(t *testing.T) {
@@ -391,5 +392,145 @@ func TestBearerAuthorizerJWKSEdDSA(t *testing.T) {
 			err := authorizer.Authorize(context.Background(), authHeader, nil)
 			So(err, ShouldBeNil)
 		})
+	})
+}
+
+func TestUserAccessControlFromBearerAccess(t *testing.T) {
+	Convey("UserAccessControlFromBearerAccess maps distribution scopes", t, func() {
+		access := []api.ResourceAccess{
+			{
+				Type:    "repository",
+				Name:    "allowed/repo",
+				Actions: []string{"pull", "push"},
+			},
+			{
+				Type:    "repository",
+				Name:    "other/repo",
+				Actions: []string{"delete"},
+			},
+			{
+				Type:    "registry",
+				Name:    "catalog",
+				Actions: []string{"pull"},
+			},
+			{
+				Type:      "repository",
+				Name:      "expired/repo",
+				Actions:   []string{"pull"},
+				ExpiresAt: jwt.NewNumericDate(time.Now().Add(-time.Hour)),
+			},
+		}
+
+		userAc := api.UserAccessControlFromBearerAccess(access)
+
+		So(userAc.IsAdmin(), ShouldBeFalse)
+		So(userAc.HasScopedPermissions(), ShouldBeTrue)
+		So(userAc.Can(constants.ReadPermission, "allowed/repo"), ShouldBeTrue)
+		So(userAc.Can(constants.ReadPermission, "private/repo"), ShouldBeFalse)
+		So(userAc.Can(constants.CreatePermission, "allowed/repo"), ShouldBeTrue)
+		So(userAc.Can(constants.UpdatePermission, "allowed/repo"), ShouldBeTrue)
+		So(userAc.Can(constants.DeletePermission, "other/repo"), ShouldBeTrue)
+		So(userAc.Can(constants.ReadPermission, "expired/repo"), ShouldBeFalse)
+	})
+
+	Convey("catalog scope with empty repository name does not grant repo read", t, func() {
+		userAc := api.UserAccessControlFromBearerAccess([]api.ResourceAccess{
+			{
+				Type:    "repository",
+				Name:    "",
+				Actions: []string{"pull"},
+			},
+			{
+				Type:    "repository",
+				Name:    "dest",
+				Actions: []string{"push"},
+			},
+		})
+
+		So(userAc.HasScopedPermissions(), ShouldBeTrue)
+		So(userAc.Can(constants.CreatePermission, "dest"), ShouldBeTrue)
+		So(userAc.Can(constants.ReadPermission, "private/src"), ShouldBeFalse)
+		So(userAc.Can(constants.ReadPermission, "src/repo"), ShouldBeFalse)
+	})
+
+	Convey("catalog-only bearer scope does not install scoped repo permissions", t, func() {
+		userAc := api.UserAccessControlFromBearerAccess([]api.ResourceAccess{
+			{
+				Type:    "repository",
+				Name:    "",
+				Actions: []string{"pull"},
+			},
+		})
+
+		So(userAc.HasScopedPermissions(), ShouldBeFalse)
+		So(userAc.Can(constants.ReadPermission, "zot-test"), ShouldBeTrue)
+	})
+
+	Convey("glob metacharacters in access names are not mapped to repo permissions", t, func() {
+		userAc := api.UserAccessControlFromBearerAccess([]api.ResourceAccess{
+			{
+				Type:    "repository",
+				Name:    "**",
+				Actions: []string{"pull"},
+			},
+			{
+				Type:    "repository",
+				Name:    "dest",
+				Actions: []string{"push"},
+			},
+		})
+
+		So(userAc.Can(constants.CreatePermission, "dest"), ShouldBeTrue)
+		So(userAc.Can(constants.ReadPermission, "private/src"), ShouldBeFalse)
+		So(userAc.Can(constants.ReadPermission, "src/repo"), ShouldBeFalse)
+	})
+}
+
+func TestBearerAuthorizerAuthenticate(t *testing.T) {
+	Convey("Authenticate returns parsed access claims on success", t, func() {
+		signingMethod := jwt.SigningMethodRS256
+
+		privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		So(err, ShouldBeNil)
+
+		pubKey := privKey.Public()
+		keyFunc := func(_ context.Context, token *jwt.Token) (any, error) {
+			return pubKey, nil
+		}
+
+		authorizer := api.NewBearerAuthorizer("realm", "service", keyFunc)
+
+		access := []api.ResourceAccess{
+			{
+				Name:    "authorized-repository",
+				Type:    "repository",
+				Actions: []string{"pull", "push"},
+			},
+		}
+
+		now := time.Now()
+		claims := api.ClaimsWithAccess{
+			Access: access,
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(now.Add(time.Minute)),
+				IssuedAt:  jwt.NewNumericDate(now),
+			},
+		}
+
+		token, err := jwt.NewWithClaims(signingMethod, claims).SignedString(privKey)
+		So(err, ShouldBeNil)
+
+		gotClaims, err := authorizer.Authenticate(context.Background(), "Bearer "+token, &api.ResourceAction{
+			Type:   "repository",
+			Name:   "authorized-repository",
+			Action: "pull",
+		})
+		So(err, ShouldBeNil)
+		So(gotClaims, ShouldNotBeNil)
+		So(gotClaims.Access, ShouldResemble, access)
+
+		userAc := api.UserAccessControlFromBearerAccess(gotClaims.Access)
+		So(userAc.Can(constants.ReadPermission, "authorized-repository"), ShouldBeTrue)
+		So(userAc.Can(constants.ReadPermission, "other-repository"), ShouldBeFalse)
 	})
 }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/google/go-github/v62/github"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/securecookie"
@@ -5724,6 +5725,345 @@ func TestAuthorizationMountBlob(t *testing.T) {
 	})
 }
 
+func signBearerTestToken(t *testing.T, serverKeyPath string, access []api.ResourceAccess) string {
+	t.Helper()
+
+	keyBytes, err := os.ReadFile(serverKeyPath)
+	So(err, ShouldBeNil)
+
+	privateKey, err := jwt.ParseRSAPrivateKeyFromPEM(keyBytes)
+	So(err, ShouldBeNil)
+
+	now := time.Now()
+	claims := api.ClaimsWithAccess{
+		Access: access,
+		RegisteredClaims: jwt.RegisteredClaims{
+			ExpiresAt: jwt.NewNumericDate(now.Add(time.Hour)),
+			IssuedAt:  jwt.NewNumericDate(now),
+		},
+	}
+
+	token, err := jwt.NewWithClaims(jwt.SigningMethodRS256, claims).SignedString(privateKey)
+	So(err, ShouldBeNil)
+
+	return token
+}
+
+func TestBearerAuthorizationMountBlob(t *testing.T) {
+	Convey("traditional bearer requires source-repo read before dedupe mount", t, func() {
+		serverCertPath, serverKeyPath, _, _ := setupBearerAuthServerCerts(t, tlsutils.KeyTypeRSA)
+
+		authTestServer := authutils.MakeAuthTestServer(serverKeyPath, "RS256", UnauthorizedNamespace)
+		defer authTestServer.Close()
+
+		conf := config.New()
+		conf.HTTP.Port = "0"
+
+		aurl, err := url.Parse(authTestServer.URL)
+		So(err, ShouldBeNil)
+
+		conf.HTTP.Auth = &config.AuthConfig{
+			Bearer: &config.BearerConfig{
+				Cert:    serverCertPath,
+				Realm:   authTestServer.URL + "/auth/token",
+				Service: aurl.Host,
+			},
+		}
+
+		ctlr := makeController(conf, t.TempDir())
+		ctlr.Config.Storage.Dedupe = true
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+
+		defer cm.StopServer()
+
+		getToken := func(method, challengeURL string) string {
+			resp, err := resty.R().Execute(method, challengeURL)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+
+			authorizationHeader := authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
+			resp, err = resty.R().
+				SetQueryParam("service", authorizationHeader.Service).
+				SetQueryParam("scope", authorizationHeader.Scope).
+				Get(authorizationHeader.Realm)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			var token authutils.AccessTokenResponse
+
+			err = json.Unmarshal(resp.Body(), &token)
+			So(err, ShouldBeNil)
+
+			return token.AccessToken
+		}
+
+		blob := []byte("bearer-mount-authz-test")
+		digest := godigest.FromBytes(blob)
+		srcRepo := "victim/private/app"
+		destRepo := "attacker/allowed/app"
+
+		token := getToken(http.MethodPost, baseURL+"/v2/"+srcRepo+"/blobs/uploads/")
+		resp, err := resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			Post(baseURL + "/v2/" + srcRepo + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+		loc := resp.Header().Get("Location")
+
+		putURL := baseURL + loc + "?digest=" + digest.String()
+		token = getToken(http.MethodPut, putURL)
+		resp, err = resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			SetHeader("Content-Length", strconv.Itoa(len(blob))).
+			SetHeader("Content-Type", "application/octet-stream").
+			SetQueryParam("digest", digest.String()).
+			SetBody(blob).
+			Put(baseURL + loc)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		headURL := baseURL + fmt.Sprintf("/v2/%s/blobs/%s", destRepo, digest)
+		token = getToken(http.MethodHead, headURL)
+		resp, err = resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			Head(headURL)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+		mountURL := baseURL + "/v2/" + destRepo + "/blobs/uploads/"
+		token = getToken(http.MethodPost, mountURL+"?mount="+digest.String())
+		resp, err = resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			SetQueryParam("mount", digest.String()).
+			Post(mountURL)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+
+		token = signBearerTestToken(t, serverKeyPath, []api.ResourceAccess{
+			{
+				Type:    "repository",
+				Name:    destRepo,
+				Actions: []string{"push"},
+			},
+			{
+				Type:    "repository",
+				Name:    srcRepo,
+				Actions: []string{"pull"},
+			},
+		})
+		resp, err = resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			SetQueryParam("mount", digest.String()).
+			Post(mountURL)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		token = getToken(http.MethodHead, headURL)
+		resp, err = resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			Head(headURL)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+	})
+}
+
+func TestBearerAuthorizationHydrateOnRead(t *testing.T) {
+	Convey("traditional bearer enforces source-repo read for hydrate-on-read", t, func() {
+		serverCertPath, serverKeyPath, _, _ := setupBearerAuthServerCerts(t, tlsutils.KeyTypeRSA)
+
+		authTestServer := authutils.MakeAuthTestServer(serverKeyPath, "RS256", UnauthorizedNamespace)
+		defer authTestServer.Close()
+
+		conf := config.New()
+		conf.HTTP.Port = "0"
+
+		aurl, err := url.Parse(authTestServer.URL)
+		So(err, ShouldBeNil)
+
+		conf.HTTP.Auth = &config.AuthConfig{
+			Bearer: &config.BearerConfig{
+				Cert:    serverCertPath,
+				Realm:   authTestServer.URL + "/auth/token",
+				Service: aurl.Host,
+			},
+		}
+
+		rootDir := t.TempDir()
+		ctlr := makeController(conf, rootDir)
+		ctlr.Config.Storage.Dedupe = true
+		ctlr.Config.Storage.HydrateBlobOnRead = true
+
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+
+		defer cm.StopServer()
+
+		getToken := func(method, challengeURL string) string {
+			resp, err := resty.R().Execute(method, challengeURL)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
+
+			authorizationHeader := authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
+			resp, err = resty.R().
+				SetQueryParam("service", authorizationHeader.Service).
+				SetQueryParam("scope", authorizationHeader.Scope).
+				Get(authorizationHeader.Realm)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			var token authutils.AccessTokenResponse
+
+			err = json.Unmarshal(resp.Body(), &token)
+			So(err, ShouldBeNil)
+
+			return token.AccessToken
+		}
+
+		blob := []byte("bearer-hydrate-on-read-test")
+		digest := godigest.FromBytes(blob)
+		srcRepo := "bearer/src"
+		destRepo := "bearer/dest"
+
+		token := getToken(http.MethodPost, baseURL+"/v2/"+srcRepo+"/blobs/uploads/")
+		resp, err := resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			Post(baseURL + "/v2/" + srcRepo + "/blobs/uploads/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+		loc := resp.Header().Get("Location")
+
+		putURL := baseURL + loc + "?digest=" + digest.String()
+		token = getToken(http.MethodPut, putURL)
+		resp, err = resty.R().
+			SetHeader("Authorization", "Bearer "+token).
+			SetHeader("Content-Length", strconv.Itoa(len(blob))).
+			SetHeader("Content-Type", "application/octet-stream").
+			SetQueryParam("digest", digest.String()).
+			SetBody(blob).
+			Put(baseURL + loc)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+
+		headURL := baseURL + fmt.Sprintf("/v2/%s/blobs/%s", destRepo, digest)
+		destBlobPath := filepath.Join(rootDir, destRepo, "blobs", string(digest.Algorithm()), digest.Encoded())
+
+		Convey("challenge-scoped dest pull only does not hydrate on HEAD or ranged GET", func() {
+			token := getToken(http.MethodHead, headURL)
+			resp, err := resty.R().
+				SetHeader("Authorization", "Bearer "+token).
+				Head(headURL)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+			resp, err = resty.R().
+				SetHeader("Authorization", "Bearer "+token).
+				SetHeader("Range", "bytes=0-0").
+				Get(headURL)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+			_, err = os.Stat(destBlobPath)
+			So(os.IsNotExist(err), ShouldBeTrue)
+		})
+
+		Convey("dest pull and push without src pull does not hydrate", func() {
+			token := signBearerTestToken(t, serverKeyPath, []api.ResourceAccess{
+				{
+					Type:    "repository",
+					Name:    destRepo,
+					Actions: []string{"pull", "push"},
+				},
+			})
+			resp, err := resty.R().
+				SetHeader("Authorization", "Bearer "+token).
+				Head(headURL)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+			resp, err = resty.R().
+				SetHeader("Authorization", "Bearer "+token).
+				SetHeader("Range", "bytes=0-0").
+				Get(headURL)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+
+			_, err = os.Stat(destBlobPath)
+			So(os.IsNotExist(err), ShouldBeTrue)
+		})
+
+		Convey("src pull and dest pull+push hydrates on HEAD and ranged GET", func() {
+			token := signBearerTestToken(t, serverKeyPath, []api.ResourceAccess{
+				{
+					Type:    "repository",
+					Name:    srcRepo,
+					Actions: []string{"pull"},
+				},
+				{
+					Type:    "repository",
+					Name:    destRepo,
+					Actions: []string{"pull", "push"},
+				},
+			})
+			resp, err := resty.R().
+				SetHeader("Authorization", "Bearer "+token).
+				Head(headURL)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			resp, err = resty.R().
+				SetHeader("Authorization", "Bearer "+token).
+				SetHeader("Range", "bytes=0-0").
+				Get(headURL)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusPartialContent)
+
+			_, err = os.Stat(destBlobPath)
+			So(err, ShouldBeNil)
+		})
+
+		Convey("dest push without src pull rejects dedupe mount POST", func() {
+			mountURL := baseURL + "/v2/" + destRepo + "/blobs/uploads/"
+			token := signBearerTestToken(t, serverKeyPath, []api.ResourceAccess{
+				{
+					Type:    "repository",
+					Name:    destRepo,
+					Actions: []string{"push"},
+				},
+			})
+			resp, err := resty.R().
+				SetHeader("Authorization", "Bearer "+token).
+				SetQueryParam("mount", digest.String()).
+				Post(mountURL)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
+		})
+
+		Convey("src pull and dest push allows dedupe mount POST", func() {
+			mountURL := baseURL + "/v2/" + destRepo + "/blobs/uploads/"
+			token := signBearerTestToken(t, serverKeyPath, []api.ResourceAccess{
+				{
+					Type:    "repository",
+					Name:    destRepo,
+					Actions: []string{"push"},
+				},
+				{
+					Type:    "repository",
+					Name:    srcRepo,
+					Actions: []string{"pull"},
+				},
+			})
+			resp, err := resty.R().
+				SetHeader("Authorization", "Bearer "+token).
+				SetQueryParam("mount", digest.String()).
+				Post(mountURL)
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
+		})
+	})
+}
+
 func TestAuthorizationMountBlobRematerializeOnRead(t *testing.T) {
 	Convey("With hydrateBlobOnRead, HEAD/range may rematerialize when permitted", t, func() {
 		conf := config.New()
@@ -5994,115 +6334,6 @@ func TestAuthorizationMountBlobCELConditions(t *testing.T) {
 			Post(baseURL + "/v2/allowed/dest2/blobs/uploads/")
 		So(err, ShouldBeNil)
 		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
-	})
-}
-
-func TestBearerAuthMountBlobWithAccessControl(t *testing.T) {
-	Convey("traditional bearer can mount/rematerialize when accessControl is also set", t, func() {
-		serverCertPath, serverKeyPath, _, _ := setupBearerAuthServerCerts(t, tlsutils.KeyTypeRSA)
-
-		authTestServer := authutils.MakeAuthTestServer(serverKeyPath, "RS256", UnauthorizedNamespace)
-		defer authTestServer.Close()
-
-		conf := config.New()
-		conf.HTTP.Port = "0"
-
-		aurl, err := url.Parse(authTestServer.URL)
-		So(err, ShouldBeNil)
-
-		conf.HTTP.Auth = &config.AuthConfig{
-			Bearer: &config.BearerConfig{
-				Cert:    serverCertPath,
-				Realm:   authTestServer.URL + "/auth/token",
-				Service: aurl.Host,
-			},
-		}
-		conf.HTTP.AccessControl = &config.AccessControlConfig{
-			Repositories: config.Repositories{
-				"**": config.PolicyGroup{
-					Policies: []config.Policy{
-						{
-							Users: []string{"alice"},
-							Actions: []string{
-								constants.ReadPermission,
-								constants.CreatePermission,
-							},
-						},
-					},
-				},
-			},
-		}
-
-		ctlr := makeController(conf, t.TempDir())
-		ctlr.Config.Storage.Dedupe = true
-		ctlr.Config.Storage.HydrateBlobOnRead = true
-
-		cm := test.NewControllerManager(ctlr)
-		baseURL := cm.StartAndWait()
-		defer cm.StopServer()
-
-		getToken := func(method, challengeURL string) string {
-			resp, err := resty.R().Execute(method, challengeURL)
-			So(err, ShouldBeNil)
-			So(resp.StatusCode(), ShouldEqual, http.StatusUnauthorized)
-
-			authorizationHeader := authutils.ParseBearerAuthHeader(resp.Header().Get("WWW-Authenticate"))
-			resp, err = resty.R().
-				SetQueryParam("service", authorizationHeader.Service).
-				SetQueryParam("scope", authorizationHeader.Scope).
-				Get(authorizationHeader.Realm)
-			So(err, ShouldBeNil)
-			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
-
-			var token authutils.AccessTokenResponse
-			err = json.Unmarshal(resp.Body(), &token)
-			So(err, ShouldBeNil)
-
-			return token.AccessToken
-		}
-
-		blob := []byte("bearer-mount-with-ac")
-		digest := godigest.FromBytes(blob)
-		srcRepo := "bearer/src"
-		destRepo := "bearer/dest"
-		rematRepo := "bearer/remat"
-
-		token := getToken(http.MethodPost, baseURL+"/v2/"+srcRepo+"/blobs/uploads/")
-		resp, err := resty.R().
-			SetHeader("Authorization", "Bearer "+token).
-			Post(baseURL + "/v2/" + srcRepo + "/blobs/uploads/")
-		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusAccepted)
-		loc := resp.Header().Get("Location")
-
-		putURL := baseURL + loc + "?digest=" + digest.String()
-		token = getToken(http.MethodPut, putURL)
-		resp, err = resty.R().
-			SetHeader("Authorization", "Bearer "+token).
-			SetHeader("Content-Length", strconv.Itoa(len(blob))).
-			SetHeader("Content-Type", "application/octet-stream").
-			SetQueryParam("digest", digest.String()).
-			SetBody(blob).
-			Put(baseURL + loc)
-		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
-
-		mountURL := baseURL + "/v2/" + destRepo + "/blobs/uploads/?mount=" + digest.String()
-		token = getToken(http.MethodPost, mountURL)
-		resp, err = resty.R().
-			SetHeader("Authorization", "Bearer "+token).
-			SetQueryParam("mount", digest.String()).
-			Post(baseURL + "/v2/" + destRepo + "/blobs/uploads/")
-		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusCreated)
-
-		headURL := baseURL + fmt.Sprintf("/v2/%s/blobs/%s", rematRepo, digest)
-		token = getToken(http.MethodHead, headURL)
-		resp, err = resty.R().
-			SetHeader("Authorization", "Bearer "+token).
-			Head(headURL)
-		So(err, ShouldBeNil)
-		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 	})
 }
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -5423,6 +5423,7 @@ func TestAuthnMetaDBErrors(t *testing.T) {
 func TestAuthorization(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		conf := config.New()
+		conf.Storage.GC = false
 		username, seedUser := test.GenerateRandomString()
 		password, seedPass := test.GenerateRandomString()
 		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
@@ -5602,6 +5603,7 @@ func TestGetUsername(t *testing.T) {
 func TestAuthorizationMountBlob(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		conf := config.New()
+		conf.Storage.GC = false
 		conf.HTTP.Port = "0"
 		// have two users: one for  user Policy, and another for default policy
 		username1, _ := test.GenerateRandomString()
@@ -5757,6 +5759,7 @@ func TestBearerAuthorizationMountBlob(t *testing.T) {
 		defer authTestServer.Close()
 
 		conf := config.New()
+		conf.Storage.GC = false
 		conf.HTTP.Port = "0"
 
 		aurl, err := url.Parse(authTestServer.URL)
@@ -5877,6 +5880,7 @@ func TestBearerAuthorizationHydrateOnRead(t *testing.T) {
 		defer authTestServer.Close()
 
 		conf := config.New()
+		conf.Storage.GC = false
 		conf.HTTP.Port = "0"
 
 		aurl, err := url.Parse(authTestServer.URL)
@@ -6067,6 +6071,7 @@ func TestBearerAuthorizationHydrateOnRead(t *testing.T) {
 func TestAuthorizationMountBlobRematerializeOnRead(t *testing.T) {
 	Convey("With hydrateBlobOnRead, HEAD/range may rematerialize when permitted", t, func() {
 		conf := config.New()
+		conf.Storage.GC = false
 		conf.HTTP.Port = "0"
 		username1, _ := test.GenerateRandomString()
 		password1, _ := test.GenerateRandomString()
@@ -6135,6 +6140,7 @@ func TestAuthorizationMountBlobRematerializeOnRead(t *testing.T) {
 func TestAuthorizationReadOnlyCannotMaterializeBlob(t *testing.T) {
 	Convey("defaultPolicy read alone does not materialize blobs on HEAD or ranged GET", t, func() {
 		conf := config.New()
+		conf.Storage.GC = false
 		conf.HTTP.Port = "0"
 
 		writerUser, _ := test.GenerateRandomString()
@@ -6228,6 +6234,7 @@ func TestAuthorizationReadOnlyCannotMaterializeBlob(t *testing.T) {
 func TestAuthorizationMountBlobCELConditions(t *testing.T) {
 	Convey("canMount evaluates CEL policy conditions", t, func() {
 		conf := config.New()
+		conf.Storage.GC = false
 		conf.HTTP.Port = "0"
 
 		writer, _ := test.GenerateRandomString()
@@ -6340,6 +6347,7 @@ func TestAuthorizationMountBlobCELConditions(t *testing.T) {
 func TestAuthorizationForTagUpdate(t *testing.T) {
 	Convey("Test authorization for updating tags including latest", t, func() {
 		conf := config.New()
+		conf.Storage.GC = false
 		conf.HTTP.Port = "0"
 
 		username, seedUser := test.GenerateRandomString()
@@ -7079,6 +7087,7 @@ func TestAuthorizationWithOnlyAnonymousPolicy(t *testing.T) {
 		const TestRepo = "my-repos/repo"
 
 		conf := config.New()
+		conf.Storage.GC = false
 		conf.HTTP.Port = "0"
 		conf.HTTP.Auth = &config.AuthConfig{}
 		conf.HTTP.AccessControl = &config.AccessControlConfig{
@@ -7330,6 +7339,7 @@ func TestAuthorizationWithAnonymousPolicyBasicAuthAndSessionHeader(t *testing.T)
 		tagUnauth := "1.0-unauth"
 
 		conf := config.New()
+		conf.Storage.GC = false
 		conf.HTTP.Port = "0"
 		conf.HTTP.Auth = &config.AuthConfig{
 			HTPasswd: config.AuthHTPasswd{
@@ -7521,6 +7531,7 @@ func TestAuthorizationWithAnonymousPolicyBasicAuthAndSessionHeader(t *testing.T)
 func TestAuthorizationWithMultiplePolicies(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		conf := config.New()
+		conf.Storage.GC = false
 		// have two users: one for  user Policy, and another for default policy
 		username1, seedUser1 := test.GenerateRandomString()
 		password1, seedPass1 := test.GenerateRandomString()
@@ -9987,6 +9998,7 @@ func TestRouteFailures(t *testing.T) {
 
 func TestPagedRepositoriesWithAuthorization(t *testing.T) {
 	conf := config.New()
+	conf.Storage.GC = false
 	conf.HTTP.Port = "0"
 	username, _ := test.GenerateRandomString()
 	password, _ := test.GenerateRandomString()

--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -1021,34 +1021,27 @@ func (rh *RouteHandler) DeleteManifest(response http.ResponseWriter, request *ht
 	response.WriteHeader(http.StatusAccepted)
 }
 
+// shouldCheckMountSourceAccess reports whether dedupe mount must verify the
+// caller can read a source repository that already holds the digest.
+func shouldCheckMountSourceAccess(
+	accessControlConfig *config.AccessControlConfig, userAc *reqCtx.UserAccessControl,
+) bool {
+	if accessControlConfig.IsAuthzEnabled() {
+		return true
+	}
+
+	return userAc.HasScopedPermissions()
+}
+
 // canMount reports whether the caller may materialize digest into destRepo from
 // the dedupe cache. That requires create on destRepo and read on at least
-// one repository that already holds the digest. Permissions are evaluated with
-// AccessController.can so policy CEL conditions apply. Call only when authz is
-// enabled.
-func (rh *RouteHandler) canMount(
-	request *http.Request, userAc *reqCtx.UserAccessControl, imgStore storageTypes.ImageStore,
+// one repository that already holds the digest.
+func canMount(userAc *reqCtx.UserAccessControl, imgStore storageTypes.ImageStore,
 	digest godigest.Digest, destRepo string,
 ) (bool, error) {
-	authnMwCtx, err := reqCtx.GetAuthnMiddlewareContext(request.Context())
-	if err == nil && authnMwCtx != nil && authnMwCtx.AuthnType == BEARER {
-		return true, nil
-	}
-
-	// Snapshot AC config and reuse the controller logger (avoid opening Log.Output per call).
-	accessControlConfig := rh.c.Config.CopyAccessControlConfig()
-	if accessControlConfig == nil {
-		accessControlConfig = &config.AccessControlConfig{}
-	}
-
-	acCtrlr := &AccessController{
-		Config: accessControlConfig,
-		Log:    rh.c.Log,
-	}
-
 	digestRef := digest.String()
 
-	if ok, _ := acCtrlr.can(request, userAc, constants.CreatePermission, destRepo, digestRef); !ok {
+	if !userAc.CanOnResource(constants.CreatePermission, destRepo, digestRef) {
 		return false, nil
 	}
 
@@ -1058,7 +1051,7 @@ func (rh *RouteHandler) canMount(
 	}
 
 	for _, repo := range repos {
-		if ok, _ := acCtrlr.can(request, userAc, constants.ReadPermission, repo, digestRef); ok {
+		if userAc.CanOnResource(constants.ReadPermission, repo, digestRef) {
 			return true, nil
 		}
 	}
@@ -1084,11 +1077,11 @@ func (rh *RouteHandler) userMayMountBlob(
 	}
 
 	accessControlConfig := rh.c.Config.CopyAccessControlConfig()
-	if !accessControlConfig.IsAuthzEnabled() {
+	if !shouldCheckMountSourceAccess(accessControlConfig, userAc) {
 		return true, nil
 	}
 
-	allowed, err := rh.canMount(request, userAc, imgStore, digest, destRepo)
+	allowed, err := canMount(userAc, imgStore, digest, destRepo)
 	if err != nil {
 		rh.c.Log.Error().Err(err).Msg("unexpected error")
 
@@ -1784,8 +1777,8 @@ func (rh *RouteHandler) CreateBlobUpload(response http.ResponseWriter, request *
 		userCanMount := true
 		accessControlConfig := rh.c.Config.CopyAccessControlConfig()
 
-		if accessControlConfig.IsAuthzEnabled() {
-			userCanMount, err = rh.canMount(request, userAc, imgStore, mountDigest, name)
+		if shouldCheckMountSourceAccess(accessControlConfig, userAc) {
+			userCanMount, err = canMount(userAc, imgStore, mountDigest, name)
 			if err != nil {
 				rh.c.Log.Error().Err(err).Msg("unexpected error")
 			}

--- a/pkg/api/routes_internal_test.go
+++ b/pkg/api/routes_internal_test.go
@@ -234,28 +234,60 @@ func TestCanMountTraditionalBearer(t *testing.T) {
 		},
 	}
 
-	rh := &RouteHandler{c: &Controller{Config: conf, Log: log.NewTestLogger()}}
 	imgStore := mocks.MockedImageStore{
 		GetAllDedupeReposCandidatesFn: func(_ godigest.Digest) ([]string, error) {
 			return []string{"src/repo"}, nil
 		},
 	}
 	digest := godigest.FromString("bearer-mount-test")
-	emptyUser := reqCtx.NewUserAccessControl()
 
 	req := httptest.NewRequest(http.MethodPost, "/v2/dest/blobs/uploads/", nil)
-	ok, err := rh.canMount(req, emptyUser, imgStore, digest, "dest")
-	require.NoError(t, err)
-	require.False(t, ok)
-
 	acCtrlr := NewAccessController(conf)
-	bearerReq := req.WithContext(acCtrlr.getAuthnMiddlewareContext(BEARER, req))
-	ok, err = rh.canMount(bearerReq, emptyUser, imgStore, digest, "dest")
+
+	configUser := reqCtx.NewUserAccessControl()
+	configUser.SetUsername("alice")
+	acCtrlr.updateUserAccessControl(req, configUser)
+	acCtrlr.attachPermissionEvaluator(req, configUser)
+
+	ok, err := canMount(configUser, imgStore, digest, "dest")
 	require.NoError(t, err)
 	require.True(t, ok)
 
-	oidcReq := req.WithContext(acCtrlr.getAuthnMiddlewareContext(BEARER_OIDC, req))
-	ok, err = rh.canMount(oidcReq, emptyUser, imgStore, digest, "dest")
+	emptyConfigUser := reqCtx.NewUserAccessControl()
+	acCtrlr.attachPermissionEvaluator(req, emptyConfigUser)
+
+	ok, err = canMount(emptyConfigUser, imgStore, digest, "dest")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	destOnlyBearer := UserAccessControlFromBearerAccess([]ResourceAccess{
+		{Type: "repository", Name: "dest", Actions: []string{"push"}},
+	})
+	ok, err = canMount(destOnlyBearer, imgStore, digest, "dest")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	authorizedBearer := UserAccessControlFromBearerAccess([]ResourceAccess{
+		{Type: "repository", Name: "dest", Actions: []string{"push"}},
+		{Type: "repository", Name: "src/repo", Actions: []string{"pull"}},
+	})
+	ok, err = canMount(authorizedBearer, imgStore, digest, "dest")
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	catalogBearer := UserAccessControlFromBearerAccess([]ResourceAccess{
+		{Type: "repository", Name: "dest", Actions: []string{"push"}},
+		{Type: "repository", Name: "", Actions: []string{"pull"}},
+	})
+	ok, err = canMount(catalogBearer, imgStore, digest, "dest")
+	require.NoError(t, err)
+	require.False(t, ok)
+
+	wildcardBearer := UserAccessControlFromBearerAccess([]ResourceAccess{
+		{Type: "repository", Name: "dest", Actions: []string{"push"}},
+		{Type: "repository", Name: "**", Actions: []string{"pull"}},
+	})
+	ok, err = canMount(wildcardBearer, imgStore, digest, "dest")
 	require.NoError(t, err)
 	require.False(t, ok)
 }
@@ -281,7 +313,6 @@ func TestCanMountDedupeCandidatesError(t *testing.T) {
 	}
 
 	candidatesErr := errors.New("candidates failed")
-	rh := &RouteHandler{c: &Controller{Config: conf, Log: log.NewTestLogger()}}
 	imgStore := mocks.MockedImageStore{
 		GetAllDedupeReposCandidatesFn: func(_ godigest.Digest) ([]string, error) {
 			return nil, candidatesErr
@@ -291,10 +322,222 @@ func TestCanMountDedupeCandidatesError(t *testing.T) {
 	userAc := reqCtx.NewUserAccessControl()
 	userAc.SetUsername("alice")
 	req := httptest.NewRequest(http.MethodPost, "/v2/dest/blobs/uploads/", nil)
+	acCtrlr := NewAccessController(conf)
+	acCtrlr.attachPermissionEvaluator(req, userAc)
 
-	ok, err := rh.canMount(req, userAc, imgStore, godigest.FromString("candidates-err"), "dest")
+	ok, err := canMount(userAc, imgStore, godigest.FromString("candidates-err"), "dest")
 	require.ErrorIs(t, err, candidatesErr)
 	require.False(t, ok)
+}
+
+func TestShouldCheckMountSourceAccess(t *testing.T) {
+	t.Parallel()
+
+	t.Run("config authz always checks regardless of scoped permissions", func(t *testing.T) {
+		t.Parallel()
+
+		require.True(t, shouldCheckMountSourceAccess(
+			&config.AccessControlConfig{},
+			reqCtx.NewUserAccessControl(),
+		))
+	})
+
+	t.Run("no config authz: catalog-only bearer skips mount source check", func(t *testing.T) {
+		t.Parallel()
+
+		catalogOnly := UserAccessControlFromBearerAccess([]ResourceAccess{
+			{Type: "repository", Name: "", Actions: []string{"pull"}},
+		})
+		require.False(t, catalogOnly.HasScopedPermissions())
+		require.False(t, shouldCheckMountSourceAccess(nil, catalogOnly))
+	})
+
+	t.Run("no config authz: scoped bearer enables mount source check", func(t *testing.T) {
+		t.Parallel()
+
+		scoped := UserAccessControlFromBearerAccess([]ResourceAccess{
+			{Type: "repository", Name: "dest", Actions: []string{"push"}},
+		})
+		require.True(t, scoped.HasScopedPermissions())
+		require.True(t, shouldCheckMountSourceAccess(nil, scoped))
+	})
+}
+
+func TestUserMayMountBlobGate(t *testing.T) {
+	t.Parallel()
+
+	digest := godigest.FromString("user-may-mount-gate")
+
+	t.Run("catalog-only bearer skips canMount and allows remount", func(t *testing.T) {
+		t.Parallel()
+
+		// Traditional bearer without AccessControl: catalog-only tokens must not
+		// install empty glob maps, so hydrate remount is not gated on source pull.
+		conf := config.New()
+		rh := &RouteHandler{c: &Controller{Config: conf, Log: log.NewTestLogger()}}
+
+		userAc := UserAccessControlFromBearerAccess([]ResourceAccess{
+			{Type: "repository", Name: "", Actions: []string{"pull"}},
+		})
+		req := httptest.NewRequest(http.MethodHead, "/v2/dest/blobs/"+digest.String(), nil)
+		userAc.SaveOnRequest(req)
+
+		candidatesCalled := false
+		imgStore := mocks.MockedImageStore{
+			GetAllDedupeReposCandidatesFn: func(_ godigest.Digest) ([]string, error) {
+				candidatesCalled = true
+
+				return nil, errors.New("should not be consulted")
+			},
+		}
+
+		ok, err := rh.userMayMountBlob(req, imgStore, digest, "dest")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.False(t, candidatesCalled)
+	})
+
+	t.Run("scoped bearer without source pull denies remount", func(t *testing.T) {
+		t.Parallel()
+
+		conf := config.New()
+		rh := &RouteHandler{c: &Controller{Config: conf, Log: log.NewTestLogger()}}
+
+		userAc := UserAccessControlFromBearerAccess([]ResourceAccess{
+			{Type: "repository", Name: "dest", Actions: []string{"push"}},
+		})
+		req := httptest.NewRequest(http.MethodHead, "/v2/dest/blobs/"+digest.String(), nil)
+		userAc.SaveOnRequest(req)
+
+		candidatesCalled := false
+		imgStore := mocks.MockedImageStore{
+			GetAllDedupeReposCandidatesFn: func(_ godigest.Digest) ([]string, error) {
+				candidatesCalled = true
+
+				return []string{"src/repo"}, nil
+			},
+		}
+
+		ok, err := rh.userMayMountBlob(req, imgStore, digest, "dest")
+		require.NoError(t, err)
+		require.False(t, ok)
+		require.True(t, candidatesCalled)
+	})
+
+	t.Run("scoped bearer with dest pull only denies remount", func(t *testing.T) {
+		t.Parallel()
+
+		conf := config.New()
+		rh := &RouteHandler{c: &Controller{Config: conf, Log: log.NewTestLogger()}}
+
+		userAc := UserAccessControlFromBearerAccess([]ResourceAccess{
+			{Type: "repository", Name: "dest", Actions: []string{"pull"}},
+		})
+		req := httptest.NewRequest(http.MethodHead, "/v2/dest/blobs/"+digest.String(), nil)
+		userAc.SaveOnRequest(req)
+
+		imgStore := mocks.MockedImageStore{
+			GetAllDedupeReposCandidatesFn: func(_ godigest.Digest) ([]string, error) {
+				return []string{"src/repo"}, nil
+			},
+		}
+
+		ok, err := rh.userMayMountBlob(req, imgStore, digest, "dest")
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("scoped bearer with dest pull and push but no src pull denies remount", func(t *testing.T) {
+		t.Parallel()
+
+		conf := config.New()
+		rh := &RouteHandler{c: &Controller{Config: conf, Log: log.NewTestLogger()}}
+
+		userAc := UserAccessControlFromBearerAccess([]ResourceAccess{
+			{Type: "repository", Name: "dest", Actions: []string{"pull", "push"}},
+		})
+		req := httptest.NewRequest(http.MethodHead, "/v2/dest/blobs/"+digest.String(), nil)
+		userAc.SaveOnRequest(req)
+
+		imgStore := mocks.MockedImageStore{
+			GetAllDedupeReposCandidatesFn: func(_ godigest.Digest) ([]string, error) {
+				return []string{"src/repo"}, nil
+			},
+		}
+
+		ok, err := rh.userMayMountBlob(req, imgStore, digest, "dest")
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("scoped bearer with source pull allows remount", func(t *testing.T) {
+		t.Parallel()
+
+		conf := config.New()
+		rh := &RouteHandler{c: &Controller{Config: conf, Log: log.NewTestLogger()}}
+
+		userAc := UserAccessControlFromBearerAccess([]ResourceAccess{
+			{Type: "repository", Name: "dest", Actions: []string{"push"}},
+			{Type: "repository", Name: "src/repo", Actions: []string{"pull"}},
+		})
+		req := httptest.NewRequest(http.MethodHead, "/v2/dest/blobs/"+digest.String(), nil)
+		userAc.SaveOnRequest(req)
+
+		imgStore := mocks.MockedImageStore{
+			GetAllDedupeReposCandidatesFn: func(_ godigest.Digest) ([]string, error) {
+				return []string{"src/repo"}, nil
+			},
+		}
+
+		ok, err := rh.userMayMountBlob(req, imgStore, digest, "dest")
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("config authz always consults canMount", func(t *testing.T) {
+		t.Parallel()
+
+		conf := config.New()
+		conf.HTTP.AccessControl = &config.AccessControlConfig{
+			Repositories: config.Repositories{
+				"**": config.PolicyGroup{
+					Policies: []config.Policy{
+						{
+							Users: []string{"alice"},
+							Actions: []string{
+								constants.ReadPermission,
+								constants.CreatePermission,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		rh := &RouteHandler{c: &Controller{Config: conf, Log: log.NewTestLogger()}}
+		req := httptest.NewRequest(http.MethodHead, "/v2/dest/blobs/"+digest.String(), nil)
+
+		userAc := reqCtx.NewUserAccessControl()
+		userAc.SetUsername("alice")
+		acCtrlr := NewAccessController(conf)
+		acCtrlr.updateUserAccessControl(req, userAc)
+		acCtrlr.attachPermissionEvaluator(req, userAc)
+		userAc.SaveOnRequest(req)
+
+		candidatesCalled := false
+		imgStore := mocks.MockedImageStore{
+			GetAllDedupeReposCandidatesFn: func(_ godigest.Digest) ([]string, error) {
+				candidatesCalled = true
+
+				return []string{"src/repo"}, nil
+			},
+		}
+
+		ok, err := rh.userMayMountBlob(req, imgStore, digest, "dest")
+		require.NoError(t, err)
+		require.True(t, ok)
+		require.True(t, candidatesCalled)
+	})
 }
 
 func TestUserMayMountBlobErrorPaths(t *testing.T) {

--- a/pkg/requestcontext/user_access_control.go
+++ b/pkg/requestcontext/user_access_control.go
@@ -32,7 +32,14 @@ type UserAccessControl struct {
 	claims           map[string]any
 	methodActions    []string
 	behaviourActions []string
+	// permissionEvaluator performs repo-level authz when glob patterns alone are
+	// insufficient (config-based authz with CEL). Nil → CanOnResource falls back to Can().
+	permissionEvaluator PermissionEvaluator
 }
+
+// PermissionEvaluator performs per-resource authorization when concrete repository
+// and reference are known (e.g. config authz with CEL conditions).
+type PermissionEvaluator func(action, repository, reference string) bool
 
 type UserAuthzInfo struct {
 	// {action: {repo: bool}}
@@ -189,6 +196,23 @@ func (uac *UserAccessControl) Can(action, repository string) bool {
 	return uac.matchesRepo(uac.authzInfo.globPatterns[action], repository)
 }
 
+// SetPermissionEvaluator attaches request-scoped policy evaluation for config-based
+// authz. Traditional bearer auth leaves this nil and relies on glob patterns only.
+func (uac *UserAccessControl) SetPermissionEvaluator(fn PermissionEvaluator) {
+	uac.permissionEvaluator = fn
+}
+
+// CanOnResource reports whether the caller may perform action on repository/reference.
+// When a permission evaluator is set (config authz), it takes precedence over glob
+// patterns so CEL conditions are evaluated against the concrete resource.
+func (uac *UserAccessControl) CanOnResource(action, repository, reference string) bool {
+	if uac.permissionEvaluator != nil {
+		return uac.permissionEvaluator(action, repository, reference)
+	}
+
+	return uac.Can(action, repository)
+}
+
 func (uac *UserAccessControl) isBehaviourAction(action string) bool {
 	return slices.Contains(uac.behaviourActions, action)
 }
@@ -202,6 +226,22 @@ func (uac *UserAccessControl) areGlobPatternsSet() bool {
 	notSet := uac.authzInfo == nil || uac.authzInfo.globPatterns == nil
 
 	return !notSet
+}
+
+// HasScopedPermissions reports whether explicit repository permissions were
+// populated (config-based authz or bearer token access claims).
+func (uac *UserAccessControl) HasScopedPermissions() bool {
+	if !uac.areGlobPatternsSet() {
+		return false
+	}
+
+	for _, patterns := range uac.authzInfo.globPatterns {
+		if len(patterns) > 0 {
+			return true
+		}
+	}
+
+	return false
 }
 
 // matchesRepo returns whether repository matches the provided action's glob patterns

--- a/pkg/requestcontext/user_access_control_test.go
+++ b/pkg/requestcontext/user_access_control_test.go
@@ -1,0 +1,26 @@
+package requestcontext_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"zotregistry.dev/zot/v2/pkg/api/constants"
+	reqCtx "zotregistry.dev/zot/v2/pkg/requestcontext"
+)
+
+// Defensive: empty installed action maps (globPatterns set, every map empty) must
+// not report scoped permissions. Production bearer mapping skips installing empty
+// maps; this covers the remaining HasScopedPermissions return for Codecov / future callers.
+func TestHasScopedPermissionsEmptyInstalledMaps(t *testing.T) {
+	t.Parallel()
+
+	uac := reqCtx.NewUserAccessControl()
+	uac.SetIsAdmin(false)
+	uac.SetGlobPatterns(constants.ReadPermission, map[string]bool{})
+	uac.SetGlobPatterns(constants.CreatePermission, map[string]bool{})
+	uac.SetGlobPatterns(constants.UpdatePermission, map[string]bool{})
+	uac.SetGlobPatterns(constants.DeletePermission, map[string]bool{})
+
+	require.False(t, uac.HasScopedPermissions())
+}


### PR DESCRIPTION
Traditional bearer validated only the target-repo JWT scope and never populated UserAc, so canMount() saw empty permissions as allow-all. Map token access claims to UserAc glob patterns at authn time, wire config authz through a request-scoped PermissionEvaluator (ac.can), and use CanOnResource in canMount so handlers need not branch on auth mode.

- Add BearerAuthorizer.Authenticate and UserAccessControlFromBearerAccess
- Attach permission evaluator in BaseAuthzHandler; add CanOnResource
- Gate mount/check paths via shouldCheckMountSourceAccess
- Add bearer, CEL, and canMount unit/integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
