### PR TITLE
fix(sync,gc): guard repo removal and reap stale .sync staging sessions

### DIFF
--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -552,6 +552,24 @@ type GlobalStorageConfig struct {
 	FastRestart *bool `mapstructure:",omitempty"`
 }
 
+// LargestGCDelay returns the largest GCDelay across the default store and substores,
+// falling back to DefaultGCDelay when none is configured.
+func (g GlobalStorageConfig) LargestGCDelay() time.Duration {
+	maxDelay := g.GCDelay
+
+	for _, sub := range g.SubPaths {
+		if sub.GCDelay > maxDelay {
+			maxDelay = sub.GCDelay
+		}
+	}
+
+	if maxDelay <= 0 {
+		return storageConstants.DefaultGCDelay
+	}
+
+	return maxDelay
+}
+
 type AccessControlConfig struct {
 	Repositories Repositories `json:"repositories" mapstructure:"repositories"`
 	AdminPolicy  Policy
@@ -1291,6 +1309,30 @@ func (c *Config) CopyExtensionsConfig() *extconf.ExtensionConfig {
 	_ = deepcopy.Copy(extensionsCopy, c.Extensions)
 
 	return extensionsCopy
+}
+
+// SyncStagingDownloadDir returns extensions.sync.downloadDir when configured.
+func (c *Config) SyncStagingDownloadDir() string {
+	if c == nil {
+		return ""
+	}
+
+	extensionsConfig := c.CopyExtensionsConfig()
+	if extensionsConfig == nil {
+		return ""
+	}
+
+	return extensionsConfig.SyncStagingDownloadDir()
+}
+
+// LargestSyncTimeout returns the largest configured sync registry timeout.
+func (c *Config) LargestSyncTimeout() time.Duration {
+	var extensionsConfig *extconf.ExtensionConfig
+	if c != nil {
+		extensionsConfig = c.CopyExtensionsConfig()
+	}
+
+	return extensionsConfig.LargestSyncTimeout()
 }
 
 // CopyLogConfig returns a copy of the log config if it exists.

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -3871,3 +3871,37 @@ func TestHTTPTimeoutAccessors(t *testing.T) {
 		So(cfg.GetHTTPWriteTimeout(), ShouldEqual, positive)
 	})
 }
+
+func TestConfigSyncStagingHelpers(t *testing.T) {
+	Convey("Config sync staging helpers", t, func() {
+		Convey("SyncStagingDownloadDir on nil config returns empty", func() {
+			var nilConf *config.Config
+
+			So(nilConf.SyncStagingDownloadDir(), ShouldEqual, "")
+		})
+
+		Convey("SyncStagingDownloadDir returns configured downloadDir", func() {
+			conf := config.New()
+			conf.Extensions = &extconf.ExtensionConfig{
+				Sync: &syncconf.Config{DownloadDir: "/tmp/sync-staging"},
+			}
+
+			So(conf.SyncStagingDownloadDir(), ShouldEqual, "/tmp/sync-staging")
+		})
+
+		Convey("GlobalStorageConfig.LargestGCDelay uses max across substores", func() {
+			storageConfig := config.GlobalStorageConfig{
+				StorageConfig: config.StorageConfig{GCDelay: time.Hour},
+				SubPaths: map[string]config.StorageConfig{
+					"/a": {GCDelay: 3 * time.Hour},
+				},
+			}
+
+			So(storageConfig.LargestGCDelay(), ShouldEqual, 3*time.Hour)
+		})
+
+		Convey("GlobalStorageConfig.LargestGCDelay falls back to default when unset", func() {
+			So(config.GlobalStorageConfig{}.LargestGCDelay(), ShouldBeGreaterThan, 0)
+		})
+	})
+}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -547,7 +547,7 @@ func (c *Controller) StartBackgroundTasks() {
 		}
 	}
 
-	// Run GC and retention tasks
+	// Run GC and retention tasks (includes local .sync staging guard and orphan reaper).
 	RunGCTasks(c.Config, c.StoreController, c.MetaDB, c.taskScheduler, c.Log, c.Audit, c.Metrics)
 
 	// Enable running dedupe blobs both ways (dedupe or restore deduped blobs)
@@ -612,14 +612,17 @@ func (c *Controller) StartBackgroundTasks() {
 func RunGCTasks(conf *config.Config, storeController storage.StoreController, metaDB mTypes.MetaDB,
 	taskScheduler *scheduler.Scheduler, logger log.Logger, audit *log.Logger, metrics monitoring.MetricServer,
 ) {
+	gc.RunSyncSessionReaperPeriodically(conf, storeController, taskScheduler, logger)
+
 	// Enable running garbage-collect periodically for DefaultStore
 	storageConfig := conf.CopyStorageConfig()
 	if storageConfig.GC {
 		gc := gc.NewGarbageCollect(storeController.DefaultStore, metaDB, gc.Options{
 			Delay:             storageConfig.GCDelay,
-			ImageRetention:    storageConfig.Retention,
 			MaxSchedulerDelay: storageConfig.GCMaxSchedulerDelay,
 			TimeWindow:        storageConfig.GCTimeWindow,
+			ImageRetention:    storageConfig.Retention,
+			StagingRoot:       storeController.SyncStagingRootForImageStore(storeController.DefaultStore),
 		}, audit, logger, metrics)
 
 		gc.CleanImageStorePeriodically(storageConfig.GCInterval, taskScheduler)
@@ -633,9 +636,11 @@ func RunGCTasks(conf *config.Config, storeController storage.StoreController, me
 				gc := gc.NewGarbageCollect(storeController.SubStore[route], metaDB,
 					gc.Options{
 						Delay:             subStorageConfig.GCDelay,
-						ImageRetention:    subStorageConfig.Retention,
 						MaxSchedulerDelay: subStorageConfig.GCMaxSchedulerDelay,
 						TimeWindow:        subStorageConfig.GCTimeWindow,
+						ImageRetention:    subStorageConfig.Retention,
+						StagingRoot: storeController.SyncStagingRootForImageStore(
+							storeController.SubStore[route]),
 					}, audit, logger, metrics)
 
 				gc.CleanImageStorePeriodically(subStorageConfig.GCInterval, taskScheduler)

--- a/pkg/extensions/config/config.go
+++ b/pkg/extensions/config/config.go
@@ -5,6 +5,7 @@ import (
 
 	"zotregistry.dev/zot/v2/pkg/extensions/config/events"
 	"zotregistry.dev/zot/v2/pkg/extensions/config/sync"
+	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 )
 
 // BaseConfig has params applicable to all extensions.
@@ -238,6 +239,24 @@ func (e *ExtensionConfig) GetSyncConfig() *sync.Config {
 	}
 
 	return e.Sync
+}
+
+// SyncStagingDownloadDir returns extensions.sync.downloadDir when configured.
+func (e *ExtensionConfig) SyncStagingDownloadDir() string {
+	if e == nil || e.Sync == nil {
+		return ""
+	}
+
+	return e.Sync.DownloadDir
+}
+
+// LargestSyncTimeout returns the largest configured sync registry timeout.
+func (e *ExtensionConfig) LargestSyncTimeout() time.Duration {
+	if e == nil || e.Sync == nil {
+		return syncConstants.DefaultSyncTimeout
+	}
+
+	return e.Sync.LargestSyncTimeout()
 }
 
 // GetMetricsPrometheusConfig returns the metrics prometheus config.

--- a/pkg/extensions/config/config_test.go
+++ b/pkg/extensions/config/config_test.go
@@ -3,12 +3,14 @@ package config_test
 import (
 	"errors"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 
 	"zotregistry.dev/zot/v2/pkg/extensions/config"
 	"zotregistry.dev/zot/v2/pkg/extensions/config/events"
 	"zotregistry.dev/zot/v2/pkg/extensions/config/sync"
+	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 )
 
 var (
@@ -553,6 +555,35 @@ func TestExtensionConfig(t *testing.T) {
 		Convey("Test GetSyncConfig()", func() {
 			testGetterWithNilConfig((*config.ExtensionConfig).GetSyncConfig, nil)
 			testGetterWithValidConfig("Sync", (*config.ExtensionConfig).GetSyncConfig, buildSyncConfig)
+		})
+
+		Convey("Test SyncStagingDownloadDir()", func() {
+			testGetterWithNilConfig((*config.ExtensionConfig).SyncStagingDownloadDir, "")
+			testGetterWithNilSubConfig("Sync", (*config.ExtensionConfig).SyncStagingDownloadDir, "")
+
+			Convey("Test with sync downloadDir configured", func() {
+				enabled := true
+				extensionConfig := buildSyncConfig(enabled)
+				extensionConfig.Sync.DownloadDir = "/tmp/sync-staging"
+
+				So(extensionConfig.SyncStagingDownloadDir(), ShouldEqual, "/tmp/sync-staging")
+			})
+		})
+
+		Convey("Test LargestSyncTimeout()", func() {
+			testGetterWithNilConfig((*config.ExtensionConfig).LargestSyncTimeout, syncConstants.DefaultSyncTimeout)
+			testGetterWithNilSubConfig("Sync", (*config.ExtensionConfig).LargestSyncTimeout, syncConstants.DefaultSyncTimeout)
+
+			Convey("returns largest configured registry timeout", func() {
+				enabled := true
+				extensionConfig := buildSyncConfig(enabled)
+				extensionConfig.Sync.Registries = []sync.RegistryConfig{
+					{SyncTimeout: 2 * time.Hour},
+					{SyncTimeout: 5 * time.Hour},
+				}
+
+				So(extensionConfig.LargestSyncTimeout(), ShouldEqual, 5*time.Hour)
+			})
 		})
 
 		Convey("Test GetMetricsPrometheusConfig()", func() {

--- a/pkg/extensions/config/sync/config.go
+++ b/pkg/extensions/config/sync/config.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/mitchellh/mapstructure"
+
+	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 )
 
 // TokenExchangeGrantType is the RFC 8693 token exchange grant, used to trade a subject
@@ -222,6 +224,37 @@ func (config *OAuth2HelperConfig) Validate() error {
 // Default is true when SyncLegacyCosignTags is unset (nil).
 func (r RegistryConfig) ShouldSyncLegacyCosignTags() bool {
 	return r.SyncLegacyCosignTags == nil || *r.SyncLegacyCosignTags
+}
+
+// SyncTimeoutOrDefault returns the configured sync timeout, or DefaultSyncTimeout when unset.
+func (r RegistryConfig) SyncTimeoutOrDefault() time.Duration {
+	if r.SyncTimeout <= 0 {
+		return syncConstants.DefaultSyncTimeout
+	}
+
+	return r.SyncTimeout
+}
+
+// LargestSyncTimeout returns the largest SyncTimeout across registries, with per-registry
+// defaults applied. When sync is not configured it returns DefaultSyncTimeout.
+func (c *Config) LargestSyncTimeout() time.Duration {
+	if c == nil {
+		return syncConstants.DefaultSyncTimeout
+	}
+
+	maxTimeout := time.Duration(0)
+
+	for _, reg := range c.Registries {
+		if timeout := reg.SyncTimeoutOrDefault(); timeout > maxTimeout {
+			maxTimeout = timeout
+		}
+	}
+
+	if maxTimeout == 0 {
+		return syncConstants.DefaultSyncTimeout
+	}
+
+	return maxTimeout
 }
 
 type Content struct {

--- a/pkg/extensions/config/sync/config_test.go
+++ b/pkg/extensions/config/sync/config_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 
 	syncconf "zotregistry.dev/zot/v2/pkg/extensions/config/sync"
+	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 )
 
 func TestRegistryConfig_ShouldSyncLegacyCosignTags(t *testing.T) {
@@ -41,6 +42,43 @@ func TestRegistryConfig_ManifestCheckInterval(t *testing.T) {
 		Convey("holds the configured duration", func() {
 			cfg := syncconf.RegistryConfig{ManifestCheckInterval: 10 * time.Minute}
 			So(cfg.ManifestCheckInterval, ShouldEqual, 10*time.Minute)
+		})
+	})
+}
+
+func TestRegistryConfig_SyncTimeoutOrDefault(t *testing.T) {
+	Convey("SyncTimeoutOrDefault", t, func() {
+		Convey("returns default when unset", func() {
+			So(syncconf.RegistryConfig{}.SyncTimeoutOrDefault(), ShouldEqual, syncConstants.DefaultSyncTimeout)
+		})
+
+		Convey("returns configured value", func() {
+			cfg := syncconf.RegistryConfig{SyncTimeout: 2 * time.Hour}
+			So(cfg.SyncTimeoutOrDefault(), ShouldEqual, 2*time.Hour)
+		})
+	})
+}
+
+func TestConfig_LargestSyncTimeout(t *testing.T) {
+	Convey("LargestSyncTimeout", t, func() {
+		Convey("returns default when sync is nil", func() {
+			So((*syncconf.Config)(nil).LargestSyncTimeout(), ShouldEqual, syncConstants.DefaultSyncTimeout)
+		})
+
+		Convey("returns default when no registries are configured", func() {
+			So((&syncconf.Config{}).LargestSyncTimeout(), ShouldEqual, syncConstants.DefaultSyncTimeout)
+		})
+
+		Convey("returns largest per-registry timeout with defaults applied", func() {
+			cfg := &syncconf.Config{
+				Registries: []syncconf.RegistryConfig{
+					{SyncTimeout: 2 * time.Hour},
+					{},
+					{SyncTimeout: 4 * time.Hour},
+				},
+			}
+
+			So(cfg.LargestSyncTimeout(), ShouldEqual, 4*time.Hour)
 		})
 	})
 }

--- a/pkg/meta/hooks.go
+++ b/pkg/meta/hooks.go
@@ -16,7 +16,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/storage"
-	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
+	"zotregistry.dev/zot/v2/pkg/storage/gc"
 )
 
 // priorTagManifest records where MetaDB believed each tag pointed before a digest PUT with tag=
@@ -224,7 +224,7 @@ func OnDeleteManifest(repo, reference, mediaType string, digest godigest.Digest,
 	if zcommon.IsReferrersTag(reference) {
 		// The store already deleted the referrers tag entry, which may have emptied the
 		// index; still attempt idle release (a no-op while content remains).
-		releaseIdleRepository(repo, storeController.GetImageStore(repo), metaDB, log)
+		releaseIdleRepository(repo, storeController, metaDB, log)
 
 		return nil
 	}
@@ -280,7 +280,7 @@ func OnDeleteManifest(repo, reference, mediaType string, digest godigest.Digest,
 
 	// The store delete has already gone through even when signature meta cleanup failed, so the
 	// index may be empty; always attempt idle release (a no-op while manifests or blobs remain).
-	releaseIdleRepository(repo, imgStore, metaDB, log)
+	releaseIdleRepository(repo, storeController, metaDB, log)
 
 	return metaErr
 }
@@ -290,7 +290,17 @@ func OnDeleteManifest(repo, reference, mediaType string, digest godigest.Digest,
 // maxRepos immediately without _catalog and the quota count diverging. A zero max blob age
 // reclaims the orphan blobs the deletes left behind. Failures are logged, not returned: the
 // manifest delete already succeeded, and ParseStorage corrects a stale record on next start.
-func releaseIdleRepository(repo string, imgStore storageTypes.ImageStore, metaDB mTypes.MetaDB, log log.Logger) {
+func releaseIdleRepository(repo string, storeController storage.StoreController, metaDB mTypes.MetaDB, log log.Logger,
+) {
+	if gc.HasInProgressSessions(storeController.SyncStagingRootForRepo(repo), repo, log) {
+		log.Info().Str("repository", repo).Str("component", "metadb").
+			Msg("skipping repository removal: blocked by removal guard")
+
+		return
+	}
+
+	imgStore := storeController.GetImageStore(repo)
+
 	var lockLatency time.Time
 
 	imgStore.Lock(&lockLatency)

--- a/pkg/meta/hooks_internal_test.go
+++ b/pkg/meta/hooks_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 
 	zerr "zotregistry.dev/zot/v2/errors"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
+	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 	"zotregistry.dev/zot/v2/pkg/log"
 	mTypes "zotregistry.dev/zot/v2/pkg/meta/types"
 	"zotregistry.dev/zot/v2/pkg/storage"
@@ -283,7 +286,9 @@ func TestReleaseIdleRepository(t *testing.T) {
 				},
 			}
 
-			So(func() { releaseIdleRepository("repo", imgStore, metaDB, logger) }, ShouldNotPanic)
+			sc := storage.StoreController{DefaultStore: imgStore}
+
+			So(func() { releaseIdleRepository("repo", sc, metaDB, logger) }, ShouldNotPanic)
 			So(metaDeleted, ShouldBeFalse)
 		})
 
@@ -311,7 +316,9 @@ func TestReleaseIdleRepository(t *testing.T) {
 				},
 			}
 
-			releaseIdleRepository("repo", imgStore, metaDB, logger)
+			sc := storage.StoreController{DefaultStore: imgStore}
+
+			releaseIdleRepository("repo", sc, metaDB, logger)
 			So(gotRepo, ShouldEqual, "repo")
 			So(gotAge, ShouldEqual, 0)
 			So(metaDeleted, ShouldEqual, "repo")
@@ -333,7 +340,9 @@ func TestReleaseIdleRepository(t *testing.T) {
 				},
 			}
 
-			releaseIdleRepository("repo", imgStore, metaDB, logger)
+			sc := storage.StoreController{DefaultStore: imgStore}
+
+			releaseIdleRepository("repo", sc, metaDB, logger)
 			So(metaDeleted, ShouldBeFalse)
 		})
 
@@ -348,7 +357,32 @@ func TestReleaseIdleRepository(t *testing.T) {
 				DeleteRepoMetaFn: func(repo string) error { return errHookInternal },
 			}
 
-			So(func() { releaseIdleRepository("repo", imgStore, metaDB, logger) }, ShouldNotPanic)
+			sc := storage.StoreController{DefaultStore: imgStore}
+
+			So(func() { releaseIdleRepository("repo", sc, metaDB, logger) }, ShouldNotPanic)
+		})
+
+		Convey("An active sync staging session blocks layout removal", func() {
+			root := t.TempDir()
+			repo := "repo"
+			session := path.Join(root, repo, syncConstants.SyncBlobUploadDir, "session-uuid")
+			So(os.MkdirAll(session, 0o755), ShouldBeNil)
+
+			removed := false
+			imgStore := mocks.MockedImageStore{
+				NameFn:    func() string { return "local" },
+				RootDirFn: func() string { return root },
+				RemoveIdleRepositoryFn: func(repo string, maxBlobAge time.Duration) (bool, error) {
+					removed = true
+
+					return true, nil
+				},
+			}
+
+			sc := storage.StoreController{DefaultStore: imgStore}
+
+			releaseIdleRepository(repo, sc, mocks.MetaDBMock{}, logger)
+			So(removed, ShouldBeFalse)
 		})
 	})
 }

--- a/pkg/meta/hooks_test.go
+++ b/pkg/meta/hooks_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"path"
 	"testing"
 
@@ -15,6 +16,7 @@ import (
 	zerr "zotregistry.dev/zot/v2/errors"
 	zcommon "zotregistry.dev/zot/v2/pkg/common"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 	"zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/meta"
 	"zotregistry.dev/zot/v2/pkg/meta/boltdb"
@@ -705,4 +707,90 @@ func TestOnDeleteManifest_OrphanedSignatureReferrerReleasesRepo(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(count, ShouldEqual, 0)
 		})
+}
+
+func TestOnDeleteManifest_syncStagingBlocksRepoRemoval(t *testing.T) {
+	Convey("OnDeleteManifest does not remove a repo while a sync staging session is active", t, func() {
+		rootDir := t.TempDir()
+		storeController := storage.StoreController{}
+		log := log.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+
+		storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
+
+		params := boltdb.DBParameters{RootDir: rootDir}
+		boltDriver, err := boltdb.GetBoltDriver(params)
+		So(err, ShouldBeNil)
+
+		metaDB, err := boltdb.New(boltDriver, log)
+		So(err, ShouldBeNil)
+
+		imgStore := storeController.GetImageStore("repo")
+		ctx := context.Background()
+		repo := "repo"
+
+		image := CreateDefaultImage()
+		digest := image.Digest()
+		body := image.ManifestDescriptor.Data
+
+		So(WriteImageToFileSystem(image, repo, "latest", storeController), ShouldBeNil)
+		So(meta.OnUpdateManifest(ctx, repo, "latest", ispec.MediaTypeImageManifest, digest, body,
+			storeController, metaDB, log), ShouldBeNil)
+
+		So(imgStore.DeleteImageManifest(ctx, repo, digest.String(), false), ShouldBeNil)
+
+		session := path.Join(rootDir, repo, syncConstants.SyncBlobUploadDir, "session-uuid")
+		So(os.MkdirAll(session, 0o755), ShouldBeNil)
+
+		So(meta.OnDeleteManifest(repo, digest.String(), ispec.MediaTypeImageManifest, digest, body,
+			storeController, metaDB, log), ShouldBeNil)
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldContain, repo)
+
+		_, err = metaDB.GetRepoMeta(ctx, repo)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("OnDeleteManifest blocks removal when staging lives only under SyncDownloadDir", t, func() {
+		rootDir := t.TempDir()
+		downloadDir := t.TempDir()
+		storeController := storage.StoreController{SyncDownloadDir: downloadDir}
+		log := log.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+
+		storeController.DefaultStore = local.NewImageStore(rootDir, true, true, log, metrics, nil, nil, nil, nil)
+
+		params := boltdb.DBParameters{RootDir: rootDir}
+		boltDriver, err := boltdb.GetBoltDriver(params)
+		So(err, ShouldBeNil)
+
+		metaDB, err := boltdb.New(boltDriver, log)
+		So(err, ShouldBeNil)
+
+		imgStore := storeController.GetImageStore("repo")
+		ctx := context.Background()
+		repo := "repo"
+
+		image := CreateDefaultImage()
+		digest := image.Digest()
+		body := image.ManifestDescriptor.Data
+
+		So(WriteImageToFileSystem(image, repo, "latest", storeController), ShouldBeNil)
+		So(meta.OnUpdateManifest(ctx, repo, "latest", ispec.MediaTypeImageManifest, digest, body,
+			storeController, metaDB, log), ShouldBeNil)
+
+		So(imgStore.DeleteImageManifest(ctx, repo, digest.String(), false), ShouldBeNil)
+
+		session := path.Join(downloadDir, repo, syncConstants.SyncBlobUploadDir, "session-uuid")
+		So(os.MkdirAll(session, 0o755), ShouldBeNil)
+
+		So(meta.OnDeleteManifest(repo, digest.String(), ispec.MediaTypeImageManifest, digest, body,
+			storeController, metaDB, log), ShouldBeNil)
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldContain, repo)
+	})
 }

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -49,6 +49,10 @@ type Options struct {
 	TimeWindow config.GCTimeWindow
 
 	ImageRetention config.ImageRetention
+
+	// StagingRoot is the local filesystem root whose <repo>/.sync/<uuid> trees block
+	// idle-repository removal during GC for this image store. Populated by RunGCTasks.
+	StagingRoot string
 }
 
 type GarbageCollect struct {
@@ -218,20 +222,25 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 		keep their grace period. This runs before deleteBlobUploads so that an upload not yet
 		old enough to be reaped still counts as in progress and keeps the repo, as
 		CleanupRepo's guard used to. */
-		removed, err := gc.imgStore.RemoveIdleRepository(repo, gc.opts.Delay)
-		if err != nil {
-			gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).
-				Msg("failed to remove idle repo")
-
-			return err
-		}
-
-		if removed && gc.metaDB != nil {
-			if err := gc.metaDB.DeleteRepoMeta(repo); err != nil {
-				/* log, don't fail: the layout is already gone, so aborting the rest of cleanRepo
-				would not bring it back, and ParseStorage drops the stale record on next start */
+		if gc.opts.StagingRoot != "" && HasInProgressSessions(gc.opts.StagingRoot, repo, gc.log) {
+			gc.log.Info().Str("module", "gc").Str("repository", repo).
+				Msg("skipping repository removal: blocked by removal guard")
+		} else {
+			removed, err := gc.imgStore.RemoveIdleRepository(repo, gc.opts.Delay)
+			if err != nil {
 				gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).
-					Msg("removed repo layout but failed to delete its meta record")
+					Msg("failed to remove idle repo")
+
+				return err
+			}
+
+			if removed && gc.metaDB != nil {
+				if err := gc.metaDB.DeleteRepoMeta(repo); err != nil {
+					/* log, don't fail: the layout is already gone, so aborting the rest of cleanRepo
+					would not bring it back, and ParseStorage drops the stale record on next start */
+					gc.log.Error().Err(err).Str("module", "gc").Str("repository", repo).
+						Msg("removed repo layout but failed to delete its meta record")
+				}
 			}
 		}
 

--- a/pkg/storage/gc/gc_test.go
+++ b/pkg/storage/gc/gc_test.go
@@ -22,6 +22,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/compat"
 	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
 	zlog "zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/meta"
 	"zotregistry.dev/zot/v2/pkg/meta/boltdb"
@@ -3439,6 +3440,132 @@ func TestGCRemoveRepoAfterAllBlobsGCed(t *testing.T) {
 		repos, err := imgStore.GetRepositories()
 		So(err, ShouldBeNil)
 		So(repos, ShouldContain, repoName)
+	})
+
+	Convey("repo kept when a .sync staging session is in progress after all blobs were GCed", t, func() {
+		log := zlog.NewTestLogger()
+		audit := zlog.NewAuditLogger("debug", "/dev/null")
+		metrics := monitoring.NewNopMetricServer()
+
+		rootDir := t.TempDir()
+		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
+
+		storeController := storage.StoreController{}
+		storeController.DefaultStore = imgStore
+
+		ctx := context.Background()
+		repoName := "gc-remove-repo-sync-guard"
+
+		img := CreateRandomImage()
+		err := WriteImageToFileSystem(img, repoName, "v1", storeController)
+		So(err, ShouldBeNil)
+
+		err = imgStore.DeleteImageManifest(ctx, repoName, "v1", true)
+		So(err, ShouldBeNil)
+
+		syncSession := path.Join(rootDir, repoName, syncConstants.SyncBlobUploadDir, "session-uuid")
+		So(os.MkdirAll(syncSession, 0o755), ShouldBeNil)
+
+		time.Sleep(1 * time.Second)
+
+		gcInstance := gc.NewGarbageCollect(imgStore, nil, gc.Options{
+			Delay: 1 * time.Second,
+			ImageRetention: config.ImageRetention{
+				Delay: 1 * time.Second,
+			},
+			StagingRoot: rootDir,
+		}, audit, log, metrics)
+
+		err = gcInstance.CleanRepo(ctx, repoName)
+		So(err, ShouldBeNil)
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldContain, repoName)
+	})
+
+	Convey("repo directory is removed when an empty .sync dir does not block removal", t, func() {
+		log := zlog.NewTestLogger()
+		audit := zlog.NewAuditLogger("debug", "/dev/null")
+		metrics := monitoring.NewNopMetricServer()
+
+		rootDir := t.TempDir()
+		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
+
+		storeController := storage.StoreController{}
+		storeController.DefaultStore = imgStore
+
+		ctx := context.Background()
+		repoName := "gc-remove-repo-empty-sync"
+
+		img := CreateRandomImage()
+		err := WriteImageToFileSystem(img, repoName, "v1", storeController)
+		So(err, ShouldBeNil)
+
+		err = imgStore.DeleteImageManifest(ctx, repoName, "v1", true)
+		So(err, ShouldBeNil)
+
+		syncDir := path.Join(rootDir, repoName, syncConstants.SyncBlobUploadDir)
+		So(os.MkdirAll(syncDir, 0o755), ShouldBeNil)
+
+		time.Sleep(1 * time.Second)
+
+		gcInstance := gc.NewGarbageCollect(imgStore, nil, gc.Options{
+			Delay: 1 * time.Second,
+			ImageRetention: config.ImageRetention{
+				Delay: 1 * time.Second,
+			},
+			StagingRoot: rootDir,
+		}, audit, log, metrics)
+
+		err = gcInstance.CleanRepo(ctx, repoName)
+		So(err, ShouldBeNil)
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldNotContain, repoName)
+	})
+
+	Convey("repo directory is removed when StagingRoot is empty even if a .sync session exists", t, func() {
+		log := zlog.NewTestLogger()
+		audit := zlog.NewAuditLogger("debug", "/dev/null")
+		metrics := monitoring.NewNopMetricServer()
+
+		rootDir := t.TempDir()
+		imgStore := local.NewImageStore(rootDir, false, false, log, metrics, nil, nil, nil, nil)
+
+		storeController := storage.StoreController{}
+		storeController.DefaultStore = imgStore
+
+		ctx := context.Background()
+		repoName := "gc-remove-repo-no-staging-root"
+
+		img := CreateRandomImage()
+		err := WriteImageToFileSystem(img, repoName, "v1", storeController)
+		So(err, ShouldBeNil)
+
+		err = imgStore.DeleteImageManifest(ctx, repoName, "v1", true)
+		So(err, ShouldBeNil)
+
+		syncSession := path.Join(rootDir, repoName, syncConstants.SyncBlobUploadDir, "session-uuid")
+		So(os.MkdirAll(syncSession, 0o755), ShouldBeNil)
+
+		time.Sleep(1 * time.Second)
+
+		gcInstance := gc.NewGarbageCollect(imgStore, nil, gc.Options{
+			Delay: 1 * time.Second,
+			ImageRetention: config.ImageRetention{
+				Delay: 1 * time.Second,
+			},
+			StagingRoot: "",
+		}, audit, log, metrics)
+
+		err = gcInstance.CleanRepo(ctx, repoName)
+		So(err, ShouldBeNil)
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldNotContain, repoName)
 	})
 }
 

--- a/pkg/storage/gc/sync_staging.go
+++ b/pkg/storage/gc/sync_staging.go
@@ -1,0 +1,322 @@
+package gc
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"time"
+
+	ispec "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
+	zlog "zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/scheduler"
+	"zotregistry.dev/zot/v2/pkg/storage"
+	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
+)
+
+// stagingRootWalkSkipDirs are not descended while scanning a local staging root for .sync sessions.
+var stagingRootWalkSkipDirs = map[string]struct{}{ //nolint:gochecknoglobals
+	ispec.ImageBlobsDir:             {},
+	storageConstants.BlobUploadDir:  {},
+	syncConstants.SyncBlobUploadDir: {},
+	ispec.ImageLayoutFile:           {},
+	ispec.ImageIndexFile:            {},
+}
+
+// syncSessionReapDelay returns how old a .sync/<uuid> session must be before the reaper
+// may delete it: max(largest configured gcDelay, largest configured syncTimeout).
+func syncSessionReapDelay(conf *config.Config) time.Duration {
+	gcDelay := conf.CopyStorageConfig().LargestGCDelay()
+	syncTimeout := conf.LargestSyncTimeout()
+
+	if syncTimeout > gcDelay {
+		return syncTimeout
+	}
+
+	return gcDelay
+}
+
+// RunSyncSessionReaperPeriodically registers a low-priority periodic reaper for orphaned local
+// .sync/<uuid> sessions. Runs regardless of whether the sync extension is enabled.
+func RunSyncSessionReaperPeriodically(conf *config.Config, storeController storage.StoreController,
+	sch *scheduler.Scheduler, log zlog.Logger,
+) {
+	roots := storeController.SyncStagingRoots()
+	if len(roots) == 0 {
+		log.Debug().Str("module", "gc").Msg("sync staging cleanup skipped: no local staging roots")
+
+		return
+	}
+
+	storageConfig := conf.CopyStorageConfig()
+
+	delay := syncSessionReapDelay(conf)
+
+	interval := storageConfig.GCInterval
+	if interval <= 0 {
+		interval = storageConstants.DefaultGCInterval
+	}
+
+	log.Info().Str("module", "gc").Dur("delay", delay).
+		Dur("interval", interval).Int("roots", len(roots)).
+		Msg("enabling sync staging session cleanup")
+
+	sch.SubmitGenerator(newSyncSessionReaperGenerator(roots, delay, log), interval, scheduler.LowPriority)
+}
+
+// HasInProgressSessions reports whether root has an active <repo>/.sync/<uuid> session directory.
+// Missing .sync is treated as idle; any other ReadDir error fails closed (true).
+// An empty root is treated as idle.
+func HasInProgressSessions(root, repo string, log zlog.Logger) bool {
+	if root == "" {
+		return false
+	}
+
+	syncDir := filepath.Join(root, repo, syncConstants.SyncBlobUploadDir)
+
+	entries, err := os.ReadDir(syncDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false
+		}
+
+		log.Error().Err(err).Str("module", "gc").Str("repository", repo).Str("dir", syncDir).
+			Msg("failed to list sync staging sessions; skipping repo removal")
+
+		return true
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			log.Info().Str("module", "gc").Str("repository", repo).Str("session", entry.Name()).
+				Msg("sync staging session present; skipping repo removal")
+
+			return true
+		}
+	}
+
+	return false
+}
+
+// collectStaleSyncSessionsAtRoot returns session directories past reapDelay under root.
+// Discovery is a pruned walk for <repo>/.sync/<uuid>/; blob subtrees are not descended.
+func collectStaleSyncSessionsAtRoot(root string, reapDelay time.Duration, log zlog.Logger) ([]string, error) {
+	now := time.Now()
+	stale := make([]string, 0)
+
+	err := filepath.WalkDir(root, func(path string, dirEntry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if os.IsNotExist(walkErr) {
+				return nil
+			}
+
+			return walkErr
+		}
+
+		if !dirEntry.IsDir() {
+			return nil
+		}
+
+		name := dirEntry.Name()
+		if name == syncConstants.SyncBlobUploadDir {
+			sessions, err := expiredSyncSessionDirs(path, reapDelay, now, log)
+			if err != nil {
+				return err
+			}
+
+			stale = append(stale, sessions...)
+
+			return filepath.SkipDir
+		}
+
+		if _, skip := stagingRootWalkSkipDirs[name]; skip {
+			return filepath.SkipDir
+		}
+
+		return nil
+	})
+	if err != nil {
+		if os.IsNotExist(err) {
+			return stale, nil
+		}
+
+		return nil, err
+	}
+
+	return stale, nil
+}
+
+// expiredSyncSessionDirs lists <syncDir>/<uuid>/ directories whose mtime is past reapDelay.
+func expiredSyncSessionDirs(syncDir string, reapDelay time.Duration, now time.Time, log zlog.Logger) ([]string, error) {
+	stale := make([]string, 0)
+
+	entries, err := os.ReadDir(syncDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return stale, nil
+		}
+
+		log.Error().Err(err).Str("module", "gc").Str("dir", syncDir).
+			Msg("failed to list sync staging sessions")
+
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+
+			log.Error().Err(err).Str("module", "gc").Str("session", entry.Name()).Str("dir", syncDir).
+				Msg("failed to stat sync staging session")
+
+			continue
+		}
+
+		if info.ModTime().Add(reapDelay).After(now) {
+			continue
+		}
+
+		stale = append(stale, filepath.Join(syncDir, entry.Name()))
+	}
+
+	return stale, nil
+}
+
+type syncSessionReaperGenerator struct {
+	roots         []string
+	reapDelay     time.Duration
+	log           zlog.Logger
+	done          bool
+	staleSessions []string
+	nextIndex     int
+}
+
+func newSyncSessionReaperGenerator(roots []string, reapDelay time.Duration,
+	log zlog.Logger,
+) *syncSessionReaperGenerator {
+	return &syncSessionReaperGenerator{
+		roots:     roots,
+		reapDelay: reapDelay,
+		log:       log,
+	}
+}
+
+func (gen *syncSessionReaperGenerator) Name() string {
+	return "SyncSessionReaperGenerator"
+}
+
+func (gen *syncSessionReaperGenerator) Next() (scheduler.Task, error) {
+	if gen.staleSessions == nil {
+		stale := make([]string, 0)
+
+		for _, root := range gen.roots {
+			sessions, err := collectStaleSyncSessionsAtRoot(root, gen.reapDelay, gen.log)
+			if err != nil {
+				// Skip the failed root so the sweep can finish and wait for the next
+				// interval. Returning the error would leave staleSessions nil and the
+				// generator Ready, causing a tight re-walk/retry loop.
+				gen.log.Error().Err(err).Str("module", "gc").Str("root", root).
+					Msg("failed to collect stale sync sessions; skipping root")
+
+				continue
+			}
+
+			stale = append(stale, sessions...)
+		}
+
+		gen.staleSessions = stale
+	}
+
+	if gen.nextIndex >= len(gen.staleSessions) {
+		gen.done = true
+
+		return nil, nil //nolint:nilnil
+	}
+
+	session := gen.staleSessions[gen.nextIndex]
+	gen.nextIndex++
+
+	return &syncSessionReaperTask{session: session, reapDelay: gen.reapDelay, log: gen.log}, nil
+}
+
+func (gen *syncSessionReaperGenerator) IsDone() bool {
+	return gen.done
+}
+
+func (gen *syncSessionReaperGenerator) IsReady() bool {
+	return true
+}
+
+func (gen *syncSessionReaperGenerator) Reset() {
+	gen.done = false
+	gen.staleSessions = nil
+	gen.nextIndex = 0
+}
+
+type syncSessionReaperTask struct {
+	session   string
+	reapDelay time.Duration
+	log       zlog.Logger
+}
+
+func (task *syncSessionReaperTask) DoWork(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	info, err := os.Stat(task.session)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		task.log.Error().Err(err).Str("module", "gc").Str("session", task.session).
+			Msg("failed to stat sync staging session before delete")
+
+		return err
+	}
+
+	if info.ModTime().Add(task.reapDelay).After(time.Now()) {
+		task.log.Debug().Str("module", "gc").Str("session", task.session).
+			Msg("sync staging session no longer past delay; skipping delete")
+
+		return nil
+	}
+
+	task.log.Info().Str("module", "gc").Str("session", task.session).
+		Msg("removing stale sync staging session")
+
+	if err := os.RemoveAll(task.session); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+
+		task.log.Error().Err(err).Str("module", "gc").Str("session", task.session).
+			Msg("failed to remove stale sync staging session")
+
+		return err
+	}
+
+	return nil
+}
+
+func (task *syncSessionReaperTask) String() string {
+	return fmt.Sprintf("{Name: %s, session: %s}", task.Name(), task.session)
+}
+
+func (task *syncSessionReaperTask) Name() string {
+	return "SyncSessionReaperTask"
+}

--- a/pkg/storage/gc/sync_staging_internal_test.go
+++ b/pkg/storage/gc/sync_staging_internal_test.go
@@ -1,0 +1,790 @@
+package gc
+
+import (
+	"context"
+	"os"
+	"path"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
+	syncconfig "zotregistry.dev/zot/v2/pkg/extensions/config/sync"
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	syncConstants "zotregistry.dev/zot/v2/pkg/extensions/sync/constants"
+	zlog "zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/scheduler"
+	"zotregistry.dev/zot/v2/pkg/storage"
+	"zotregistry.dev/zot/v2/pkg/storage/local"
+	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+func testStoreWithRepos(t *testing.T, root string, repos ...string) storage.StoreController {
+	t.Helper()
+
+	log := zlog.NewTestLogger()
+	metrics := monitoring.NewNopMetricServer()
+	localStore := local.NewImageStore(root, false, false, log, metrics, nil, nil, nil, nil)
+	ctx := context.Background()
+
+	for _, repo := range repos {
+		if err := localStore.InitRepo(ctx, repo); err != nil {
+			t.Fatalf("InitRepo(%q): %v", repo, err)
+		}
+	}
+
+	return storage.StoreController{DefaultStore: localStore}
+}
+
+func plantStaleSyncSession(t *testing.T, syncDir, name string, age time.Duration) string {
+	t.Helper()
+
+	session := filepath.Join(syncDir, name)
+	if err := os.MkdirAll(session, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q): %v", session, err)
+	}
+
+	older := time.Now().Add(-age)
+	if err := os.Chtimes(session, older, older); err != nil {
+		t.Fatalf("Chtimes(%q): %v", session, err)
+	}
+
+	return session
+}
+
+func confWithReapDelay(gcDelay time.Duration) *config.Config {
+	conf := config.New()
+	conf.Storage.GCDelay = gcDelay
+	conf.Extensions = &extconf.ExtensionConfig{
+		Sync: &syncconfig.Config{
+			Registries: []syncconfig.RegistryConfig{{SyncTimeout: gcDelay}},
+		},
+	}
+
+	return conf
+}
+
+func runSchedulerUntil(t *testing.T, sch *scheduler.Scheduler, timeout time.Duration, condition func() bool) {
+	t.Helper()
+
+	go sch.RunScheduler()
+	defer sch.Shutdown()
+
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if condition() {
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("condition not met within %v", timeout)
+}
+
+func TestRunSyncSessionReaperPeriodicallyNilExtensions(t *testing.T) {
+	Convey("RunSyncSessionReaperPeriodically with nil extensions config does not panic", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		root := t.TempDir()
+
+		conf := config.New()
+		conf.Extensions = nil
+
+		localStore := local.NewImageStore(root, false, false, log, metrics, nil, nil, nil, nil)
+		sc := storage.StoreController{DefaultStore: localStore}
+
+		sch := scheduler.NewScheduler(conf, metrics, log)
+		So(func() { RunSyncSessionReaperPeriodically(conf, sc, sch, log) }, ShouldNotPanic)
+		So(sc.SyncStagingRoots(), ShouldResemble, []string{root})
+	})
+
+	Convey("RunSyncSessionReaperPeriodically uses default GC interval when unset", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		root := t.TempDir()
+		repo := "repo"
+		testStoreWithRepos(t, root, repo)
+
+		conf := confWithReapDelay(time.Hour)
+		conf.Storage.GCInterval = 0
+
+		sc := storage.StoreController{DefaultStore: local.NewImageStore(root, false, false, log, metrics, nil, nil, nil, nil)}
+		sch := scheduler.NewScheduler(conf, metrics, log)
+
+		staleDir := plantStaleSyncSession(t,
+			filepath.Join(root, repo, syncConstants.SyncBlobUploadDir), "stale-session", 2*time.Hour)
+
+		So(func() { RunSyncSessionReaperPeriodically(conf, sc, sch, log) }, ShouldNotPanic)
+
+		runSchedulerUntil(t, sch, 2*time.Second, func() bool {
+			_, err := os.Stat(staleDir)
+
+			return os.IsNotExist(err)
+		})
+	})
+}
+
+func TestSyncSessionReapDelay(t *testing.T) {
+	Convey("syncSessionReapDelay from config", t, func() {
+		Convey("uses largest GCDelay across substores", func() {
+			conf := config.New()
+			conf.Storage.GCDelay = time.Hour
+			conf.Storage.SubPaths = map[string]config.StorageConfig{
+				"/a": {GCDelay: 3 * time.Hour},
+				"/b": {GCDelay: 2 * time.Hour},
+			}
+
+			So(syncSessionReapDelay(conf), ShouldEqual, 3*time.Hour)
+		})
+
+		Convey("defaults to max(default GCDelay, default SyncTimeout)", func() {
+			So(syncSessionReapDelay(config.New()), ShouldEqual, syncConstants.DefaultSyncTimeout)
+		})
+
+		Convey("sync timeout wins when larger", func() {
+			conf := config.New()
+			conf.Storage.GCDelay = 2 * time.Hour
+			conf.Extensions = &extconf.ExtensionConfig{
+				Sync: &syncconfig.Config{
+					Registries: []syncconfig.RegistryConfig{{SyncTimeout: 3 * time.Hour}},
+				},
+			}
+
+			So(syncSessionReapDelay(conf), ShouldEqual, 3*time.Hour)
+		})
+
+		Convey("gc delay wins when larger", func() {
+			conf := config.New()
+			conf.Storage.GCDelay = 4 * time.Hour
+			conf.Extensions = &extconf.ExtensionConfig{
+				Sync: &syncconfig.Config{
+					Registries: []syncconfig.RegistryConfig{{SyncTimeout: 3 * time.Hour}},
+				},
+			}
+
+			So(syncSessionReapDelay(conf), ShouldEqual, 4*time.Hour)
+		})
+	})
+}
+
+func TestHasInProgressSessions(t *testing.T) {
+	Convey("HasInProgressSessions", t, func() {
+		log := zlog.NewTestLogger()
+		repo := "org/app"
+
+		Convey("session blocks removal", func() {
+			root := t.TempDir()
+			session := path.Join(root, repo, syncConstants.SyncBlobUploadDir, "session-uuid")
+			So(os.MkdirAll(session, 0o755), ShouldBeNil)
+
+			So(HasInProgressSessions(root, repo, log), ShouldBeTrue)
+		})
+
+		Convey("empty root does not block", func() {
+			So(HasInProgressSessions("", repo, log), ShouldBeFalse)
+		})
+
+		Convey("empty .sync does not block", func() {
+			root := t.TempDir()
+			syncDir := path.Join(root, repo, syncConstants.SyncBlobUploadDir)
+			So(os.MkdirAll(syncDir, 0o755), ShouldBeNil)
+
+			So(HasInProgressSessions(root, repo, log), ShouldBeFalse)
+		})
+
+		Convey("ReadDir error fails closed", func() {
+			root := t.TempDir()
+			syncDir := path.Join(root, repo, syncConstants.SyncBlobUploadDir)
+			So(os.MkdirAll(syncDir, 0o755), ShouldBeNil)
+			So(os.Chmod(syncDir, 0o000), ShouldBeNil)
+
+			Reset(func() {
+				_ = os.Chmod(syncDir, 0o755)
+			})
+
+			So(HasInProgressSessions(root, repo, log), ShouldBeTrue)
+		})
+	})
+}
+
+func TestCollectStaleSyncSessionsAtRoot(t *testing.T) {
+	Convey("collectStaleSyncSessionsAtRoot discovers stale sessions via pruned walk", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		testStoreWithRepos(t, root, "a", "org/nested")
+
+		staleA := plantStaleSyncSession(t,
+			filepath.Join(root, "a", syncConstants.SyncBlobUploadDir), "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", 2*time.Hour)
+		staleNested := plantStaleSyncSession(t,
+			filepath.Join(root, "org/nested", syncConstants.SyncBlobUploadDir), "bbbbbbbb-cccc-dddd-eeee-ffffffffffffff", 2*time.Hour)
+
+		sessions, err := collectStaleSyncSessionsAtRoot(root, time.Hour, log)
+		So(err, ShouldBeNil)
+		So(sessions, ShouldContain, staleA)
+		So(sessions, ShouldContain, staleNested)
+	})
+
+	Convey("collectStaleSyncSessionsAtRoot does not descend into blob subtrees", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "heavy"
+		testStoreWithRepos(t, root, repo)
+
+		blobLeaf := filepath.Join(root, repo, "blobs", "sha256", "aa", "bb", "cc", "dd")
+		So(os.MkdirAll(blobLeaf, 0o755), ShouldBeNil)
+		trap := filepath.Join(blobLeaf, "trap")
+		So(os.WriteFile(trap, []byte("x"), 0o000), ShouldBeNil)
+
+		stale := plantStaleSyncSession(t,
+			filepath.Join(root, repo, syncConstants.SyncBlobUploadDir), "stale-session", 2*time.Hour)
+
+		sessions, err := collectStaleSyncSessionsAtRoot(root, time.Hour, log)
+		So(err, ShouldBeNil)
+		So(sessions, ShouldContain, stale)
+	})
+
+	Convey("collectStaleSyncSessionsAtRoot reaps unregistered sessions under SyncDownloadDir", t, func() {
+		log := zlog.NewTestLogger()
+		downloadDir := t.TempDir()
+
+		orphanRepo := "new-repo"
+		stale := plantStaleSyncSession(t,
+			filepath.Join(downloadDir, orphanRepo, syncConstants.SyncBlobUploadDir), "orphan-session", 2*time.Hour)
+
+		sessions, err := collectStaleSyncSessionsAtRoot(downloadDir, time.Hour, log)
+		So(err, ShouldBeNil)
+		So(sessions, ShouldContain, stale)
+	})
+
+	Convey("collectStaleSyncSessionsAtRoot reaps unregistered sessions on a local store root", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		testStoreWithRepos(t, root)
+
+		orphanRepo := "new-repo"
+		stale := plantStaleSyncSession(t,
+			filepath.Join(root, orphanRepo, syncConstants.SyncBlobUploadDir), "orphan-session", 2*time.Hour)
+
+		sessions, err := collectStaleSyncSessionsAtRoot(root, time.Hour, log)
+		So(err, ShouldBeNil)
+		So(sessions, ShouldContain, stale)
+	})
+
+	Convey("collectStaleSyncSessionsAtRoot finds sessions for nested repo names", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "org/team/app"
+		testStoreWithRepos(t, root, repo)
+
+		stale := plantStaleSyncSession(t,
+			filepath.Join(root, repo, syncConstants.SyncBlobUploadDir), "nested-session", 2*time.Hour)
+
+		sessions, err := collectStaleSyncSessionsAtRoot(root, time.Hour, log)
+		So(err, ShouldBeNil)
+		So(sessions, ShouldContain, stale)
+	})
+}
+
+func TestSyncSessionReaper(t *testing.T) {
+	Convey("syncSessionReaperGenerator reaps stale sessions and keeps recent ones", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "org/app"
+		testStoreWithRepos(t, root, repo)
+
+		syncDir := filepath.Join(root, repo, syncConstants.SyncBlobUploadDir)
+		staleDir := plantStaleSyncSession(t, syncDir, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", 2*time.Hour)
+
+		freshDir := filepath.Join(syncDir, "bbbbbbbb-cccc-dddd-eeee-ffffffffffffff")
+		So(os.MkdirAll(freshDir, 0o755), ShouldBeNil)
+
+		gen := newSyncSessionReaperGenerator([]string{root}, time.Hour, log)
+		So(gen.Name(), ShouldEqual, "SyncSessionReaperGenerator")
+		So(gen.IsReady(), ShouldBeTrue)
+
+		task, err := gen.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldNotBeNil)
+		So(gen.IsDone(), ShouldBeFalse)
+		So(task.Name(), ShouldEqual, "SyncSessionReaperTask")
+		So(task.String(), ShouldContainSubstring, staleDir)
+
+		err = task.DoWork(context.Background())
+		So(err, ShouldBeNil)
+
+		_, err = os.Stat(staleDir)
+		So(os.IsNotExist(err), ShouldBeTrue)
+		_, err = os.Stat(freshDir)
+		So(err, ShouldBeNil)
+
+		task, err = gen.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldBeNil)
+		So(gen.IsDone(), ShouldBeTrue)
+
+		gen.Reset()
+		So(gen.IsDone(), ShouldBeFalse)
+	})
+
+	Convey("second Next without DoWork does not re-emit the same session", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "org/app"
+		testStoreWithRepos(t, root, repo)
+
+		syncDir := filepath.Join(root, repo, syncConstants.SyncBlobUploadDir)
+		staleDir := plantStaleSyncSession(t, syncDir, "stale-session", 2*time.Hour)
+
+		gen := newSyncSessionReaperGenerator([]string{root}, time.Hour, log)
+
+		task, err := gen.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldNotBeNil)
+		So(gen.IsDone(), ShouldBeFalse)
+
+		taskAgain, err := gen.Next()
+		So(err, ShouldBeNil)
+		So(taskAgain, ShouldBeNil)
+		So(gen.IsDone(), ShouldBeTrue)
+
+		So(task.DoWork(context.Background()), ShouldBeNil)
+		_, err = os.Stat(staleDir)
+		So(os.IsNotExist(err), ShouldBeTrue)
+	})
+
+	Convey("syncSessionReaperGenerator returns nil when no sessions exist", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		testStoreWithRepos(t, root)
+
+		gen := newSyncSessionReaperGenerator([]string{root}, time.Hour, log)
+		task, err := gen.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldBeNil)
+		So(gen.IsDone(), ShouldBeTrue)
+	})
+
+	Convey("DoWork skips a session that is no longer past the delay", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "repo"
+		testStoreWithRepos(t, root, repo)
+
+		session := plantStaleSyncSession(t,
+			filepath.Join(root, repo, syncConstants.SyncBlobUploadDir), "recent", 2*time.Hour)
+
+		gen := newSyncSessionReaperGenerator([]string{root}, time.Hour, log)
+		task, err := gen.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldNotBeNil)
+
+		now := time.Now()
+		So(os.Chtimes(session, now, now), ShouldBeNil)
+
+		So(task.DoWork(context.Background()), ShouldBeNil)
+		_, err = os.Stat(session)
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestRunSyncSessionReaperPeriodically_reapsStaleSessionViaScheduler(t *testing.T) {
+	Convey("RunSyncSessionReaperPeriodically reaps stale sessions via the scheduler", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		root := t.TempDir()
+		repo := "repo"
+		testStoreWithRepos(t, root, repo)
+
+		conf := confWithReapDelay(time.Hour)
+		conf.Storage.GCInterval = 20 * time.Millisecond
+
+		sc := storage.StoreController{DefaultStore: local.NewImageStore(root, false, false, log, metrics, nil, nil, nil, nil)}
+		sch := scheduler.NewScheduler(conf, metrics, log)
+
+		syncDir := filepath.Join(root, repo, syncConstants.SyncBlobUploadDir)
+		staleDir := plantStaleSyncSession(t, syncDir, "stale-session", 2*time.Hour)
+		freshDir := filepath.Join(syncDir, "fresh-session")
+		So(os.MkdirAll(freshDir, 0o755), ShouldBeNil)
+
+		RunSyncSessionReaperPeriodically(conf, sc, sch, log)
+
+		runSchedulerUntil(t, sch, 2*time.Second, func() bool {
+			_, err := os.Stat(staleDir)
+
+			return os.IsNotExist(err)
+		})
+
+		_, err := os.Stat(freshDir)
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestRunSyncSessionReaperPeriodically_skipsWhenNoStagingRoots(t *testing.T) {
+	Convey("RunSyncSessionReaperPeriodically skips registration when there are no staging roots", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		remoteRoot := t.TempDir()
+		repo := "repo"
+
+		remote := mocks.MockedImageStore{
+			NameFn:    func() string { return "s3" },
+			RootDirFn: func() string { return remoteRoot },
+		}
+		sc := storage.StoreController{DefaultStore: remote}
+		So(sc.SyncStagingRoots(), ShouldBeEmpty)
+
+		session := plantStaleSyncSession(t,
+			filepath.Join(remoteRoot, repo, syncConstants.SyncBlobUploadDir), "orphan", 2*time.Hour)
+
+		conf := confWithReapDelay(time.Hour)
+		conf.Storage.GCInterval = 20 * time.Millisecond
+		sch := scheduler.NewScheduler(conf, metrics, log)
+
+		RunSyncSessionReaperPeriodically(conf, sc, sch, log)
+
+		sch.RunScheduler()
+		time.Sleep(200 * time.Millisecond)
+		sch.Shutdown()
+
+		_, err := os.Stat(session)
+		So(err, ShouldBeNil)
+	})
+}
+
+func TestRunSyncSessionReaperPeriodically_reapsUnderSyncDownloadDir(t *testing.T) {
+	Convey("RunSyncSessionReaperPeriodically uses SyncDownloadDir as the staging root", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		storeRoot := t.TempDir()
+		downloadDir := t.TempDir()
+		repo := "repo"
+
+		sc := storage.StoreController{
+			DefaultStore:    local.NewImageStore(storeRoot, false, false, log, metrics, nil, nil, nil, nil),
+			SyncDownloadDir: downloadDir,
+		}
+		So(sc.SyncStagingRoots(), ShouldResemble, []string{downloadDir})
+
+		staleDir := plantStaleSyncSession(t,
+			filepath.Join(downloadDir, repo, syncConstants.SyncBlobUploadDir), "stale-session", 2*time.Hour)
+
+		conf := confWithReapDelay(time.Hour)
+		conf.Storage.GCInterval = 20 * time.Millisecond
+		sch := scheduler.NewScheduler(conf, metrics, log)
+
+		RunSyncSessionReaperPeriodically(conf, sc, sch, log)
+
+		runSchedulerUntil(t, sch, 2*time.Second, func() bool {
+			_, err := os.Stat(staleDir)
+
+			return os.IsNotExist(err)
+		})
+	})
+}
+
+func TestSyncSessionReaperGenerator_multipleRoots(t *testing.T) {
+	Convey("syncSessionReaperGenerator emits one task per stale session across staging roots", t, func() {
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		defaultRoot := t.TempDir()
+		subRoot := t.TempDir()
+
+		defaultStore := local.NewImageStore(defaultRoot, false, false, log, metrics, nil, nil, nil, nil)
+		subStore := local.NewImageStore(subRoot, false, false, log, metrics, nil, nil, nil, nil)
+		sc := storage.StoreController{
+			DefaultStore: defaultStore,
+			SubStore: map[string]storageTypes.ImageStore{
+				"/a": subStore,
+			},
+		}
+
+		testStoreWithRepos(t, defaultRoot, "centos")
+		testStoreWithRepos(t, subRoot, "a/myrepo")
+
+		staleDefault := plantStaleSyncSession(t,
+			filepath.Join(defaultRoot, "centos", syncConstants.SyncBlobUploadDir), "default-stale", 2*time.Hour)
+		staleSub := plantStaleSyncSession(t,
+			filepath.Join(subRoot, "a/myrepo", syncConstants.SyncBlobUploadDir), "sub-stale", 2*time.Hour)
+
+		gen := newSyncSessionReaperGenerator(sc.SyncStagingRoots(), time.Hour, log)
+
+		task, err := gen.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldNotBeNil)
+		So(task.(*syncSessionReaperTask).session, ShouldBeIn, staleDefault, staleSub)
+		So(task.DoWork(context.Background()), ShouldBeNil)
+
+		task, err = gen.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldNotBeNil)
+		So(task.(*syncSessionReaperTask).session, ShouldBeIn, staleDefault, staleSub)
+		So(task.DoWork(context.Background()), ShouldBeNil)
+
+		task, err = gen.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldBeNil)
+		So(gen.IsDone(), ShouldBeTrue)
+
+		_, err = os.Stat(staleDefault)
+		So(os.IsNotExist(err), ShouldBeTrue)
+		_, err = os.Stat(staleSub)
+		So(os.IsNotExist(err), ShouldBeTrue)
+	})
+}
+
+func TestCollectStaleSyncSessionsAtRoot_skipsNonDirectoryEntries(t *testing.T) {
+	Convey("expiredSyncSessionDirs ignores non-directory entries under .sync", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "repo"
+		testStoreWithRepos(t, root, repo)
+
+		syncDir := filepath.Join(root, repo, syncConstants.SyncBlobUploadDir)
+		So(os.MkdirAll(syncDir, 0o755), ShouldBeNil)
+		So(os.WriteFile(filepath.Join(syncDir, "not-a-session"), []byte("x"), 0o644), ShouldBeNil)
+		stale := plantStaleSyncSession(t, syncDir, "stale-session", 2*time.Hour)
+
+		sessions, err := collectStaleSyncSessionsAtRoot(root, time.Hour, log)
+		So(err, ShouldBeNil)
+		So(sessions, ShouldResemble, []string{stale})
+	})
+}
+
+func TestCollectStaleSyncSessionsAtRoot_missingRoot(t *testing.T) {
+	Convey("collectStaleSyncSessionsAtRoot on a missing root returns empty", t, func() {
+		log := zlog.NewTestLogger()
+		root := filepath.Join(t.TempDir(), "does-not-exist")
+
+		sessions, err := collectStaleSyncSessionsAtRoot(root, time.Hour, log)
+		So(err, ShouldBeNil)
+		So(sessions, ShouldBeEmpty)
+	})
+}
+
+func TestCollectStaleSyncSessionsAtRoot_readDirError(t *testing.T) {
+	Convey("collectStaleSyncSessionsAtRoot propagates ReadDir errors", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "repo"
+		testStoreWithRepos(t, root, repo)
+
+		syncDir := filepath.Join(root, repo, syncConstants.SyncBlobUploadDir)
+		plantStaleSyncSession(t, syncDir, "stale-session", 2*time.Hour)
+		So(os.Chmod(syncDir, 0o000), ShouldBeNil)
+
+		Reset(func() {
+			_ = os.Chmod(syncDir, 0o755)
+		})
+
+		_, err := collectStaleSyncSessionsAtRoot(root, time.Hour, log)
+		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestCollectStaleSyncSessionsAtRoot_skipsFreshSessions(t *testing.T) {
+	Convey("collectStaleSyncSessionsAtRoot does not return sessions within the reap delay", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "repo"
+		testStoreWithRepos(t, root, repo)
+
+		syncDir := filepath.Join(root, repo, syncConstants.SyncBlobUploadDir)
+		fresh := filepath.Join(syncDir, "fresh-session")
+		So(os.MkdirAll(fresh, 0o755), ShouldBeNil)
+
+		sessions, err := collectStaleSyncSessionsAtRoot(root, time.Hour, log)
+		So(err, ShouldBeNil)
+		So(sessions, ShouldBeEmpty)
+	})
+}
+
+func TestCollectStaleSyncSessionsAtRoot_walkError(t *testing.T) {
+	Convey("collectStaleSyncSessionsAtRoot propagates walk errors", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "repo"
+		testStoreWithRepos(t, root, repo)
+
+		syncDir := filepath.Join(root, repo, syncConstants.SyncBlobUploadDir)
+		plantStaleSyncSession(t, syncDir, "stale-session", 2*time.Hour)
+
+		repoDir := filepath.Join(root, repo)
+		So(os.Chmod(repoDir, 0o000), ShouldBeNil)
+
+		Reset(func() {
+			_ = os.Chmod(repoDir, 0o755)
+		})
+
+		_, err := collectStaleSyncSessionsAtRoot(root, time.Hour, log)
+		So(err, ShouldNotBeNil)
+	})
+}
+
+func TestSyncSessionReaperGenerator_skipsFailedRoot(t *testing.T) {
+	Convey("syncSessionReaperGenerator skips unreadable roots and continues the sweep", t, func() {
+		log := zlog.NewTestLogger()
+		badRoot := t.TempDir()
+		goodRoot := t.TempDir()
+		repo := "repo"
+
+		testStoreWithRepos(t, badRoot, repo)
+		testStoreWithRepos(t, goodRoot, repo)
+
+		plantStaleSyncSession(t,
+			filepath.Join(badRoot, repo, syncConstants.SyncBlobUploadDir), "bad-stale", 2*time.Hour)
+		staleGood := plantStaleSyncSession(t,
+			filepath.Join(goodRoot, repo, syncConstants.SyncBlobUploadDir), "good-stale", 2*time.Hour)
+
+		badRepoDir := filepath.Join(badRoot, repo)
+		So(os.Chmod(badRepoDir, 0o000), ShouldBeNil)
+
+		Reset(func() {
+			_ = os.Chmod(badRepoDir, 0o755)
+		})
+
+		gen := newSyncSessionReaperGenerator([]string{badRoot, goodRoot}, time.Hour, log)
+
+		task, err := gen.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldNotBeNil)
+		So(task.(*syncSessionReaperTask).session, ShouldEqual, staleGood)
+		So(gen.IsDone(), ShouldBeFalse)
+
+		So(task.DoWork(context.Background()), ShouldBeNil)
+		_, err = os.Stat(staleGood)
+		So(os.IsNotExist(err), ShouldBeTrue)
+
+		task, err = gen.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldBeNil)
+		So(gen.IsDone(), ShouldBeTrue)
+	})
+
+	Convey("syncSessionReaperGenerator finishes when every root fails discovery", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "repo"
+		testStoreWithRepos(t, root, repo)
+
+		plantStaleSyncSession(t,
+			filepath.Join(root, repo, syncConstants.SyncBlobUploadDir), "stale-session", 2*time.Hour)
+
+		repoDir := filepath.Join(root, repo)
+		So(os.Chmod(repoDir, 0o000), ShouldBeNil)
+
+		Reset(func() {
+			_ = os.Chmod(repoDir, 0o755)
+		})
+
+		gen := newSyncSessionReaperGenerator([]string{root}, time.Hour, log)
+		task, err := gen.Next()
+		So(err, ShouldBeNil)
+		So(task, ShouldBeNil)
+		So(gen.IsDone(), ShouldBeTrue)
+	})
+}
+
+func TestSyncSessionReaperTask_contextCancelled(t *testing.T) {
+	Convey("syncSessionReaperTask returns ctx.Err when cancelled", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "repo"
+		testStoreWithRepos(t, root, repo)
+
+		first := plantStaleSyncSession(t,
+			filepath.Join(root, repo, syncConstants.SyncBlobUploadDir), "first", 2*time.Hour)
+
+		task := &syncSessionReaperTask{
+			session:   first,
+			reapDelay: time.Hour,
+			log:       log,
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		So(task.DoWork(ctx), ShouldEqual, context.Canceled)
+	})
+}
+
+func TestSyncSessionReaperTask_sessionAlreadyRemoved(t *testing.T) {
+	Convey("syncSessionReaperTask ignores sessions removed before DoWork", t, func() {
+		log := zlog.NewTestLogger()
+		task := &syncSessionReaperTask{
+			session:   filepath.Join(t.TempDir(), "missing", "session"),
+			reapDelay: time.Hour,
+			log:       log,
+		}
+
+		So(task.DoWork(context.Background()), ShouldBeNil)
+	})
+}
+
+func TestSyncSessionReaperTask_removeAllError(t *testing.T) {
+	Convey("syncSessionReaperTask returns RemoveAll errors", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "repo"
+		testStoreWithRepos(t, root, repo)
+
+		syncDir := filepath.Join(root, repo, syncConstants.SyncBlobUploadDir)
+		session := plantStaleSyncSession(t, syncDir, "stale-session", 2*time.Hour)
+		So(os.Chmod(syncDir, 0o555), ShouldBeNil)
+
+		Reset(func() {
+			_ = os.Chmod(syncDir, 0o755)
+		})
+
+		task := &syncSessionReaperTask{
+			session:   session,
+			reapDelay: time.Hour,
+			log:       log,
+		}
+
+		So(task.DoWork(context.Background()), ShouldNotBeNil)
+	})
+}
+
+func TestSyncSessionReaperTask_statError(t *testing.T) {
+	Convey("syncSessionReaperTask returns stat errors before delete", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "repo"
+		testStoreWithRepos(t, root, repo)
+
+		syncDir := filepath.Join(root, repo, syncConstants.SyncBlobUploadDir)
+		session := plantStaleSyncSession(t, syncDir, "stale-session", 2*time.Hour)
+		So(os.Chmod(syncDir, 0o644), ShouldBeNil)
+
+		Reset(func() {
+			_ = os.Chmod(syncDir, 0o755)
+		})
+
+		task := &syncSessionReaperTask{
+			session:   session,
+			reapDelay: time.Hour,
+			log:       log,
+		}
+
+		So(task.DoWork(context.Background()), ShouldNotBeNil)
+	})
+}
+
+func TestHasInProgressSessions_matchesStoreControllerRoot(t *testing.T) {
+	Convey("HasInProgressSessions uses SyncStagingRootForRepo", t, func() {
+		log := zlog.NewTestLogger()
+		root := t.TempDir()
+		repo := "org/app"
+		sc := testStoreWithRepos(t, root, repo)
+
+		session := path.Join(root, repo, syncConstants.SyncBlobUploadDir, "session-uuid")
+		So(os.MkdirAll(session, 0o755), ShouldBeNil)
+
+		So(HasInProgressSessions(sc.SyncStagingRootForRepo(repo), repo, log), ShouldBeTrue)
+	})
+}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -126,6 +126,8 @@ func New(config *config.Config, linter common.Lint, metrics monitoring.MetricSer
 		}
 	}
 
+	storeController.SyncDownloadDir = config.SyncStagingDownloadDir()
+
 	return storeController, nil
 }
 

--- a/pkg/storage/storage_controller.go
+++ b/pkg/storage/storage_controller.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"strings"
 
+	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
 	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
 )
 
@@ -15,6 +16,9 @@ const (
 type StoreController struct {
 	DefaultStore storageTypes.ImageStore
 	SubStore     map[string]storageTypes.ImageStore
+	// SyncDownloadDir is extensions.sync.downloadDir when set at init. On-demand sync staging
+	// for all stores (including remote-backed ones) lives under this directory.
+	SyncDownloadDir string
 }
 
 func GetRoutePrefix(name string) string {
@@ -67,4 +71,58 @@ func (sc StoreController) GetDefaultImageStore() storageTypes.ImageStore {
 
 func (sc StoreController) GetImageSubStores() map[string]storageTypes.ImageStore {
 	return sc.SubStore
+}
+
+// SyncStagingRootForImageStore returns the local filesystem root where on-demand sync staging
+// for repos in this image store may exist. When SyncDownloadDir is set, staging always lives
+// there (including for remote serving stores). Otherwise it is the store RootDir for local
+// drivers. An empty return means this store has no local staging to guard.
+func (sc StoreController) SyncStagingRootForImageStore(imgStore storageTypes.ImageStore) string {
+	if sc.SyncDownloadDir != "" {
+		return sc.SyncDownloadDir
+	}
+
+	if imgStore == nil || imgStore.Name() != storageConstants.LocalStorageDriverName {
+		return ""
+	}
+
+	return imgStore.RootDir()
+}
+
+// SyncStagingRootForRepo returns the staging root for the image store that serves repo.
+func (sc StoreController) SyncStagingRootForRepo(repo string) string {
+	return sc.SyncStagingRootForImageStore(sc.GetImageStore(repo))
+}
+
+// SyncStagingRoots returns local filesystem roots that may contain on-demand sync staging
+// sessions under <repo>/.sync/<uuid>/.
+func (sc StoreController) SyncStagingRoots() []string {
+	if sc.SyncDownloadDir != "" {
+		return []string{sc.SyncDownloadDir}
+	}
+
+	seen := make(map[string]struct{})
+	roots := make([]string, 0)
+
+	add := func(imgStore storageTypes.ImageStore) {
+		root := sc.SyncStagingRootForImageStore(imgStore)
+		if root == "" {
+			return
+		}
+
+		if _, ok := seen[root]; ok {
+			return
+		}
+
+		seen[root] = struct{}{}
+		roots = append(roots, root)
+	}
+
+	add(sc.DefaultStore)
+
+	for _, imgStore := range sc.SubStore {
+		add(imgStore)
+	}
+
+	return roots
 }

--- a/pkg/storage/storage_controller_test.go
+++ b/pkg/storage/storage_controller_test.go
@@ -1,0 +1,120 @@
+package storage_test
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	"zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/storage"
+	"zotregistry.dev/zot/v2/pkg/storage/local"
+	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+func TestStoreControllerSyncStagingRoots(t *testing.T) {
+	Convey("StoreController sync staging root accessors", t, func() {
+		logger := log.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+
+		Convey("SyncStagingRoots returns downloadDir when set", func() {
+			downloadDir := t.TempDir()
+			localStore := local.NewImageStore(t.TempDir(), false, false, logger, metrics, nil, nil, nil, nil)
+
+			sc := storage.StoreController{
+				DefaultStore:    localStore,
+				SyncDownloadDir: downloadDir,
+			}
+
+			So(sc.SyncStagingRoots(), ShouldResemble, []string{downloadDir})
+		})
+
+		Convey("SyncStagingRoots returns local store roots when downloadDir is empty", func() {
+			defaultRoot := t.TempDir()
+			subRoot := t.TempDir()
+			defaultStore := local.NewImageStore(defaultRoot, false, false, logger, metrics, nil, nil, nil, nil)
+			subStore := local.NewImageStore(subRoot, false, false, logger, metrics, nil, nil, nil, nil)
+
+			storeController := storage.StoreController{
+				DefaultStore: defaultStore,
+				SubStore: map[string]storageTypes.ImageStore{
+					"/a": subStore,
+				},
+			}
+
+			roots := storeController.SyncStagingRoots()
+			So(roots, ShouldContain, defaultRoot)
+			So(roots, ShouldContain, subRoot)
+			So(len(roots), ShouldEqual, 2)
+		})
+
+		Convey("SyncStagingRoots skips non-local stores", func() {
+			remote := mocks.MockedImageStore{
+				NameFn:    func() string { return "s3" },
+				RootDirFn: func() string { return "/remote" },
+			}
+
+			sc := storage.StoreController{DefaultStore: remote}
+
+			So(sc.SyncStagingRoots(), ShouldBeEmpty)
+		})
+
+		Convey("SyncStagingRootForImageStore returns downloadDir when set", func() {
+			downloadDir := t.TempDir()
+			localRoot := t.TempDir()
+			localStore := local.NewImageStore(localRoot, false, false, logger, metrics, nil, nil, nil, nil)
+
+			sc := storage.StoreController{SyncDownloadDir: downloadDir}
+
+			So(sc.SyncStagingRootForImageStore(localStore), ShouldEqual, downloadDir)
+		})
+
+		Convey("SyncStagingRootForImageStore returns root for local stores", func() {
+			localRoot := t.TempDir()
+			localStore := local.NewImageStore(localRoot, false, false, logger, metrics, nil, nil, nil, nil)
+
+			So(storage.StoreController{}.SyncStagingRootForImageStore(localStore), ShouldEqual, localRoot)
+		})
+
+		Convey("SyncStagingRootForImageStore returns empty for non-local stores", func() {
+			remote := mocks.MockedImageStore{
+				NameFn:    func() string { return "s3" },
+				RootDirFn: func() string { return "/remote" },
+			}
+
+			So(storage.StoreController{}.SyncStagingRootForImageStore(remote), ShouldBeEmpty)
+		})
+
+		Convey("SyncStagingRootForRepo resolves the serving store", func() {
+			defaultRoot := t.TempDir()
+			subRoot := t.TempDir()
+			defaultStore := local.NewImageStore(defaultRoot, false, false, logger, metrics, nil, nil, nil, nil)
+			subStore := local.NewImageStore(subRoot, false, false, logger, metrics, nil, nil, nil, nil)
+
+			storeController := storage.StoreController{
+				DefaultStore: defaultStore,
+				SubStore: map[string]storageTypes.ImageStore{
+					"/a": subStore,
+				},
+			}
+
+			So(storeController.SyncStagingRootForRepo("centos"), ShouldEqual, defaultRoot)
+			So(storeController.SyncStagingRootForRepo("a/myrepo"), ShouldEqual, subRoot)
+		})
+
+		Convey("SyncStagingRoots deduplicates identical local roots", func() {
+			sharedRoot := t.TempDir()
+			sharedStore := local.NewImageStore(sharedRoot, false, false, logger, metrics, nil, nil, nil, nil)
+
+			storeController := storage.StoreController{
+				DefaultStore: sharedStore,
+				SubStore: map[string]storageTypes.ImageStore{
+					"/a": sharedStore,
+				},
+			}
+
+			So(storeController.SyncStagingRoots(), ShouldResemble, []string{sharedRoot})
+		})
+	})
+}


### PR DESCRIPTION
On-demand sync stages blobs under <repo>/.sync/<uuid>/; without cleanup,
GC and manifest-delete could remove the repo while a session was still
active, or leave orphaned sessions after a crash.

- Block CleanupRepo and idle repo removal when a staging session exists
- Add a periodic reaper (GC interval) for sessions older than
  max(gcDelay, syncTimeout); runs whenever local staging roots exist
- Discover stale sessions with a pruned walk per staging root (not a full
  blob-tree scan); emit one scheduler task per session directory
- Resolve staging roots via StoreController (downloadDir or local stores)
- Add LargestGCDelay / LargestSyncTimeout config helpers
- Tests for guards, reaper generator lifecycle, scheduler integration,
  hook paths, and error-path coverage
  
 Resolves https://github.com/project-zot/zot/issues/4240