### PR TITLE
fix(cli): reload config on Kubernetes ConfigMap updates

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -196,6 +196,26 @@ jobs:
             sudo ./scripts/enable_userns.sh
             ./examples/kind/kind-ci.sh
 
+  kind-config-reload:
+    name: Config hot reload on ConfigMap update
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          check-latest: true
+          go-version-file: .go-version
+      - uses: ./.github/actions/install-prebuilt-binaries
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
+      - name: Run config hot reload ConfigMap test
+        run: |
+          sudo ./scripts/enable_userns.sh
+          make USE_PREBUILT=1 run-kind-config-reload
+
   kind-sync-ondemand:
     name: On-demand sync mirror regression (issue 4184)
     needs: build-binaries

--- a/Makefile
+++ b/Makefile
@@ -634,6 +634,10 @@ run-blackbox-sync-nightly: check-blackbox-prerequisites $(ZOT_BIN_DEP) $(ZOT_MIN
 run-kind-sync-ondemand: $(KIND) $(ZOT_BIN_DEP)
 	./examples/kind/kind-sync-ondemand.sh
 
+.PHONY: run-kind-config-reload
+run-kind-config-reload: $(KIND) $(ZOT_BIN_DEP)
+	./examples/kind/kind-config-reload.sh
+
 # When USE_PREBUILT=1, assert compile outputs already exist so test targets
 # can reuse a downloaded bin/ without invoking the phony binary/bench/cli targets.
 .PHONY: require-binary

--- a/examples/kind/kind-config-reload.sh
+++ b/examples/kind/kind-config-reload.sh
@@ -1,0 +1,272 @@
+#!/bin/bash
+# kind-config-reload.sh
+#
+# End-to-end test for config hot reload under a Kubernetes ConfigMap mount.
+#
+# kubelet updates a mounted ConfigMap through its AtomicWriter: a new payload
+# directory is written and the ..data symlink is atomically retargeted, so the
+# watched file never receives a Write event. The config reloader must pick the
+# change up anyway (stat fingerprint polling) and apply the reloadable subset
+# without a pod restart.
+#
+# This test:
+#   1. Builds a minimal Docker image that packages the locally compiled zot binary.
+#   2. Creates a kind cluster and deploys zot with its config in a ConfigMap and
+#      htpasswd credentials in a Secret (both mounted as volumes, no subPath).
+#   3. Asserts the initial accessControl: alice can list the catalog, bob gets 403.
+#   4. Patches the ConfigMap to grant bob access.
+#   5. Asserts zot logs the reload, bob's requests start succeeding, and the pod
+#      was neither restarted nor recreated.
+#
+# Prerequisites:
+#   make check-blackbox-prerequisites
+#   make OS=linux binary
+#
+# Usage:
+#   ./examples/kind/kind-config-reload.sh
+
+set -o errexit
+set -o pipefail
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+cd "${ROOT_DIR}"
+
+# The image runs Linux regardless of the host, so the packaged binary must too.
+ARCH=$(go env GOARCH)
+ZOT_BINARY="${ROOT_DIR}/bin/zot-linux-${ARCH}"
+
+if [ ! -x "${ZOT_BINARY}" ]; then
+    echo "Error: ${ZOT_BINARY} not found. Run 'make OS=linux ARCH=${ARCH} binary' first." >&2
+    exit 1
+fi
+
+# Prefer the project-local kind binary installed by check-blackbox-prerequisites.
+if [ -x "${ROOT_DIR}/hack/tools/bin/kind" ]; then
+    KIND="${ROOT_DIR}/hack/tools/bin/kind"
+elif command -v kind &>/dev/null; then
+    KIND="kind"
+else
+    echo "Error: kind not found. Run 'make check-blackbox-prerequisites' first." >&2
+    exit 1
+fi
+
+ZOT_LISTEN_PORT="5000"
+KIND_NODE_IMAGE="kindest/node:v1.28.7"
+POD_WAIT_TIMEOUT="180s"
+# kubelet syncs mounted ConfigMaps on its own cadence (up to about a minute),
+# then the reloader debounce fires; two minutes is a comfortable ceiling.
+RELOAD_TIMEOUT_SECONDS=120
+
+COMMIT_HASH=$(git describe --always --tags --long)
+RUN_SUFFIX="$(git rev-parse --short HEAD)-$$"
+CLUSTER_NAME="zot-config-reload-${RUN_SUFFIX}"
+CONTROL_PLANE="${CLUSTER_NAME}-control-plane"
+ZOT_IMAGE="zot-config-reload:${COMMIT_HASH}"
+# Pinned digest for reproducible CI/nightly runs (index digest; docker --platform selects arch).
+DISTROLESS_BASE_IMAGE="gcr.io/distroless/base-debian12@sha256:9c05cfd65f41c93a909ea67eb05b920a3b838780ea55df5421d48295d98ff957"
+
+KUBECONFIG_FILE=$(mktemp /tmp/kind-config-reload-kubeconfig-XXXXX)
+export KUBECONFIG="${KUBECONFIG_FILE}"
+
+log_info()  { echo "[INFO]  $*"; }
+log_error() { echo "[ERROR] $*" >&2; }
+
+KUBECTL_CTX="kind-${CLUSTER_NAME}"
+
+cleanup() {
+    log_info "Cleaning up..."
+    "${KIND}" delete cluster --name "${CLUSTER_NAME}" 2>/dev/null || true
+    docker rmi -f "${ZOT_IMAGE}" 2>/dev/null || true
+    rm -f "${KUBECONFIG_FILE}"
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# Build a minimal zot Docker image from the locally compiled binary. The config
+# is NOT baked in: it is mounted from a ConfigMap, which is the behavior under
+# test.
+# ---------------------------------------------------------------------------
+log_info "Building zot Docker image (${ZOT_IMAGE}) from local binary..."
+BUILD_CTX=$(mktemp -d)
+cp "${ZOT_BINARY}" "${BUILD_CTX}/zot"
+docker build \
+    --platform "linux/${ARCH}" \
+    -t "${ZOT_IMAGE}" \
+    -f - "${BUILD_CTX}" <<DOCKER
+FROM ${DISTROLESS_BASE_IMAGE}
+COPY zot /usr/bin/zot
+ENTRYPOINT ["/usr/bin/zot"]
+EXPOSE ${ZOT_LISTEN_PORT}
+DOCKER
+rm -rf "${BUILD_CTX}"
+log_info "Image built: ${ZOT_IMAGE}"
+
+log_info "Creating kind cluster '${CLUSTER_NAME}'..."
+EXISTING_CLUSTERS=$("${KIND}" get clusters 2>/dev/null || true)
+if grep -qx "${CLUSTER_NAME}" <<<"${EXISTING_CLUSTERS}"; then
+    "${KIND}" delete cluster --name "${CLUSTER_NAME}"
+fi
+
+cat <<EOF | "${KIND}" create cluster --name "${CLUSTER_NAME}" --config=-
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: ${KIND_NODE_IMAGE}
+EOF
+
+kubectl --context "${KUBECTL_CTX}" wait --for=condition=Ready nodes --all --timeout=180s
+
+log_info "Loading ${ZOT_IMAGE} into the kind cluster..."
+"${KIND}" load docker-image "${ZOT_IMAGE}" --name "${CLUSTER_NAME}"
+
+# ---------------------------------------------------------------------------
+# Deploy zot: config from a ConfigMap, htpasswd from a Secret, both mounted as
+# whole volumes (subPath mounts are never updated by kubelet).
+# ---------------------------------------------------------------------------
+# bcrypt hashes for alice:alice and bob:bob (static so the test is
+# deterministic; generated with htpasswd -nbB).
+HTPASSWD='alice:$2y$05$dKbJtzXazxTrbI.4TmZLN.oSqM7np42T9tkCKdi0XDJ.LnjnSB55K
+bob:$2y$05$UnHJ2xeU/SalnWRjqUf7UeuPG5Q/T4.fkKUBvpTtTPyl81wFw1DP.'
+
+config_json() {
+    local users=$1
+
+    cat <<EOF
+{
+    "distSpecVersion": "1.1.1",
+    "storage": {"rootDirectory": "/var/lib/registry"},
+    "http": {
+        "address": "0.0.0.0",
+        "port": "${ZOT_LISTEN_PORT}",
+        "realm": "zot",
+        "auth": {"htpasswd": {"path": "/etc/zot-auth/htpasswd"}, "failDelay": 1},
+        "accessControl": {
+            "repositories": {
+                "**": {
+                    "policies": [{"users": [${users}], "actions": ["read", "create"]}],
+                    "defaultPolicy": []
+                }
+            }
+        }
+    },
+    "log": {"level": "debug"}
+}
+EOF
+}
+
+log_info "Creating Secret, ConfigMap and Deployment..."
+kubectl --context "${KUBECTL_CTX}" create secret generic zot-htpasswd \
+    --from-literal=htpasswd="${HTPASSWD}"
+kubectl --context "${KUBECTL_CTX}" create configmap zot-config \
+    --from-literal=config.json="$(config_json '"alice"')"
+
+cat <<EOF | kubectl --context "${KUBECTL_CTX}" apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zot
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: zot}
+  template:
+    metadata:
+      labels: {app: zot}
+    spec:
+      containers:
+      - name: zot
+        image: ${ZOT_IMAGE}
+        imagePullPolicy: Never
+        args: ["serve", "/etc/zot/config.json"]
+        ports:
+        - containerPort: ${ZOT_LISTEN_PORT}
+        volumeMounts:
+        - {name: config, mountPath: /etc/zot, readOnly: true}
+        - {name: htpasswd, mountPath: /etc/zot-auth, readOnly: true}
+        - {name: data, mountPath: /var/lib/registry}
+      volumes:
+      - name: config
+        configMap: {name: zot-config}
+      - name: htpasswd
+        secret: {secretName: zot-htpasswd}
+      - name: data
+        emptyDir: {}
+EOF
+
+kubectl --context "${KUBECTL_CTX}" wait --for=condition=Available deployment/zot \
+    --timeout="${POD_WAIT_TIMEOUT}"
+
+POD=$(kubectl --context "${KUBECTL_CTX}" get pods -l app=zot -o jsonpath='{.items[0].metadata.name}')
+POD_UID=$(kubectl --context "${KUBECTL_CTX}" get pod "${POD}" -o jsonpath='{.metadata.uid}')
+log_info "zot pod: ${POD}"
+
+kubectl --context "${KUBECTL_CTX}" port-forward deployment/zot "13000:${ZOT_LISTEN_PORT}" &
+PF_PID=$!
+trap 'kill ${PF_PID} 2>/dev/null || true; cleanup' EXIT
+sleep 3
+
+# Probe a repo-scoped endpoint: the catalog is filtered per user (an
+# unauthorized user gets an empty 200), while tags/list is denied outright.
+# An authorized user gets 404 for the nonexistent repo, a denied one gets 403.
+tags_status() {
+    local user=$1 pass=$2
+    curl -s -o /dev/null -w '%{http_code}' -u "${user}:${pass}" \
+        "http://127.0.0.1:13000/v2/testrepo/tags/list" || true
+}
+
+log_info "Asserting initial accessControl (alice authorized, bob denied)..."
+for i in $(seq 1 30); do
+    [ "$(tags_status alice alice)" = "404" ] && break
+    sleep 2
+done
+[ "$(tags_status alice alice)" = "404" ] || { log_error "alice is not authorized (got $(tags_status alice alice))"; exit 1; }
+[ "$(tags_status bob bob)" = "403" ] || { log_error "bob was not denied before the change (got $(tags_status bob bob))"; exit 1; }
+
+log_info "Patching the ConfigMap to grant bob access (kubelet AtomicWriter update)..."
+kubectl --context "${KUBECTL_CTX}" create configmap zot-config \
+    --from-literal=config.json="$(config_json '"alice", "bob"')" \
+    --dry-run=client -o yaml | kubectl --context "${KUBECTL_CTX}" replace -f -
+
+log_info "Waiting up to ${RELOAD_TIMEOUT_SECONDS}s for the reload to land..."
+DEADLINE=$(( $(date +%s) + RELOAD_TIMEOUT_SECONDS ))
+RELOADED=0
+while [ "$(date +%s)" -lt "${DEADLINE}" ]; do
+    if [ "$(tags_status bob bob)" = "404" ]; then
+        RELOADED=1
+        break
+    fi
+    sleep 3
+done
+
+# Capture the logs once, then feed them to matchers as here-strings. Any
+# producer piped into grep -q trips pipefail via SIGPIPE when grep exits on the
+# first match and the producer is still writing.
+ZOT_LOGS=$(kubectl --context "${KUBECTL_CTX}" logs "${POD}")
+
+log_info "zot logs (reload lines):"
+grep -E "config file changed|reloaded params" <<<"${ZOT_LOGS}" || true
+
+if [ "${RELOADED}" != "1" ]; then
+    log_error "bob still denied after ${RELOAD_TIMEOUT_SECONDS}s; config reload did not happen"
+    tail -40 <<<"${ZOT_LOGS}"
+    exit 1
+fi
+
+grep -q "config file changed" <<<"${ZOT_LOGS}" || {
+    log_error "reload log line missing even though authorization changed"
+    exit 1
+}
+
+log_info "Asserting the pod was neither restarted nor recreated..."
+POD_NOW=$(kubectl --context "${KUBECTL_CTX}" get pods -l app=zot -o jsonpath='{.items[0].metadata.name}')
+POD_UID_NOW=$(kubectl --context "${KUBECTL_CTX}" get pod "${POD_NOW}" -o jsonpath='{.metadata.uid}')
+RESTARTS=$(kubectl --context "${KUBECTL_CTX}" get pod "${POD_NOW}" \
+    -o jsonpath='{.status.containerStatuses[0].restartCount}')
+
+if [ "${POD_UID_NOW}" != "${POD_UID}" ] || [ "${RESTARTS}" != "0" ]; then
+    log_error "pod changed or restarted (uid ${POD_UID} -> ${POD_UID_NOW}, restarts ${RESTARTS})"
+    exit 1
+fi
+
+log_info "PASS: ConfigMap update reloaded accessControl live, zero pod restarts."

--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -231,8 +231,10 @@ func (amw *AuthnMiddleware) basicAuthn(ctlr *Controller, userAc *reqCtx.UserAcce
 		return true, nil
 	}
 
-	// next, LDAP if configured (network-based which can lose connectivity)
-	if authConfig.IsLdapAuthEnabled() {
+	// next, LDAP if configured (network-based which can lose connectivity). A
+	// reload can enable ldap without a client existing to serve it, which
+	// LoadNewConfig warns about once rather than on every request through here.
+	if authConfig.IsLdapAuthEnabled() && amw.ldapClient != nil {
 		ok, _, ldapgroups, err := amw.ldapClient.Authenticate(identity, passphrase)
 		if ok && err == nil {
 			// Process request
@@ -359,6 +361,7 @@ func (amw *AuthnMiddleware) tryAuthnHandlers(ctlr *Controller) mux.MiddlewareFun
 			ServerName:         ldapConfig.Address,
 			Log:                ctlr.Log,
 			SubtreeSearch:      ldapConfig.SubtreeSearch,
+			CACertPath:         ldapConfig.CACert,
 		}
 
 		amw.ldapClient = ctlr.LDAPClient

--- a/pkg/api/authz_internal_test.go
+++ b/pkg/api/authz_internal_test.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -544,6 +547,155 @@ func TestControllerLoadNewConfigRecompilesConditions(t *testing.T) {
 	_, hasOld := updated[`req.repository == "old"`]
 	assert.False(t, hasOld, "old expression should be evicted after reload")
 }
+
+// TestControllerLoadNewConfigWarnsWhenLdapHasNoClient verifies that ldap turned
+// on by a reload is reported once, by the reload, rather than on every request
+// that reaches the ldap branch of the auth middleware.
+func TestControllerLoadNewConfigWarnsWhenLdapHasNoClient(t *testing.T) {
+	t.Parallel()
+
+	logPath := path.Join(t.TempDir(), "zot.log")
+
+	htp := NewHTPasswd(log.NewLogger("debug", ""))
+	htw, err := NewHTPasswdWatcher(htp, "")
+	assert.NoError(t, err)
+
+	original := config.New()
+	original.HTTP.Auth = &config.AuthConfig{}
+
+	ctlr := &Controller{
+		Config:          original,
+		Log:             log.NewLogger("debug", logPath),
+		HTPasswd:        htp,
+		HTPasswdWatcher: htw,
+	}
+
+	// the client is built during startup, which this config had no ldap for
+	assert.Nil(t, ctlr.LDAPClient)
+
+	newConfig := config.New()
+	newConfig.HTTP.Auth = &config.AuthConfig{LDAP: &config.LDAPConfig{}}
+
+	ctlr.LoadNewConfig(newConfig)
+
+	logs, err := os.ReadFile(logPath)
+	assert.NoError(t, err)
+	assert.Equal(t, 1,
+		strings.Count(string(logs), "ldap auth enabled by config reload requires a restart to take effect"),
+		"the warning belongs to the reload, not to every request reaching ldap")
+}
+
+// TestControllerLoadNewConfigWarnsOnStartupOnlyLdapFields verifies that ldap
+// settings a reload cannot push into the live client are reported. Only the
+// bind credentials reach it, so an address or baseDN change is applied to the
+// config and nowhere else.
+func TestControllerLoadNewConfigWarnsOnStartupOnlyLdapFields(t *testing.T) {
+	t.Parallel()
+
+	logPath := path.Join(t.TempDir(), "zot.log")
+
+	htp := NewHTPasswd(log.NewLogger("debug", ""))
+	htw, err := NewHTPasswdWatcher(htp, "")
+	assert.NoError(t, err)
+
+	original := config.New()
+	original.HTTP.Auth = &config.AuthConfig{LDAP: &config.LDAPConfig{
+		Address: "ldap.example.com",
+		Port:    389,
+		BaseDN:  "ou=users,dc=example,dc=org",
+	}}
+
+	ctlr := &Controller{
+		Config:          original,
+		Log:             log.NewLogger("debug", logPath),
+		HTPasswd:        htp,
+		HTPasswdWatcher: htw,
+		// the client the server is actually authenticating against
+		LDAPClient: &LDAPClient{
+			Host:       "ldap.example.com",
+			Port:       389,
+			Base:       "ou=users,dc=example,dc=org",
+			UseSSL:     true,
+			CACertPath: "/etc/zot/ldap-ca.pem",
+			Log:        log.NewLogger("debug", ""),
+		},
+	}
+
+	newConfig := config.New()
+	newConfig.HTTP.Auth = &config.AuthConfig{LDAP: &config.LDAPConfig{
+		Address: "ldap-2.example.com",
+		Port:    636,
+		BaseDN:  "ou=people,dc=example,dc=org",
+		CACert:  "/etc/zot/ldap-ca-2.pem",
+	}}
+
+	ctlr.LoadNewConfig(newConfig)
+
+	logs, err := os.ReadFile(logPath)
+	assert.NoError(t, err)
+
+	line := string(logs)
+	assert.Contains(t, line, "ldap changes are outside the reloadable set")
+	for _, field := range []string{"address", "port", "baseDN", "caCert"} {
+		assert.Contains(t, line, field, "the changed field should be named in the warning")
+	}
+}
+
+// TestLdapRestartRequiredFields pins which ldap settings a reload can and
+// cannot apply to a client that is already serving.
+func TestLdapRestartRequiredFields(t *testing.T) {
+	t.Parallel()
+
+	client := &LDAPClient{
+		Host:               "ldap.example.com",
+		Port:               389,
+		Base:               "ou=users,dc=example,dc=org",
+		UseSSL:             true,
+		SkipTLS:            true,
+		InsecureSkipVerify: false,
+		SubtreeSearch:      false,
+		UserAttribute:      "uid",
+		UserGroupAttribute: "memberOf",
+		UserFilter:         "(!(nsaccountlock=TRUE))",
+	}
+
+	matching := &config.LDAPConfig{
+		Address:            "ldap.example.com",
+		Port:               389,
+		BaseDN:             "ou=users,dc=example,dc=org",
+		Insecure:           false,
+		StartTLS:           false,
+		SkipVerify:         false,
+		SubtreeSearch:      false,
+		UserAttribute:      "uid",
+		UserGroupAttribute: "memberOf",
+		UserFilter:         "(!(nsaccountlock=TRUE))",
+	}
+
+	assert.Empty(t, ldapRestartRequiredFields(client, matching),
+		"a config the client already matches needs no restart")
+
+	assert.Nil(t, ldapRestartRequiredFields(nil, matching))
+	assert.Nil(t, ldapRestartRequiredFields(client, nil))
+
+	// the bind credentials are the part a reload does apply, so changing them
+	// alone must not ask for a restart
+	credsOnly := *matching
+	credsOnly.CredentialsFile = "/etc/zot/ldap-creds.json"
+	assert.Empty(t, ldapRestartRequiredFields(client, &credsOnly))
+
+	changed := *matching
+	changed.Address = "ldap-2.example.com"
+	changed.SubtreeSearch = true
+	assert.Equal(t, []string{"address", "subtreeSearch"}, ldapRestartRequiredFields(client, &changed))
+
+	// the trust anchors are read into a pool at startup, so pointing caCert at a
+	// new file leaves the client verifying against the old one
+	rotatedCA := *matching
+	rotatedCA.CACert = "/etc/zot/ldap-ca-2.pem"
+	assert.Equal(t, []string{"caCert"}, ldapRestartRequiredFields(client, &rotatedCA))
+}
+
 
 // TestPolicyConditionForwardedFor verifies that req.client.forwardedFor
 // exposes the X-Forwarded-For chain split into a list, and that conditions

--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -1193,6 +1193,22 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 	}
 }
 
+// SnapshotJSON returns the config serialized under the read lock with secrets
+// left unmasked, for callers that compare two configs and report only which
+// fields differ. It is a view, not a clone: whatever JSON does not carry is
+// absent, session keys and ldap bind credentials among it. Use Sanitize for
+// anything shown to a user, and the Copy* accessors for real values.
+func (c *Config) SnapshotJSON() ([]byte, error) {
+	if c == nil {
+		return nil, nil
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return json.Marshal(c)
+}
+
 // CopyAuthConfig returns a copy of the auth config if it exists.
 func (c *Config) CopyAuthConfig() *AuthConfig {
 	if c == nil {

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -1,6 +1,7 @@
 package config_test
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -3904,6 +3905,50 @@ func TestConfigSyncStagingHelpers(t *testing.T) {
 			So(config.GlobalStorageConfig{}.LargestGCDelay(), ShouldBeGreaterThan, 0)
 		})
 	})
+}
+
+func TestSnapshotJSON(t *testing.T) {
+	Convey("A nil config has no snapshot", t, func() {
+		var conf *config.Config
+
+		blob, err := conf.SnapshotJSON()
+		So(err, ShouldBeNil)
+		So(blob, ShouldBeNil)
+	})
+
+	Convey("Secrets are left unmasked, so a rotation still reads as a change", t, func() {
+		conf := config.New()
+		conf.Storage.StorageDriver = map[string]any{"name": "s3", "secretkey": "rotate-me"}
+
+		blob, err := conf.SnapshotJSON()
+		So(err, ShouldBeNil)
+		So(string(blob), ShouldContainSubstring, "rotate-me")
+
+		// Sanitize is the masking one; comparing two masked configs would make
+		// a rotated secret look unchanged
+		So(string(mustJSON(conf.Sanitize())), ShouldNotContainSubstring, "rotate-me")
+	})
+
+	Convey("It is a view, not a clone: what JSON drops is absent", t, func() {
+		conf := config.New()
+		conf.HTTP.Auth = &config.AuthConfig{LDAP: &config.LDAPConfig{Address: "ldap.example.com"}}
+		conf.HTTP.Auth.LDAP.SetBindPassword("super-secret")
+		conf.HTTP.Auth.SessionHashKey = []byte("hash-key-material")
+
+		blob, err := conf.SnapshotJSON()
+		So(err, ShouldBeNil)
+
+		So(string(blob), ShouldContainSubstring, "ldap.example.com")
+		So(string(blob), ShouldNotContainSubstring, "super-secret")
+		So(string(blob), ShouldNotContainSubstring, "hash-key-material")
+	})
+}
+
+func mustJSON(conf *config.Config) []byte {
+	blob, err := json.Marshal(conf)
+	So(err, ShouldBeNil)
+
+	return blob
 }
 
 func TestEventsFingerprint(t *testing.T) {

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -7,8 +7,10 @@ import (
 	"crypto/x509"
 	goerrors "errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -484,6 +486,40 @@ func (c *Controller) reloadEventRecorder() {
 	c.Log.Info().Bool("enabled", eventRecorder != nil).Msg("reloaded event recorder")
 }
 
+// ldapRestartRequiredFields reports the ldap settings the running client was
+// built from that differ from the new config. A reload refreshes only the bind
+// credentials, so these are applied to the config while the live client keeps
+// serving with the old ones, which is worth telling the operator about.
+func ldapRestartRequiredFields(client *LDAPClient, ldapConf *config.LDAPConfig) []string {
+	if client == nil || ldapConf == nil {
+		return nil
+	}
+
+	changed := map[string]bool{
+		"address":            client.Host != ldapConf.Address,
+		"caCert":             client.CACertPath != ldapConf.CACert,
+		"port":               client.Port != ldapConf.Port,
+		"baseDN":             client.Base != ldapConf.BaseDN,
+		"insecure":           client.UseSSL == ldapConf.Insecure,
+		"startTLS":           client.SkipTLS == ldapConf.StartTLS,
+		"skipVerify":         client.InsecureSkipVerify != ldapConf.SkipVerify,
+		"subtreeSearch":      client.SubtreeSearch != ldapConf.SubtreeSearch,
+		"userAttribute":      client.UserAttribute != ldapConf.UserAttribute,
+		"userGroupAttribute": client.UserGroupAttribute != ldapConf.UserGroupAttribute,
+		"userFilter":         client.UserFilter != ldapConf.UserFilter,
+	}
+
+	fields := []string{}
+
+	for _, field := range slices.Sorted(maps.Keys(changed)) {
+		if changed[field] {
+			fields = append(fields, field)
+		}
+	}
+
+	return fields
+}
+
 func (c *Controller) LoadNewConfig(newConfig *config.Config) {
 	// Update only reloadable config fields atomically
 	c.Config.UpdateReloadableConfig(newConfig)
@@ -507,11 +543,24 @@ func (c *Controller) LoadNewConfig(newConfig *config.Config) {
 		_ = c.HTPasswdWatcher.ChangeFile("")
 	}
 
-	if c.LDAPClient != nil && authConfig.IsLdapAuthEnabled() {
-		c.LDAPClient.lock.Lock()
-		c.LDAPClient.BindDN = authConfig.LDAP.BindDN()
-		c.LDAPClient.BindPassword = authConfig.LDAP.BindPassword()
-		c.LDAPClient.lock.Unlock()
+	if authConfig.IsLdapAuthEnabled() {
+		if c.LDAPClient != nil {
+			// only the bind credentials reach the live client, so anything else
+			// the client was built from is applied to the config and nowhere else
+			if fields := ldapRestartRequiredFields(c.LDAPClient, authConfig.LDAP); len(fields) > 0 {
+				c.Log.Warn().Strs("fields", fields).
+					Msg("ldap changes are outside the reloadable set and need a restart to take effect")
+			}
+
+			c.LDAPClient.lock.Lock()
+			c.LDAPClient.BindDN = authConfig.LDAP.BindDN()
+			c.LDAPClient.BindPassword = authConfig.LDAP.BindPassword()
+			c.LDAPClient.lock.Unlock()
+		} else {
+			// the client is built at startup, so ldap turned on by a reload has
+			// none to authenticate against
+			c.Log.Warn().Msg("ldap auth enabled by config reload requires a restart to take effect")
+		}
 	}
 
 	c.reloadEventRecorder()

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2641,8 +2641,7 @@ func TestBasicAuthWithReloadedCredentials(t *testing.T) {
 		ctlr := api.NewController(conf)
 		ctlrManager := test.NewControllerManager(ctlr)
 
-		hotReloader, err := server.NewHotReloader(ctlr, configPath, ldapConfigPath)
-		So(err, ShouldBeNil)
+		hotReloader := server.NewHotReloader(ctlr, configPath, ldapConfigPath)
 
 		hotReloader.Start()
 

--- a/pkg/api/ldap.go
+++ b/pkg/api/ldap.go
@@ -32,6 +32,7 @@ type LDAPClient struct {
 	Conn               *ldap.Conn
 	ClientCertificates []tls.Certificate // Adding client certificates
 	ClientCAs          *x509.CertPool
+	CACertPath         string // the caCert ClientCAs was built from, for restart-required detection
 	Log                log.Logger
 	lock               sync.Mutex
 }

--- a/pkg/cli/server/config_reloader.go
+++ b/pkg/cli/server/config_reloader.go
@@ -1,35 +1,73 @@
 package server
 
 import (
+	"encoding/json"
 	"errors"
+	"maps"
 	"os"
 	"os/signal"
+	"path/filepath"
+	"reflect"
+	"slices"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 
 	"zotregistry.dev/zot/v2/pkg/api"
 	"zotregistry.dev/zot/v2/pkg/api/config"
-	"zotregistry.dev/zot/v2/pkg/log"
 )
 
+const (
+	// configEventDebounceInterval coalesces bursts of fsnotify events into one reload.
+	configEventDebounceInterval = 150 * time.Millisecond
+	// configStatCheckInterval is the polling interval used as a backstop when
+	// inotify watching is unavailable or events were dropped.
+	configStatCheckInterval = 1 * time.Second
+)
+
+// HotReloader reloads the server configuration when the config file (or the
+// LDAP credentials file it references) changes. The file watch gives
+// low-latency reloads; the stat fingerprint poll is the guarantee, catching
+// changes the watch cannot see (Kubernetes ConfigMap/Secret symlink swaps).
 type HotReloader struct {
 	watcher             *fsnotify.Watcher
 	configPath          string
 	ldapCredentialsPath string
 	ctlr                *api.Controller
-	logger              log.Logger
 
-	done     chan struct{}
+	// the fields below belong to the watcher loop once Start has launched it,
+	// and are only touched from there.
+	debounceTimer *time.Timer
+	// stat fingerprints at the last successful reload; polling compares
+	// identity, size and mtime against them.
+	configInfo os.FileInfo
+	ldapInfo   os.FileInfo
+	// a credentials path a failed load decoded, fingerprinted so its arrival
+	// retries the config. The live path keeps its own watch: a config that
+	// failed for an unrelated reason must not stop tracking the file the
+	// running config still authenticates against.
+	pendingLdapPath string
+	pendingLdapInfo os.FileInfo
+
+	done chan struct{}
+	// mu guards stopped, which Start writes and Stop reads
+	mu sync.Mutex
+	// closed by the watcher loop on exit, so Stop can wait out an in-flight reload
+	stopped  chan struct{}
 	stopOnce sync.Once
 }
 
-func NewHotReloader(ctlr *api.Controller, filePath, ldapCredentialsPath string) (*HotReloader, error) {
-	// creates a new file watcher
+func NewHotReloader(ctlr *api.Controller, filePath, ldapCredentialsPath string) *HotReloader {
+	// carry on without a watcher rather than refusing to start: the fingerprint
+	// poll drives reloads on its own, so inotify being unavailable degrades the
+	// latency of a reload, not whether one happens
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
-		return nil, err
+		ctlr.Log.Error().Err(err).Msg("failed to create fsnotify watcher, relying on stat-based polling")
+
+		watcher = nil
 	}
 
 	hotReloader := &HotReloader{
@@ -37,11 +75,16 @@ func NewHotReloader(ctlr *api.Controller, filePath, ldapCredentialsPath string) 
 		configPath:          filePath,
 		ldapCredentialsPath: ldapCredentialsPath,
 		ctlr:                ctlr,
-		logger:              log.NewLogger("info", ""),
 		done:                make(chan struct{}),
 	}
 
-	return hotReloader, nil
+	// fingerprint the files as they were loaded, not as they are once the
+	// controller has finished initialising: a replacement landing in between
+	// would otherwise be baselined as already applied and never reload
+	hotReloader.configInfo = statOrNil(filePath)
+	hotReloader.ldapInfo = statOrNil(ldapCredentialsPath)
+
+	return hotReloader
 }
 
 func signalHandler(ctlr *api.Controller, hr *HotReloader, sigCh chan os.Signal) {
@@ -75,81 +118,392 @@ func (hr *HotReloader) Stop() {
 		if hr.watcher != nil {
 			_ = hr.watcher.Close()
 		}
+
+		hr.mu.Lock()
+		stopped := hr.stopped
+		hr.mu.Unlock()
+
+		// wait for the loop and any in-flight reload; nil if Start never ran
+		if stopped != nil {
+			<-stopped
+		}
 	})
 }
 
 func (hr *HotReloader) Start() {
-	// run watcher
-	go func() {
-		defer hr.watcher.Close()
-
-		go func() {
-			for {
-				select {
-				case <-hr.done:
-					return
-				// watch for events
-				case event, ok := <-hr.watcher.Events:
-					if !ok {
-						return
-					}
-					if event.Op == fsnotify.Write {
-						hr.logger.Info().Msg("config file changed, trying to reload config")
-
-						newConfig := config.New()
-
-						err := LoadConfiguration(newConfig, hr.configPath)
-						if err != nil {
-							hr.logger.Error().Err(err).Msg("failed to reload config, retry writing it.")
-
-							continue
-						}
-
-						authConfig := hr.ctlr.Config.CopyAuthConfig()
-						if authConfig.IsLdapAuthEnabled() &&
-							authConfig.LDAP.CredentialsFile != newConfig.HTTP.Auth.LDAP.CredentialsFile {
-							err = hr.watcher.Remove(authConfig.LDAP.CredentialsFile)
-							if err != nil && !errors.Is(err, fsnotify.ErrNonExistentWatch) {
-								hr.logger.Error().Err(err).Msg("failed to remove old watch for the credentials file")
-							}
-
-							err = hr.watcher.Add(newConfig.HTTP.Auth.LDAP.CredentialsFile)
-							if err != nil {
-								hr.logger.Panic().Err(err).Str("ldap-credentials-file", newConfig.HTTP.Auth.LDAP.CredentialsFile).
-									Msg("failed to watch ldap credentials file")
-							}
-						}
-
-						// stop background tasks gracefully
-						hr.ctlr.StopBackgroundTasks()
-
-						// load new config
-						hr.ctlr.LoadNewConfig(newConfig)
-
-						// start background tasks based on new loaded config
-						hr.ctlr.StartBackgroundTasks()
-					}
-				// watch for errors
-				case err, ok := <-hr.watcher.Errors:
-					if !ok {
-						return
-					}
-					hr.logger.Panic().Err(err).Str("config", hr.configPath).Msg("fsnotfy error while watching config")
-				}
-			}
-		}()
-
+	// watch failures are tolerated: the fingerprint poll is the backstop
+	if hr.watcher != nil {
 		if err := hr.watcher.Add(hr.configPath); err != nil {
-			hr.logger.Panic().Err(err).Str("config", hr.configPath).Msg("failed to add config file to fsnotify watcher")
+			hr.ctlr.Log.Error().Err(err).Str("config", hr.configPath).
+				Msg("failed to add config file to fsnotify watcher, relying on stat-based polling")
 		}
 
 		if hr.ldapCredentialsPath != "" {
 			if err := hr.watcher.Add(hr.ldapCredentialsPath); err != nil {
-				hr.logger.Panic().Err(err).Str("ldap-credentials", hr.ldapCredentialsPath).
-					Msg("failed to add ldap-credentials to fsnotify watcher")
+				hr.ctlr.Log.Error().Err(err).Str("ldap-credentials", hr.ldapCredentialsPath).
+					Msg("failed to add ldap-credentials to fsnotify watcher, relying on stat-based polling")
 			}
 		}
+	}
 
-		<-hr.done
-	}()
+	hr.mu.Lock()
+	hr.stopped = make(chan struct{})
+	stopped := hr.stopped
+	hr.mu.Unlock()
+
+	go hr.loop(stopped)
+}
+
+func (hr *HotReloader) loop(stopped chan struct{}) {
+	defer close(stopped)
+
+	// nil channels block forever in a select, which is what leaves the loop
+	// polling-only when there is no watcher
+	var eventsCh chan fsnotify.Event
+
+	var errorsCh chan error
+
+	if hr.watcher != nil {
+		eventsCh = hr.watcher.Events
+		errorsCh = hr.watcher.Errors
+	}
+
+	statTicker := time.NewTicker(configStatCheckInterval)
+	defer statTicker.Stop()
+
+	for {
+		select {
+		case <-hr.done:
+			return
+
+		// watch for events
+		case event, ok := <-eventsCh:
+			if !ok {
+				return
+			}
+
+			// only in-place writes: a replaced file retires the watched inode
+			// without one, and the poll is what picks that up
+			if event.Op&fsnotify.Write == 0 {
+				continue
+			}
+
+			if !samePath(event.Name, hr.configPath) &&
+				!samePath(event.Name, hr.ldapCredentialsPath) {
+				continue
+			}
+
+			hr.scheduleReload()
+
+		case <-hr.getDebounceChannel():
+			hr.debounceTimer = nil
+
+			select {
+			case <-hr.done:
+				return
+			default:
+			}
+
+			hr.reloadConfig("debounced file change")
+
+		case <-statTicker.C:
+			// always poll: it covers whatever the watch missed
+			hr.pollForChanges()
+
+		// watch for errors
+		case err, ok := <-errorsCh:
+			if !ok {
+				return
+			}
+
+			// events may have been dropped, which the next poll tick resolves
+			hr.ctlr.Log.Error().Err(err).Str("config", hr.configPath).
+				Msg("failed to watch config file, relying on stat-based polling")
+		}
+	}
+}
+
+// pollForChanges reloads when a fingerprint moved. It is what picks up a file
+// that was replaced rather than written in place, which is how a Kubernetes
+// ConfigMap update arrives, and it re-binds the watch to the new inode.
+func (hr *HotReloader) pollForChanges() {
+	if !hr.checkFilesChanged() {
+		return
+	}
+
+	hr.readdWatches()
+
+	// a write may have armed a debounce for this same change, which would
+	// reload a second time and restart every background task again for one edit
+	hr.cancelPendingReload()
+
+	hr.reloadConfig("stat-based polling")
+}
+
+func (hr *HotReloader) reloadConfig(reason string) {
+	hr.ctlr.Log.Info().Str("config", hr.configPath).Str("reason", reason).
+		Msg("config file changed, trying to reload config")
+
+	// sample fingerprints before reading, so a replacement mid-read is re-detected
+	configInfo := statOrNil(hr.configPath)
+	ldapInfo := statOrNil(hr.ldapCredentialsPath)
+
+	newConfig := config.New()
+
+	err := LoadConfiguration(newConfig, hr.configPath)
+	if err != nil {
+		hr.ctlr.Log.Error().Err(err).Str("config", hr.configPath).
+			Msg("failed to reload config, retry writing it.")
+
+		// a load that failed on its credentials file decoded where that file
+		// should be, so fingerprint it: its arrival then retries the config,
+		// which baselining alone would never notice
+		hr.pendingLdapPath = ldapCredentialsPath(newConfig)
+		hr.pendingLdapInfo = statOrNil(hr.pendingLdapPath)
+
+		// baseline the bad file so the poll does not retry every tick; the
+		// next actual change retries
+		hr.configInfo = configInfo
+		hr.ldapInfo = ldapInfo
+
+		return
+	}
+
+	ldapInfo = hr.followLdapCredentials(ldapCredentialsPath(newConfig), ldapInfo)
+
+	// stop background tasks gracefully
+	hr.ctlr.StopBackgroundTasks()
+
+	// load new config
+	hr.ctlr.LoadNewConfig(newConfig)
+
+	// start background tasks based on new loaded config
+	hr.ctlr.StartBackgroundTasks()
+
+	hr.warnNonReloadableChanges(newConfig)
+
+	hr.configInfo = configInfo
+	hr.ldapInfo = ldapInfo
+	hr.pendingLdapPath = ""
+	hr.pendingLdapInfo = nil
+}
+
+// ldapCredentialsPath returns the credentials file a config refers to, which is
+// decoded even by a load that then failed to read it.
+func ldapCredentialsPath(conf *config.Config) string {
+	if conf.HTTP.Auth == nil || conf.HTTP.Auth.LDAP == nil {
+		return ""
+	}
+
+	return conf.HTTP.Auth.LDAP.CredentialsFile
+}
+
+// followLdapCredentials moves the watch and the fingerprint onto newPath when
+// the config points somewhere else: moved, newly added, or removed with LDAP.
+func (hr *HotReloader) followLdapCredentials(newPath string, ldapInfo os.FileInfo) os.FileInfo {
+	oldPath := hr.ldapCredentialsPath
+	if newPath == oldPath {
+		return ldapInfo
+	}
+
+	if oldPath != "" && hr.watcher != nil {
+		if err := hr.watcher.Remove(oldPath); err != nil && !errors.Is(err, fsnotify.ErrNonExistentWatch) {
+			hr.ctlr.Log.Error().Err(err).Msg("failed to remove old watch for the credentials file")
+		}
+	}
+
+	hr.ldapCredentialsPath = newPath
+
+	if newPath != "" && hr.watcher != nil {
+		if err := hr.watcher.Add(newPath); err != nil {
+			hr.ctlr.Log.Error().Err(err).Str("ldap-credentials-file", newPath).
+				Msg("failed to watch ldap credentials file, relying on stat-based polling")
+		}
+	}
+
+	return statOrNil(newPath)
+}
+
+// warnNonReloadableChanges logs config fields that still differ between the
+// file and the effective configuration after a reload: they need a restart.
+func (hr *HotReloader) warnNonReloadableChanges(newConfig *config.Config) {
+	// compared unmasked: sanitizing both sides turns a rotated secret into the
+	// same mask on each and hides a change that needs a restart. Only the field
+	// paths are logged, never the values.
+	effectiveJSON, err := hr.ctlr.Config.SnapshotJSON()
+	if err != nil {
+		return
+	}
+
+	desiredJSON, err := json.Marshal(newConfig)
+	if err != nil {
+		return
+	}
+
+	effective, err := jsonAsMap(effectiveJSON)
+	if err != nil {
+		return
+	}
+
+	desired, err := jsonAsMap(desiredJSON)
+	if err != nil {
+		return
+	}
+
+	fields := diffConfigPaths("", effective, desired)
+	if len(fields) > 0 {
+		hr.ctlr.Log.Warn().Strs("fields", fields).
+			Msg("config changes are outside the reloadable set and need a restart to take effect")
+	}
+}
+
+func jsonAsMap(blob []byte) (map[string]any, error) {
+	var out map[string]any
+	if err := json.Unmarshal(blob, &out); err != nil {
+		return nil, err
+	}
+
+	return out, nil
+}
+
+// diffConfigPaths returns the dotted paths whose values differ between two
+// JSON object trees; nested objects recurse, anything else compares wholesale.
+func diffConfigPaths(prefix string, effective, desired map[string]any) []string {
+	keys := make(map[string]struct{})
+	for key := range effective {
+		keys[key] = struct{}{}
+	}
+
+	for key := range desired {
+		keys[key] = struct{}{}
+	}
+
+	paths := []string{}
+
+	for _, key := range slices.Sorted(maps.Keys(keys)) {
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+
+		effectiveVal, desiredVal := effective[key], desired[key]
+
+		effectiveMap, effectiveIsMap := effectiveVal.(map[string]any)
+
+		desiredMap, desiredIsMap := desiredVal.(map[string]any)
+		if effectiveIsMap && desiredIsMap {
+			paths = append(paths, diffConfigPaths(path, effectiveMap, desiredMap)...)
+
+			continue
+		}
+
+		if !reflect.DeepEqual(effectiveVal, desiredVal) {
+			paths = append(paths, path)
+		}
+	}
+
+	return paths
+}
+
+// checkFilesChanged reports whether the config or LDAP credentials file differs
+// from the baseline fingerprint recorded at the last successful reload.
+// Identity (os.SameFile) catches atomic-rename replacements even when the new
+// file preserves the old timestamp; size catches same-inode rewrites within one
+// coarse-timestamp granule; mtime catches plain in-place edits.
+func (hr *HotReloader) checkFilesChanged() bool {
+	return fileChanged(hr.configPath, hr.configInfo) ||
+		fileChanged(hr.ldapCredentialsPath, hr.ldapInfo) ||
+		fileChanged(hr.pendingLdapPath, hr.pendingLdapInfo)
+}
+
+func fileChanged(path string, prev os.FileInfo) bool {
+	if path == "" {
+		return false
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		// Transient during atomic replacements; the next tick sees the new file.
+		return false
+	}
+
+	if prev == nil {
+		return true
+	}
+
+	return !os.SameFile(prev, info) || prev.Size() != info.Size() || !prev.ModTime().Equal(info.ModTime())
+}
+
+func (hr *HotReloader) getDebounceChannel() <-chan time.Time {
+	if hr.debounceTimer == nil {
+		return nil
+	}
+
+	return hr.debounceTimer.C
+}
+
+// cancelPendingReload disarms a debounce that is already scheduled, so a reload
+// happening now is not repeated by one queued a moment earlier.
+func (hr *HotReloader) cancelPendingReload() {
+	if hr.debounceTimer == nil {
+		return
+	}
+
+	// since go1.23 a timer channel is unbuffered and Stop guarantees no value
+	// prepared before it can still arrive, so dropping the timer is enough
+	hr.debounceTimer.Stop()
+	hr.debounceTimer = nil
+}
+
+func (hr *HotReloader) scheduleReload() {
+	if hr.debounceTimer != nil {
+		// Reset carries the same guarantee: the pending tick, if any, is dropped
+		hr.debounceTimer.Reset(configEventDebounceInterval)
+
+		return
+	}
+
+	hr.debounceTimer = time.NewTimer(configEventDebounceInterval)
+}
+
+func (hr *HotReloader) readdWatches() {
+	if hr.watcher == nil {
+		return
+	}
+
+	if err := hr.watcher.Add(hr.configPath); err != nil {
+		hr.ctlr.Log.Debug().Err(err).Str("config", hr.configPath).
+			Msg("failed to re-add config watch, relying on stat-based polling")
+	}
+
+	ldapPath := hr.ldapCredentialsPath
+
+	if ldapPath != "" {
+		if err := hr.watcher.Add(ldapPath); err != nil {
+			hr.ctlr.Log.Debug().Err(err).Str("ldap-credentials", ldapPath).
+				Msg("failed to re-add ldap-credentials watch, relying on stat-based polling")
+		}
+	}
+}
+
+// samePath reports whether a fsnotify event name refers to the watched file.
+func samePath(eventName, filePath string) bool {
+	if eventName == "" || filePath == "" {
+		return false
+	}
+
+	return filepath.Clean(eventName) == filepath.Clean(filePath)
+}
+
+func statOrNil(path string) os.FileInfo {
+	if path == "" {
+		return nil
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil
+	}
+
+	return info
 }

--- a/pkg/cli/server/config_reloader_internal_test.go
+++ b/pkg/cli/server/config_reloader_internal_test.go
@@ -1,6 +1,8 @@
 package server //nolint:testpackage // white-box tests for unexported signalHandler and watcher close
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -88,8 +90,7 @@ func newTestHotReloader(t *testing.T) *HotReloader {
 	err := os.WriteFile(configPath, []byte(`{}`), 0o600)
 	So(err, ShouldBeNil)
 
-	reloader, err := NewHotReloader(api.NewController(testServerConfig(t)), configPath, "")
-	So(err, ShouldBeNil)
+	reloader := NewHotReloader(api.NewController(testServerConfig(t)), configPath, "")
 
 	return reloader
 }
@@ -120,6 +121,343 @@ func waitForWatch(reloader *HotReloader, timeout time.Duration) bool {
 	}
 
 	return false
+}
+
+// TestCancelPendingReload covers the case where a poll tick lands inside the
+// debounce window opened by a write: the poll reloads immediately, and the
+// timer left armed would reload the same change a second time, restarting
+// every background task again.
+func TestCancelPendingReload(t *testing.T) {
+	Convey("cancelling drops a debounce that has not fired", t, func() {
+		reloader := &HotReloader{}
+
+		reloader.scheduleReload()
+		So(reloader.getDebounceChannel(), ShouldNotBeNil)
+
+		reloader.cancelPendingReload()
+		So(reloader.getDebounceChannel(), ShouldBeNil)
+	})
+
+	Convey("cancelling a debounce that already fired still retires it", t, func() {
+		reloader := &HotReloader{}
+
+		reloader.scheduleReload()
+
+		// let it fire, so a tick is already prepared
+		time.Sleep(configEventDebounceInterval * 2)
+
+		reloader.cancelPendingReload()
+
+		// the loop must not be able to select that tick afterwards
+		So(reloader.getDebounceChannel(), ShouldBeNil)
+	})
+
+	Convey("scheduling again while armed extends the same timer", t, func() {
+		reloader := &HotReloader{}
+
+		reloader.scheduleReload()
+		first := reloader.getDebounceChannel()
+		So(first, ShouldNotBeNil)
+
+		reloader.scheduleReload()
+
+		// a burst of writes coalesces into one reload rather than one each
+		So(reloader.getDebounceChannel(), ShouldEqual, first)
+	})
+
+	Convey("cancelling with nothing scheduled is a no-op", t, func() {
+		reloader := &HotReloader{}
+
+		So(func() { reloader.cancelPendingReload() }, ShouldNotPanic)
+		So(reloader.getDebounceChannel(), ShouldBeNil)
+	})
+
+	Convey("a poll-driven reload drops the debounce armed for the same change", t, func() {
+		reloader := newTestHotReloader(t)
+		t.Cleanup(reloader.Stop)
+
+		// baseline as Start does, so only a later change reads as one
+		reloader.configInfo = statOrNil(reloader.configPath)
+
+		// a write arrived and armed the debounce
+		reloader.scheduleReload()
+		So(reloader.getDebounceChannel(), ShouldNotBeNil)
+
+		// the poll then sees that same change first. What it reloads does not
+		// matter here: cancelling happens before the reload is attempted, and a
+		// config that fails to load keeps this off the controller's background
+		// tasks, which this controller never started.
+		So(os.WriteFile(reloader.configPath, []byte("not json"), 0o600), ShouldBeNil)
+
+		reloader.pollForChanges()
+
+		// left armed it fires straight after, reloading the same edit twice
+		So(reloader.getDebounceChannel(), ShouldBeNil)
+	})
+}
+
+func TestFileChanged(t *testing.T) {
+	Convey("an unset path never counts as changed", t, func() {
+		So(fileChanged("", nil), ShouldBeFalse)
+	})
+
+	Convey("a path that cannot be stat'd is left for the next tick", t, func() {
+		// transient while a replacement is in flight, so not a change yet
+		So(fileChanged(filepath.Join(t.TempDir(), "absent.json"), nil), ShouldBeFalse)
+	})
+
+	Convey("a file with no baseline counts as changed", t, func() {
+		path := filepath.Join(t.TempDir(), "zot.json")
+		So(os.WriteFile(path, []byte(`{}`), 0o600), ShouldBeNil)
+
+		So(fileChanged(path, nil), ShouldBeTrue)
+	})
+
+	Convey("a rewrite of the same file counts as changed", t, func() {
+		path := filepath.Join(t.TempDir(), "zot.json")
+		So(os.WriteFile(path, []byte(`{}`), 0o600), ShouldBeNil)
+
+		before := statOrNil(path)
+		So(before, ShouldNotBeNil)
+		So(fileChanged(path, before), ShouldBeFalse)
+
+		// a different size is enough, even inside one timestamp granule
+		So(os.WriteFile(path, []byte(`{"a":1}`), 0o600), ShouldBeNil)
+		So(fileChanged(path, before), ShouldBeTrue)
+	})
+
+	Convey("a replacement by rename counts as changed", t, func() {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "zot.json")
+		So(os.WriteFile(path, []byte(`{}`), 0o600), ShouldBeNil)
+
+		before := statOrNil(path)
+		So(before, ShouldNotBeNil)
+
+		// same content and size, different inode: only identity catches this
+		replacement := filepath.Join(dir, "zot.json.new")
+		So(os.WriteFile(replacement, []byte(`{}`), 0o600), ShouldBeNil)
+		So(os.Rename(replacement, path), ShouldBeNil)
+
+		So(fileChanged(path, before), ShouldBeTrue)
+	})
+}
+
+func TestStatOrNil(t *testing.T) {
+	Convey("an unset path has no fingerprint", t, func() {
+		So(statOrNil(""), ShouldBeNil)
+	})
+
+	Convey("a missing file has no fingerprint", t, func() {
+		So(statOrNil(filepath.Join(t.TempDir(), "absent.json")), ShouldBeNil)
+	})
+}
+
+func TestSamePath(t *testing.T) {
+	Convey("an empty name or target never matches", t, func() {
+		So(samePath("", "/etc/zot/config.json"), ShouldBeFalse)
+		So(samePath("/etc/zot/config.json", ""), ShouldBeFalse)
+	})
+
+	Convey("paths match after cleaning", t, func() {
+		So(samePath("/etc/zot/../zot/config.json", "/etc/zot/config.json"), ShouldBeTrue)
+		So(samePath("/etc/zot/other.json", "/etc/zot/config.json"), ShouldBeFalse)
+	})
+}
+
+// TestWatchFailuresFallBackToPolling covers the paths taken when inotify cannot
+// be established or is lost: none of them may stop the reloader, because the
+// stat poll still carries reloads on its own.
+func TestWatchFailuresFallBackToPolling(t *testing.T) {
+	Convey("files that are not there yet still start the reloader", t, func() {
+		dir := t.TempDir()
+
+		reloader := NewHotReloader(api.NewController(testServerConfig(t)),
+			filepath.Join(dir, "absent.json"), filepath.Join(dir, "absent-creds.json"))
+		t.Cleanup(reloader.Stop)
+
+		// both watcher.Add calls fail, and Start has to carry on regardless
+		So(func() { reloader.Start() }, ShouldNotPanic)
+	})
+
+	Convey("re-adding watches for files that are gone is tolerated", t, func() {
+		reloader := newTestHotReloader(t)
+		t.Cleanup(reloader.Stop)
+
+		reloader.ldapCredentialsPath = filepath.Join(t.TempDir(), "absent-creds.json")
+		So(os.Remove(reloader.configPath), ShouldBeNil)
+
+		So(func() { reloader.readdWatches() }, ShouldNotPanic)
+	})
+
+	Convey("a watcher error is logged without stopping the loop", t, func() {
+		reloader := newTestHotReloader(t)
+
+		watcherErrors := make(chan error, 1)
+		reloader.watcher.Errors = watcherErrors
+		// block the Events case so the select has to take the error
+		reloader.watcher.Events = nil
+
+		reloader.Start()
+
+		watcherErrors <- errors.New("inotify queue overflow")
+
+		// dropped events are the poll's problem, so the loop keeps running
+		time.Sleep(200 * time.Millisecond)
+		So(isClosed(reloader.done), ShouldBeFalse)
+
+		reloader.Stop()
+		So(isClosed(reloader.done), ShouldBeTrue)
+	})
+}
+
+// TestPollingOnlyMode covers the reloader running with no fsnotify watcher at
+// all, which is what a host out of inotify instances looks like: reloads must
+// still happen, just at poll latency.
+func TestPollingOnlyMode(t *testing.T) {
+	Convey("a reloader with no watcher still starts and stops", t, func() {
+		reloader := newTestHotReloader(t)
+
+		// stand in for fsnotify.NewWatcher having failed
+		So(reloader.watcher.Close(), ShouldBeNil)
+		reloader.watcher = nil
+
+		So(func() { reloader.Start() }, ShouldNotPanic)
+		So(func() { reloader.readdWatches() }, ShouldNotPanic)
+		So(func() { reloader.Stop() }, ShouldNotPanic)
+	})
+
+	Convey("a poll still reloads with no watcher present", t, func() {
+		reloader := newTestHotReloader(t)
+		t.Cleanup(reloader.Stop)
+
+		So(reloader.watcher.Close(), ShouldBeNil)
+		reloader.watcher = nil
+
+		// a change the watch could never have reported
+		So(os.WriteFile(reloader.configPath, []byte("not json"), 0o600), ShouldBeNil)
+		So(reloader.checkFilesChanged(), ShouldBeTrue)
+
+		So(func() { reloader.pollForChanges() }, ShouldNotPanic)
+
+		// the poll consumed the change, so it is not seen twice
+		So(reloader.checkFilesChanged(), ShouldBeFalse)
+	})
+}
+
+// TestBaselineTakenAtConstruction covers a config replaced while the controller
+// was still initialising: the fingerprint has to describe what was loaded, not
+// what happens to be on disk once Start finally runs.
+func TestBaselineTakenAtConstruction(t *testing.T) {
+	Convey("a change landing before Start is still seen as a change", t, func() {
+		reloader := newTestHotReloader(t)
+		t.Cleanup(reloader.Stop)
+
+		// the file moves on while Controller.Init is still running
+		So(os.WriteFile(reloader.configPath, []byte(`{"a":1}`), 0o600), ShouldBeNil)
+
+		reloader.Start()
+
+		// Start must not adopt the new file as the baseline: the running config
+		// was built from the old one and still needs reloading
+		So(reloader.checkFilesChanged(), ShouldBeTrue)
+	})
+}
+
+func TestFailedLoadKeepsWatchingLiveCredentials(t *testing.T) {
+	Convey("a load that failed for an unrelated reason keeps the live credentials file", t, func() {
+		dir := t.TempDir()
+		credsPath := filepath.Join(dir, "ldap-creds.json")
+		So(os.WriteFile(credsPath, []byte(`{"bindDN":"cn=ro","bindPassword":"pass"}`), 0o600), ShouldBeNil)
+
+		configPath := filepath.Join(dir, "zot.json")
+		So(os.WriteFile(configPath, []byte(`{}`), 0o600), ShouldBeNil)
+
+		reloader := NewHotReloader(api.NewController(testServerConfig(t)), configPath, credsPath)
+		t.Cleanup(reloader.Stop)
+
+		// a syntax error that has nothing to do with ldap
+		So(os.WriteFile(configPath, []byte("{ this is not json"), 0o600), ShouldBeNil)
+
+		reloader.reloadConfig("test")
+
+		// the running config still authenticates against this file, so dropping
+		// it would stop noticing rotations there
+		So(reloader.ldapCredentialsPath, ShouldEqual, credsPath)
+
+		So(os.WriteFile(credsPath, []byte(`{"bindDN":"cn=rw","bindPassword":"new"}`), 0o600), ShouldBeNil)
+		So(reloader.checkFilesChanged(), ShouldBeTrue)
+	})
+}
+
+func TestFailedLoadFollowsPendingCredentials(t *testing.T) {
+	Convey("a load that failed on its credentials file follows that file", t, func() {
+		reloader := newTestHotReloader(t)
+		t.Cleanup(reloader.Stop)
+
+		credsPath := filepath.Join(t.TempDir(), "ldap-creds.json")
+
+		conf := fmt.Sprintf(`{
+			"distSpecVersion": "1.1.1",
+			"storage": {"rootDirectory": %q},
+			"http": {
+				"address": "127.0.0.1", "port": "0",
+				"auth": {"ldap": {
+					"credentialsFile": %q,
+					"address": "127.0.0.1", "port": 389,
+					"baseDN": "ou=users,dc=example,dc=org", "userAttribute": "uid"
+				}}
+			}
+		}`, t.TempDir(), credsPath)
+
+		So(os.WriteFile(reloader.configPath, []byte(conf), 0o600), ShouldBeNil)
+
+		// the credentials file is not there yet, so the load fails after having
+		// decoded where it should be
+		reloader.reloadConfig("test")
+
+		So(reloader.pendingLdapPath, ShouldEqual, credsPath)
+		So(reloader.checkFilesChanged(), ShouldBeFalse)
+
+		// creating it has to read as a change, or the config is never retried
+		So(os.WriteFile(credsPath, []byte(`{"bindDN":"cn=ro","bindPassword":"pass"}`), 0o600), ShouldBeNil)
+		So(reloader.checkFilesChanged(), ShouldBeTrue)
+	})
+}
+
+func TestWarnsOnRotatedNonReloadableSecret(t *testing.T) {
+	Convey("a rotated storage secret is reported without being logged", t, func() {
+		dir := t.TempDir()
+		logPath := filepath.Join(dir, "zot.log")
+
+		conf := testServerConfig(t)
+		conf.Log = &config.LogConfig{Level: "debug", Output: logPath}
+		conf.Storage.StorageDriver = map[string]any{"name": "s3", "secretkey": "old-secret-value"}
+
+		configPath := filepath.Join(dir, "zot.json")
+		So(os.WriteFile(configPath, []byte(`{}`), 0o600), ShouldBeNil)
+
+		reloader := NewHotReloader(api.NewController(conf), configPath, "")
+		t.Cleanup(reloader.Stop)
+
+		// the storage driver is outside the reloadable set, so rotating its
+		// secret needs a restart
+		newConfig := config.New()
+		newConfig.Storage.RootDirectory = conf.Storage.RootDirectory
+		newConfig.Storage.StorageDriver = map[string]any{"name": "s3", "secretkey": "new-secret-value"}
+
+		reloader.warnNonReloadableChanges(newConfig)
+
+		logs, err := os.ReadFile(logPath)
+		So(err, ShouldBeNil)
+
+		So(string(logs), ShouldContainSubstring, "need a restart")
+		So(string(logs), ShouldContainSubstring, "secretkey")
+
+		// the path is enough: the value itself must never reach the log
+		So(string(logs), ShouldNotContainSubstring, "new-secret-value")
+		So(string(logs), ShouldNotContainSubstring, "old-secret-value")
+	})
 }
 
 func waitChan(done <-chan struct{}, timeout time.Duration) bool {

--- a/pkg/cli/server/config_reloader_test.go
+++ b/pkg/cli/server/config_reloader_test.go
@@ -3,9 +3,14 @@
 package server_test
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -624,5 +629,335 @@ func TestConfigReloader(t *testing.T) {
 		So(string(data), ShouldContainSubstring, "\"Prefix\":\"zot-test\"")
 		So(string(data), ShouldContainSubstring, "\"Regex\":\".*\"")
 		So(string(data), ShouldContainSubstring, "\"Semver\":true")
+	})
+}
+
+func TestConfigReloaderKubernetesConfigMapUpdate(t *testing.T) {
+	Convey("reload config on a Kubernetes-style atomic symlink swap", t, func() {
+		logPath := test.MakeTempFilePath(t, "zot-log.txt")
+
+		username := "alice"
+		password := "alice"
+
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString(username, password))
+		rootDir := t.TempDir()
+
+		mkConfig := func(user string) string {
+			return fmt.Sprintf(`{
+				"distSpecVersion": "1.1.1",
+				"storage": {
+				  "rootDirectory": "%s"
+				},
+				"http": {
+				  "address": "127.0.0.1",
+				  "port": "0",
+				  "realm": "zot",
+				  "auth": {
+					"htpasswd": {
+					  "path": "%s"
+					},
+					"failDelay": 1
+				  },
+				  "accessControl": {
+					"repositories": {
+						"**": {
+					  	"policies": [
+							{
+						  	"users": ["%s"],
+						  	"actions": ["read"]
+							}
+					  	],
+					  	"defaultPolicy": ["read"]
+						}
+					}
+				  }
+				},
+				"log": {
+				  "level": "debug",
+				  "output": "%s"
+				}
+			  }`, rootDir, htpasswdPath, user, logPath)
+		}
+
+		// Lay the config out the way kubelet's AtomicWriter mounts a ConfigMap:
+		// config.json -> ..data/config.json -> ..<timestamped dir>/config.json
+		mountDir := t.TempDir()
+		payloadV1 := filepath.Join(mountDir, "..2024_01_01")
+		So(os.MkdirAll(payloadV1, 0o755), ShouldBeNil)
+		So(os.WriteFile(filepath.Join(payloadV1, "config.json"), []byte(mkConfig("charlie")), 0o600), ShouldBeNil)
+		So(os.Symlink("..2024_01_01", filepath.Join(mountDir, "..data")), ShouldBeNil)
+		So(os.Symlink(filepath.Join("..data", "config.json"), filepath.Join(mountDir, "config.json")), ShouldBeNil)
+
+		So(startServerFromConfigFile(t, filepath.Join(mountDir, "config.json")), ShouldBeNil)
+
+		// Update the way kubelet does: write the new payload dir, atomically
+		// retarget the ..data symlink via rename(2), remove the old payload.
+		// No Write event is ever emitted for config.json itself.
+		payloadV2 := filepath.Join(mountDir, "..2024_01_02")
+		So(os.MkdirAll(payloadV2, 0o755), ShouldBeNil)
+		So(os.WriteFile(filepath.Join(payloadV2, "config.json"), []byte(mkConfig("alice")), 0o600), ShouldBeNil)
+		So(os.Symlink("..2024_01_02", filepath.Join(mountDir, "..data_tmp")), ShouldBeNil)
+		So(os.Rename(filepath.Join(mountDir, "..data_tmp"), filepath.Join(mountDir, "..data")), ShouldBeNil)
+		So(os.RemoveAll(payloadV1), ShouldBeNil)
+
+		// wait for the reload: debounced event or, at the latest, a poll tick
+		reloaded := false
+
+		for range 100 {
+			time.Sleep(100 * time.Millisecond)
+
+			data, err := os.ReadFile(logPath)
+			So(err, ShouldBeNil)
+
+			if strings.Contains(string(data), "\"Users\":[\"alice\"]") {
+				reloaded = true
+
+				break
+			}
+		}
+
+		data, err := os.ReadFile(logPath)
+		So(err, ShouldBeNil)
+
+		t.Logf("log file: %s", data)
+		So(reloaded, ShouldBeTrue)
+		So(string(data), ShouldContainSubstring, "reloaded params")
+		So(string(data), ShouldContainSubstring, "loaded new configuration settings")
+	})
+}
+
+func TestConfigReloaderNonReloadableWarn(t *testing.T) {
+	Convey("warn when a changed config field is outside the reloadable set", t, func() {
+		logPath := test.MakeTempFilePath(t, "zot-log.txt")
+
+		mkContent := func(rootDir string, gc bool) string {
+			return fmt.Sprintf(`{
+				"distSpecVersion": "1.1.1",
+				"storage": {"rootDirectory": "%s", "gc": %t},
+				"http": {"address": "127.0.0.1", "port": "0"},
+				"log": {"level": "debug", "output": "%s"}
+			}`, rootDir, gc, logPath)
+		}
+
+		rootDirA := t.TempDir()
+		rootDirB := t.TempDir()
+
+		cfgfile := test.MakeTempFile(t, "zot-test.json")
+		defer cfgfile.Close()
+		_, err := cfgfile.WriteString(mkContent(rootDirA, false))
+		So(err, ShouldBeNil)
+
+		So(startServerFromConfigFile(t, cfgfile.Name()), ShouldBeNil)
+
+		// change one reloadable field (gc) and one non-reloadable field (rootDirectory)
+		err = cfgfile.Truncate(0)
+		So(err, ShouldBeNil)
+		_, err = cfgfile.Seek(0, io.SeekStart)
+		So(err, ShouldBeNil)
+		_, err = cfgfile.WriteString(mkContent(rootDirB, true))
+		So(err, ShouldBeNil)
+		So(cfgfile.Close(), ShouldBeNil)
+
+		found := false
+
+		for range 100 {
+			time.Sleep(100 * time.Millisecond)
+
+			data, err := os.ReadFile(logPath)
+			So(err, ShouldBeNil)
+
+			if strings.Contains(string(data), "outside the reloadable set") {
+				found = true
+
+				break
+			}
+		}
+
+		data, err := os.ReadFile(logPath)
+		So(err, ShouldBeNil)
+
+		t.Logf("log file: %s", data)
+		So(found, ShouldBeTrue)
+		So(string(data), ShouldContainSubstring, "Storage.RootDirectory")
+		// the reloadable field was applied, so it is not in the warning
+		So(string(data), ShouldContainSubstring, "reloaded params")
+	})
+}
+
+func TestConfigReloaderLdapTransitions(t *testing.T) {
+	Convey("adding and removing ldap auth on reload", t, func() {
+		logPath := test.MakeTempFilePath(t, "zot-log.txt")
+
+		htpasswdPath := test.MakeHtpasswdFileFromString(t, test.GetBcryptCredString("alice", "alice"))
+		rootDir := t.TempDir()
+
+		credsFile := test.MakeTempFile(t, "ldap-creds.json")
+		_, err := credsFile.WriteString(`{"bindDN":"cn=ro,dc=example,dc=org","bindPassword":"ro-pass"}`)
+		So(err, ShouldBeNil)
+		So(credsFile.Close(), ShouldBeNil)
+
+		mkConfig := func(withLdap bool) string {
+			ldap := ""
+			if withLdap {
+				ldap = fmt.Sprintf(`"ldap": {
+					"credentialsFile": "%s",
+					"address": "127.0.0.1",
+					"port": 10389,
+					"baseDN": "ou=users,dc=example,dc=org",
+					"userAttribute": "uid"
+				},`, credsFile.Name())
+			}
+
+			return fmt.Sprintf(`{
+				"distSpecVersion": "1.1.1",
+				"storage": {"rootDirectory": "%s"},
+				"http": {
+					"address": "127.0.0.1", "port": "0", "realm": "zot",
+					"auth": {%s "htpasswd": {"path": "%s"}, "failDelay": 1}
+				},
+				"log": {"level": "debug", "output": "%s"}
+			}`, rootDir, ldap, htpasswdPath, logPath)
+		}
+
+		cfgfile := test.MakeTempFile(t, "zot-test.json")
+		defer cfgfile.Close()
+		_, err = cfgfile.WriteString(mkConfig(false))
+		So(err, ShouldBeNil)
+
+		baseURL, err := startServerFromConfigFileURL(t, cfgfile.Name())
+		So(err, ShouldBeNil)
+
+		rewrite := func(content string) {
+			So(cfgfile.Truncate(0), ShouldBeNil)
+			_, err := cfgfile.Seek(0, io.SeekStart)
+			So(err, ShouldBeNil)
+			_, err = cfgfile.WriteString(content)
+			So(err, ShouldBeNil)
+			So(cfgfile.Sync(), ShouldBeNil)
+		}
+
+		// latest "basic authentication (LDAP)" log entry wins: startup and every
+		// reload emit one
+		waitForLdap := func(want bool) bool {
+			for range 100 {
+				time.Sleep(100 * time.Millisecond)
+
+				data, err := os.ReadFile(logPath)
+				So(err, ShouldBeNil)
+
+				val, found := false, false
+
+				for line := range strings.SplitSeq(string(data), "\n") {
+					var entry map[string]any
+					if json.Unmarshal([]byte(line), &entry) != nil {
+						continue
+					}
+
+					if entry["message"] == "basic authentication (LDAP)" {
+						if enabled, ok := entry["enabled"].(bool); ok {
+							val, found = enabled, true
+						}
+					}
+				}
+
+				if found && val == want {
+					return true
+				}
+			}
+
+			return false
+		}
+
+		// enable ldap on reload: previously the credentials file was never
+		// picked up for watching on this transition
+		rewrite(mkConfig(true))
+		So(waitForLdap(true), ShouldBeTrue)
+
+		// a failed htpasswd login now falls through to the ldap path, which has
+		// no client when ldap was enabled by reload: must 401, not panic
+		request, err := http.NewRequestWithContext(context.Background(), http.MethodGet,
+			baseURL+"/v2/", nil)
+		So(err, ShouldBeNil)
+		request.SetBasicAuth("alice", "wrong-password")
+
+		resp, err := http.DefaultClient.Do(request)
+		So(err, ShouldBeNil)
+		So(resp.StatusCode, ShouldEqual, http.StatusUnauthorized)
+		So(resp.Body.Close(), ShouldBeNil)
+
+		// disable ldap on reload: previously a nil dereference in the reloader
+		rewrite(mkConfig(false))
+		So(waitForLdap(false), ShouldBeTrue)
+
+		// the reloader survived both transitions: one more reload still lands
+		rewrite(mkConfig(true))
+		So(waitForLdap(true), ShouldBeTrue)
+	})
+}
+
+func TestConfigReloaderInvalidConfig(t *testing.T) {
+	Convey("an invalid rewrite is retried on the next change, not every poll tick", t, func() {
+		logPath := test.MakeTempFilePath(t, "zot-log.txt")
+		rootDir := t.TempDir()
+
+		mkConfig := func(level string) string {
+			return fmt.Sprintf(`{
+				"distSpecVersion": "1.1.1",
+				"storage": {"rootDirectory": "%s"},
+				"http": {"address": "127.0.0.1", "port": "0"},
+				"log": {"level": "%s", "output": "%s"}
+			}`, rootDir, level, logPath)
+		}
+
+		cfgfile := test.MakeTempFile(t, "zot-test.json")
+		defer cfgfile.Close()
+		_, err := cfgfile.WriteString(mkConfig("debug"))
+		So(err, ShouldBeNil)
+
+		So(startServerFromConfigFile(t, cfgfile.Name()), ShouldBeNil)
+
+		rewrite := func(content string) {
+			So(cfgfile.Truncate(0), ShouldBeNil)
+			_, err := cfgfile.Seek(0, io.SeekStart)
+			So(err, ShouldBeNil)
+			_, err = cfgfile.WriteString(content)
+			So(err, ShouldBeNil)
+			So(cfgfile.Sync(), ShouldBeNil)
+		}
+
+		countFailures := func() int {
+			data, err := os.ReadFile(logPath)
+			So(err, ShouldBeNil)
+
+			return strings.Count(string(data), "failed to reload config")
+		}
+
+		rewrite(`{not json`)
+		time.Sleep(4 * time.Second)
+
+		failures := countFailures()
+		So(failures, ShouldBeGreaterThanOrEqualTo, 1)
+		// a 1s poll would have logged a failure per tick for 4s
+		So(failures, ShouldBeLessThanOrEqualTo, 2)
+
+		// a valid rewrite still lands
+		rewrite(mkConfig("info"))
+
+		reloaded := false
+
+		for range 100 {
+			time.Sleep(100 * time.Millisecond)
+
+			data, err := os.ReadFile(logPath)
+			So(err, ShouldBeNil)
+
+			if strings.Contains(string(data), "reloaded params") {
+				reloaded = true
+
+				break
+			}
+		}
+
+		So(reloaded, ShouldBeTrue)
 	})
 }

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -118,12 +118,7 @@ func InitController(conf *config.Config, configPath string) (*api.Controller, *H
 		ldapCredentials = conf.HTTP.Auth.LDAP.CredentialsFile
 	}
 
-	hotReloader, err := NewHotReloader(ctlr, configPath, ldapCredentials)
-	if err != nil {
-		ctlr.Log.Error().Err(err).Msg("failed to create a new hot reloader")
-
-		return nil, nil, err
-	}
+	hotReloader := NewHotReloader(ctlr, configPath, ldapCredentials)
 
 	if err := ctlr.Init(); err != nil {
 		hotReloader.Stop()

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -3616,18 +3616,30 @@ func tryInitControllerFromConfigFile(t *testing.T, cfgPath string) error {
 }
 
 // startServerFromConfigFile loads config, starts a hot-reloading controller, and
-// registers shutdown on both Convey Reset (per-case) and t.Cleanup (test end).
+// waits until it serves. It registers shutdown on both Convey Reset (per-case)
+// and t.Cleanup (test end).
 func startServerFromConfigFile(t *testing.T, cfgPath string) error {
+	t.Helper()
+
+	_, err := startServerFromConfigFileURL(t, cfgPath)
+
+	return err
+}
+
+// startServerFromConfigFileURL is startServerFromConfigFile returning the base
+// URL the server bound to, so a test that talks to it can leave the port as "0"
+// rather than reserving one before the bind.
+func startServerFromConfigFileURL(t *testing.T, cfgPath string) (string, error) {
 	t.Helper()
 
 	conf := config.New()
 	if err := cli.LoadConfiguration(conf, cfgPath); err != nil {
-		return err
+		return "", err
 	}
 
 	ctlr, hotReloader, err := cli.InitController(conf, cfgPath)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	ctrlManager := NewControllerManager(ctlr)
@@ -3642,7 +3654,7 @@ func startServerFromConfigFile(t *testing.T, cfgPath string) error {
 
 	ctrlManager.WaitServerReady()
 
-	return nil
+	return ctrlManager.BaseURL(), nil
 }
 
 func TestRetentionDelayDefaults(t *testing.T) {

--- a/pkg/extensions/sync/sync_test.go
+++ b/pkg/extensions/sync/sync_test.go
@@ -2227,8 +2227,7 @@ func TestConfigReloader(t *testing.T) {
 			_, err := cfgfile.WriteString(content)
 			So(err, ShouldBeNil)
 
-			hotReloader, err := cli.NewHotReloader(dctlr, cfgfile.Name(), "")
-			So(err, ShouldBeNil)
+			hotReloader := cli.NewHotReloader(dctlr, cfgfile.Name(), "")
 
 			hotReloader.Start()
 
@@ -2375,8 +2374,7 @@ func TestConfigReloader(t *testing.T) {
 			_, err := cfgfile.WriteString(content)
 			So(err, ShouldBeNil)
 
-			hotReloader, err := cli.NewHotReloader(dctlr, cfgfile.Name(), "")
-			So(err, ShouldBeNil)
+			hotReloader := cli.NewHotReloader(dctlr, cfgfile.Name(), "")
 
 			hotReloader.Start()
 


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

No existing issue covers it. It is the config-reloader counterpart of #4285, which fixed the same failure mode for the htpasswd watcher.

**What does this PR do / Why do we need it**:

The config hot reloader watches only the config file and reacts only to `Write` events. A Kubernetes ConfigMap or Secret mount never produces one: kubelet's AtomicWriter writes a new payload directory and atomically retargets the `..data` symlink, so the watched inode is deleted and the watch dies silently. On Kubernetes any config change, accessControl edits included, is never applied until the pod restarts. Reproduced by laying the config out as a ConfigMap mount and updating it the way kubelet does: an in-place write reloads fine, the atomic symlink retarget never triggers a reload.

The fix keeps the watch on the file itself, for the low-latency path when someone edits it in place, and adds a periodic stat fingerprint check (identity via `os.SameFile`, size, mtime) as the guarantee. The poll is what makes a ConfigMap update work: it detects the replacement, re-adds the watch to the inode that replaced the retired one, and reloads.

Because the poll carries reloads on its own, fsnotify is now optional rather than required. A watcher that cannot be created no longer fails startup: the reloader keeps a nil watcher and selects over nil channels, exactly as the htpasswd watcher does, so a host out of inotify instances gets reloads at poll latency instead of a server that refuses to boot. The fingerprint baseline is also taken when the reloader is constructed rather than when it starts, so a config replaced while `Controller.Init` is still running is still seen as a change instead of being adopted as the baseline and lost.

This is deliberately narrower than #4285. That change watches the parent directory and matches `..data` swaps, which ties the watcher to the kubelet mount layout; here the poll already answers the same question without the config reloader needing to know what a ConfigMap looks like, so the event side only handles `Write`.

After a reload, fields that still differ between the file and the effective configuration are logged at warn level: the reload applies only the reloadable subset, so anything left over needs a restart, and an operator editing a ConfigMap deserves to see that rather than assume the reload covered it.

Two adjacent fixes the tests turned up:

- The credentials file is followed nil-safely across every LDAP transition (moved, newly enabled, removed), where before removing the ldap section panicked the reloader and adding one left the file unwatched. An ldap section enabled by reload has no client built at startup, so the auth path guards against it and the reload, rather than every request reaching that guard, warns that a restart is needed. The same reload also names the ldap settings a restart is needed for: only the bind credentials reach the live client, so an address, port, baseDN or filter change is applied to the config while the client keeps serving with the old ones, which the generic field diff cannot see because both sides already agree.
- An invalid config no longer re-reads on every poll tick; the failed file is fingerprinted so the next real change retries, and the failure is logged through the controller's logger so it reaches the operator's configured output.

`Stop` also waits for the watcher loop, so an in-flight reload cannot overlap the controller shutdown that follows it.

**How to verify it**

Unit tests create the kubelet AtomicWriter layout (`config.json -> ..data/config.json -> ..<payload dir>`), start the server, update the config via a new payload directory plus an atomic `rename(2)` of the `..data` symlink, and assert the new accessControl is loaded. They fail on the previous implementation. Also covered: the restart-required warning, every LDAP transition including a request that must not panic, the ldap settings that need a restart, the invalid-config retry, that a poll-driven reload cancels a debounce armed for the same change so one edit cannot reload twice, that the reloader runs with no watcher at all, and that a change landing before `Start` is not adopted as the baseline.

`examples/kind/kind-config-reload.sh` runs the whole scenario on a kind cluster, replacing a ConfigMap to grant a second user access and asserting the change lands live with zero pod restarts. A nightly workflow job runs it.

**Checklist**

- [x] Local build and lint pass
- [x] Existing config reloader tests pass unchanged
