### PR TITLE
feat(events): configurable CloudEvents source and type namespace

### DIFF
--- a/examples/config-events.json
+++ b/examples/config-events.json
@@ -13,6 +13,8 @@
   "extensions": {
     "events": {
       "enable": true,
+      "source": "registry.example.com/tenant-a",
+      "typePrefix": "com.example.registry",
       "sinks": [{
           "type": "nats",
           "address": "nats://127.0.0.1:4222",

--- a/pkg/cli/server/root.go
+++ b/pkg/cli/server/root.go
@@ -592,6 +592,22 @@ func validateMetricsConfig(cfg *extconf.ExtensionConfig) error {
 	return nil
 }
 
+func validateEventsConfig(cfg *extconf.ExtensionConfig) error {
+	eventsCfg := cfg.GetEventsConfig()
+	if eventsCfg == nil {
+		return nil
+	}
+
+	// The prefix replaces the leading segment of dot-separated event types,
+	// so it must not create empty segments in the rendered type.
+	prefix := eventsCfg.TypePrefix
+	if strings.HasPrefix(prefix, ".") || strings.HasSuffix(prefix, ".") || strings.Contains(prefix, "..") {
+		return fmt.Errorf("%w: events typePrefix must not contain a leading, trailing or double dot", zerr.ErrBadConfig)
+	}
+
+	return nil
+}
+
 func validateExtensionsConfig(cfg *config.Config, logger zlog.Logger) error {
 	extensionsConfig := cfg.CopyExtensionsConfig()
 	if extensionsConfig != nil && extensionsConfig.Mgmt != nil {
@@ -609,6 +625,12 @@ func validateExtensionsConfig(cfg *config.Config, logger zlog.Logger) error {
 			logger.Error().Err(joinedErr).Msg("invalid metrics config")
 
 			return joinedErr
+		}
+
+		if eventsValErr := validateEventsConfig(extensionsConfig); eventsValErr != nil {
+			logger.Error().Err(eventsValErr).Msg("invalid events config")
+
+			return eventsValErr
 		}
 
 		if extensionsConfig.Search != nil && extensionsConfig.Search.CVE != nil &&

--- a/pkg/cli/server/root_test.go
+++ b/pkg/cli/server/root_test.go
@@ -4269,6 +4269,47 @@ func TestMetricsConfigurationValidation(t *testing.T) {
 	})
 }
 
+func TestVerifyEventsConfig(t *testing.T) {
+	Convey("events typePrefix validation", t, func() {
+		makeContent := func(typePrefix string) string {
+			return `{
+				"storage": {"rootDirectory": "/tmp/zot"},
+				"http": {
+					"address": "127.0.0.1", "port": "8080"
+				},
+				"extensions": {
+					"events": {
+						"enable": true,
+						"typePrefix": "` + typePrefix + `",
+						"sinks": [{
+							"type": "http",
+							"address": "http://127.0.0.1:8000",
+							"timeout": "10s"
+						}]
+					}
+				}
+			}`
+		}
+
+		for _, typePrefix := range []string{".example", "example.", "com..example"} {
+			Convey("Reject typePrefix "+typePrefix, func() {
+				cfg := config.New()
+				tmpfile := MakeTempFileWithContent(t, "zot-test.json", makeContent(typePrefix))
+				err := cli.LoadConfiguration(cfg, tmpfile)
+				So(err, ShouldNotBeNil)
+				So(err, ShouldWrap, zerr.ErrBadConfig)
+			})
+		}
+
+		Convey("Allow a valid typePrefix", func() {
+			cfg := config.New()
+			tmpfile := MakeTempFileWithContent(t, "zot-test.json", makeContent("com.example.registry"))
+			err := cli.LoadConfiguration(cfg, tmpfile)
+			So(err, ShouldBeNil)
+		})
+	})
+}
+
 func TestManifestCheckIntervalConfig(t *testing.T) {
 	Convey("manifestCheckInterval validation", t, func() {
 		Convey("Parse a valid manifestCheckInterval", func() {

--- a/pkg/extensions/config/events/config.go
+++ b/pkg/extensions/config/events/config.go
@@ -30,6 +30,17 @@ func IsSupportedSink(sinkType SinkType) bool {
 type Config struct {
 	Enable *bool
 	Sinks  []SinkConfig
+
+	// Source overrides the CloudEvents source attribute on every event this
+	// instance publishes. Empty keeps the built-in value. Set it when a
+	// receiver has to tell one deployment, or one tenant, from another: the
+	// built-in value is the same for every zot in existence.
+	Source string
+
+	// TypePrefix overrides the namespace event types are published under, so
+	// image.updated becomes "<TypePrefix>.image.updated". Empty keeps the
+	// built-in namespace.
+	TypePrefix string
 }
 
 type SinkConfig struct {

--- a/pkg/extensions/events/builder.go
+++ b/pkg/extensions/events/builder.go
@@ -14,11 +14,13 @@ import (
 type eventBuilder struct {
 	data      map[string]any
 	eventType EventType
+	identity  Identity
 }
 
-func newEventBuilder() *eventBuilder {
+func newEventBuilder(identity Identity) *eventBuilder {
 	return &eventBuilder{
-		data: make(map[string]any),
+		data:     make(map[string]any),
+		identity: identity,
 	}
 }
 
@@ -55,10 +57,10 @@ func (b *eventBuilder) Build() (*cloudevents.Event, error) {
 		return nil, zerr.ErrEventTypeEmpty
 	}
 	event := cloudevents.NewEvent()
-	event.SetType(b.eventType.String())
+	event.SetType(b.identity.TypeOf(b.eventType))
 	event.SetID(uuid.New().String())
 	event.SetTime(time.Now())
-	event.SetSource(EventSource)
+	event.SetSource(b.identity.SourceOrDefault())
 
 	if b.data != nil {
 		if err := event.SetData(cloudevents.ApplicationJSON, b.data); err != nil {

--- a/pkg/extensions/events/common.go
+++ b/pkg/extensions/events/common.go
@@ -2,13 +2,59 @@ package events
 
 import (
 	"context"
+	"strings"
 	"time"
 )
 
 const (
 	DefaultHTTPTimeout = 30 * time.Second
 	EventSource        = "zotregistry.dev"
+
+	// DefaultEventTypePrefix is the namespace every built-in event type is
+	// published under. It is the leading segment of the EventType constants
+	// below, and Identity replaces it when an operator configures their own.
+	DefaultEventTypePrefix = "zotregistry"
 )
+
+// Identity is the CloudEvents source and type namespace a recorder publishes
+// under. Both fields are optional and fall back to the built-in values, so a
+// zero Identity reproduces the previous behaviour exactly.
+//
+// An operator running zot as part of a larger service needs these: the source
+// identifies the producer to a receiver, and a single hardcoded value cannot
+// distinguish one deployment, or one tenant, from another.
+type Identity struct {
+	// Source is the CloudEvents source attribute. Defaults to EventSource.
+	Source string
+
+	// TypePrefix replaces the leading namespace of each event type, so
+	// image.updated is published as "<TypePrefix>.image.updated". Defaults to
+	// DefaultEventTypePrefix.
+	TypePrefix string
+}
+
+// SourceOrDefault returns the configured source, or the built-in one.
+func (i Identity) SourceOrDefault() string {
+	if i.Source == "" {
+		return EventSource
+	}
+
+	return i.Source
+}
+
+// TypeOf renders an event type under the configured namespace.
+func (i Identity) TypeOf(eventType EventType) string {
+	name := eventType.String()
+	if i.TypePrefix == "" || i.TypePrefix == DefaultEventTypePrefix {
+		return name
+	}
+
+	if suffix, found := strings.CutPrefix(name, DefaultEventTypePrefix+"."); found {
+		return i.TypePrefix + "." + suffix
+	}
+
+	return name
+}
 
 type EventType string
 

--- a/pkg/extensions/events/events.go
+++ b/pkg/extensions/events/events.go
@@ -15,8 +15,9 @@ import (
 )
 
 type eventRecorder struct {
-	log   log.Logger
-	sinks []Sink
+	log      log.Logger
+	sinks    []Sink
+	identity Identity
 }
 
 var _ Recorder = (*eventRecorder)(nil)
@@ -75,7 +76,7 @@ func (r eventRecorder) publish(event *cloudevents.Event) {
 }
 
 func (r eventRecorder) RepositoryCreated(name string, ectx *EventContext) {
-	event, err := newEventBuilder().
+	event, err := newEventBuilder(r.identity).
 		WithEventType(RepositoryCreatedEventType).
 		WithDataField("name", name).
 		WithEventContext(ectx).
@@ -90,7 +91,7 @@ func (r eventRecorder) RepositoryCreated(name string, ectx *EventContext) {
 }
 
 func (r eventRecorder) ImageUpdated(name, reference, digest, mediaType, manifest string, ectx *EventContext) {
-	event, err := newEventBuilder().
+	event, err := newEventBuilder(r.identity).
 		WithEventType(ImageUpdatedEventType).
 		WithDataField("name", name).
 		WithDataField("reference", reference).
@@ -109,7 +110,7 @@ func (r eventRecorder) ImageUpdated(name, reference, digest, mediaType, manifest
 }
 
 func (r eventRecorder) ImageDeleted(name, reference, digest, mediaType string, ectx *EventContext) {
-	event, err := newEventBuilder().
+	event, err := newEventBuilder(r.identity).
 		WithEventType(ImageDeletedEventType).
 		WithDataField("name", name).
 		WithDataField("reference", reference).
@@ -127,7 +128,7 @@ func (r eventRecorder) ImageDeleted(name, reference, digest, mediaType string, e
 }
 
 func (r eventRecorder) ImageLintFailed(name, reference, digest, mediaType, manifest string, ectx *EventContext) {
-	event, err := newEventBuilder().
+	event, err := newEventBuilder(r.identity).
 		WithEventType(ImageLintFailedEventType).
 		WithDataField("name", name).
 		WithDataField("reference", reference).
@@ -148,7 +149,7 @@ func (r eventRecorder) ImageLintFailed(name, reference, digest, mediaType, manif
 func (r eventRecorder) ImageScanned(name, reference, digest, mediaType string,
 	summary ImageScanSummary, ectx *EventContext,
 ) {
-	event, err := newEventBuilder().
+	event, err := newEventBuilder(r.identity).
 		WithEventType(ImageScannedEventType).
 		WithDataField("name", name).
 		WithDataField("reference", reference).

--- a/pkg/extensions/events/extension.go
+++ b/pkg/extensions/events/extension.go
@@ -14,13 +14,22 @@ type Sink interface {
 	Close() error
 }
 
+// NewRecorder builds a recorder publishing under the built-in source and type
+// namespace.
 func NewRecorder(logger log.Logger, sinks ...Sink) (Recorder, error) {
+	return NewRecorderWithIdentity(logger, Identity{}, sinks...)
+}
+
+// NewRecorderWithIdentity builds a recorder publishing under the given source
+// and type namespace. A zero Identity behaves exactly like NewRecorder.
+func NewRecorderWithIdentity(logger log.Logger, identity Identity, sinks ...Sink) (Recorder, error) {
 	if sinks == nil {
 		return nil, zerr.ErrEventSinkIsNil
 	}
 
 	return &eventRecorder{
-		sinks: sinks,
-		log:   logger,
+		sinks:    sinks,
+		log:      logger,
+		identity: identity,
 	}, nil
 }

--- a/pkg/extensions/events/identity_test.go
+++ b/pkg/extensions/events/identity_test.go
@@ -1,0 +1,57 @@
+//go:build events
+
+package events_test
+
+import (
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/extensions/events"
+)
+
+func TestIdentityDefaults(t *testing.T) {
+	Convey("A zero Identity reproduces the built-in values", t, func() {
+		var identity events.Identity
+
+		So(identity.SourceOrDefault(), ShouldEqual, events.EventSource)
+		So(identity.TypeOf(events.ImageUpdatedEventType), ShouldEqual, "zotregistry.image.updated")
+		So(identity.TypeOf(events.RepositoryCreatedEventType), ShouldEqual, "zotregistry.repository.created")
+	})
+
+	Convey("Naming the built-in prefix explicitly changes nothing", t, func() {
+		identity := events.Identity{TypePrefix: events.DefaultEventTypePrefix}
+
+		So(identity.TypeOf(events.ImageDeletedEventType), ShouldEqual, "zotregistry.image.deleted")
+	})
+}
+
+func TestIdentityOverrides(t *testing.T) {
+	Convey("A configured source replaces the built-in one", t, func() {
+		identity := events.Identity{Source: "https://registry.example.com/acme"}
+
+		So(identity.SourceOrDefault(), ShouldEqual, "https://registry.example.com/acme")
+	})
+
+	Convey("A configured prefix renames the namespace and keeps the event", t, func() {
+		identity := events.Identity{TypePrefix: "com.example.registry"}
+
+		So(identity.TypeOf(events.ImageUpdatedEventType), ShouldEqual, "com.example.registry.image.updated")
+		So(identity.TypeOf(events.ImageDeletedEventType), ShouldEqual, "com.example.registry.image.deleted")
+		So(identity.TypeOf(events.ImageLintFailedEventType), ShouldEqual, "com.example.registry.image.lint_failed")
+		So(identity.TypeOf(events.RepositoryCreatedEventType), ShouldEqual, "com.example.registry.repository.created")
+	})
+
+	Convey("Source and prefix are independent", t, func() {
+		identity := events.Identity{Source: "urn:acme:registry:1", TypePrefix: "com.example"}
+
+		So(identity.SourceOrDefault(), ShouldEqual, "urn:acme:registry:1")
+		So(identity.TypeOf(events.ImageUpdatedEventType), ShouldEqual, "com.example.image.updated")
+	})
+
+	Convey("A type outside the built-in namespace is left alone", t, func() {
+		identity := events.Identity{TypePrefix: "com.example"}
+
+		So(identity.TypeOf(events.EventType("custom.thing.happened")), ShouldEqual, "custom.thing.happened")
+	})
+}

--- a/pkg/extensions/extension_events.go
+++ b/pkg/extensions/extension_events.go
@@ -57,5 +57,10 @@ func NewEventRecorder(config *config.Config, log log.Logger) (events.Recorder, e
 		return nil, zerr.ErrExtensionNotEnabled
 	}
 
-	return events.NewRecorder(log, sinks...)
+	identity := events.Identity{
+		Source:     eventConfig.Source,
+		TypePrefix: eventConfig.TypePrefix,
+	}
+
+	return events.NewRecorderWithIdentity(log, identity, sinks...)
 }


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:

No existing issue.

**What does this PR do / Why do we need it**:

The CloudEvents source and every event type are compile-time constants, so each delivery announces `zotregistry.dev` with types under `zotregistry.*`. The CloudEvents spec intends `source` to identify the producer, but an operator running zot inside a larger platform cannot present their own identity, and a receiver has no way to tell one deployment, or one tenant, from another: the value is identical for every zot in existence.

This adds two optional fields to the events extension config:

- `source` overrides the CloudEvents source attribute on every event the instance publishes.
- `typePrefix` replaces the leading namespace of each event type, so `image.updated` is published as `<typePrefix>.image.updated`.

Both default to empty, which keeps the built-in values, so upgrading changes nothing until an operator sets them. `NewRecorder` keeps its signature; the override goes through a new `NewRecorderWithIdentity`. A type outside the built-in namespace passes through untouched.

**How to verify it**

Unit tests cover the default fallbacks, the source override, the type renaming, and the passthrough of non-namespaced types. `examples/config-events.json` shows the new fields and passes `zot verify`.
