### PR TITLE
test(blackbox): add mount authorization tests with curl and regctl

### DIFF
--- a/test/blackbox/ci.sh
+++ b/test/blackbox/ci.sh
@@ -15,7 +15,7 @@ PATH=$PATH:${SCRIPTPATH}/../../hack/tools/bin
 echo "Setting up Docker images..."
 ${SCRIPTPATH}/setup_images.sh
 
-tests=("pushpull" "pushpull_authn" "delete_images" "referrers" "sbom" "metadata" "anonymous_policy"
+tests=("pushpull" "pushpull_authn" "pushpull_mount" "pushpull_mount_hydrate" "delete_images" "referrers" "sbom" "metadata" "anonymous_policy"
       "annotations" "detect_manifest_collision" "cve" "sync" "sync_docker" "sync_replica_cluster"
       "scrub" "garbage_collect" "metrics" "metrics_minimal" "multiarch_index" "docker_compat" "redis_local" "redis_session_store"
       "events_nats" "events_http" "events_nats_lint_failure" "events_http_lint_failure" "events_sink_failure" "events_config_decoding"

--- a/test/blackbox/helpers_pushpull_mount.bash
+++ b/test/blackbox/helpers_pushpull_mount.bash
@@ -1,0 +1,224 @@
+# Helpers for blob mount authorization blackbox tests (curl + regctl).
+
+load helpers_pushpull_authn
+
+MOUNT_USER1=mountuser1
+MOUNT_PASS1=mountSecret1
+MOUNT_USER2=mountuser2
+MOUNT_PASS2=mountSecret2
+MOUNT_REPO1="${MOUNT_USER1}/myrepo"
+MOUNT_REPO2="${MOUNT_USER2}/myrepo"
+MOUNT_REPO2_OTHER="${MOUNT_USER2}/otherrepo"
+MOUNT_REPO1_SECOND="${MOUNT_USER1}/mysecondrepo"
+MOUNT_REPO1_CURL="${MOUNT_USER1}/curldestrepo"
+MOUNT_REPO1_NOHYDRATE_HEAD="${MOUNT_USER1}/nohydratehead"
+MOUNT_REPO1_NOHYDRATE_RANGE="${MOUNT_USER1}/nohydraterange"
+MOUNT_REPO1_HYDRATE_HEAD="${MOUNT_USER1}/hydratehead"
+MOUNT_REPO1_HYDRATE_RANGE="${MOUNT_USER1}/hydraterange"
+MOUNT_REPO2_HYDRATE_HEAD="${MOUNT_USER2}/hydratehead"
+MOUNT_REPO2_HYDRATE_RANGE="${MOUNT_USER2}/hydraterange"
+
+function mount_write_htpasswd_file() {
+    local htpasswd_file=${1}
+
+    htpasswd -Bbn "${MOUNT_USER1}" "${MOUNT_PASS1}" >>"${htpasswd_file}"
+    htpasswd -Bbn "${MOUNT_USER2}" "${MOUNT_PASS2}" >>"${htpasswd_file}"
+}
+
+# Args: config, root, port, htpasswd, log, hydrateBlobOnRead (true|false, default false)
+function mount_write_zot_config() {
+    local zot_config_file=${1}
+    local zot_root_dir=${2}
+    local zot_port=${3}
+    local zot_htpasswd_file=${4}
+    local log_file=${5}
+    local hydrate_blob_on_read=${6:-false}
+
+    cat >"${zot_config_file}" <<EOF
+{
+  "distSpecVersion":"1.1.1",
+  "storage":{
+    "dedupe": true,
+    "gc": false,
+    "hydrateBlobOnRead": ${hydrate_blob_on_read},
+    "rootDirectory": "${zot_root_dir}"
+  },
+  "http": {
+    "address": "127.0.0.1",
+    "port": "${zot_port}",
+    "realm":"zot",
+    "auth": {
+      "htpasswd": {
+        "path": "${zot_htpasswd_file}"
+      },
+      "failDelay": 5
+    },
+    "accessControl": {
+      "repositories": {
+        "${MOUNT_USER1}/**": {
+          "policies": [
+            {
+              "users": ["${MOUNT_USER1}"],
+              "actions": ["read", "create"]
+            }
+          ]
+        },
+        "${MOUNT_USER2}/**": {
+          "policies": [
+            {
+              "users": ["${MOUNT_USER2}"],
+              "actions": ["read", "create"]
+            }
+          ]
+        }
+      }
+    }
+  },
+  "log":{
+    "level":"debug",
+    "output": "${log_file}"
+  }
+}
+EOF
+}
+
+# Args: $1 = hydrateBlobOnRead (true|false, default false)
+function mount_setup_file() {
+    local hydrate_blob_on_read=${1:-false}
+
+    if ! verify_authn_prerequisites; then
+        exit 1
+    fi
+
+    pushpull_isolate_regctl_config
+
+    skopeo --insecure-policy copy --format=oci \
+        docker://ghcr.io/project-zot/test-images/busybox:1.36 \
+        oci:${TEST_DATA_DIR}/busybox:1.36
+
+    local zot_root_dir=${BATS_FILE_TMPDIR}/zot
+    local zot_config_file=${BATS_FILE_TMPDIR}/zot_config.json
+    local zot_htpasswd_file=${BATS_FILE_TMPDIR}/zot_htpasswd
+    local log_file=${zot_root_dir}/zot-log.json
+
+    zot_port=$(get_free_port_for_service "zot")
+    echo "${zot_port}" >"${BATS_FILE_TMPDIR}/zot.port"
+    : >"${zot_htpasswd_file}"
+    mount_write_htpasswd_file "${zot_htpasswd_file}"
+
+    echo "${zot_root_dir}" >&3
+    mkdir -p "${zot_root_dir}"
+    touch "${log_file}"
+
+    mount_write_zot_config "${zot_config_file}" "${zot_root_dir}" "${zot_port}" \
+        "${zot_htpasswd_file}" "${log_file}" "${hydrate_blob_on_read}"
+
+    zot_serve "${ZOT_PATH}" "${zot_config_file}"
+    wait_zot_reachable "${zot_port}"
+
+    local regctl="${ROOT_DIR}/hack/tools/bin/regctl"
+    local -a regctl_host=(--host "reg=localhost:${zot_port},tls=disabled")
+
+    run "${regctl}" "${regctl_host[@]}" registry login \
+        "localhost:${zot_port}" -u "${MOUNT_USER1}" -p "${MOUNT_PASS1}"
+    [ "${status}" -eq 0 ]
+    run "${regctl}" "${regctl_host[@]}" image copy "ocidir://${TEST_DATA_DIR}/busybox:1.36" \
+        "localhost:${zot_port}/${MOUNT_REPO1}:1.36"
+    [ "${status}" -eq 0 ]
+
+    mount_save_first_layer_digest
+}
+
+function mount_teardown() {
+    authn_teardown
+}
+
+function mount_teardown_file() {
+    authn_teardown_file
+}
+
+function mount_get_regctl() {
+    echo "${ROOT_DIR}/hack/tools/bin/regctl"
+}
+
+function mount_regctl_host_flags() {
+    echo "--host reg=localhost:$(get_zot_port),tls=disabled"
+}
+
+function mount_regctl_login() {
+    local user=${1}
+    local pass=${2}
+
+    run "$(mount_get_regctl)" $(mount_regctl_host_flags) registry login \
+        "localhost:$(get_zot_port)" -u "${user}" -p "${pass}"
+    [ "${status}" -eq 0 ]
+}
+
+function mount_save_first_layer_digest() {
+    local digest_file=${BATS_FILE_TMPDIR}/layer.digest
+
+    run skopeo inspect "oci:${TEST_DATA_DIR}/busybox:1.36"
+    [ "${status}" -eq 0 ]
+
+    run jq -r '.Layers[0]' <<<"${output}"
+    [ "${status}" -eq 0 ]
+    [ -n "${output}" ]
+
+    echo "${output}" >"${digest_file}"
+}
+
+function mount_get_layer_digest() {
+    cat "${BATS_FILE_TMPDIR}/layer.digest"
+}
+
+# Args: $1=user, $2=pass, $3=dest repo, $4=mount digest, $5=optional from repo
+# Sets $output to the HTTP status code.
+function mount_curl_blob_upload() {
+    local user=${1}
+    local pass=${2}
+    local dest_repo=${3}
+    local mount_digest=${4}
+    local from_repo=${5:-}
+    local zot_port query
+
+    zot_port=$(get_zot_port)
+    query="mount=${mount_digest}"
+    if [ -n "${from_repo}" ]; then
+        query="${query}&from=${from_repo}"
+    fi
+
+    run curl -s -o /dev/null -w "%{http_code}" -u "${user}:${pass}" \
+        -X POST "http://127.0.0.1:${zot_port}/v2/${dest_repo}/blobs/uploads/?${query}"
+}
+
+# Args: $1=user, $2=pass, $3=repo, $4=digest
+# Sets $output to the HTTP status code.
+function mount_curl_blob_head() {
+    local user=${1}
+    local pass=${2}
+    local repo=${3}
+    local digest=${4}
+    local zot_port
+
+    zot_port=$(get_zot_port)
+
+    run curl -s -o /dev/null -w "%{http_code}" -u "${user}:${pass}" \
+        -I "http://127.0.0.1:${zot_port}/v2/${repo}/blobs/${digest}"
+}
+
+# Args: $1=user, $2=pass, $3=repo, $4=digest, $5=optional Range value (default bytes=0-0)
+# Sets $output to the HTTP status code.
+function mount_curl_blob_range_get() {
+    local user=${1}
+    local pass=${2}
+    local repo=${3}
+    local digest=${4}
+    local range=${5:-bytes=0-0}
+    local zot_port
+
+    zot_port=$(get_zot_port)
+
+    run curl -s -o /dev/null -w "%{http_code}" -u "${user}:${pass}" \
+        -H "Range: ${range}" \
+        "http://127.0.0.1:${zot_port}/v2/${repo}/blobs/${digest}"
+}

--- a/test/blackbox/pushpull_mount.bats
+++ b/test/blackbox/pushpull_mount.bats
@@ -1,0 +1,143 @@
+load helpers_zot
+load helpers_pushpull_mount
+load ../port_helper
+
+function setup_file() {
+    mount_setup_file
+}
+
+function teardown() {
+    mount_teardown
+}
+
+function teardown_file() {
+    mount_teardown_file
+}
+
+@test "curl mount denied without source read returns 202" {
+    local digest
+    digest=$(mount_get_layer_digest)
+
+    mount_curl_blob_upload "${MOUNT_USER2}" "${MOUNT_PASS2}" "${MOUNT_REPO2}" "${digest}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "202" ]
+}
+
+@test "curl mount denied with from returns 202" {
+    local digest
+    digest=$(mount_get_layer_digest)
+
+    mount_curl_blob_upload "${MOUNT_USER2}" "${MOUNT_PASS2}" "${MOUNT_REPO2_OTHER}" \
+        "${digest}" "${MOUNT_REPO1}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "202" ]
+}
+
+# hydrateBlobOnRead defaults to false: authorized callers still do not rematerialize
+# via HEAD / ranged GET (repo-local StatBlob only). Contrast pushpull_mount_hydrate.bats.
+@test "curl HEAD with hydrate off does not rematerialize returns 404" {
+    local digest
+    digest=$(mount_get_layer_digest)
+
+    mount_curl_blob_head "${MOUNT_USER1}" "${MOUNT_PASS1}" \
+        "${MOUNT_REPO1_NOHYDRATE_HEAD}" "${digest}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "404" ]
+}
+
+@test "curl ranged GET with hydrate off does not rematerialize returns 404" {
+    local digest
+    digest=$(mount_get_layer_digest)
+
+    mount_curl_blob_range_get "${MOUNT_USER1}" "${MOUNT_PASS1}" \
+        "${MOUNT_REPO1_NOHYDRATE_RANGE}" "${digest}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "404" ]
+}
+
+@test "regctl blob head with hydrate off does not rematerialize fails" {
+    local digest zot_port
+    digest=$(mount_get_layer_digest)
+    zot_port=$(get_zot_port)
+
+    mount_regctl_login "${MOUNT_USER1}" "${MOUNT_PASS1}"
+    run "$(mount_get_regctl)" $(mount_regctl_host_flags) blob head \
+        "localhost:${zot_port}/${MOUNT_REPO1_NOHYDRATE_HEAD}" "${digest}"
+    [ "${status}" -ne 0 ]
+}
+
+@test "regctl blob copy mount denied without source read returns 202" {
+    local digest log_file regctl status
+    digest=$(mount_get_layer_digest)
+    log_file="${BATS_FILE_TMPDIR}/regctl-blob-copy-denied.log"
+    regctl="$(mount_get_regctl)"
+
+    mount_regctl_login "${MOUNT_USER2}" "${MOUNT_PASS2}"
+    set +e
+    "${regctl}" $(mount_regctl_host_flags) blob copy \
+        "localhost:$(get_zot_port)/${MOUNT_REPO1}" \
+        "localhost:$(get_zot_port)/${MOUNT_REPO2_OTHER}" \
+        "${digest}" -v trace 2>"${log_file}"
+    status=$?
+    set -e
+    [ "${status}" -eq 1 ]
+
+    grep -Fq "202 Accepted" "${log_file}"
+}
+
+@test "regctl blob copy with source read succeeds" {
+    local digest zot_port
+    digest=$(mount_get_layer_digest)
+    zot_port=$(get_zot_port)
+
+    mount_regctl_login "${MOUNT_USER1}" "${MOUNT_PASS1}"
+    run "$(mount_get_regctl)" $(mount_regctl_host_flags) blob copy \
+        "localhost:${zot_port}/${MOUNT_REPO1}" \
+        "localhost:${zot_port}/${MOUNT_REPO1_SECOND}" \
+        "${digest}"
+    [ "${status}" -eq 0 ]
+
+    run "$(mount_get_regctl)" $(mount_regctl_host_flags) blob head \
+        "localhost:${zot_port}/${MOUNT_REPO1_SECOND}" "${digest}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "curl mount allowed with source read returns 201" {
+    local digest zot_port
+    digest=$(mount_get_layer_digest)
+    zot_port=$(get_zot_port)
+
+    mount_regctl_login "${MOUNT_USER1}" "${MOUNT_PASS1}"
+    run "$(mount_get_regctl)" $(mount_regctl_host_flags) blob head \
+        "localhost:${zot_port}/${MOUNT_REPO1_CURL}" "${digest}"
+    [ "${status}" -ne 0 ]
+
+    mount_curl_blob_upload "${MOUNT_USER1}" "${MOUNT_PASS1}" "${MOUNT_REPO1_CURL}" \
+        "${digest}" "${MOUNT_REPO1}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "201" ]
+
+    run "$(mount_get_regctl)" $(mount_regctl_host_flags) blob head \
+        "localhost:${zot_port}/${MOUNT_REPO1_CURL}" "${digest}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "curl cross-repo mount allowed after blob is readable returns 201" {
+    local digest zot_port
+    digest=$(mount_get_layer_digest)
+    zot_port=$(get_zot_port)
+
+    mount_regctl_login "${MOUNT_USER2}" "${MOUNT_PASS2}"
+    run "$(mount_get_regctl)" $(mount_regctl_host_flags) image copy "ocidir://${TEST_DATA_DIR}/busybox:1.36" \
+        "localhost:${zot_port}/${MOUNT_REPO2}:1.36"
+    [ "${status}" -eq 0 ]
+
+    run "$(mount_get_regctl)" $(mount_regctl_host_flags) blob head \
+        "localhost:${zot_port}/${MOUNT_REPO2_OTHER}" "${digest}"
+    [ "${status}" -ne 0 ]
+
+    mount_curl_blob_upload "${MOUNT_USER2}" "${MOUNT_PASS2}" "${MOUNT_REPO2_OTHER}" \
+        "${digest}" "${MOUNT_REPO2}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "201" ]
+}

--- a/test/blackbox/pushpull_mount_hydrate.bats
+++ b/test/blackbox/pushpull_mount_hydrate.bats
@@ -1,0 +1,77 @@
+# hydrateBlobOnRead rematerialization authz (HEAD / ranged GET).
+# Mount POST coverage lives in pushpull_mount.bats (explicit mounts are unaffected
+# by hydrateBlobOnRead); this suite uses a separate zot with hydrate enabled so
+# HEAD absence checks in the mount suite stay meaningful.
+
+load helpers_zot
+load helpers_pushpull_mount
+load ../port_helper
+
+function setup_file() {
+    mount_setup_file true
+}
+
+function teardown() {
+    mount_teardown
+}
+
+function teardown_file() {
+    mount_teardown_file
+}
+
+@test "curl HEAD hydrate denied without source read returns 404" {
+    local digest
+    digest=$(mount_get_layer_digest)
+
+    mount_curl_blob_head "${MOUNT_USER2}" "${MOUNT_PASS2}" \
+        "${MOUNT_REPO2_HYDRATE_HEAD}" "${digest}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "404" ]
+}
+
+@test "curl ranged GET hydrate denied without source read returns 404" {
+    local digest
+    digest=$(mount_get_layer_digest)
+
+    mount_curl_blob_range_get "${MOUNT_USER2}" "${MOUNT_PASS2}" \
+        "${MOUNT_REPO2_HYDRATE_RANGE}" "${digest}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "404" ]
+}
+
+@test "regctl blob head hydrate denied without source read fails" {
+    local digest zot_port
+    digest=$(mount_get_layer_digest)
+    zot_port=$(get_zot_port)
+
+    mount_regctl_login "${MOUNT_USER2}" "${MOUNT_PASS2}"
+    run "$(mount_get_regctl)" $(mount_regctl_host_flags) blob head \
+        "localhost:${zot_port}/${MOUNT_REPO2_HYDRATE_HEAD}" "${digest}"
+    [ "${status}" -ne 0 ]
+}
+
+@test "curl HEAD hydrate allowed with source read returns 200" {
+    local digest zot_port
+    digest=$(mount_get_layer_digest)
+    zot_port=$(get_zot_port)
+
+    mount_regctl_login "${MOUNT_USER1}" "${MOUNT_PASS1}"
+    mount_curl_blob_head "${MOUNT_USER1}" "${MOUNT_PASS1}" \
+        "${MOUNT_REPO1_HYDRATE_HEAD}" "${digest}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "200" ]
+
+    run "$(mount_get_regctl)" $(mount_regctl_host_flags) blob head \
+        "localhost:${zot_port}/${MOUNT_REPO1_HYDRATE_HEAD}" "${digest}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "curl ranged GET hydrate allowed with source read returns 206" {
+    local digest
+    digest=$(mount_get_layer_digest)
+
+    mount_curl_blob_range_get "${MOUNT_USER1}" "${MOUNT_PASS1}" \
+        "${MOUNT_REPO1_HYDRATE_RANGE}" "${digest}"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "206" ]
+}

--- a/test/ports.json
+++ b/test/ports.json
@@ -486,5 +486,17 @@
       "begin": 11560,
       "end": 11569
     }
+  },
+  "blackbox/pushpull_mount.bats": {
+    "zot": {
+      "begin": 11580,
+      "end": 11589
+    }
+  },
+  "blackbox/pushpull_mount_hydrate.bats": {
+    "zot": {
+      "begin": 11600,
+      "end": 11609
+    }
   }
 }


### PR DESCRIPTION
Add pushpull_mount.bats to verify dedupe mount behavior under per-user access control: curl asserts 202 when mount is denied and 201 when allowed; regctl blob copy covers denied (202 in trace log, copy fails) and allowed (copy + blob head succeed) paths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.