### PR TITLE
fix(api): don't 500 on GET manifest when download-stats update fails

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -578,11 +578,15 @@ func (rh *RouteHandler) GetManifest(response http.ResponseWriter, request *http.
 	}
 
 	if rh.c.MetaDB != nil {
-		err := meta.OnGetManifest(name, reference, mediaType, content, rh.c.StoreController, rh.c.MetaDB, rh.c.Log)
-		if err != nil && !errors.Is(err, zerr.ErrImageMetaNotFound) && !errors.Is(err, zerr.ErrRepoMetaNotFound) {
-			response.WriteHeader(http.StatusInternalServerError)
-
-			return
+		// OnGetManifest only updates best-effort download bookkeeping (download count and
+		// last-pull timestamp). The manifest has already been retrieved and verified above, so a
+		// failure here must not fail the client's read. In particular, a burst of concurrent
+		// pulls of the same repo (e.g. a large fan-out job) contends the per-repo metaDB lock and
+		// UpdateStatsOnDownload returns a lock error; turning that into a 500 discards a perfectly
+		// good manifest and causes spurious ImagePullBackOff. Log it and serve the manifest.
+		if err := meta.OnGetManifest(name, reference, mediaType, content, rh.c.StoreController, rh.c.MetaDB, rh.c.Log); err != nil {
+			rh.c.Log.Warn().Err(err).Str("name", name).Str("reference", reference).
+				Msg("failed to update download stats; serving manifest anyway")
 		}
 	}
 

--- a/pkg/meta/hooks.go
+++ b/pkg/meta/hooks.go
@@ -343,7 +343,9 @@ func OnGetManifest(name, reference, mediaType string, body []byte,
 
 	err = metaDB.UpdateStatsOnDownload(name, reference)
 	if err != nil {
-		log.Error().Err(err).Str("repository", name).Str("reference", reference).
+		// Best-effort bookkeeping: the caller serves the manifest regardless of this error
+		// (e.g. a contended per-repo metaDB lock under a concurrent pull burst), so log at warn.
+		log.Warn().Err(err).Str("repository", name).Str("reference", reference).
 			Msg("failed to update stats on download image")
 
 		return err


### PR DESCRIPTION
## What / why

Fixes #4390.

`GetManifest` in `pkg/api/routes.go` treats the download-statistics bookkeeping hook (`meta.OnGetManifest`) as fatal: any error other than the two "not found" sentinels turns into an HTTP 500. But the manifest has **already been retrieved and verified** by the time this hook runs — `OnGetManifest` → `MetaDB.UpdateStatsOnDownload` only increments `DownloadCount` and sets `LastPullTimestamp`.

In the redis metaDB implementation that update runs under a per-repo distributed lock (`withRSLocks` / redsync). Under a burst of concurrent pulls of the same repo (e.g. a large fan-out job whose worker pods all pull the same image at once), the lock is contended, redsync exhausts its retries, and `UpdateStatsOnDownload` returns a lock error. That was being turned into a 500, discarding a perfectly good manifest and causing spurious kubelet `ImagePullBackOff`.

## Change

- `pkg/api/routes.go`: don't fail the client's manifest read on an `OnGetManifest` error. The manifest is served regardless; the bookkeeping failure is logged at warn.
- `pkg/meta/hooks.go`: downgrade the now-non-fatal `UpdateStatsOnDownload` failure log from `Error` to `Warn`.

## Impact / safety

The failing operation is best-effort bookkeeping only:
- `DownloadCount` feeds search/GraphQL stats.
- `LastPullTimestamp` feeds retention (`pulledWithin`); on a lock loss there is by definition a concurrent winner that already updated the timestamp.

No effect on serving correctness, GC, dedupe, sync, or data integrity.

See #4390 for the full root-cause analysis and observed 1:1 correlation between the 500s and the redis lock failures.