### PR TITLE
ci: parallelize ecosystem client-tools jobs with shared build artifact

### DIFF
--- a/.github/actions/build-zot-binaries/action.yaml
+++ b/.github/actions/build-zot-binaries/action.yaml
@@ -18,10 +18,6 @@ inputs:
     description: 'Newline-separated paths under bin/ to upload (required when upload-artifact is true)'
     required: false
     default: ''
-  include-oras:
-    description: 'Also fetch oras into hack/tools/bin and upload as artifact "oras"'
-    required: false
-    default: 'false'
   go-version:
     description: 'Go version for setup-go'
     required: false
@@ -71,23 +67,11 @@ runs:
     - name: Build binaries
       shell: bash
       run: make ${{ inputs.make-targets }}
-    - name: Fetch oras
-      if: ${{ inputs.include-oras == 'true' }}
-      shell: bash
-      run: make "$PWD/hack/tools/bin/oras"
     - name: Upload binaries
       if: ${{ inputs.upload-artifact == 'true' }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ inputs.artifact-path }}
-        if-no-files-found: error
-        retention-days: ${{ inputs.retention-days }}
-    - name: Upload oras
-      if: ${{ inputs.upload-artifact == 'true' && inputs.include-oras == 'true' }}
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-      with:
-        name: oras
-        path: hack/tools/bin/oras
         if-no-files-found: error
         retention-days: ${{ inputs.retention-days }}

--- a/.github/actions/download-ecosystem-bins/action.yaml
+++ b/.github/actions/download-ecosystem-bins/action.yaml
@@ -1,0 +1,30 @@
+name: 'Download ecosystem prebuilt binaries'
+description: >
+  Restore bin/ and hack/tools/ from the ecosystem-tools build artifact and
+  ensure executables under bin/ and hack/tools/bin/ are marked executable.
+  Installs prebuilt skopeo to /usr/bin when present in the artifact.
+inputs:
+  artifact-name:
+    description: 'Name of the upload-artifact produced by the build job'
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - name: Download ecosystem bins
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+    - name: Fix executable bits and install skopeo
+      shell: bash
+      run: |
+        set -euo pipefail
+        chmod -R a+x bin hack/tools/bin
+        # bats libexec helpers must be executable too
+        if [ -d hack/tools/libexec ]; then
+          chmod -R a+x hack/tools/libexec
+        fi
+        # Copy only; setup-ecosystem-tools verifies after installing shared libs.
+        if [ -x hack/tools/bin/skopeo ]; then
+          sudo cp hack/tools/bin/skopeo /usr/bin/skopeo
+        fi
+        ls -la bin hack/tools/bin

--- a/.github/actions/setup-ecosystem-tools/action.yaml
+++ b/.github/actions/setup-ecosystem-tools/action.yaml
@@ -1,0 +1,152 @@
+name: 'Setup ecosystem client tools'
+description: >
+  Shared install for ecosystem-tools workflows. Optional components are gated
+  so parallel jobs only pay for what they need.
+inputs:
+  with-docker:
+    description: 'Install Docker CE and plugins'
+    required: false
+    default: 'true'
+  with-crio:
+    description: 'Install and start CRI-O (for crictl / upgrade bats)'
+    required: false
+    default: 'false'
+  with-npm:
+    description: 'Install npm and global oidc-provider/express (openid claim mapping)'
+    required: false
+    default: 'false'
+  with-dex:
+    description: 'Build and start Dex in the background (cloud_only.bats)'
+    required: false
+    default: 'false'
+  with-userns:
+    description: 'Run scripts/enable_userns.sh (stacker / annotations)'
+    required: false
+    default: 'false'
+  with-haproxy:
+    description: 'Install haproxy (scale-out bats)'
+    required: false
+    default: 'false'
+  with-valkey:
+    description: 'Install valkey-tools (redis scale-out / redis bats helpers)'
+    required: false
+    default: 'false'
+  with-go:
+    description: >
+      Install swag and download Go modules for this repo. Set false when using
+      prebuilt zot bins; setup-go is still required if this action builds Dex.
+    required: false
+    default: 'true'
+  with-skopeo:
+    description: >
+      Build skopeo from source into /usr/bin. Set false when skopeo was restored
+      from the ecosystem-bins artifact (hack/tools/bin/skopeo).
+    required: false
+    default: 'true'
+runs:
+  using: "composite"
+  steps:
+    - name: Go modules and swag
+      if: ${{ inputs.with-go == 'true' }}
+      shell: bash
+      run: |
+        cd "$GITHUB_WORKSPACE"
+        go install github.com/swaggo/swag/cmd/swag@v1.16.2
+        go mod download
+
+    - name: Apt base packages
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo apt-get update
+        pkgs=(
+          libgpgme-dev libassuan-dev libbtrfs-dev
+          libdevmapper-dev pkg-config rpm uidmap jq whois
+        )
+        if [ "${{ inputs.with-haproxy }}" = "true" ]; then
+          pkgs+=(haproxy)
+        fi
+        if [ "${{ inputs.with-valkey }}" = "true" ]; then
+          pkgs+=(valkey-tools)
+        fi
+        if [ "${{ inputs.with-npm }}" = "true" ]; then
+          pkgs+=(npm)
+        fi
+        sudo apt-get install -y "${pkgs[@]}"
+
+    - name: Install skopeo
+      if: ${{ inputs.with-skopeo == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd "$GITHUB_WORKSPACE"
+        git clone -b v1.12.0 https://github.com/containers/skopeo.git
+        cd skopeo
+        make bin/skopeo
+        sudo cp bin/skopeo /usr/bin
+        skopeo -v
+
+    - name: Verify prebuilt skopeo
+      if: ${{ inputs.with-skopeo != 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ -x "$GITHUB_WORKSPACE/hack/tools/bin/skopeo" ] && ! command -v skopeo >/dev/null 2>&1; then
+          sudo cp "$GITHUB_WORKSPACE/hack/tools/bin/skopeo" /usr/bin/skopeo
+        fi
+        skopeo -v
+
+    - name: Install CRI-O
+      if: ${{ inputs.with-crio == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        curl -fsSL https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/prerelease:/main:/build/deb/Release.key \
+          | sudo gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
+        echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/prerelease:/main:/build/deb/ /" \
+          | sudo tee /etc/apt/sources.list.d/cri-o.list
+        sudo apt update
+        sudo apt install -y cri-o runc
+        sudo systemctl enable crio.service
+        sudo systemctl start crio.service
+        sudo chmod 0777 /var/run/crio/crio.sock
+
+    - name: Install Docker
+      if: ${{ inputs.with-docker == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+        sudo chmod a+r /etc/apt/keyrings/docker.asc
+        echo \
+          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+          $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+        sudo apt update
+        sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+        docker version
+
+    - name: Install npm OIDC packages
+      if: ${{ inputs.with-npm == 'true' }}
+      shell: bash
+      run: |
+        sudo npm install -g oidc-provider express
+
+    - name: Build and start Dex
+      if: ${{ inputs.with-dex == 'true' }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        cd "$GITHUB_WORKSPACE"
+        git clone https://github.com/dexidp/dex.git
+        cd dex/
+        git checkout v2.39.1
+        make bin/dex
+        ./bin/dex serve "$GITHUB_WORKSPACE/test/dex/config-dev.yaml" &
+
+    - name: Enable user namespaces for stacker
+      if: ${{ inputs.with-userns == 'true' }}
+      shell: bash
+      run: |
+        cd "$GITHUB_WORKSPACE"
+        sudo ./scripts/enable_userns.sh

--- a/.github/workflows/cluster.yaml
+++ b/.github/workflows/cluster.yaml
@@ -22,7 +22,6 @@ jobs:
       - uses: ./.github/actions/build-zot-binaries
         with:
           make-targets: binary bench
-          include-oras: "true"
           artifact-path: |
             bin/zot-linux-amd64
             bin/zb-linux-amd64
@@ -122,13 +121,11 @@ jobs:
         with:
           name: zot-linux-amd64-binaries
           path: bin
-      - name: Download oras
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: oras
-          path: hack/tools/bin
-      - name: Mark binaries executable
-        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64 hack/tools/bin/oras
+      - name: Fetch oras
+        run: |
+          # OS/ARCH avoid Makefile `go env` for the oras curl URL; $PWD matches $(ORAS).
+          OS=linux ARCH=amd64 make "$PWD/hack/tools/bin/oras"
+          chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64 hack/tools/bin/oras
 
       - name: Run push-pull tests
         run: |
@@ -389,13 +386,11 @@ jobs:
         with:
           name: zot-linux-amd64-binaries
           path: bin
-      - name: Download oras
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: oras
-          path: hack/tools/bin
-      - name: Mark binaries executable
-        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64 hack/tools/bin/oras
+      - name: Fetch oras
+        run: |
+          # OS/ARCH avoid Makefile `go env` for the oras curl URL; $PWD matches $(ORAS).
+          OS=linux ARCH=amd64 make "$PWD/hack/tools/bin/oras"
+          chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64 hack/tools/bin/oras
 
       - name: Run push-pull tests
         run: |

--- a/.github/workflows/ecosystem-tools-with-floci.yaml
+++ b/.github/workflows/ecosystem-tools-with-floci.yaml
@@ -12,81 +12,87 @@ on:
 permissions: read-all
 
 jobs:
-  floci-client-tools:
-    name: floci - Check client tools
+  build:
+    name: Build binaries and tools
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install libs for skopeo build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev \
+            libdevmapper-dev pkg-config
+      - uses: ./.github/actions/build-zot-binaries
+        with:
+          make-targets: binary binary-minimal cli bench blackbox-tools
+          artifact-name: ecosystem-bins-${{ github.sha }}
+          artifact-path: |
+            bin/
+            hack/tools/
+
+  floci-blackbox-cloud:
+    name: floci - Blackbox cloud CI
+    needs: build
     runs-on: cncf-ubuntu-32-128-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: ./.github/actions/download-ecosystem-bins
+        with:
+          artifact-name: ecosystem-bins-${{ github.sha }}
+      # Needed for Dex build in setup-ecosystem-tools and for Makefile/helpers `go env`.
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           cache: false
           check-latest: true
           go-version: 1.26.x
-      - name: Install dependencies
-        run: |
-          cd $GITHUB_WORKSPACE
-          go install github.com/swaggo/swag/cmd/swag@v1.16.2
-          go mod download
-          sudo apt-get update
-          sudo apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev \
-            libdevmapper-dev pkg-config rpm uidmap haproxy jq valkey-tools whois \
-            npm
-          # install skopeo
-          git clone -b v1.12.0 https://github.com/containers/skopeo.git
-          cd skopeo
-          make bin/skopeo
-          sudo cp bin/skopeo /usr/bin
-          skopeo -v
-          # install cri-o (for crictl)
-          OS=xUbuntu_22.04
-          CRIO_VERSION=1.26
-          curl -fsSL https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/prerelease:/main:/build/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
-          echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/prerelease:/main:/build/deb/ /" | sudo tee /etc/apt/sources.list.d/cri-o.list
-          sudo apt update
-          sudo apt install -y cri-o runc
-          sudo systemctl enable crio.service
-          sudo systemctl start crio.service
-          sudo chmod 0777 /var/run/crio/crio.sock
-          # install docker
-          # Add Docker's official GPG key:
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          echo \
-          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-           $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt update
-          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-          docker version
-          # install nodejs deps (for oidc claim mapping support)
-          sudo npm install -g oidc-provider express
-          # install dex
-          git clone https://github.com/dexidp/dex.git
-          cd dex/
-          git checkout v2.39.1
-          make bin/dex
-          ./bin/dex serve $GITHUB_WORKSPACE/test/dex/config-dev.yaml &
-          # Prepare for stacker run on Ubuntu 24
-          cd $GITHUB_WORKSPACE
-          sudo ./scripts/enable_userns.sh
-      - name: Run CI tests
-        run: |
-          make run-blackbox-ci
+      - uses: ./.github/actions/setup-ecosystem-tools
+        with:
+          with-docker: "true"
+          with-dex: "true"
+          with-go: "false"
+          with-skopeo: "false"
       - uses: ./.github/actions/setup-floci
       - name: Run cloud-only tests
         run: |
-          make run-blackbox-cloud-ci
+          make run-blackbox-cloud-ci USE_PREBUILT=1
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
+      - uses: ./.github/actions/teardown-floci
+        if: always()
 
-      # DynamoDB scale-out tests
+  floci-scale-out-dynamodb:
+    name: floci - Cloud scale-out DynamoDB
+    needs: build
+    runs-on: cncf-ubuntu-32-128-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/download-ecosystem-bins
+        with:
+          artifact-name: ecosystem-bins-${{ github.sha }}
+      # Makefile and bats helpers resolve bin paths via `go env GOOS/GOARCH`.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-ecosystem-tools
+        with:
+          with-docker: "true"
+          with-haproxy: "true"
+          with-go: "false"
+          with-skopeo: "false"
+      - uses: ./.github/actions/setup-floci
       - name: Run cloud scale-out DynamoDB tests
         id: dynamodb_scale
         run: |
-          make run-cloud-scale-out-tests
+          make run-cloud-scale-out-tests USE_PREBUILT=1
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
@@ -111,20 +117,50 @@ jobs:
             exit 0
           fi
         continue-on-error: true
-      - name: Clean up DynamoDB scale-out logs
-        run: |
-          rm -r /tmp/zot-ft-logs
+      - name: Upload zb test results zip as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zb-cloud-scale-out-dynamodb-results-floci-${{ github.sha }}
+          path: ./zb-results/
+          if-no-files-found: ignore
       - name: Fail job if DynamoDB error
         if: ${{ steps.dynamodb_scale.outcome != 'success' || steps.dynamodb_multihop.outcome != 'success' }}
         run: |
           echo "DynamoDB scale-out tests failed"
           exit 1
+      - uses: ./.github/actions/teardown-floci
+        if: always()
 
-      # Redis scale-out tests
+  floci-scale-out-redis:
+    name: floci - Cloud scale-out Redis
+    needs: build
+    runs-on: cncf-ubuntu-32-128-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/download-ecosystem-bins
+        with:
+          artifact-name: ecosystem-bins-${{ github.sha }}
+      # Makefile and bats helpers resolve bin paths via `go env GOOS/GOARCH`.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-ecosystem-tools
+        with:
+          with-docker: "true"
+          with-haproxy: "true"
+          with-valkey: "true"
+          with-go: "false"
+          with-skopeo: "false"
+      - uses: ./.github/actions/setup-floci
       - name: Run cloud scale-out Redis tests
         id: redis_scale
         run: |
-          make run-cloud-scale-out-redis-tests
+          make run-cloud-scale-out-redis-tests USE_PREBUILT=1
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
@@ -149,19 +185,17 @@ jobs:
             exit 0
           fi
         continue-on-error: true
-      - name: Clean up Redis scale-out logs
-        run: |
-          rm -rf /tmp/zot-ft-logs/redis
+      - name: Upload zb test results zip as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zb-cloud-scale-out-redis-results-floci-${{ github.sha }}
+          path: ./zb-results/
+          if-no-files-found: ignore
       - name: Fail job if Redis error
         if: ${{ steps.redis_scale.outcome != 'success' || steps.redis_multihop.outcome != 'success' }}
         run: |
           echo "Redis scale-out tests failed"
           exit 1
-      - name: Upload zb test results zip as build artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: zb-cloud-scale-out-functional-results-floci-${{ github.sha }}
-          path: ./zb-results/
       - uses: ./.github/actions/teardown-floci
         if: always()

--- a/.github/workflows/ecosystem-tools.yaml
+++ b/.github/workflows/ecosystem-tools.yaml
@@ -12,81 +12,141 @@ on:
 permissions: read-all
 
 jobs:
-  client-tools:
-    name: Check client tools
-    runs-on: cncf-ubuntu-32-128-x86
+  build:
+    name: Build binaries and tools
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Install libs for skopeo build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev \
+            libdevmapper-dev pkg-config
+      - uses: ./.github/actions/build-zot-binaries
+        with:
+          make-targets: binary binary-minimal cli bench blackbox-tools
+          artifact-name: ecosystem-bins-${{ github.sha }}
+          artifact-path: |
+            bin/
+            hack/tools/
+
+  blackbox-ci:
+    name: Blackbox CI (${{ matrix.shard }})
+    needs: build
+    runs-on: cncf-ubuntu-32-128-x86
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: upgrade
+            with-crio: "true"
+            with-npm: "false"
+            with-userns: "false"
+            with-valkey: "false"
+          - shard: sync
+            with-crio: "false"
+            with-npm: "false"
+            with-userns: "false"
+            with-valkey: "false"
+          - shard: registry
+            with-crio: "true"
+            with-npm: "false"
+            with-userns: "false"
+            with-valkey: "false"
+          - shard: host-deps
+            with-crio: "false"
+            with-npm: "true"
+            with-userns: "true"
+            with-valkey: "true"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/download-ecosystem-bins
+        with:
+          artifact-name: ecosystem-bins-${{ github.sha }}
+      # Makefile and bats helpers resolve bin paths via `go env GOOS/GOARCH`.
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           cache: false
           check-latest: true
           go-version: 1.26.x
-      - name: Install dependencies
+      - uses: ./.github/actions/setup-ecosystem-tools
+        with:
+          with-docker: "true"
+          with-crio: ${{ matrix.with-crio }}
+          with-npm: ${{ matrix.with-npm }}
+          with-userns: ${{ matrix.with-userns }}
+          with-valkey: ${{ matrix.with-valkey }}
+          with-go: "false"
+          with-skopeo: "false"
+      - name: Run blackbox CI shard
         run: |
-          cd $GITHUB_WORKSPACE
-          go install github.com/swaggo/swag/cmd/swag@v1.16.2
-          go mod download
-          sudo apt-get update
-          sudo apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev \
-            libdevmapper-dev pkg-config rpm uidmap haproxy jq valkey-tools whois \
-            npm
-          # install skopeo
-          git clone -b v1.12.0 https://github.com/containers/skopeo.git
-          cd skopeo
-          make bin/skopeo
-          sudo cp bin/skopeo /usr/bin
-          skopeo -v
-          # install cri-o (for crictl)
-          OS=xUbuntu_22.04
-          CRIO_VERSION=1.26
-          curl -fsSL https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/prerelease:/main:/build/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg
-          echo "deb [signed-by=/etc/apt/keyrings/cri-o-apt-keyring.gpg] https://download.opensuse.org/repositories/isv:/kubernetes:/addons:/cri-o:/prerelease:/main:/build/deb/ /" | sudo tee /etc/apt/sources.list.d/cri-o.list
-          sudo apt update
-          sudo apt install -y cri-o runc
-          sudo systemctl enable crio.service
-          sudo systemctl start crio.service
-          sudo chmod 0777 /var/run/crio/crio.sock
-          # install docker
-          # Add Docker's official GPG key:
-          sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-          sudo chmod a+r /etc/apt/keyrings/docker.asc
-          echo \
-          "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-           $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt update
-          sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-          docker version
-          # install nodejs deps (for oidc claim mapping support)
-          sudo npm install -g oidc-provider express
-          # install dex
-          git clone https://github.com/dexidp/dex.git
-          cd dex/
-          git checkout v2.39.1
-          make bin/dex
-          ./bin/dex serve $GITHUB_WORKSPACE/test/dex/config-dev.yaml &
-          # Prepare for stacker run on Ubuntu 24
-          cd $GITHUB_WORKSPACE
-          sudo ./scripts/enable_userns.sh
-      - name: Run CI tests
-        run: |
-          make run-blackbox-ci
+          make run-blackbox-ci-shard SHARD=${{ matrix.shard }} USE_PREBUILT=1
+
+  blackbox-cloud:
+    name: Blackbox cloud CI
+    needs: build
+    runs-on: cncf-ubuntu-32-128-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/download-ecosystem-bins
+        with:
+          artifact-name: ecosystem-bins-${{ github.sha }}
+      # Needed for Dex build in setup-ecosystem-tools and for Makefile/helpers `go env`.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-ecosystem-tools
+        with:
+          with-docker: "true"
+          with-dex: "true"
+          with-go: "false"
+          with-skopeo: "false"
       - uses: ./.github/actions/setup-localstack
       - name: Run cloud-only tests
         run: |
-          make run-blackbox-cloud-ci
+          make run-blackbox-cloud-ci USE_PREBUILT=1
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
+      - uses: ./.github/actions/teardown-localstack
+        if: always()
 
-      # DynamoDB scale-out tests
+  scale-out-dynamodb:
+    name: Cloud scale-out DynamoDB
+    needs: build
+    runs-on: cncf-ubuntu-32-128-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/download-ecosystem-bins
+        with:
+          artifact-name: ecosystem-bins-${{ github.sha }}
+      # Makefile and bats helpers resolve bin paths via `go env GOOS/GOARCH`.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-ecosystem-tools
+        with:
+          with-docker: "true"
+          with-haproxy: "true"
+          with-go: "false"
+          with-skopeo: "false"
+      - uses: ./.github/actions/setup-localstack
       - name: Run cloud scale-out DynamoDB tests
         id: dynamodb_scale
         run: |
-          make run-cloud-scale-out-tests
+          make run-cloud-scale-out-tests USE_PREBUILT=1
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
@@ -111,20 +171,50 @@ jobs:
             exit 0
           fi
         continue-on-error: true
-      - name: Clean up DynamoDB scale-out logs
-        run: |
-          rm -r /tmp/zot-ft-logs
+      - name: Upload zb test results zip as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zb-cloud-scale-out-dynamodb-results-${{ github.sha }}
+          path: ./zb-results/
+          if-no-files-found: ignore
       - name: Fail job if DynamoDB error
         if: ${{ steps.dynamodb_scale.outcome != 'success' || steps.dynamodb_multihop.outcome != 'success' }}
         run: |
           echo "DynamoDB scale-out tests failed"
           exit 1
+      - uses: ./.github/actions/teardown-localstack
+        if: always()
 
-      # Redis scale-out tests
+  scale-out-redis:
+    name: Cloud scale-out Redis
+    needs: build
+    runs-on: cncf-ubuntu-32-128-x86
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/download-ecosystem-bins
+        with:
+          artifact-name: ecosystem-bins-${{ github.sha }}
+      # Makefile and bats helpers resolve bin paths via `go env GOOS/GOARCH`.
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          cache: false
+          check-latest: true
+          go-version: 1.26.x
+      - uses: ./.github/actions/setup-ecosystem-tools
+        with:
+          with-docker: "true"
+          with-haproxy: "true"
+          with-valkey: "true"
+          with-go: "false"
+          with-skopeo: "false"
+      - uses: ./.github/actions/setup-localstack
       - name: Run cloud scale-out Redis tests
         id: redis_scale
         run: |
-          make run-cloud-scale-out-redis-tests
+          make run-cloud-scale-out-redis-tests USE_PREBUILT=1
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
@@ -149,19 +239,44 @@ jobs:
             exit 0
           fi
         continue-on-error: true
-      - name: Clean up Redis scale-out logs
-        run: |
-          rm -rf /tmp/zot-ft-logs/redis
+      - name: Upload zb test results zip as build artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: zb-cloud-scale-out-redis-results-${{ github.sha }}
+          path: ./zb-results/
+          if-no-files-found: ignore
       - name: Fail job if Redis error
         if: ${{ steps.redis_scale.outcome != 'success' || steps.redis_multihop.outcome != 'success' }}
         run: |
           echo "Redis scale-out tests failed"
           exit 1
-      - name: Upload zb test results zip as build artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        if: always()
-        with:
-          name: zb-cloud-scale-out-functional-results-${{ github.sha }}
-          path: ./zb-results/
       - uses: ./.github/actions/teardown-localstack
         if: always()
+
+  # Aggregator whose job name matches the pre-refactor required status check.
+  client-tools:
+    name: Check client tools
+    if: ${{ always() }}
+    needs:
+      - blackbox-ci
+      - blackbox-cloud
+      - scale-out-dynamodb
+      - scale-out-redis
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm all ecosystem jobs succeeded
+        run: |
+          set -euo pipefail
+          ok=true
+          check() {
+            echo "$1: $2"
+            if [ "$2" != "success" ]; then
+              ok=false
+            fi
+          }
+          check blackbox-ci "${{ needs.blackbox-ci.result }}"
+          check blackbox-cloud "${{ needs.blackbox-cloud.result }}"
+          check scale-out-dynamodb "${{ needs.scale-out-dynamodb.result }}"
+          check scale-out-redis "${{ needs.scale-out-redis.result }}"
+          "${ok}"

--- a/.github/workflows/sync-3rdparty-images.yaml
+++ b/.github/workflows/sync-3rdparty-images.yaml
@@ -50,8 +50,8 @@ jobs:
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # setup oras
-          make $PWD/hack/tools/bin/oras
+          # setup oras (OS/ARCH avoid Makefile `go env`; $PWD matches $(ORAS))
+          OS=linux ARCH=amd64 make "$PWD/hack/tools/bin/oras"
           export PATH=$PATH:$PWD/hack/tools/bin
           test -n "${GHCR_TOKEN}" || { echo "Missing GHCR token"; exit 1; }
           echo "${GHCR_TOKEN}" | oras login -u "${GITHUB_ACTOR}" --password-stdin ghcr.io

--- a/Makefile
+++ b/Makefile
@@ -36,19 +36,23 @@ STACKER_VERSION := v1.1.0-rc3
 KIND := $(TOOLSDIR)/bin/kind
 KIND_VERSION := v0.31.0
 BATS := $(TOOLSDIR)/bin/bats
+SKOPEO := $(TOOLSDIR)/bin/skopeo
+SKOPEO_VERSION ?= v1.12.0
 TESTDATA := $(TOP_LEVEL)/test/data
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
-# 1: reuse existing bin/ (CI after artifact download). 0: compile via phony binary/bench.
+# 1: reuse existing bin/ (CI after artifact download). 0: compile via phony binary/bench/cli.
 USE_PREBUILT ?= 0
 ifeq ($(USE_PREBUILT),1)
 ZOT_BIN_DEP := require-binary
 ZOT_MIN_DEP := require-binary-minimal
 ZB_DEP := require-bench
+ZLI_DEP := require-cli
 else
 ZOT_BIN_DEP := binary
 ZOT_MIN_DEP := binary-minimal
 ZB_DEP := bench
+ZLI_DEP := cli
 endif
 GREP_BIN_PATH ?= $(shell which grep)
 BLACKBOX_DOCKER_ENV = BUILDX_NO_DEFAULT_ATTESTATIONS=1 DOCKER_DEFAULT_PLATFORM=linux/amd64
@@ -542,6 +546,16 @@ $(BATS):
 	cd bats-core; ./install.sh $(TOOLSDIR); cd ..; \
 	rm -rf bats-core
 
+# Build skopeo into hack/tools/bin for the ecosystem-tools shared CI artifact.
+$(SKOPEO):
+	mkdir -p $(TOOLSDIR)/bin
+	rm -rf skopeo-src
+	git clone -b $(SKOPEO_VERSION) --depth 1 https://github.com/containers/skopeo.git skopeo-src
+	$(MAKE) -C skopeo-src bin/skopeo
+	cp skopeo-src/bin/skopeo $(SKOPEO)
+	chmod +x $(SKOPEO)
+	rm -rf skopeo-src
+
 .PHONY: check-blackbox-prerequisites
 check-blackbox-prerequisites: check-linux check-skopeo $(BATS) $(REGCLIENT) $(ORAS) $(HELM) $(CRICTL) $(NOTATION) $(COSIGN) $(STACKER) $(KIND)
 	which skopeo && skopeo --version; \
@@ -554,8 +568,12 @@ check-blackbox-prerequisites: check-linux check-skopeo $(BATS) $(REGCLIENT) $(OR
 	which cosign && cosign version; \
 	which kind && kind version;
 
+# Download blackbox client tools into hack/tools/bin (includes skopeo for CI artifacts).
+.PHONY: blackbox-tools
+blackbox-tools: $(BATS) $(REGCLIENT) $(ORAS) $(HELM) $(CRICTL) $(NOTATION) $(COSIGN) $(STACKER) $(KIND) $(SKOPEO)
+
 .PHONY: run-blackbox-tests
-run-blackbox-tests: $(BATS_TEST_FILE_PATH) check-blackbox-prerequisites binary binary-minimal cli bench
+run-blackbox-tests: $(BATS_TEST_FILE_PATH) check-blackbox-prerequisites $(ZOT_BIN_DEP) $(ZOT_MIN_DEP) $(ZLI_DEP) $(ZB_DEP)
 	echo running bats test "$(BATS_TEST_FILE_PATH)"; \
 	$(BLACKBOX_DOCKER_ENV) $(BATS) $(BATS_FLAGS) $(BATS_TEST_FILE_PATH)
 
@@ -581,12 +599,18 @@ run-cloud-scale-out-redis-high-scale-tests: check-blackbox-prerequisites check-a
 	$(BATS) $(BATS_FLAGS) test/scale-out/cloud_scale_out_redis_scale.bats
 
 .PHONY: run-blackbox-ci
-run-blackbox-ci: check-blackbox-prerequisites binary binary-minimal cli
+run-blackbox-ci: check-blackbox-prerequisites $(ZOT_BIN_DEP) $(ZOT_MIN_DEP) $(ZLI_DEP)
 	echo running CI bats tests concurrently; \
 	$(BLACKBOX_DOCKER_ENV) BATS_FLAGS="$(BATS_FLAGS)" test/blackbox/ci.sh
 
+# SHARD selects a BLACKBOX_CI_SHARD value: upgrade, sync, registry, host-deps, or all.
+.PHONY: run-blackbox-ci-shard
+run-blackbox-ci-shard: check-blackbox-prerequisites $(ZOT_BIN_DEP) $(ZOT_MIN_DEP) $(ZLI_DEP)
+	echo running CI bats tests concurrently \(shard=$(SHARD)\); \
+	$(BLACKBOX_DOCKER_ENV) BLACKBOX_CI_SHARD="$(SHARD)" BATS_FLAGS="$(BATS_FLAGS)" test/blackbox/ci.sh
+
 .PHONY: run-blackbox-cloud-ci
-run-blackbox-cloud-ci: check-blackbox-prerequisites check-awslocal binary $(BATS)
+run-blackbox-cloud-ci: check-blackbox-prerequisites check-awslocal $(ZOT_BIN_DEP) $(ZOT_MIN_DEP)
 	echo running cloud CI bats tests; \
 	$(BATS) $(BATS_FLAGS) test/blackbox/cloud_only.bats
 	$(BATS) $(BATS_FLAGS) test/blackbox/sync_cloud.bats
@@ -608,7 +632,7 @@ run-kind-sync-ondemand: check-blackbox-prerequisites $(ZOT_BIN_DEP)
 	./examples/kind/kind-sync-ondemand.sh
 
 # When USE_PREBUILT=1, assert compile outputs already exist so test targets
-# can reuse a downloaded bin/ without invoking the phony binary/bench targets.
+# can reuse a downloaded bin/ without invoking the phony binary/bench/cli targets.
 .PHONY: require-binary
 require-binary:
 	@test -x bin/zot-$(OS)-$(ARCH)$(BIN_EXT) || { echo "missing prebuilt bin/zot-$(OS)-$(ARCH)$(BIN_EXT)" >&2; exit 1; }
@@ -621,6 +645,10 @@ require-binary-minimal:
 require-bench:
 	@test -x bin/zb-$(OS)-$(ARCH)$(BIN_EXT) || { echo "missing prebuilt bin/zb-$(OS)-$(ARCH)$(BIN_EXT)" >&2; exit 1; }
 
+.PHONY: require-cli
+require-cli:
+	@test -x bin/zli-$(OS)-$(ARCH)$(BIN_EXT) || { echo "missing prebuilt bin/zli-$(OS)-$(ARCH)$(BIN_EXT)" >&2; exit 1; }
+
 .PHONY: fuzz-all
 fuzz-all: fuzztime=${1}
 fuzz-all:
@@ -632,7 +660,9 @@ fuzz-all:
 	bash test/scripts/fuzzAll.sh ${fuzztime}; \
 	rm -rf pkg/storage/testdata; \
 
-$(STACKER): check-linux
+# check-linux is order-only so a restored binary is not treated as stale
+# just because the phony OS check always "updates".
+$(STACKER): | check-linux
 	mkdir -p $(TOOLSDIR)/bin; \
 	curl -fsSL https://github.com/project-stacker/stacker/releases/download/$(STACKER_VERSION)/stacker -o $@; \
 	chmod +x $@
@@ -642,7 +672,7 @@ $(COSIGN):
 	curl -fsSL https://github.com/sigstore/cosign/releases/download/v$(COSIGN_VERSION)/cosign-$(OS)-$(ARCH) -o $@; \
 	chmod +x $@
 
-$(KIND): check-linux
+$(KIND): | check-linux
 	mkdir -p $(TOOLSDIR)/bin; \
 	curl -fsSL https://kind.sigs.k8s.io/dl/$(KIND_VERSION)/kind-$(OS)-$(ARCH) -o $@; \
 	chmod +x $@

--- a/test/blackbox/ci.sh
+++ b/test/blackbox/ci.sh
@@ -11,15 +11,53 @@ SCRIPTPATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 BATS=${SCRIPTPATH}/../../hack/tools/bin/bats
 PATH=$PATH:${SCRIPTPATH}/../../hack/tools/bin
 
-# Pre-download Docker images before running tests
-echo "Setting up Docker images..."
-${SCRIPTPATH}/setup_images.sh
+# BLACKBOX_CI_SHARD selects a subset for parallel GitHub Actions jobs.
+# Shards are CI-oriented (deps / theme), not zot build-tag "extensions":
+#   registry  — dist-spec / auth / client push-pull style suites (+ systemd)
+#   sync      — sync and related GC/scrub suites
+#   host-deps — needs Docker helper images, npm OIDC provider, and/or stacker userns
+#   upgrade   — release→new binary upgrade matrix (needs CRI-O)
+# "all" is the ordered reunion of those shards.
+shard_registry=("pushpull" "pushpull_authn" "pushpull_mount" "pushpull_mount_hydrate"
+      "delete_images" "referrers" "sbom" "metadata" "anonymous_policy"
+      "detect_manifest_collision" "cve" "metrics" "metrics_minimal"
+      "multiarch_index" "docker_compat" "fips140" "fips140_authn"
+      "dynamic_tls" "quota" "systemd")
+shard_sync=("sync" "sync_docker" "sync_replica_cluster" "scrub" "garbage_collect")
+shard_host_deps=("annotations" "redis_local" "redis_session_store"
+      "events_nats" "events_http" "events_nats_lint_failure" "events_http_lint_failure"
+      "events_sink_failure" "events_config_decoding" "openid_claim_mapping"
+      "events_http_scan")
+shard_upgrade=("upgrade" "upgrade_minimal")
 
-tests=("pushpull" "pushpull_authn" "pushpull_mount" "pushpull_mount_hydrate" "delete_images" "referrers" "sbom" "metadata" "anonymous_policy"
-      "annotations" "detect_manifest_collision" "cve" "sync" "sync_docker" "sync_replica_cluster"
-      "scrub" "garbage_collect" "metrics" "metrics_minimal" "multiarch_index" "docker_compat" "redis_local" "redis_session_store"
-      "events_nats" "events_http" "events_nats_lint_failure" "events_http_lint_failure" "events_sink_failure" "events_config_decoding"
-      "fips140" "fips140_authn" "openid_claim_mapping" "upgrade" "upgrade_minimal" "dynamic_tls" "quota" "events_http_scan" "systemd")
+case "${BLACKBOX_CI_SHARD:-all}" in
+  upgrade)
+    tests=("${shard_upgrade[@]}")
+    ;;
+  sync)
+    tests=("${shard_sync[@]}")
+    ;;
+  registry)
+    tests=("${shard_registry[@]}")
+    ;;
+  host-deps)
+    tests=("${shard_host_deps[@]}")
+    ;;
+  all)
+    tests=("${shard_registry[@]}" "${shard_sync[@]}" "${shard_host_deps[@]}" "${shard_upgrade[@]}")
+    ;;
+  *)
+    echo "unknown BLACKBOX_CI_SHARD=${BLACKBOX_CI_SHARD}" >&2
+    echo "expected one of: upgrade, sync, registry, host-deps, all" >&2
+    exit 1
+    ;;
+esac
+
+# Preload helper images after shard selection so each matrix job only pulls what it needs.
+echo "Setting up Docker images for shard '${BLACKBOX_CI_SHARD:-all}'..."
+${SCRIPTPATH}/setup_images.sh "${BLACKBOX_CI_SHARD:-all}"
+
+echo "Running blackbox CI shard '${BLACKBOX_CI_SHARD:-all}': ${tests[*]}"
 
 for test in ${tests[*]}; do
     ${BATS} ${BATS_FLAGS} ${SCRIPTPATH}/${test}.bats > ${test}.log & pids+=($!)

--- a/test/blackbox/setup_images.sh
+++ b/test/blackbox/setup_images.sh
@@ -1,26 +1,54 @@
 #!/bin/bash
 
-# Pre-download Docker images used in blackbox tests
-# This script ensures all required images are available before tests start
+# Pre-download Docker images used in blackbox tests.
+# Optional first argument (or BLACKBOX_CI_SHARD) selects a shard-aware subset:
+#   registry / upgrade — busybox-docker (docker_compat / pushpull / upgrade helpers)
+#   host-deps — nats, nats-box, python, redis
+#   sync — none of the helper images
+#   all (default) — every image below
 
 set -e
 
-echo "Pre-downloading Docker images for blackbox tests..."
+SHARD="${1:-${BLACKBOX_CI_SHARD:-all}}"
 
-# List of images used in the tests
-IMAGES=(
-    "ghcr.io/project-zot/ci-images/nats:2.11.1"
-    "ghcr.io/project-zot/ci-images/nats-box:0.19.7"
-    "ghcr.io/project-zot/ci-images/python:3.11"
-    "ghcr.io/project-zot/ci-images/redis:7.4.2"
-    "ghcr.io/project-zot/test-images/busybox-docker:1.37"
-)
+echo "Pre-downloading Docker images for blackbox tests (shard=${SHARD})..."
 
-# Function to download an image if not already present
+IMG_NATS="ghcr.io/project-zot/ci-images/nats:2.11.1"
+IMG_NATS_BOX="ghcr.io/project-zot/ci-images/nats-box:0.19.7"
+IMG_PYTHON="ghcr.io/project-zot/ci-images/python:3.11"
+IMG_REDIS="ghcr.io/project-zot/ci-images/redis:7.4.2"
+IMG_BUSYBOX_DOCKER="ghcr.io/project-zot/test-images/busybox-docker:1.37"
+
+IMAGES=()
+case "${SHARD}" in
+  registry|upgrade)
+    IMAGES=("${IMG_BUSYBOX_DOCKER}")
+    ;;
+  host-deps)
+    IMAGES=("${IMG_NATS}" "${IMG_NATS_BOX}" "${IMG_PYTHON}" "${IMG_REDIS}")
+    ;;
+  sync)
+    IMAGES=()
+    ;;
+  all)
+    IMAGES=(
+      "${IMG_NATS}"
+      "${IMG_NATS_BOX}"
+      "${IMG_PYTHON}"
+      "${IMG_REDIS}"
+      "${IMG_BUSYBOX_DOCKER}"
+    )
+    ;;
+  *)
+    echo "unknown shard '${SHARD}' for image preload; expected registry|host-deps|sync|upgrade|all" >&2
+    exit 1
+    ;;
+esac
+
 download_image() {
     local image="$1"
     echo "Checking for image: $image"
-    
+
     if docker image inspect "$image" >/dev/null 2>&1; then
         echo "✓ Image $image already exists"
     else
@@ -34,7 +62,11 @@ download_image() {
     fi
 }
 
-# Download all images
+if [ "${#IMAGES[@]}" -eq 0 ]; then
+    echo "No helper Docker images required for shard '${SHARD}'."
+    exit 0
+fi
+
 for image in "${IMAGES[@]}"; do
     download_image "$image"
 done

--- a/test/blackbox/sync_cloud.bats
+++ b/test/blackbox/sync_cloud.bats
@@ -313,6 +313,8 @@ function teardown_file() {
 
 @test "sign/verify with notation" {
     zot_port3=`cat ${BATS_FILE_TMPDIR}/zot.port3`
+    run notation cert generate-test "notation-sign-sync-test"
+    [ "$status" -eq 0 ]
 
     local trust_policy_file=/tmp/trustpolicy.json
 


### PR DESCRIPTION
- Split ecosystem-tools into blackbox shards, cloud, and DynamoDB/Redis
  scale-out jobs, with floci limited to cloud/scale-out
- Share bin/ and hack/tools/ via a build artifact, download-ecosystem-bins,
  and USE_PREBUILT=1 so jobs do not rebuild zot and client tools
- Factor runner setup into setup-ecosystem-tools with per-job feature flags
- Add a gate job for the required status check
- Fetch oras only in cluster.yaml instead of the shared build action
