### PR TITLE
feat(zb): add --max-timeout-failures budget for GC stress flakes

### DIFF
--- a/.github/workflows/gc-stress-test-with-floci.yaml
+++ b/.github/workflows/gc-stress-test-with-floci.yaml
@@ -72,7 +72,7 @@ jobs:
             make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-s3-minio.json &
             sleep 10
-            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080
 
             killall --wait -r zot-*
 
@@ -160,7 +160,7 @@ jobs:
             make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-s3-minio.json &
             sleep 10
-            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080
 
             killall --wait -r zot-*
 

--- a/.github/workflows/gc-stress-test.yaml
+++ b/.github/workflows/gc-stress-test.yaml
@@ -32,7 +32,7 @@ jobs:
             make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-local.json &
             sleep 10
-            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080
 
             killall --wait -r zot-*
 
@@ -74,7 +74,7 @@ jobs:
             make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-local.json &
             sleep 10
-            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080
 
             killall --wait -r zot-*
 
@@ -156,7 +156,7 @@ jobs:
             make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-s3-minio.json &
             sleep 10
-            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080
 
             killall --wait -r zot-*
 
@@ -244,7 +244,7 @@ jobs:
             make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-s3-minio.json &
             sleep 10
-            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080
+            bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080
 
             killall --wait -r zot-*
 

--- a/cmd/zb/README.md
+++ b/cmd/zb/README.md
@@ -12,6 +12,7 @@ Flags:
   -c, --concurrency int              Number of multiple requests to make at a time (default 1)
   -h, --help                         help for zb
   -l, --list-tests                   Print a list of all available tests. When used together with test regex, lists the tests that match the regex.
+      --max-timeout-failures int     Max timeout failures allowed across the run (default 0); non-timeout failures always fail
   -o, --output-format string         Output format of test results: stdout (default), json, ci-cd
   -r, --repo string                  Use specified repo on remote registry for test data
   -n, --requests int                 Number of requests to perform (default 1)
@@ -23,6 +24,8 @@ Flags:
   -v, --version                      Show the version and exit
   -d, --working-dir string           Use specified directory to store test data
 ```
+
+`--max-timeout-failures` is a run-wide budget for timeout-related request failures only (including client errors that look like server read/write timeouts, such as `use of closed network connection`). Failures are still reported per test. Non-timeout failures always cause a non-zero exit. With default `0`, any timeout failure also fails the run.
   
 ## Command example
 ```

--- a/cmd/zb/main.go
+++ b/cmd/zb/main.go
@@ -17,7 +17,7 @@ func NewPerfRootCmd() *cobra.Command {
 
 	var auth, workdir, repo, outFmt, srcIPs, srcCIDR, testRegexStr, upstreamServerURL string
 
-	var concurrency, requests int
+	var concurrency, requests, maxTimeoutFailures int
 
 	var skipCleanup, listTests bool
 
@@ -50,6 +50,10 @@ func NewPerfRootCmd() *cobra.Command {
 				panic("requests cannot be less than concurrency")
 			}
 
+			if maxTimeoutFailures < 0 {
+				panic("max-timeout-failures cannot be negative")
+			}
+
 			var testRegex *regexp.Regexp
 
 			if testRegexStr != "" {
@@ -69,7 +73,7 @@ func NewPerfRootCmd() *cobra.Command {
 
 			Perf(
 				workdir, url, auth, repo, concurrency, requests, outFmt,
-				srcIPs, srcCIDR, skipCleanup, testRegex, upstreamServerURL,
+				srcIPs, srcCIDR, skipCleanup, testRegex, upstreamServerURL, maxTimeoutFailures,
 			)
 		},
 	}
@@ -88,6 +92,8 @@ func NewPerfRootCmd() *cobra.Command {
 		"Number of multiple requests to make at a time")
 	rootCmd.Flags().IntVarP(&requests, "requests", "n", 1,
 		"Number of requests to perform")
+	rootCmd.Flags().IntVar(&maxTimeoutFailures, "max-timeout-failures", 0,
+		"Max timeout failures allowed across the run (default 0); non-timeout failures always fail")
 	rootCmd.Flags().StringVarP(&outFmt, "output-format", "o", "",
 		"Output format of test results: stdout (default), json, ci-cd")
 	rootCmd.Flags().BoolVar(&skipCleanup, "skip-cleanup", false,

--- a/cmd/zb/main_test.go
+++ b/cmd/zb/main_test.go
@@ -1,12 +1,24 @@
 package main //nolint:testpackage // separate binary
 
 import (
+	"errors"
+	"net"
 	"testing"
+	"time"
 
 	. "github.com/smartystreets/goconvey/convey"
 
 	"zotregistry.dev/zot/v2/pkg/api"
 	"zotregistry.dev/zot/v2/pkg/api/config"
+)
+
+var (
+	errSomethingElse     = errors.New("something else")
+	errIOTimeout         = errors.New("i/o timeout")
+	errDeadlineExceeded  = errors.New("context deadline exceeded")
+	errClosedConn        = errors.New("write tcp: use of closed network connection")
+	errUnexpectedStatus  = errors.New("unexpected status")
+	errConnectionRefused = errors.New("connection refused")
 )
 
 func TestIntegration(t *testing.T) {
@@ -19,5 +31,70 @@ func TestIntegration(t *testing.T) {
 		So(cl, ShouldNotBeNil)
 
 		So(cl.Execute(), ShouldBeNil)
+	})
+}
+
+func TestMaxTimeoutFailuresFlag(t *testing.T) {
+	Convey("max-timeout-failures flag is registered with default 0", t, func() {
+		cl := NewPerfRootCmd()
+		flag := cl.Flags().Lookup("max-timeout-failures")
+		So(flag, ShouldNotBeNil)
+		So(flag.DefValue, ShouldEqual, "0")
+	})
+}
+
+func TestShouldFailRun(t *testing.T) {
+	Convey("run fails on hard failures or timeout budget overrun", t, func() {
+		So(shouldFailRun(0, 0, 0), ShouldBeFalse)
+		So(shouldFailRun(0, 1, 0), ShouldBeTrue)
+		So(shouldFailRun(0, 1, 1), ShouldBeFalse)
+		So(shouldFailRun(0, 2, 1), ShouldBeTrue)
+		So(shouldFailRun(1, 0, 5), ShouldBeTrue)
+		So(shouldFailRun(1, 1, 1), ShouldBeTrue)
+		So(shouldFailRun(0, 0, 5), ShouldBeFalse)
+	})
+}
+
+func TestIsTimeoutError(t *testing.T) {
+	Convey("timeout error classification", t, func() {
+		So(isTimeoutError(nil), ShouldBeFalse)
+		So(isTimeoutError(errSomethingElse), ShouldBeFalse)
+		So(isTimeoutError(errIOTimeout), ShouldBeTrue)
+		So(isTimeoutError(errDeadlineExceeded), ShouldBeTrue)
+		So(isTimeoutError(errClosedConn), ShouldBeTrue)
+		So(isTimeoutError(&timeoutNetError{}), ShouldBeTrue)
+	})
+}
+
+type timeoutNetError struct{}
+
+func (e *timeoutNetError) Error() string   { return "read tcp: i/o timeout" }
+func (e *timeoutNetError) Timeout() bool   { return true }
+func (e *timeoutNetError) Temporary() bool { return true }
+
+var _ net.Error = (*timeoutNetError)(nil)
+
+func TestUpdateStatsTimeoutCount(t *testing.T) {
+	Convey("timeoutErrorCount increments only for timeout errors", t, func() {
+		summary := newStatsSummary("test")
+
+		updateStats(&summary, statsRecord{
+			latency:    time.Second,
+			isConnFail: true,
+			err:        errIOTimeout,
+		})
+		updateStats(&summary, statsRecord{
+			latency: time.Second,
+			isErr:   true,
+			err:     errUnexpectedStatus,
+		})
+		updateStats(&summary, statsRecord{
+			latency:    time.Second,
+			isConnFail: true,
+			err:        errConnectionRefused,
+		})
+
+		So(summary.errorCount, ShouldEqual, 3)
+		So(summary.timeoutErrorCount, ShouldEqual, 1)
 	})
 }

--- a/cmd/zb/perf.go
+++ b/cmd/zb/perf.go
@@ -3,6 +3,7 @@ package main
 import (
 	crand "crypto/rand"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"log"
 	"math/big"
@@ -129,6 +130,7 @@ type statsSummary struct {
 	rps                  float32
 	mixedSize, mixedType bool
 	errorCount           int
+	timeoutErrorCount    int
 	errors               map[string]int
 	manifestHeadTTFBs    []time.Duration
 	manifestGetTTFBs     []time.Duration
@@ -171,6 +173,10 @@ type statsRecord struct {
 func updateStats(summary *statsSummary, record statsRecord) {
 	if record.isConnFail || record.isErr {
 		summary.errorCount++
+
+		if isTimeoutError(record.err) {
+			summary.timeoutErrorCount++
+		}
 	}
 
 	if record.err != nil {
@@ -778,7 +784,7 @@ func Perf(
 	workdir, url, auth, repo string,
 	concurrency int, requests int,
 	outFmt string, srcIPs string, srcCIDR string, skipCleanup bool,
-	testRegex *regexp.Regexp, upstreamServerURL string,
+	testRegex *regexp.Regexp, upstreamServerURL string, maxTimeoutFailures int,
 ) {
 	// logging
 	log.SetFlags(0)
@@ -794,6 +800,7 @@ func Perf(
 	}
 	log.Printf("Concurrency Level:\t%v", concurrency)
 	log.Printf("Total requests:\t%v", requests)
+	log.Printf("Max timeout failures:\t%v", maxTimeoutFailures)
 
 	if workdir == "" {
 		cwd, err := os.Getwd()
@@ -851,7 +858,8 @@ func Perf(
 
 	var err error
 
-	zbError := false
+	totalFailures := 0
+	timeoutFailures := 0
 
 	// get host ips from command line to make requests from
 	var ips []string
@@ -920,9 +928,8 @@ func Perf(
 		printStats(requests, &summary)
 		statsSummaries = append(statsSummaries, summary)
 
-		if summary.errorCount != 0 && !zbError {
-			zbError = true
-		}
+		totalFailures += summary.errorCount
+		timeoutFailures += summary.timeoutErrorCount
 	}
 
 	if err = outputTestResults(statsSummaries, outFmt); err != nil {
@@ -934,9 +941,68 @@ func Perf(
 		teardown(workdir)
 	})
 
-	if zbError {
+	hardFailures := totalFailures - timeoutFailures
+
+	printFailureBudget(hardFailures, timeoutFailures, maxTimeoutFailures)
+
+	if shouldFailRun(hardFailures, timeoutFailures, maxTimeoutFailures) {
 		os.Exit(1)
 	}
+}
+
+// isTimeoutError reports whether err looks like a request timeout (or the common
+// client-side symptom when a server closes the connection after its own timeout).
+func isTimeoutError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return true
+	}
+
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		return true
+	}
+
+	msg := strings.ToLower(err.Error())
+
+	return strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "deadline exceeded") ||
+		strings.Contains(msg, "use of closed network connection")
+}
+
+// shouldFailRun reports whether the run should exit non-zero.
+// Non-timeout failures always fail the run; timeout failures use the budget.
+func shouldFailRun(hardFailures, timeoutFailures, maxTimeoutFailures int) bool {
+	return hardFailures > 0 || timeoutFailures > maxTimeoutFailures
+}
+
+func printFailureBudget(hardFailures, timeoutFailures, maxTimeoutFailures int) {
+	log.Printf("\n============")
+	log.Printf("Total failed requests:\t%v", hardFailures+timeoutFailures)
+	log.Printf("Timeout failures:\t%v", timeoutFailures)
+	log.Printf("Other failures:\t%v", hardFailures)
+	log.Printf("Timeout failure budget:\t%v", maxTimeoutFailures)
+
+	if hardFailures == 0 && timeoutFailures == 0 {
+		return
+	}
+
+	if shouldFailRun(hardFailures, timeoutFailures, maxTimeoutFailures) {
+		if hardFailures > 0 {
+			log.Printf("Non-timeout failures present:\t%v", hardFailures)
+		}
+
+		if timeoutFailures > maxTimeoutFailures {
+			log.Printf("Timeout failure budget exceeded:\t%v/%v", timeoutFailures, maxTimeoutFailures)
+		}
+
+		return
+	}
+
+	log.Printf("Timeout failure budget used:\t%v/%v", timeoutFailures, maxTimeoutFailures)
 }
 
 // outputTestResults outputs the test results in the specified format.


### PR DESCRIPTION
Allow a small number of timeout-related request failures across a zb
run before exiting non-zero. Non-timeout failures still fail the run.
GC stress workflows use --max-timeout-failures 1 to absorb occasional
S3 HTTP timeouts.

Workaround frequent errors such as
https://github.com/project-zot/zot/actions/runs/33546853042/job/99986383432?pr=4387

We should disable this eventually.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
