### PR TITLE
fix(search): configure the GraphQL server explicitly instead of the e…

### DIFF
--- a/pkg/api/constants/consts.go
+++ b/pkg/api/constants/consts.go
@@ -32,8 +32,8 @@ const (
 	// MaxSearchBodySize is the maximum number of bytes accepted for a GraphQL search request body.
 	// The richest query zot's own CLI/UI issue is a few hundred bytes; 1 MiB leaves generous headroom
 	// for hand-written queries while bounding the memory a single request can force the server to
-	// buffer before GraphQL parsing (which has its own, tighter token budget - see
-	// extensions.searchParserTokenLimit) even gets a chance to run.
+	// buffer before GraphQL parsing (which has its own, tighter token budget; see
+	// searchParserTokenLimit in pkg/extensions/extension_search.go) even gets a chance to run.
 	MaxSearchBodySize            = 1 * 1024 * 1024
 	BlobUploadUUID               = "Blob-Upload-UUID"
 	DefaultMediaType             = "application/json"

--- a/pkg/api/constants/consts.go
+++ b/pkg/api/constants/consts.go
@@ -28,7 +28,13 @@ const (
 	// MaxImageTrustBodySize is the maximum number of bytes accepted for image-trust key/certificate uploads.
 	MaxImageTrustBodySize = 8 * 1024 * 1024
 	// MaxTokenRequestBodySize is the maximum form body size accepted by the token endpoint.
-	MaxTokenRequestBodySize      = 64 * 1024
+	MaxTokenRequestBodySize = 64 * 1024
+	// MaxSearchBodySize is the maximum number of bytes accepted for a GraphQL search request body.
+	// The richest query zot's own CLI/UI issue is a few hundred bytes; 1 MiB leaves generous headroom
+	// for hand-written queries while bounding the memory a single request can force the server to
+	// buffer before GraphQL parsing (which has its own, tighter token budget - see
+	// extensions.searchParserTokenLimit) even gets a chance to run.
+	MaxSearchBodySize            = 1 * 1024 * 1024
 	BlobUploadUUID               = "Blob-Upload-UUID"
 	DefaultMediaType             = "application/json"
 	BinaryMediaType              = "application/octet-stream"

--- a/pkg/common/http_server.go
+++ b/pkg/common/http_server.go
@@ -56,6 +56,19 @@ func ACHeadersMiddleware(config *config.Config, allowedMethods ...string) mux.Mi
 	}
 }
 
+// MaxBodySizeMiddleware caps the request body at maxBytes before it reaches the wrapped
+// handler, so a handler that buffers its whole body into memory (e.g. io.ReadAll) can't be
+// forced to allocate an unbounded amount for a single request.
+func MaxBodySizeMiddleware(maxBytes int64) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+			req.Body = http.MaxBytesReader(resp, req.Body, maxBytes)
+
+			next.ServeHTTP(resp, req)
+		})
+	}
+}
+
 func CORSHeadersMiddleware(allowOrigin string) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {

--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -40,6 +40,13 @@ const (
 	// dispatch an unbounded number of resolvers - each of which may hit the CVE scanner or metadb -
 	// concurrently. The richest known real query costs on the order of 30; 500 leaves ample headroom.
 	searchComplexityLimit = 500
+	// searchQueryCacheSize bounds the query cache's entry count. gqlgen keys each entry on the raw
+	// query text and stores the parsed document as the value, so a single entry can retain a
+	// document close to the full MaxSearchBodySize (a valid, low-token document can still pack long
+	// string literals into most of that body) - a large entry count would let an unauthenticated
+	// client hold many distinct such documents in memory at once. 64 keeps the worst case in the
+	// tens of MiB while still caching the handful of distinct queries zot's own CLI/UI issue.
+	searchQueryCacheSize = 64
 )
 
 type CveScanner cveinfo.Scanner
@@ -145,7 +152,7 @@ func newSearchGQLHandler(resConfig gql_generated.Config) *gqlHandler.Server {
 	srv.AddTransport(transport.GET{})
 	srv.AddTransport(transport.POST{})
 
-	srv.SetQueryCache(lru.New[*ast.QueryDocument](1000))
+	srv.SetQueryCache(lru.New[*ast.QueryDocument](searchQueryCacheSize))
 	srv.SetParserTokenLimit(searchParserTokenLimit)
 
 	srv.Use(extension.Introspection{})

--- a/pkg/extensions/extension_search.go
+++ b/pkg/extensions/extension_search.go
@@ -7,7 +7,11 @@ import (
 	"time"
 
 	gqlHandler "github.com/99designs/gqlgen/graphql/handler"
+	"github.com/99designs/gqlgen/graphql/handler/extension"
+	"github.com/99designs/gqlgen/graphql/handler/lru"
+	"github.com/99designs/gqlgen/graphql/handler/transport"
 	"github.com/gorilla/mux"
+	"github.com/vektah/gqlparser/v2/ast"
 
 	"zotregistry.dev/zot/v2/pkg/api/config"
 	"zotregistry.dev/zot/v2/pkg/api/constants"
@@ -23,6 +27,20 @@ import (
 )
 
 const scanInterval = 15 * time.Minute
+
+const (
+	// searchParserTokenLimit bounds the number of lexical tokens a single GraphQL document may
+	// contain, enforced during parsing, before the (potentially superlinear) field-merge validation
+	// that follows it ever runs. The richest query zot's own CLI/UI issue (GlobalSearch, nested
+	// Images/Manifests/Layers) is well under 300 tokens; 2000 leaves headroom for hand-written
+	// queries while keeping a document built from many repeated/aliased selections cheap to reject.
+	searchParserTokenLimit = 2000
+	// searchComplexityLimit bounds total query complexity (by default, gqlgen counts each requested
+	// field as 1, summed recursively), so a document with many distinct aliased root fields can't
+	// dispatch an unbounded number of resolvers - each of which may hit the CVE scanner or metadb -
+	// concurrently. The richest known real query costs on the order of 30; 500 leaves ample headroom.
+	searchComplexityLimit = 500
+)
 
 type CveScanner cveinfo.Scanner
 
@@ -106,8 +124,32 @@ func SetupSearchRoutes(conf *config.Config, router *mux.Router, storeController 
 	extRouter.Use(zcommon.CORSHeadersMiddleware(conf.HTTP.AllowOrigin))
 	extRouter.Use(zcommon.ACHeadersMiddleware(conf, allowedMethods...))
 	extRouter.Use(zcommon.AddExtensionSecurityHeaders())
+	extRouter.Use(zcommon.MaxBodySizeMiddleware(constants.MaxSearchBodySize))
 	extRouter.Methods(allowedMethods...).
-		Handler(gqlHandler.NewDefaultServer(gql_generated.NewExecutableSchema(resConfig))) //nolint: staticcheck
+		Handler(newSearchGQLHandler(resConfig))
 
 	log.Info().Msg("finished setting up search routes")
+}
+
+// newSearchGQLHandler builds the GraphQL server by hand instead of using gqlgen's
+// NewDefaultServer, which the library itself documents as "not suitable for production use":
+// it wires up every transport (including websocket, which zot's route never allows through
+// allowedMethods above) and applies no budget on parser tokens, query complexity, or request
+// body size, so a small valid document with many repeated/aliased selections can force
+// superlinear parsing/validation work and dispatch an attacker-chosen number of resolvers -
+// some of which reach the CVE scanner - before a single error is returned. This route has no
+// authentication in the default container config, so those budgets are the only gate.
+func newSearchGQLHandler(resConfig gql_generated.Config) *gqlHandler.Server {
+	srv := gqlHandler.New(gql_generated.NewExecutableSchema(resConfig))
+
+	srv.AddTransport(transport.GET{})
+	srv.AddTransport(transport.POST{})
+
+	srv.SetQueryCache(lru.New[*ast.QueryDocument](1000))
+	srv.SetParserTokenLimit(searchParserTokenLimit)
+
+	srv.Use(extension.Introspection{})
+	srv.Use(extension.FixedComplexityLimit(searchComplexityLimit))
+
+	return srv
 }

--- a/pkg/extensions/search/search_dos_test.go
+++ b/pkg/extensions/search/search_dos_test.go
@@ -122,11 +122,15 @@ func TestSearchGQLResourceLimits(t *testing.T) {
 				SetBody(body).
 				Post(baseURL + "/v2/_zot/ext/search")
 
-			isRejectedByClosingConnection := err != nil
 			// A body-size rejection may close the connection instead of returning a well-formed
-			// response; either outcome proves the server didn't buffer and process the oversized
-			// body as a normal request.
-			if isRejectedByClosingConnection {
+			// response; if that happens, assert it's a connection-close style error so an
+			// unrelated failure (e.g. DNS, unreachable server) can't masquerade as a pass.
+			if err != nil {
+				msg := strings.ToLower(err.Error())
+				isConnClose := strings.Contains(msg, "eof") || strings.Contains(msg, "connection reset") ||
+					strings.Contains(msg, "broken pipe") || strings.Contains(msg, "closed network connection")
+				So(isConnClose, ShouldBeTrue)
+
 				return
 			}
 

--- a/pkg/extensions/search/search_dos_test.go
+++ b/pkg/extensions/search/search_dos_test.go
@@ -1,0 +1,151 @@
+//go:build search
+
+package search_test
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+	"gopkg.in/resty.v1"
+
+	"zotregistry.dev/zot/v2/pkg/api"
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
+	. "zotregistry.dev/zot/v2/pkg/test/common"
+)
+
+// buildRepeatedFieldQuery builds a single valid GraphQL document containing count repeated,
+// unaliased selections of the same root field - the shape that forces validation's field-merge
+// work to scale with count.
+func buildRepeatedFieldQuery(count int) string {
+	var builder strings.Builder
+
+	builder.WriteString("{")
+
+	for range count {
+		builder.WriteString(`CVEListForImage(image:"repo:tag"){Tag}`)
+	}
+
+	builder.WriteString("}")
+
+	return builder.String()
+}
+
+func TestSearchGQLResourceLimits(t *testing.T) {
+	Convey("Search GraphQL endpoint enforces request budgets", t, func() {
+		rootDir := t.TempDir()
+
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		conf.Storage.RootDirectory = rootDir
+		defaultVal := true
+		conf.Extensions = &extconf.ExtensionConfig{
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
+		}
+
+		ctlr := api.NewController(conf)
+		if err := ctlr.Init(); err != nil {
+			t.Fatal(err)
+		}
+
+		go func() {
+			if err := ctlr.Run(); !errors.Is(err, http.ErrServerClosed) {
+				panic(err)
+			}
+		}()
+
+		defer ctlr.Shutdown()
+
+		cm := NewControllerManager(ctlr)
+		cm.WaitServerReady()
+		baseURL := cm.BaseURL()
+
+		Convey("a small, legitimate query is resolved normally", func() {
+			resp, err := resty.R().
+				SetHeader("Content-Type", "application/json").
+				SetBody(map[string]string{"query": buildRepeatedFieldQuery(1)}).
+				Post(baseURL + "/v2/_zot/ext/search")
+
+			So(err, ShouldBeNil)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+			var result struct {
+				Errors []struct {
+					Message string `json:"message"`
+				} `json:"errors"`
+			}
+			So(json.Unmarshal(resp.Body(), &result), ShouldBeNil)
+			// CVE scanning isn't configured, so the resolver runs and returns its own,
+			// expected error - proving the request reached resolution rather than being
+			// rejected by a request budget.
+			So(len(result.Errors), ShouldEqual, 1)
+			So(result.Errors[0].Message, ShouldContainSubstring, "cve search is disabled")
+		})
+
+		Convey("a document with many repeated selections is rejected before resolution", func() {
+			// Comfortably over searchParserTokenLimit (2000): each repetition is 8 tokens,
+			// so 400 repetitions is ~3200 tokens.
+			resp, err := resty.R().
+				SetHeader("Content-Type", "application/json").
+				SetBody(map[string]string{"query": buildRepeatedFieldQuery(400)}).
+				Post(baseURL + "/v2/_zot/ext/search")
+
+			So(err, ShouldBeNil)
+
+			var result struct {
+				Errors []struct {
+					Message string `json:"message"`
+				} `json:"errors"`
+			}
+			So(json.Unmarshal(resp.Body(), &result), ShouldBeNil)
+			So(len(result.Errors), ShouldBeGreaterThan, 0)
+			// Rejected at parse time, not at the resolver: the disabled-CVE message must not
+			// appear, since that would mean every repeated field was individually resolved.
+			for _, gqlErr := range result.Errors {
+				So(gqlErr.Message, ShouldNotContainSubstring, "cve search is disabled")
+			}
+		})
+
+		Convey("an oversized request body is rejected without being fully buffered", func() {
+			oversized := strings.Repeat("a", 2*1024*1024) // 2 MiB, over MaxSearchBodySize (1 MiB)
+			body := `{"query":"{CVEListForImage(image:\"repo:tag\"){Tag}}","extensions":{"padding":"` +
+				oversized + `"}}`
+
+			resp, err := resty.R().
+				SetHeader("Content-Type", "application/json").
+				SetHeader("Content-Length", strconv.Itoa(len(body))).
+				SetBody(body).
+				Post(baseURL + "/v2/_zot/ext/search")
+
+			isRejectedByClosingConnection := err != nil
+			// A body-size rejection may close the connection instead of returning a well-formed
+			// response; either outcome proves the server didn't buffer and process the oversized
+			// body as a normal request.
+			if isRejectedByClosingConnection {
+				return
+			}
+
+			// The handler still answers with its usual 200 + GraphQL error envelope (gqlgen's own
+			// behavior), but the response is a short "body too large" error, not a resolved
+			// CVEListForImage result - proving the oversized body was capped, not processed.
+			So(len(resp.Body()), ShouldBeLessThan, 1024)
+
+			var result struct {
+				Errors []struct {
+					Message string `json:"message"`
+				} `json:"errors"`
+			}
+			So(json.Unmarshal(resp.Body(), &result), ShouldBeNil)
+			So(len(result.Errors), ShouldBeGreaterThan, 0)
+
+			for _, gqlErr := range result.Errors {
+				So(gqlErr.Message, ShouldNotContainSubstring, "cve search is disabled")
+			}
+		})
+	})
+}

--- a/pkg/extensions/search/search_dos_test.go
+++ b/pkg/extensions/search/search_dos_test.go
@@ -121,10 +121,9 @@ func TestSearchGQLResourceLimits(t *testing.T) {
 				SetHeader("Content-Length", strconv.Itoa(len(body))).
 				SetBody(body).
 				Post(baseURL + "/v2/_zot/ext/search")
-
-			// A body-size rejection may close the connection instead of returning a well-formed
-			// response; if that happens, assert it's a connection-close style error so an
-			// unrelated failure (e.g. DNS, unreachable server) can't masquerade as a pass.
+				// A body-size rejection may close the connection instead of returning a well-formed
+				// response; if that happens, assert it's a connection-close style error so an
+				// unrelated failure (e.g. DNS, unreachable server) can't masquerade as a pass.
 			if err != nil {
 				msg := strings.ToLower(err.Error())
 				isConnClose := strings.Contains(msg, "eof") || strings.Contains(msg, "connection reset") ||

--- a/pkg/extensions/search/search_dos_test.go
+++ b/pkg/extensions/search/search_dos_test.go
@@ -99,14 +99,20 @@ func TestSearchGQLResourceLimits(t *testing.T) {
 
 			var result struct {
 				Errors []struct {
-					Message string `json:"message"`
+					Message    string `json:"message"`
+					Extensions struct {
+						Code string `json:"code"`
+					} `json:"extensions"`
 				} `json:"errors"`
 			}
 			So(json.Unmarshal(resp.Body(), &result), ShouldBeNil)
 			So(len(result.Errors), ShouldBeGreaterThan, 0)
-			// Rejected at parse time, not at the resolver: the disabled-CVE message must not
-			// appear, since that would mean every repeated field was individually resolved.
+			// Assert the parse-time error code specifically, not just "some error, no
+			// resolution": FixedComplexityLimit(500) would reject this same document (400
+			// repetitions cost ~800 complexity) even without SetParserTokenLimit, so a looser
+			// assertion wouldn't catch the parser token limit being removed or misconfigured.
 			for _, gqlErr := range result.Errors {
+				So(gqlErr.Extensions.Code, ShouldEqual, "GRAPHQL_PARSE_FAILED")
 				So(gqlErr.Message, ShouldNotContainSubstring, "cve search is disabled")
 			}
 		})


### PR DESCRIPTION
…xample default

gqlgen's NewDefaultServer is documented as an example server, not for production use: it wires up every transport (including websocket, which the search route never allows through its GET/POST-only method list) and applies no limit on parser tokens, query complexity, or request body size. Replace it with an explicitly configured server: only the GET/POST transports the route actually uses, a request body cap, a parser token limit, and a query complexity limit, all sized against the richest queries zot's own CLI/UI issue.

Adds a regression test covering the new limits and confirming ordinary queries still resolve normally.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:


**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
