### PR TITLE
 ci: build zot binaries once per workflow and reuse them

### DIFF
--- a/.github/actions/build-zot-binaries/action.yaml
+++ b/.github/actions/build-zot-binaries/action.yaml
@@ -1,0 +1,93 @@
+name: 'Build and upload zot linux/amd64 binaries'
+description: >
+  setup-go, restore build.yaml go caches (read-only), and run make targets.
+  Optionally upload bin/ artifacts. Caller must checkout the repo first.
+inputs:
+  make-targets:
+    description: 'Space-separated make targets (e.g. "binary bench")'
+    required: true
+  upload-artifact:
+    description: 'Upload built binaries as a workflow artifact'
+    required: false
+    default: 'true'
+  artifact-name:
+    description: 'upload-artifact name for zot binaries'
+    required: false
+    default: zot-linux-amd64-binaries
+  artifact-path:
+    description: 'Newline-separated paths under bin/ to upload (required when upload-artifact is true)'
+    required: false
+    default: ''
+  include-oras:
+    description: 'Also fetch oras into hack/tools/bin and upload as artifact "oras"'
+    required: false
+    default: 'false'
+  go-version:
+    description: 'Go version for setup-go'
+    required: false
+    default: '1.26.x'
+  retention-days:
+    description: 'Artifact retention in days'
+    required: false
+    default: '1'
+runs:
+  using: "composite"
+  steps:
+    - name: Require artifact-path when uploading
+      if: ${{ inputs.upload-artifact == 'true' }}
+      shell: bash
+      run: |
+        if [ -z "$(echo "${{ inputs.artifact-path }}" | tr -d '[:space:]')" ]; then
+          echo "artifact-path is required when upload-artifact is true" >&2
+          exit 1
+        fi
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      with:
+        cache: false
+        check-latest: true
+        go-version: ${{ inputs.go-version }}
+    - name: Restore go dependencies
+      id: cache-go-dependencies
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-mod-
+    - name: Restore go build output
+      id: cache-go-build
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: |
+          ~/.cache/go-build
+        key: linux-amd64-go-build-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          linux-amd64-go-build-
+    - name: Install go dependencies
+      if: steps.cache-go-dependencies.outputs.cache-hit != 'true'
+      shell: bash
+      run: go mod download
+    - name: Build binaries
+      shell: bash
+      run: make ${{ inputs.make-targets }}
+    - name: Fetch oras
+      if: ${{ inputs.include-oras == 'true' }}
+      shell: bash
+      run: make "$PWD/hack/tools/bin/oras"
+    - name: Upload binaries
+      if: ${{ inputs.upload-artifact == 'true' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ inputs.artifact-path }}
+        if-no-files-found: error
+        retention-days: ${{ inputs.retention-days }}
+    - name: Upload oras
+      if: ${{ inputs.upload-artifact == 'true' && inputs.include-oras == 'true' }}
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: oras
+        path: hack/tools/bin/oras
+        if-no-files-found: error
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -17,14 +17,16 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - uses: ./.github/actions/build-zot-binaries
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
-      # Run benchmark with `go test -bench` and stores the output to a file
+          make-targets: binary bench
+          upload-artifact: "false"
+      # Cache restore unpacks ~2GB onto disk; settle before the short bench so
+      # the first suite (Get Catalog) is not dominated by writeback.
+      - name: Flush disk after cache restore
+        run: sync
       - name: Run benchmark
-        run: make BENCH_OUTPUT=ci-cd run-bench
+        run: make USE_PREBUILT=1 BENCH_OUTPUT=ci-cd run-bench
       # Download previous benchmark result from cache (if exists)
       - name: Download previous benchmark data
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Generate zot config schema on Release
         if: github.event_name == 'release' && github.event.action == 'published' && matrix.os == 'linux' && matrix.arch == 'amd64'
         run: |
-          make verify-config-schema
+          make USE_PREBUILT=1 verify-config-schema
 
       - if: github.event_name == 'release' && github.event.action == 'published'
         name: Publish artifacts on releases

--- a/.github/workflows/cluster.yaml
+++ b/.github/workflows/cluster.yaml
@@ -12,23 +12,32 @@ on:
 permissions: read-all
 
 jobs:
-  minio-bolt:
-    name: Stateless zot with minio and boltdb
+  build-binaries:
+    name: Build zot and zb (linux/amd64)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - uses: ./.github/actions/build-zot-binaries
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          make-targets: binary bench
+          include-oras: "true"
+          artifact-path: |
+            bin/zot-linux-amd64
+            bin/zb-linux-amd64
+
+  minio-bolt:
+    name: Stateless zot with minio and boltdb
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
-          go install github.com/swaggo/swag/cmd/swag@v1.16.2
-          go mod download
           sudo apt-get update
           sudo apt-get -y install rpm uidmap
           # install skopeo
@@ -36,13 +45,6 @@ jobs:
 
           # install haproxy
           sudo apt-get install haproxy
-
-      - name: Build binaries
-        run: |
-          cd $GITHUB_WORKSPACE
-          make binary
-          make bench
-          make $PWD/hack/tools/bin/oras
 
       - name: Setup minio service
         run: |
@@ -114,6 +116,19 @@ jobs:
           haskell: true
           large-packages: true
           swap-storage: true
+
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Download oras
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: oras
+          path: hack/tools/bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64 hack/tools/bin/oras
 
       - name: Run push-pull tests
         run: |
@@ -272,21 +287,15 @@ jobs:
 
   minio-redis:
     name: Stateless zot with minio and redis
+    needs: build-binaries
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
-          go install github.com/swaggo/swag/cmd/swag@v1.16.2
-          go mod download
           sudo apt-get update
           sudo apt-get -y install rpm uidmap
           # install skopeo
@@ -294,13 +303,6 @@ jobs:
 
           # install haproxy
           sudo apt-get install haproxy
-
-      - name: Build binaries
-        run: |
-          cd $GITHUB_WORKSPACE
-          make binary
-          make bench
-          make $PWD/hack/tools/bin/oras
 
       - name: Setup minio service
         run: |
@@ -381,6 +383,19 @@ jobs:
           haskell: true
           large-packages: true
           swap-storage: true
+
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Download oras
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: oras
+          path: hack/tools/bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64 hack/tools/bin/oras
 
       - name: Run push-pull tests
         run: |

--- a/.github/workflows/compare-binary-size.yaml
+++ b/.github/workflows/compare-binary-size.yaml
@@ -13,26 +13,26 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Build PR binaries
+        uses: ./.github/actions/build-zot-binaries
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          make-targets: binary-minimal bench cli
+          upload-artifact: "false"
       - name: Checkout zot (main branch)
         run: |
           mkdir -p $GITHUB_WORKSPACE/zot_main
           git clone https://github.com/project-zot/zot zot_main/
       - name: Check if zot-minimal binary increased with more than 1%
         run: |
-          echo "Building zot-minimal and check size"
-          cd $GITHUB_WORKSPACE
-          make binary-minimal
-          BINSIZE=$(stat -c%s "bin/zot-linux-amd64-minimal")
+          PR_BIN="$GITHUB_WORKSPACE/bin/zot-linux-amd64-minimal"
+          MAIN_BIN="$GITHUB_WORKSPACE/zot_main/bin/zot-linux-amd64-minimal"
 
-          echo "Building zot-minimal on main branch and check size"
-          cd zot_main
-          make binary-minimal
-          BINSIZE_MAIN=$(stat -c%s "bin/zot-linux-amd64-minimal")
+          echo "PR binary (already built): $PR_BIN"
+          BINSIZE=$(stat -c%s "$PR_BIN")
+
+          echo "Building zot-minimal on main branch"
+          make -C "$GITHUB_WORKSPACE/zot_main" binary-minimal
+          BINSIZE_MAIN=$(stat -c%s "$MAIN_BIN")
 
           echo "PR binary size: $BINSIZE Bytes"
           echo "main branch binary size: $BINSIZE_MAIN Bytes"
@@ -49,15 +49,15 @@ jobs:
       - if: always()
         name: Check if zb binary increased with more than 1%
         run: |
-          echo "Building zb and check size"
-          cd $GITHUB_WORKSPACE
-          make bench
-          BINSIZE=$(stat -c%s "bin/zb-linux-amd64")
+          PR_BIN="$GITHUB_WORKSPACE/bin/zb-linux-amd64"
+          MAIN_BIN="$GITHUB_WORKSPACE/zot_main/bin/zb-linux-amd64"
 
-          echo "Building zb on main branch and check size"
-          cd zot_main
-          make bench
-          BINSIZE_MAIN=$(stat -c%s "bin/zb-linux-amd64")
+          echo "PR binary (already built): $PR_BIN"
+          BINSIZE=$(stat -c%s "$PR_BIN")
+
+          echo "Building zb on main branch"
+          make -C "$GITHUB_WORKSPACE/zot_main" bench
+          BINSIZE_MAIN=$(stat -c%s "$MAIN_BIN")
 
           echo "PR binary size: $BINSIZE Bytes"
           echo "main branch binary size: $BINSIZE_MAIN Bytes"
@@ -74,15 +74,15 @@ jobs:
       - if: always()
         name: Check if zli binary increased with more than 1%
         run: |
-          echo "Building zli and check size"
-          cd $GITHUB_WORKSPACE
-          make cli
-          BINSIZE=$(stat -c%s "bin/zli-linux-amd64")
+          PR_BIN="$GITHUB_WORKSPACE/bin/zli-linux-amd64"
+          MAIN_BIN="$GITHUB_WORKSPACE/zot_main/bin/zli-linux-amd64"
 
-          echo "Building zli on main branch and check size"
-          cd zot_main
-          make cli
-          BINSIZE_MAIN=$(stat -c%s "bin/zli-linux-amd64")
+          echo "PR binary (already built): $PR_BIN"
+          BINSIZE=$(stat -c%s "$PR_BIN")
+
+          echo "Building zli on main branch"
+          make -C "$GITHUB_WORKSPACE/zot_main" cli
+          BINSIZE_MAIN=$(stat -c%s "$MAIN_BIN")
 
           echo "PR binary size: $BINSIZE Bytes"
           echo "main branch binary size: $BINSIZE_MAIN Bytes"

--- a/.github/workflows/gc-stress-test-with-floci.yaml
+++ b/.github/workflows/gc-stress-test-with-floci.yaml
@@ -12,18 +12,35 @@ on:
 permissions: read-all
 
 jobs:
+  build-binaries:
+    name: Build zot and zb (linux/amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/build-zot-binaries
+        with:
+          make-targets: binary bench
+          artifact-path: |
+            bin/zot-linux-amd64
+            bin/zb-linux-amd64
+
   floci-gc-referrers-stress-s3:
     name: floci GC(with referrers) on S3(minio) with short interval
+    needs: build-binaries
     runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - uses: ./.github/actions/setup-floci
       - name: Setup minio service
         run: |
@@ -68,8 +85,6 @@ jobs:
       - name: Run zb
         id: bench
         run: |
-            make binary
-            make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-s3-minio.json &
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080
@@ -102,16 +117,19 @@ jobs:
 
   floci-gc-stress-s3:
     name: floci GC(without referrers) on S3(minio) with short interval
+    needs: build-binaries
     runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - uses: ./.github/actions/setup-floci
       - name: Setup minio service
         run: |
@@ -156,8 +174,6 @@ jobs:
       - name: Run zb
         id: bench
         run: |
-            make binary
-            make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-s3-minio.json &
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080

--- a/.github/workflows/gc-stress-test.yaml
+++ b/.github/workflows/gc-stress-test.yaml
@@ -12,24 +12,39 @@ on:
 permissions: read-all
 
 jobs:
+  build-binaries:
+    name: Build zot and zb (linux/amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/build-zot-binaries
+        with:
+          make-targets: binary bench
+          artifact-path: |
+            bin/zot-linux-amd64
+            bin/zb-linux-amd64
+
   gc-referrers-stress-local:
     name: GC(with referrers) on filesystem with short interval
+    needs: build-binaries
     runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
 
       - name: Run zb
         id: bench
         run: |
-            make binary
-            make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-local.json &
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080
@@ -56,22 +71,23 @@ jobs:
 
   gc-stress-local:
     name: GC(without referrers) on filesystem with short interval
+    needs: build-binaries
     runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
 
       - name: Run zb
         id: bench
         run: |
-            make binary
-            make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-local.json &
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080
@@ -98,16 +114,19 @@ jobs:
 
   gc-referrers-stress-s3:
     name: GC(with referrers) on S3(minio) with short interval
+    needs: build-binaries
     runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - uses: ./.github/actions/setup-localstack
       - name: Setup minio service
         run: |
@@ -152,8 +171,6 @@ jobs:
       - name: Run zb
         id: bench
         run: |
-            make binary
-            make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-s3-minio.json &
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080
@@ -186,16 +203,19 @@ jobs:
 
   gc-stress-s3:
     name: GC(without referrers) on S3(minio) with short interval
+    needs: build-binaries
     runs-on: cncf-ubuntu-8-32-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - uses: ./.github/actions/setup-localstack
       - name: Setup minio service
         run: |
@@ -240,8 +260,6 @@ jobs:
       - name: Run zb
         id: bench
         run: |
-            make binary
-            make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-s3-minio.json &
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd --max-timeout-failures 1 http://localhost:8080

--- a/.github/workflows/nightly-with-floci.yaml
+++ b/.github/workflows/nightly-with-floci.yaml
@@ -16,8 +16,24 @@ permissions: read-all
 #  3. run many, many, many instances of zot with shared storage and metadata front-ended by HAProxy. start a long-running zb run with high concurrency and number of requests
 #  to achieve a long-running sustained load on the system. The system is expected to perform well without errors and return performance data after the test.
 jobs:
+  build-binaries:
+    name: Build zot and zb (linux/amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/build-zot-binaries
+        with:
+          make-targets: binary binary-minimal bench
+          artifact-path: |
+            bin/zot-linux-amd64
+            bin/zb-linux-amd64
+            bin/zot-linux-amd64-minimal
+
   floci-dedupe:
     name: floci Dedupe/restore blobs
+    needs: build-binaries
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -27,6 +43,13 @@ jobs:
         with:
           check-latest: true
           go-version: 1.26.x
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64 bin/zot-linux-amd64-minimal
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
@@ -45,7 +68,7 @@ jobs:
         run: |
             # test restoring s3 blobs after cache is deleted
             # test deduping filesystem blobs after switching dedupe to enable
-            make run-blackbox-dedupe-nightly
+            make USE_PREBUILT=1 run-blackbox-dedupe-nightly
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
@@ -54,6 +77,7 @@ jobs:
 
   floci-sync:
     name: floci Sync harness
+    needs: build-binaries
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
@@ -64,6 +88,13 @@ jobs:
         with:
           check-latest: true
           go-version: 1.26.x
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64 bin/zot-linux-amd64-minimal
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
@@ -71,20 +102,23 @@ jobs:
           go mod download
       - name: Run sync harness
         run: |
-            make run-blackbox-sync-nightly
+            make USE_PREBUILT=1 run-blackbox-sync-nightly
 
   floci-gc-referrers-stress-s3:
     name: floci GC(with referrers) on S3(floci) with short interval
+    needs: build-binaries
     runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - uses: ./.github/actions/setup-floci
         with:
           persistent_mode: "1"
@@ -99,8 +133,6 @@ jobs:
         timeout-minutes: 240
         id: bench
         run: |
-            make binary
-            make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-s3-localstack.json &
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080 --skip-cleanup
@@ -124,16 +156,19 @@ jobs:
 
   floci-gc-stress-s3:
     name: floci GC(without referrers) on S3(floci) with short interval
+    needs: build-binaries
     runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - uses: ./.github/actions/setup-floci
         with:
           persistent_mode: "1"
@@ -148,8 +183,6 @@ jobs:
         timeout-minutes: 240
         id: bench
         run: |
-            make binary
-            make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-s3-localstack.json &
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080 --skip-cleanup
@@ -193,6 +226,7 @@ jobs:
 
   floci-cloud-scale-out:
     name: floci s3+dynamodb scale-out
+    needs: build-binaries
     runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -203,6 +237,13 @@ jobs:
           cache: false
           check-latest: true
           go-version: 1.26.x
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
@@ -223,7 +264,7 @@ jobs:
       - name: Run cloud scale-out high scale performance tests
         id: scale
         run: |
-          make run-cloud-scale-out-high-scale-tests
+          make USE_PREBUILT=1 run-cloud-scale-out-high-scale-tests
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
@@ -267,6 +308,7 @@ jobs:
 
   floci-cloud-scale-out-redis:
     name: floci s3+redis scale-out
+    needs: build-binaries
     runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -277,6 +319,13 @@ jobs:
           cache: false
           check-latest: true
           go-version: 1.26.x
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
@@ -297,7 +346,7 @@ jobs:
       - name: Run cloud scale-out Redis tests
         id: scale
         run: |
-          make run-cloud-scale-out-redis-high-scale-tests
+          make USE_PREBUILT=1 run-cloud-scale-out-redis-high-scale-tests
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -14,8 +14,24 @@ permissions: read-all
 #  3. run many, many, many instances of zot with shared storage and metadata front-ended by HAProxy. start a long-running zb run with high concurrency and number of requests
 #  to achieve a long-running sustained load on the system. The system is expected to perform well without errors and return performance data after the test.
 jobs:
+  build-binaries:
+    name: Build zot and zb (linux/amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/build-zot-binaries
+        with:
+          make-targets: binary binary-minimal bench
+          artifact-path: |
+            bin/zot-linux-amd64
+            bin/zb-linux-amd64
+            bin/zot-linux-amd64-minimal
+
   dedupe:
     name: Dedupe/restore blobs
+    needs: build-binaries
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -25,6 +41,13 @@ jobs:
         with:
           check-latest: true
           go-version: 1.26.x
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64 bin/zot-linux-amd64-minimal
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
@@ -43,7 +66,7 @@ jobs:
         run: |
             # test restoring s3 blobs after cache is deleted
             # test deduping filesystem blobs after switching dedupe to enable
-            make run-blackbox-dedupe-nightly
+            make USE_PREBUILT=1 run-blackbox-dedupe-nightly
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
@@ -52,6 +75,7 @@ jobs:
 
   sync:
     name: Sync harness
+    needs: build-binaries
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
@@ -62,6 +86,13 @@ jobs:
         with:
           check-latest: true
           go-version: 1.26.x
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64 bin/zot-linux-amd64-minimal
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
@@ -69,20 +100,23 @@ jobs:
           go mod download
       - name: Run sync harness
         run: |
-            make run-blackbox-sync-nightly
+            make USE_PREBUILT=1 run-blackbox-sync-nightly
 
   gc-referrers-stress-s3:
     name: GC(with referrers) on S3(localstack) with short interval
+    needs: build-binaries
     runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - uses: ./.github/actions/setup-localstack
       - name: Create zot-storage bucket on LocalStack
         run: |
@@ -95,8 +129,6 @@ jobs:
         timeout-minutes: 240
         id: bench
         run: |
-            make binary
-            make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-referrers-bench-s3-localstack.json &
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080 --skip-cleanup
@@ -120,16 +152,19 @@ jobs:
 
   gc-stress-s3:
     name: GC(without referrers) on S3(localstack) with short interval
+    needs: build-binaries
     runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - uses: ./.github/actions/setup-localstack
       - name: Create zot-storage bucket on LocalStack
         run: |
@@ -142,8 +177,6 @@ jobs:
         timeout-minutes: 240
         id: bench
         run: |
-            make binary
-            make bench
             ./bin/zot-linux-amd64 serve test/gc-stress/config-gc-bench-s3-localstack.json &
             sleep 10
             bin/zb-linux-amd64 -c 10 -n 100 -o ci-cd http://localhost:8080 --skip-cleanup
@@ -216,6 +249,7 @@ jobs:
 
   kind-sync-ondemand:
     name: On-demand sync mirror regression (issue 4184)
+    needs: build-binaries
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -234,12 +268,17 @@ jobs:
           sudo apt-get install -y libgpgme-dev libassuan-dev libbtrfs-dev libdevmapper-dev pkg-config rpm uidmap jq
       - name: Free up disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # main
-      - name: Build zot binary
-        run: make binary
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64
       - name: Run on-demand sync mirror regression test
         run: |
           sudo ./scripts/enable_userns.sh
-          ./examples/kind/kind-sync-ondemand.sh
+          make USE_PREBUILT=1 run-kind-sync-ondemand
 
   oidc-workload-identity:
     name: OIDC Workload Identity E2E
@@ -290,6 +329,7 @@ jobs:
 
   cloud-scale-out:
     name: s3+dynamodb scale-out
+    needs: build-binaries
     runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -300,6 +340,13 @@ jobs:
           cache: false
           check-latest: true
           go-version: 1.26.x
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
@@ -318,7 +365,7 @@ jobs:
       - name: Run cloud scale-out high scale performance tests
         id: scale
         run: |
-          make run-cloud-scale-out-high-scale-tests
+          make USE_PREBUILT=1 run-cloud-scale-out-high-scale-tests
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake
@@ -362,6 +409,7 @@ jobs:
 
   cloud-scale-out-redis:
     name: s3+redis scale-out
+    needs: build-binaries
     runs-on: cncf-ubuntu-16-64-x86
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -372,6 +420,13 @@ jobs:
           cache: false
           check-latest: true
           go-version: 1.26.x
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zb-linux-amd64
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
@@ -390,7 +445,7 @@ jobs:
       - name: Run cloud scale-out Redis tests
         id: scale
         run: |
-          make run-cloud-scale-out-redis-high-scale-tests
+          make USE_PREBUILT=1 run-cloud-scale-out-redis-high-scale-tests
         env:
           AWS_ACCESS_KEY_ID: fake
           AWS_SECRET_ACCESS_KEY: fake

--- a/.github/workflows/oci-conformance-action.yaml
+++ b/.github/workflows/oci-conformance-action.yaml
@@ -20,20 +20,17 @@ jobs:
     runs-on: ubuntu-latest
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    - name: Install go 1.26
-      uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-      with:
-        cache: false
-        check-latest: true
-        go-version: 1.26.x
     - name: Checkout this PR
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
         persist-credentials: false
+    - uses: ./.github/actions/build-zot-binaries
+      with:
+        make-targets: binary
+        upload-artifact: "false"
     - name: Start zot server
       run: |
           cd $GITHUB_WORKSPACE
-          make binary
           RUNNER_TRACKING_ID="" && ./bin/zot-linux-amd64 serve examples/config-conformance.json &
           IP=`hostname -I | awk '{print $1}'`
           echo "OCI_REGISTRY=${IP}:8080" >> $GITHUB_ENV

--- a/.github/workflows/tls.yaml
+++ b/.github/workflows/tls.yaml
@@ -10,7 +10,20 @@ on:
 permissions: read-all
 
 jobs:
+  build-binaries:
+    name: Build zot (linux/amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/build-zot-binaries
+        with:
+          make-targets: binary
+          artifact-path: bin/zot-linux-amd64
+
   tls-check:
+    needs: build-binaries
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -25,21 +38,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64
       - name: Install dependencies
         run: |
           cd $GITHUB_WORKSPACE
           mkdir -p test/data
           cd test/data
           ../scripts/gen_certs.sh
-      - name: Build binary
-        run: |
-          cd $GITHUB_WORKSPACE
-          make binary
       - name: Start zot server (${{ matrix.mode }})
         run: |
           cd $GITHUB_WORKSPACE

--- a/.github/workflows/verify-config.yaml
+++ b/.github/workflows/verify-config.yaml
@@ -22,27 +22,11 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Install go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+      - uses: ./.github/actions/build-zot-binaries
         with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
-      - name: Cache go dependencies
-        id: cache-go-dependencies
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: |
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-mod-
-      - name: Install go dependencies
-        if: steps.cache-go-dependencies.outputs.cache-hit != 'true'
-        run: |
-          cd $GITHUB_WORKSPACE
-          go mod download
+          make-targets: binary
+          upload-artifact: "false"
       - name: run verify-config
         run: |
           cd $GITHUB_WORKSPACE
-          make verify-config
+          make USE_PREBUILT=1 verify-config

--- a/.github/workflows/web-scan.yaml
+++ b/.github/workflows/web-scan.yaml
@@ -14,35 +14,39 @@ permissions:
   contents: read
 
 jobs:
+  build-binaries:
+    name: Build zot binaries (linux/amd64)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/build-zot-binaries
+        with:
+          make-targets: binary binary-minimal
+          artifact-path: |
+            bin/zot-linux-amd64
+            bin/zot-linux-amd64-minimal
+
   zap_scan:
+    needs: build-binaries
     runs-on: ubuntu-latest
     name: Scan ZOT using ZAP
     strategy:
       matrix:
         flavor: [zot-linux-amd64-minimal, zot-linux-amd64]
     steps:
-      - name: Install go
-        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
-        with:
-          cache: false
-          check-latest: true
-          go-version: 1.26.x
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Build zot
-        run: |
-          echo "Building $FLAVOR"
-          cd $GITHUB_WORKSPACE
-          if [[ $FLAVOR == "zot-linux-amd64-minimal" ]]; then
-            make binary-minimal
-          else
-            make binary
-          fi
-          ls -l bin/
-        env:
-          FLAVOR: ${{ matrix.flavor }}
+      - name: Download prebuilt binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: zot-linux-amd64-binaries
+          path: bin
+      - name: Mark binaries executable
+        run: chmod +x bin/zot-linux-amd64 bin/zot-linux-amd64-minimal
       - name: Bringup zot server
         run: |
           # upload images, zot can serve OCI image layouts directly like so

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,17 @@ BATS := $(TOOLSDIR)/bin/bats
 TESTDATA := $(TOP_LEVEL)/test/data
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
+# 1: reuse existing bin/ (CI after artifact download). 0: compile via phony binary/bench.
+USE_PREBUILT ?= 0
+ifeq ($(USE_PREBUILT),1)
+ZOT_BIN_DEP := require-binary
+ZOT_MIN_DEP := require-binary-minimal
+ZB_DEP := require-bench
+else
+ZOT_BIN_DEP := binary
+ZOT_MIN_DEP := binary-minimal
+ZB_DEP := bench
+endif
 GREP_BIN_PATH ?= $(shell which grep)
 BLACKBOX_DOCKER_ENV = BUILDX_NO_DEFAULT_ATTESTATIONS=1 DOCKER_DEFAULT_PLATFORM=linux/amd64
 
@@ -263,9 +274,11 @@ $(TESTDATA): testdata-certs testdata-images
 	ls -R -l ${TESTDATA}
 
 .PHONY: run-bench
-run-bench: binary bench
+run-bench: $(ZOT_BIN_DEP) $(ZB_DEP)
 	bin/zot-$(OS)-$(ARCH) serve examples/config-bench.json & echo $$! > zot.PID
 	curl --connect-timeout 3 --max-time 5 --retry 60 --retry-delay 1 --retry-max-time 180 --retry-connrefused http://localhost:8080/v2/
+	curl -fsS --retry 5 --retry-delay 1 http://localhost:8080/v2/_catalog
+	curl -fsS http://localhost:8080/v2/_catalog
 	bin/zb-$(OS)-$(ARCH) -c 10 -n 100 -o $(BENCH_OUTPUT) http://localhost:8080
 	@if [ -e zot.PID ]; then \
 		kill -TERM $$(cat zot.PID) || true; \
@@ -427,7 +440,7 @@ run: binary
 verify-config: _verify-config verify-config-warnings verify-config-committed verify-config-schema
 
 .PHONY: _verify-config
-_verify-config: binary
+_verify-config: $(ZOT_BIN_DEP)
 	rm -f output.txt
 	$(foreach file, $(filter-out $(wildcard examples/config-*-credentials.json), $(wildcard examples/config-*)), ./bin/zot-$(OS)-$(ARCH) verify $(file) 2>&1 | tee -a output.txt || exit 1;)
 
@@ -455,7 +468,7 @@ check-jsonschema:
 	jsonschema --version || (echo "You need python3-jsonschema to validate config examples against generated schema"; exit 1)
 
 .PHONY: verify-config-schema
-verify-config-schema: binary check-jsonschema
+verify-config-schema: $(ZOT_BIN_DEP) check-jsonschema
 	./bin/zot-$(OS)-$(ARCH) schema > bin/zot-schema.json
 	for i in $(filter-out $(wildcard examples/config-*-credentials.json), $(wildcard examples/config-*.json)); do echo $$i; jsonschema bin/zot-schema.json -i "$$i" -o pretty; done
 
@@ -547,23 +560,23 @@ run-blackbox-tests: $(BATS_TEST_FILE_PATH) check-blackbox-prerequisites binary b
 	$(BLACKBOX_DOCKER_ENV) $(BATS) $(BATS_FLAGS) $(BATS_TEST_FILE_PATH)
 
 .PHONY: run-cloud-scale-out-tests
-run-cloud-scale-out-tests: check-blackbox-prerequisites check-awslocal binary bench test-prereq
+run-cloud-scale-out-tests: check-blackbox-prerequisites check-awslocal $(ZOT_BIN_DEP) $(ZB_DEP) test-prereq
 	echo running scale out bats test; \
 	$(BATS) $(BATS_FLAGS) test/scale-out/cloud_scale_out_no_auth.bats; \
 	$(BATS) $(BATS_FLAGS) test/scale-out/cloud_scale_out_basic_auth_tls.bats
 
 .PHONY: run-cloud-scale-out-redis-tests
-run-cloud-scale-out-redis-tests: check-blackbox-prerequisites check-awslocal binary bench test-prereq
+run-cloud-scale-out-redis-tests: check-blackbox-prerequisites check-awslocal $(ZOT_BIN_DEP) $(ZB_DEP) test-prereq
 	echo running redis scale out bats test; \
 	$(BATS) $(BATS_FLAGS) test/scale-out/cloud_scale_out_redis.bats
 
 .PHONY: run-cloud-scale-out-high-scale-tests
-run-cloud-scale-out-high-scale-tests: check-blackbox-prerequisites check-awslocal binary bench test-prereq
+run-cloud-scale-out-high-scale-tests: check-blackbox-prerequisites check-awslocal $(ZOT_BIN_DEP) $(ZB_DEP) test-prereq
 	echo running cloud scale out bats high scale test; \
 	$(BATS) $(BATS_FLAGS) test/scale-out/cloud_scale_out_basic_auth_tls_scale.bats
 
 .PHONY: run-cloud-scale-out-redis-high-scale-tests
-run-cloud-scale-out-redis-high-scale-tests: check-blackbox-prerequisites check-awslocal binary bench test-prereq
+run-cloud-scale-out-redis-high-scale-tests: check-blackbox-prerequisites check-awslocal $(ZOT_BIN_DEP) $(ZB_DEP) test-prereq
 	echo running redis scale out high scale bats test; \
 	$(BATS) $(BATS_FLAGS) test/scale-out/cloud_scale_out_redis_scale.bats
 
@@ -580,19 +593,33 @@ run-blackbox-cloud-ci: check-blackbox-prerequisites check-awslocal binary $(BATS
 	$(BATS) $(BATS_FLAGS) test/blackbox/redis_s3.bats
 
 .PHONY: run-blackbox-dedupe-nightly
-run-blackbox-dedupe-nightly: check-blackbox-prerequisites check-awslocal binary binary-minimal
+run-blackbox-dedupe-nightly: check-blackbox-prerequisites check-awslocal $(ZOT_BIN_DEP) $(ZOT_MIN_DEP)
 	echo running nightly dedupe tests; \
 	$(BATS) $(BATS_FLAGS) test/blackbox/restore_s3_blobs.bats && \
 	$(BATS) $(BATS_FLAGS) test/blackbox/pushpull_running_dedupe.bats
 
 .PHONY: run-blackbox-sync-nightly
-run-blackbox-sync-nightly: check-blackbox-prerequisites binary binary-minimal bench
+run-blackbox-sync-nightly: check-blackbox-prerequisites $(ZOT_BIN_DEP) $(ZOT_MIN_DEP) $(ZB_DEP)
 	echo running nightly sync tests; \
 	$(BATS) $(BATS_FLAGS) test/blackbox/sync_harness.bats
 
 .PHONY: run-kind-sync-ondemand
-run-kind-sync-ondemand: check-blackbox-prerequisites binary
+run-kind-sync-ondemand: check-blackbox-prerequisites $(ZOT_BIN_DEP)
 	./examples/kind/kind-sync-ondemand.sh
+
+# When USE_PREBUILT=1, assert compile outputs already exist so test targets
+# can reuse a downloaded bin/ without invoking the phony binary/bench targets.
+.PHONY: require-binary
+require-binary:
+	@test -x bin/zot-$(OS)-$(ARCH)$(BIN_EXT) || { echo "missing prebuilt bin/zot-$(OS)-$(ARCH)$(BIN_EXT)" >&2; exit 1; }
+
+.PHONY: require-binary-minimal
+require-binary-minimal:
+	@test -x bin/zot-$(OS)-$(ARCH)-minimal$(BIN_EXT) || { echo "missing prebuilt bin/zot-$(OS)-$(ARCH)-minimal$(BIN_EXT)" >&2; exit 1; }
+
+.PHONY: require-bench
+require-bench:
+	@test -x bin/zb-$(OS)-$(ARCH)$(BIN_EXT) || { echo "missing prebuilt bin/zb-$(OS)-$(ARCH)$(BIN_EXT)" >&2; exit 1; }
 
 .PHONY: fuzz-all
 fuzz-all: fuzztime=${1}


### PR DESCRIPTION
ci: build zot binaries once per workflow and reuse them

Stop parallel jobs from recompiling the same linux/amd64 zot/zb
binaries. Centralize build plus read-only restore of build.yaml go
caches in a composite action; share artifacts across dependent jobs
where work is parallelized.

Keep local Make compiling by default. CI passes USE_PREBUILT=1 so
phony binary/bench targets are not invoked after an artifact download.

- Add build-zot-binaries (setup-go, cache restore, make, optional upload)
- Wire shared build jobs into GC stress, cluster, nightly, tls, web-scan
- Reuse the action in-job for benchmark, oci-conformance, compare-binary-size, verify-config
- Gate artifact upload on a non-empty artifact-path
- Warm the benchmark runner (sync + catalog GETs) after large cache restores

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
