### PR TITLE
feat(events): reload the event recorder on config change

### DIFF
--- a/pkg/api/config/config.go
+++ b/pkg/api/config/config.go
@@ -18,6 +18,7 @@ import (
 	"zotregistry.dev/zot/v2/pkg/buildinfo"
 	"zotregistry.dev/zot/v2/pkg/compat"
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
+	eventsconf "zotregistry.dev/zot/v2/pkg/extensions/config/events"
 	storageConstants "zotregistry.dev/zot/v2/pkg/storage/constants"
 )
 
@@ -1186,6 +1187,9 @@ func (c *Config) UpdateReloadableConfig(newConfig *Config) {
 
 		// Update scrub extension
 		c.Extensions.Scrub = newConfig.Extensions.Scrub
+
+		// Update events extension
+		c.Extensions.Events = newConfig.Extensions.Events
 	}
 }
 
@@ -1498,6 +1502,35 @@ func (c *Config) StorageFingerprint() string {
 	for name, subPath := range norm.SubPaths {
 		subPath.GCMaxSchedulerDelay = 0
 		norm.SubPaths[name] = subPath
+	}
+
+	// encoding/json sorts map keys, so the serialization is deterministic across restarts.
+	blob, err := json.Marshal(norm)
+	if err != nil {
+		return ""
+	}
+
+	sum := sha256.Sum256(blob)
+
+	return hex.EncodeToString(sum[:])
+}
+
+// EventsFingerprint returns a stable SHA-256 of the events extension config.
+func (c *Config) EventsFingerprint() string {
+	if c == nil {
+		return ""
+	}
+
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	if c.Extensions == nil || c.Extensions.Events == nil {
+		return ""
+	}
+
+	var norm eventsconf.Config
+	if err := DeepCopy(c.Extensions.Events, &norm); err != nil {
+		return ""
 	}
 
 	// encoding/json sorts map keys, so the serialization is deterministic across restarts.

--- a/pkg/api/config/config_test.go
+++ b/pkg/api/config/config_test.go
@@ -3905,3 +3905,60 @@ func TestConfigSyncStagingHelpers(t *testing.T) {
 		})
 	})
 }
+
+func TestEventsFingerprint(t *testing.T) {
+	newConf := func(address string) *config.Config {
+		enabled := true
+		conf := config.New()
+		conf.Extensions = &extconf.ExtensionConfig{
+			Events: &eventsconf.Config{
+				Enable: &enabled,
+				Sinks: []eventsconf.SinkConfig{{
+					Type:    eventsconf.HTTP,
+					Address: address,
+					Timeout: 5 * time.Second,
+				}},
+			},
+		}
+
+		return conf
+	}
+
+	Convey("EventsFingerprint", t, func() {
+		Convey("nil config yields an empty fingerprint", func() {
+			var nilConf *config.Config
+
+			So(nilConf.EventsFingerprint(), ShouldEqual, "")
+		})
+
+		Convey("no extensions or no events yields an empty fingerprint", func() {
+			So(config.New().EventsFingerprint(), ShouldEqual, "")
+
+			conf := config.New()
+			conf.Extensions = &extconf.ExtensionConfig{}
+			So(conf.EventsFingerprint(), ShouldEqual, "")
+		})
+
+		Convey("identical events config yields an identical, non-empty fingerprint", func() {
+			fingerprint := newConf("http://receiver").EventsFingerprint()
+
+			So(fingerprint, ShouldNotEqual, "")
+			So(newConf("http://receiver").EventsFingerprint(), ShouldEqual, fingerprint)
+		})
+
+		Convey("changing a sink changes the fingerprint", func() {
+			base := newConf("http://receiver").EventsFingerprint()
+
+			So(newConf("http://elsewhere").EventsFingerprint(), ShouldNotEqual, base)
+
+			credentials := newConf("http://receiver")
+			credentials.Extensions.Events.Sinks[0].Credentials = &eventsconf.Credentials{Token: "rotated"}
+			So(credentials.EventsFingerprint(), ShouldNotEqual, base)
+
+			disabled := newConf("http://receiver")
+			off := false
+			disabled.Extensions.Events.Enable = &off
+			So(disabled.EventsFingerprint(), ShouldNotEqual, base)
+		})
+	})
+}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -48,15 +48,19 @@ type Controller struct {
 	Server          *http.Server
 	Metrics         monitoring.MetricServer
 	EventRecorder   events.Recorder
-	CveScanner      ext.CveScanner
-	SyncOnDemand    ext.SyncOnDemand
-	RelyingParties  map[string]rp.RelyingParty
-	CookieStore     *CookieStore
-	HTPasswd        *HTPasswd
-	HTPasswdWatcher *HTPasswdWatcher
-	LDAPClient      *LDAPClient
-	taskScheduler   *scheduler.Scheduler
-	Healthz         *common.Healthz
+	// EventRecorder, typed so a reload can replace what it points at
+	eventReloader *events.ReloadableRecorder
+	// events config the installed recorder was built from
+	eventsFingerprint string
+	CveScanner        ext.CveScanner
+	SyncOnDemand      ext.SyncOnDemand
+	RelyingParties    map[string]rp.RelyingParty
+	CookieStore       *CookieStore
+	HTPasswd          *HTPasswd
+	HTPasswdWatcher   *HTPasswdWatcher
+	LDAPClient        *LDAPClient
+	taskScheduler     *scheduler.Scheduler
+	Healthz           *common.Healthz
 	// runtime params (atomic: Run may set the port concurrently with GetPort readers, e.g. tests)
 	chosenPort atomic.Int64
 	// TLS certificate management
@@ -448,9 +452,36 @@ func (c *Controller) InitEventRecorder() error {
 		return err
 	}
 
-	c.EventRecorder = eventRecorder
+	// wrapped even when disabled, so a reload can enable events
+	c.eventReloader = events.NewReloadableRecorder(eventRecorder)
+	c.EventRecorder = c.eventReloader
+	c.eventsFingerprint = c.Config.EventsFingerprint()
 
 	return nil
+}
+
+// reloadEventRecorder rebuilds the recorder when the events config changed.
+func (c *Controller) reloadEventRecorder() {
+	fingerprint := c.Config.EventsFingerprint()
+	if c.eventReloader == nil || fingerprint == c.eventsFingerprint {
+		return
+	}
+
+	eventRecorder, err := ext.NewEventRecorder(c.Config, c.Log)
+	if err != nil && !goerrors.Is(err, errors.ErrExtensionNotEnabled) {
+		// the fingerprint stays behind so a later reload retries
+		c.Log.Error().Err(err).Msg("failed to rebuild event recorder, keeping the previous one")
+
+		return
+	}
+
+	if replaced := c.eventReloader.Swap(eventRecorder); replaced != nil {
+		replaced.Close()
+	}
+
+	c.eventsFingerprint = fingerprint
+
+	c.Log.Info().Bool("enabled", eventRecorder != nil).Msg("reloaded event recorder")
 }
 
 func (c *Controller) LoadNewConfig(newConfig *config.Config) {
@@ -482,6 +513,8 @@ func (c *Controller) LoadNewConfig(newConfig *config.Config) {
 		c.LDAPClient.BindPassword = authConfig.LDAP.BindPassword()
 		c.LDAPClient.lock.Unlock()
 	}
+
+	c.reloadEventRecorder()
 
 	c.InitCVEInfo()
 
@@ -516,6 +549,11 @@ func (c *Controller) Shutdown() {
 	if c.Server != nil {
 		ctx := context.Background()
 		_ = c.Server.Shutdown(ctx)
+	}
+
+	// close event sinks
+	if c.EventRecorder != nil {
+		c.EventRecorder.Close()
 	}
 
 	// close metadb

--- a/pkg/api/controller_events_internal_test.go
+++ b/pkg/api/controller_events_internal_test.go
@@ -1,0 +1,329 @@
+//go:build events
+
+package api
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	cehttp "github.com/cloudevents/sdk-go/v2/protocol/http"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
+	eventsconf "zotregistry.dev/zot/v2/pkg/extensions/config/events"
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	"zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/storage"
+	tlsutils "zotregistry.dev/zot/v2/pkg/test/tls"
+)
+
+// eventSink is a receiving endpoint standing in for a webhook.
+func eventSink(t *testing.T) (string, chan *cloudevents.Event) {
+	t.Helper()
+
+	received := make(chan *cloudevents.Event, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		event, err := cehttp.NewEventFromHTTPRequest(req)
+		if err != nil {
+			resp.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+
+		received <- event
+		resp.WriteHeader(http.StatusOK)
+	}))
+
+	t.Cleanup(server.Close)
+
+	return server.URL, received
+}
+
+// countingEventSink also reports how many connections were opened to it.
+func countingEventSink(t *testing.T) (string, chan *cloudevents.Event, *atomic.Int32) {
+	t.Helper()
+
+	var opened atomic.Int32
+
+	received := make(chan *cloudevents.Event, 8)
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+		event, err := cehttp.NewEventFromHTTPRequest(req)
+		if err != nil {
+			resp.WriteHeader(http.StatusBadRequest)
+
+			return
+		}
+
+		received <- event
+		resp.WriteHeader(http.StatusOK)
+	}))
+	server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+		if state == http.StateNew {
+			opened.Add(1)
+		}
+	}
+	server.Start()
+
+	t.Cleanup(server.Close)
+
+	return server.URL, received, &opened
+}
+
+func eventsConfig(address string) *config.Config {
+	enabled := true
+	cfg := config.New()
+	cfg.Extensions = &extconf.ExtensionConfig{}
+
+	if address != "" {
+		cfg.Extensions.Events = &eventsconf.Config{
+			Enable: &enabled,
+			Sinks: []eventsconf.SinkConfig{{
+				Type:    eventsconf.HTTP,
+				Address: address,
+				Timeout: 5 * time.Second,
+			}},
+		}
+	}
+
+	return cfg
+}
+
+// refuteEvent reports whether the sink stayed silent long enough to be sure.
+func refuteEvent(received chan *cloudevents.Event) bool {
+	select {
+	case <-received:
+		return false
+	case <-time.After(2 * time.Second):
+		return true
+	}
+}
+
+func awaitEvent(received chan *cloudevents.Event) *cloudevents.Event {
+	select {
+	case event := <-received:
+		return event
+	case <-time.After(5 * time.Second):
+		return nil
+	}
+}
+
+func TestEventRecorderReload(t *testing.T) {
+	Convey("A changed events config re-points the recorder without a restart", t, func() {
+		firstURL, firstSink := eventSink(t)
+		secondURL, secondSink := eventSink(t)
+
+		ctlr := NewController(eventsConfig(firstURL))
+		ctlr.Log = log.NewTestLogger()
+		So(ctlr.InitEventRecorder(), ShouldBeNil)
+
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(firstSink), ShouldNotBeNil)
+
+		// the full reload path, not just the recorder helper
+		ctlr.LoadNewConfig(eventsConfig(secondURL))
+
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(secondSink), ShouldNotBeNil)
+		So(refuteEvent(firstSink), ShouldBeTrue)
+	})
+
+	Convey("Events enabled by a reload start being delivered", t, func() {
+		sinkURL, sink := eventSink(t)
+
+		ctlr := NewController(eventsConfig(""))
+		ctlr.Log = log.NewTestLogger()
+		So(ctlr.InitEventRecorder(), ShouldBeNil)
+
+		// nothing to publish to yet, and publishing must still be safe
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+
+		ctlr.LoadNewConfig(eventsConfig(sinkURL))
+
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(sink), ShouldNotBeNil)
+	})
+
+	Convey("Events disabled by a reload stop being delivered", t, func() {
+		sinkURL, sink := eventSink(t)
+
+		ctlr := NewController(eventsConfig(sinkURL))
+		ctlr.Log = log.NewTestLogger()
+		So(ctlr.InitEventRecorder(), ShouldBeNil)
+
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(sink), ShouldNotBeNil)
+
+		ctlr.LoadNewConfig(eventsConfig(""))
+
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(refuteEvent(sink), ShouldBeTrue)
+	})
+
+	Convey("An unchanged events config keeps the same recorder", t, func() {
+		sinkURL, sink, opened := countingEventSink(t)
+
+		ctlr := NewController(eventsConfig(sinkURL))
+		ctlr.Log = log.NewTestLogger()
+		So(ctlr.InitEventRecorder(), ShouldBeNil)
+
+		// deliver first, so a keep-alive connection is open when the reload lands
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(sink), ShouldNotBeNil)
+		So(opened.Load(), ShouldEqual, 1)
+
+		ctlr.LoadNewConfig(eventsConfig(sinkURL))
+
+		// a rebuild would have dialled a second connection
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(sink), ShouldNotBeNil)
+		So(opened.Load(), ShouldEqual, 1)
+	})
+}
+
+func TestEventRecorderReloadReachesImageStores(t *testing.T) {
+	Convey("A swap reaches the stores the recorder was handed to at startup", t, func() {
+		firstURL, firstSink := eventSink(t)
+		secondURL, secondSink := eventSink(t)
+
+		conf := eventsConfig(firstURL)
+		conf.Storage.RootDirectory = t.TempDir()
+
+		ctlr := NewController(conf)
+		ctlr.Log = log.NewTestLogger()
+		So(ctlr.InitEventRecorder(), ShouldBeNil)
+
+		// the stores are handed the recorder once, exactly as Init does
+		storeController, err := storage.New(ctlr.Config, nil, monitoring.NewNopMetricServer(),
+			ctlr.Log, ctlr.EventRecorder)
+		So(err, ShouldBeNil)
+
+		store := storeController.GetDefaultImageStore()
+		So(store.InitRepo(context.Background(), "before"), ShouldBeNil)
+		So(awaitEvent(firstSink), ShouldNotBeNil)
+
+		ctlr.LoadNewConfig(eventsConfig(secondURL))
+
+		So(store.InitRepo(context.Background(), "after"), ShouldBeNil)
+		So(awaitEvent(secondSink), ShouldNotBeNil)
+		So(refuteEvent(firstSink), ShouldBeTrue)
+	})
+}
+
+// brokenEventsConfig keeps a usable sink ahead of one with a missing CA file.
+func brokenEventsConfig() *config.Config {
+	conf := eventsConfig("http://receiver")
+	conf.Extensions.Events.Sinks = append(conf.Extensions.Events.Sinks, eventsconf.SinkConfig{
+		Type:      eventsconf.HTTP,
+		Address:   "http://receiver",
+		Timeout:   5 * time.Second,
+		TLSConfig: &eventsconf.TLSConfig{CACertFile: "/nonexistent/ca.pem"},
+	})
+
+	return conf
+}
+
+func TestEventRecorderReloadFailures(t *testing.T) {
+	Convey("A recorder that cannot be built at startup fails Init", t, func() {
+		ctlr := NewController(brokenEventsConfig())
+		ctlr.Log = log.NewTestLogger()
+
+		So(ctlr.InitEventRecorder(), ShouldNotBeNil)
+	})
+
+	Convey("A rebuild that fails keeps the previous recorder delivering", t, func() {
+		sinkURL, sink := eventSink(t)
+
+		ctlr := NewController(eventsConfig(sinkURL))
+		ctlr.Log = log.NewTestLogger()
+		So(ctlr.InitEventRecorder(), ShouldBeNil)
+
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(sink), ShouldNotBeNil)
+
+		ctlr.LoadNewConfig(brokenEventsConfig())
+
+		// the broken config was rejected, so the working sink is still in place
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(sink), ShouldNotBeNil)
+	})
+}
+
+func TestEventRecorderReloadRetriesAfterFailure(t *testing.T) {
+	Convey("A rebuild that failed is retried when the same config comes back", t, func() {
+		firstURL, firstSink := eventSink(t)
+		secondURL, secondSink := eventSink(t)
+
+		ctlr := NewController(eventsConfig(firstURL))
+		ctlr.Log = log.NewTestLogger()
+		So(ctlr.InitEventRecorder(), ShouldBeNil)
+
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(firstSink), ShouldNotBeNil)
+
+		// valid except for a CA file that is not there yet
+		caPath := path.Join(t.TempDir(), "ca.pem")
+		pending := eventsConfig(secondURL)
+		pending.Extensions.Events.Sinks[0].TLSConfig = &eventsconf.TLSConfig{CACertFile: caPath}
+
+		ctlr.LoadNewConfig(pending)
+
+		// the rebuild failed, so the previous sink is still the live one
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(firstSink), ShouldNotBeNil)
+
+		// the missing piece arrives and the very same config is applied again
+		caCert, _, err := tlsutils.GenerateCACert()
+		So(err, ShouldBeNil)
+		So(os.WriteFile(caPath, caCert, 0o600), ShouldBeNil)
+
+		ctlr.LoadNewConfig(pending)
+
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(secondSink), ShouldNotBeNil)
+	})
+}
+
+func TestShutdownClosesEventRecorder(t *testing.T) {
+	Convey("shutdown closes the recorder instead of dropping it", t, func() {
+		sinkURL, sink, opened := countingEventSink(t)
+
+		ctlr := NewController(eventsConfig(sinkURL))
+		ctlr.Log = log.NewTestLogger()
+		So(ctlr.InitEventRecorder(), ShouldBeNil)
+
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(awaitEvent(sink), ShouldNotBeNil)
+		So(opened.Load(), ShouldEqual, 1)
+
+		ctlr.Shutdown()
+
+		// closed and detached, so nothing reaches the sink
+		ctlr.EventRecorder.RepositoryCreated("repo", nil)
+		So(refuteEvent(sink), ShouldBeTrue)
+	})
+
+	Convey("shutdown is safe when events are disabled", t, func() {
+		ctlr := NewController(eventsConfig(""))
+		ctlr.Log = log.NewTestLogger()
+		So(ctlr.InitEventRecorder(), ShouldBeNil)
+
+		So(func() { ctlr.Shutdown() }, ShouldNotPanic)
+	})
+
+	Convey("shutdown is safe before a recorder was ever built", t, func() {
+		ctlr := NewController(eventsConfig(""))
+		ctlr.Log = log.NewTestLogger()
+
+		So(ctlr.EventRecorder, ShouldBeNil)
+		So(func() { ctlr.Shutdown() }, ShouldNotPanic)
+	})
+}

--- a/pkg/extensions/events/events.go
+++ b/pkg/extensions/events/events.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"os"
+	"sync"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
 
@@ -18,18 +19,22 @@ type eventRecorder struct {
 	log      log.Logger
 	sinks    []Sink
 	identity Identity
+	// publish dispatches asynchronously, so wait before tearing sinks down
+	inFlight sync.WaitGroup
 }
 
 var _ Recorder = (*eventRecorder)(nil)
 
-func (r eventRecorder) Close() {
+func (r *eventRecorder) Close() {
+	r.inFlight.Wait()
+
 	err := r.closeSinks()
 	if err != nil {
 		r.log.Error().Err(err).Msg("failed to close sinks")
 	}
 }
 
-func (r eventRecorder) closeSinks() error {
+func (r *eventRecorder) closeSinks() error {
 	var retErr error
 
 	for _, sink := range r.sinks {
@@ -41,8 +46,8 @@ func (r eventRecorder) closeSinks() error {
 	return retErr
 }
 
-func (r eventRecorder) publish(event *cloudevents.Event) {
-	go func() {
+func (r *eventRecorder) publish(event *cloudevents.Event) {
+	r.inFlight.Go(func() {
 		succeeded := 0
 
 		for _, sink := range r.sinks {
@@ -72,10 +77,10 @@ func (r eventRecorder) publish(event *cloudevents.Event) {
 			Int("sinksSucceeded", succeeded).
 			Int("sinksFailed", len(r.sinks)-succeeded).
 			Msg(msg)
-	}()
+	})
 }
 
-func (r eventRecorder) RepositoryCreated(name string, ectx *EventContext) {
+func (r *eventRecorder) RepositoryCreated(name string, ectx *EventContext) {
 	event, err := newEventBuilder(r.identity).
 		WithEventType(RepositoryCreatedEventType).
 		WithDataField("name", name).
@@ -90,7 +95,7 @@ func (r eventRecorder) RepositoryCreated(name string, ectx *EventContext) {
 	r.publish(event)
 }
 
-func (r eventRecorder) ImageUpdated(name, reference, digest, mediaType, manifest string, ectx *EventContext) {
+func (r *eventRecorder) ImageUpdated(name, reference, digest, mediaType, manifest string, ectx *EventContext) {
 	event, err := newEventBuilder(r.identity).
 		WithEventType(ImageUpdatedEventType).
 		WithDataField("name", name).
@@ -109,7 +114,7 @@ func (r eventRecorder) ImageUpdated(name, reference, digest, mediaType, manifest
 	r.publish(event)
 }
 
-func (r eventRecorder) ImageDeleted(name, reference, digest, mediaType string, ectx *EventContext) {
+func (r *eventRecorder) ImageDeleted(name, reference, digest, mediaType string, ectx *EventContext) {
 	event, err := newEventBuilder(r.identity).
 		WithEventType(ImageDeletedEventType).
 		WithDataField("name", name).
@@ -127,7 +132,7 @@ func (r eventRecorder) ImageDeleted(name, reference, digest, mediaType string, e
 	r.publish(event)
 }
 
-func (r eventRecorder) ImageLintFailed(name, reference, digest, mediaType, manifest string, ectx *EventContext) {
+func (r *eventRecorder) ImageLintFailed(name, reference, digest, mediaType, manifest string, ectx *EventContext) {
 	event, err := newEventBuilder(r.identity).
 		WithEventType(ImageLintFailedEventType).
 		WithDataField("name", name).
@@ -146,7 +151,7 @@ func (r eventRecorder) ImageLintFailed(name, reference, digest, mediaType, manif
 	r.publish(event)
 }
 
-func (r eventRecorder) ImageScanned(name, reference, digest, mediaType string,
+func (r *eventRecorder) ImageScanned(name, reference, digest, mediaType string,
 	summary ImageScanSummary, ectx *EventContext,
 ) {
 	event, err := newEventBuilder(r.identity).

--- a/pkg/extensions/events/events_test.go
+++ b/pkg/extensions/events/events_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -730,4 +731,63 @@ func randomString() string {
 	}
 
 	return string(buf)
+}
+
+// blockingSink holds a publish open until released.
+type blockingSink struct {
+	emitting chan struct{}
+	release  chan struct{}
+	closed   atomic.Bool
+}
+
+func (s *blockingSink) Emit(*cloudevents.Event) cloudevents.Result {
+	close(s.emitting)
+	<-s.release
+
+	return nil
+}
+
+func (s *blockingSink) Close() error {
+	s.closed.Store(true)
+
+	return nil
+}
+
+var _ events.Sink = (*blockingSink)(nil)
+
+func TestRecorderCloseWaitsForInFlightPublishes(t *testing.T) {
+	Convey("Close does not tear a sink down under an event still going out", t, func() {
+		sink := &blockingSink{emitting: make(chan struct{}), release: make(chan struct{})}
+
+		recorder, err := events.NewRecorder(log.NewTestLogger(), sink)
+		So(err, ShouldBeNil)
+
+		recorder.RepositoryCreated("test", nil)
+		<-sink.emitting
+
+		closed := make(chan struct{})
+
+		go func() {
+			recorder.Close()
+			close(closed)
+		}()
+
+		select {
+		case <-closed:
+			t.Fatal("Close returned while a publish was still in flight")
+		case <-time.After(200 * time.Millisecond):
+		}
+
+		So(sink.closed.Load(), ShouldBeFalse)
+
+		close(sink.release)
+
+		select {
+		case <-closed:
+		case <-time.After(5 * time.Second):
+			t.Fatal("Close did not return after the publish finished")
+		}
+
+		So(sink.closed.Load(), ShouldBeTrue)
+	})
 }

--- a/pkg/extensions/events/http_sink.go
+++ b/pkg/extensions/events/http_sink.go
@@ -18,6 +18,7 @@ import (
 type HTTPSink struct {
 	cloudevents.Client
 
+	client *http.Client
 	config eventsconf.SinkConfig
 }
 
@@ -75,6 +76,7 @@ func NewHTTPSink(config eventsconf.SinkConfig) (*HTTPSink, error) {
 
 	return &HTTPSink{
 		Client: ceClient,
+		client: httpClient,
 		config: config,
 	}, nil
 }
@@ -96,10 +98,12 @@ func (s *HTTPSink) Emit(event *cloudevents.Event) cloudevents.Result {
 	return s.Send(ctx, *event)
 }
 
-// Close implements a method to clean up resources.
+// Close releases the connections this sink pooled from its cloned transport.
 func (s *HTTPSink) Close() error {
-	// For HTTP clients, typically no specific cleanup is needed
-	// We could cancel any in-flight requests if we tracked them
+	if s.client != nil {
+		s.client.CloseIdleConnections()
+	}
+
 	return nil
 }
 

--- a/pkg/extensions/events/http_sink_test.go
+++ b/pkg/extensions/events/http_sink_test.go
@@ -3,6 +3,7 @@
 package events_test
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -193,5 +194,57 @@ func TestHTTPSink(t *testing.T) {
 
 		err = sink.Close()
 		So(err, ShouldBeNil)
+	})
+
+	Convey("HTTPSink.Close drops the connections it pooled", t, func() {
+		var open atomic.Int32
+
+		server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		server.Config.ConnState = func(_ net.Conn, state http.ConnState) {
+			if state == http.StateNew {
+				open.Add(1)
+			}
+
+			if state == http.StateClosed || state == http.StateHijacked {
+				open.Add(-1)
+			}
+		}
+		server.Start()
+
+		defer server.Close()
+
+		event := cloudevents.NewEvent()
+		event.SetID("1234")
+		event.SetType("test.event")
+		event.SetSource("unit.test")
+
+		cfg := eventsconf.SinkConfig{
+			Type:    eventsconf.HTTP,
+			Address: server.URL,
+		}
+
+		sink, err := events.NewHTTPSink(cfg)
+		So(err, ShouldBeNil)
+
+		So(cloudevents.IsACK(sink.Emit(&event)), ShouldBeTrue)
+
+		So(open.Load(), ShouldEqual, 1)
+
+		So(sink.Close(), ShouldBeNil)
+
+		var remaining int32
+
+		for range 100 {
+			remaining = open.Load()
+			if remaining == 0 {
+				break
+			}
+
+			time.Sleep(50 * time.Millisecond)
+		}
+
+		So(remaining, ShouldEqual, 0)
 	})
 }

--- a/pkg/extensions/events/reloadable.go
+++ b/pkg/extensions/events/reloadable.go
@@ -1,0 +1,99 @@
+package events
+
+import (
+	"sync"
+)
+
+// ReloadableRecorder is a Recorder whose delegate a reload can replace, so
+// every consumer follows without touching an emit site.
+type ReloadableRecorder struct {
+	// held across the whole forwarded call, so Swap can drain the delegate
+	mu       sync.RWMutex
+	recorder Recorder
+	closed   bool
+}
+
+var _ Recorder = (*ReloadableRecorder)(nil)
+
+func NewReloadableRecorder(recorder Recorder) *ReloadableRecorder {
+	return &ReloadableRecorder{recorder: recorder}
+}
+
+// Swap installs recorder and returns the delegate it replaced, once the calls
+// still inside it have returned, for the caller to close.
+func (r *ReloadableRecorder) Swap(recorder Recorder) Recorder {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// a reload that raced shutdown must not install into a closed wrapper, so
+	// hand its recorder back to be closed rather than leaving it live
+	if r.closed {
+		return recorder
+	}
+
+	previous := r.recorder
+	r.recorder = recorder
+
+	return previous
+}
+
+// with runs record against the installed delegate, if there is one.
+func (r *ReloadableRecorder) with(record func(recorder Recorder)) {
+	if r == nil {
+		return
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.recorder != nil {
+		record(r.recorder)
+	}
+}
+
+// Close detaches the delegate before closing it, so Swap drains it first.
+func (r *ReloadableRecorder) Close() {
+	if r == nil {
+		return
+	}
+
+	r.mu.Lock()
+	previous := r.recorder
+	r.recorder = nil
+	r.closed = true
+	r.mu.Unlock()
+
+	if previous != nil {
+		previous.Close()
+	}
+}
+
+func (r *ReloadableRecorder) RepositoryCreated(name string, ectx *EventContext) {
+	r.with(func(recorder Recorder) { recorder.RepositoryCreated(name, ectx) })
+}
+
+func (r *ReloadableRecorder) ImageUpdated(name, reference, digest, mediaType, manifest string, ectx *EventContext) {
+	r.with(func(recorder Recorder) {
+		recorder.ImageUpdated(name, reference, digest, mediaType, manifest, ectx)
+	})
+}
+
+func (r *ReloadableRecorder) ImageDeleted(name, reference, digest, mediaType string, ectx *EventContext) {
+	r.with(func(recorder Recorder) {
+		recorder.ImageDeleted(name, reference, digest, mediaType, ectx)
+	})
+}
+
+func (r *ReloadableRecorder) ImageLintFailed(name, reference, digest, mediaType, manifest string, ectx *EventContext) {
+	r.with(func(recorder Recorder) {
+		recorder.ImageLintFailed(name, reference, digest, mediaType, manifest, ectx)
+	})
+}
+
+func (r *ReloadableRecorder) ImageScanned(name, reference, digest, mediaType string,
+	summary ImageScanSummary, ectx *EventContext,
+) {
+	r.with(func(recorder Recorder) {
+		recorder.ImageScanned(name, reference, digest, mediaType, summary, ectx)
+	})
+}

--- a/pkg/extensions/events/reloadable_test.go
+++ b/pkg/extensions/events/reloadable_test.go
@@ -1,0 +1,297 @@
+package events_test
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/extensions/events"
+)
+
+// countingRecorder counts what it was asked to publish.
+type countingRecorder struct {
+	created    atomic.Int64
+	updated    atomic.Int64
+	deleted    atomic.Int64
+	lintFailed atomic.Int64
+	scanned    atomic.Int64
+	closed     atomic.Bool
+}
+
+func (r *countingRecorder) Close() { r.closed.Store(true) }
+
+func (r *countingRecorder) RepositoryCreated(string, *events.EventContext) { r.created.Add(1) }
+
+func (r *countingRecorder) ImageUpdated(_, _, _, _, _ string, _ *events.EventContext) {
+	r.updated.Add(1)
+}
+
+func (r *countingRecorder) ImageDeleted(_, _, _, _ string, _ *events.EventContext) {
+	r.deleted.Add(1)
+}
+
+func (r *countingRecorder) ImageLintFailed(_, _, _, _, _ string, _ *events.EventContext) {
+	r.lintFailed.Add(1)
+}
+
+func (r *countingRecorder) ImageScanned(_, _, _, _ string, _ events.ImageScanSummary,
+	_ *events.EventContext,
+) {
+	r.scanned.Add(1)
+}
+
+func TestReloadableRecorder(t *testing.T) {
+	Convey("A swap routes later events to the new delegate", t, func() {
+		first, second := &countingRecorder{}, &countingRecorder{}
+		reloadable := events.NewReloadableRecorder(first)
+
+		reloadable.RepositoryCreated("repo", nil)
+		So(first.created.Load(), ShouldEqual, 1)
+
+		replaced := reloadable.Swap(second)
+		So(replaced, ShouldEqual, first)
+
+		reloadable.RepositoryCreated("repo", nil)
+		reloadable.ImageUpdated("repo", "tag", "digest", "mediaType", "manifest", nil)
+
+		So(first.created.Load(), ShouldEqual, 1)
+		So(second.created.Load(), ShouldEqual, 1)
+		So(second.updated.Load(), ShouldEqual, 1)
+	})
+
+	Convey("Events are dropped while no delegate is installed", t, func() {
+		recorder := &countingRecorder{}
+		reloadable := events.NewReloadableRecorder(nil)
+
+		So(func() { reloadable.RepositoryCreated("repo", nil) }, ShouldNotPanic)
+
+		// disabled at startup, enabled by a reload
+		So(reloadable.Swap(recorder), ShouldBeNil)
+		reloadable.RepositoryCreated("repo", nil)
+		So(recorder.created.Load(), ShouldEqual, 1)
+
+		// and disabled again by a later reload
+		So(reloadable.Swap(nil), ShouldEqual, recorder)
+		reloadable.RepositoryCreated("repo", nil)
+		So(recorder.created.Load(), ShouldEqual, 1)
+	})
+
+	Convey("Close reaches the current delegate", t, func() {
+		recorder := &countingRecorder{}
+		reloadable := events.NewReloadableRecorder(recorder)
+
+		reloadable.Close()
+		So(recorder.closed.Load(), ShouldBeTrue)
+	})
+
+	Convey("Close detaches the delegate it closed", t, func() {
+		recorder := &countingRecorder{}
+		reloadable := events.NewReloadableRecorder(recorder)
+
+		reloadable.Close()
+		So(recorder.closed.Load(), ShouldBeTrue)
+
+		// emitting into sinks that are already closed is what detaching avoids
+		reloadable.RepositoryCreated("repo", nil)
+		So(recorder.created.Load(), ShouldEqual, 0)
+
+		So(func() { reloadable.Close() }, ShouldNotPanic)
+	})
+
+	Convey("Close waits for a call already inside the delegate", t, func() {
+		entered, release := make(chan struct{}), make(chan struct{})
+		blocking := &blockingRecorder{entered: entered, release: release}
+		reloadable := events.NewReloadableRecorder(blocking)
+
+		go reloadable.RepositoryCreated("repo", nil)
+		<-entered
+
+		closed := make(chan struct{})
+
+		go func() {
+			reloadable.Close()
+			close(closed)
+		}()
+
+		// the call has not dispatched its publish yet
+		select {
+		case <-closed:
+			t.Fatal("Close returned while the delegate was still in use")
+		case <-time.After(200 * time.Millisecond):
+		}
+
+		close(release)
+
+		select {
+		case <-closed:
+			So(blocking.closed.Load(), ShouldBeTrue)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Close did not return after the call finished")
+		}
+	})
+
+	Convey("Closing a wrapper with no delegate is safe and still terminal", t, func() {
+		var reloadable events.ReloadableRecorder
+
+		So(func() { reloadable.Close() }, ShouldNotPanic)
+
+		// nothing was there to close, but the wrapper is closed all the same
+		recorder := &countingRecorder{}
+		So(reloadable.Swap(recorder), ShouldEqual, recorder)
+	})
+
+	Convey("A swap after close installs nothing and hands the recorder back", t, func() {
+		installed, late := &countingRecorder{}, &countingRecorder{}
+		reloadable := events.NewReloadableRecorder(installed)
+
+		reloadable.Close()
+		So(installed.closed.Load(), ShouldBeTrue)
+
+		// a reload still in flight when shutdown closed the wrapper: its
+		// recorder comes straight back, so the caller closes it
+		So(reloadable.Swap(late), ShouldEqual, late)
+
+		reloadable.RepositoryCreated("repo", nil)
+		So(late.created.Load(), ShouldEqual, 0)
+		So(installed.created.Load(), ShouldEqual, 0)
+
+		// and closing stays a no-op rather than closing what was handed back
+		So(func() { reloadable.Close() }, ShouldNotPanic)
+	})
+
+	Convey("A nil wrapper records nothing instead of panicking", t, func() {
+		var reloadable *events.ReloadableRecorder
+
+		So(func() { reloadable.RepositoryCreated("repo", nil) }, ShouldNotPanic)
+		So(func() { reloadable.Close() }, ShouldNotPanic)
+	})
+
+	Convey("Publishing while swapping is race free", t, func() {
+		reloadable := events.NewReloadableRecorder(&countingRecorder{})
+
+		var waitGroup sync.WaitGroup
+
+		waitGroup.Add(2)
+
+		go func() {
+			defer waitGroup.Done()
+
+			for range 200 {
+				reloadable.RepositoryCreated("repo", nil)
+			}
+		}()
+
+		go func() {
+			defer waitGroup.Done()
+
+			for range 200 {
+				reloadable.Swap(&countingRecorder{})
+			}
+		}()
+
+		waitGroup.Wait()
+	})
+
+	Convey("Every event kind reaches the delegate and is safe without one", t, func() {
+		recorder := &countingRecorder{}
+		reloadable := events.NewReloadableRecorder(recorder)
+
+		reloadable.ImageDeleted("repo", "tag", "digest", "mediaType", nil)
+		reloadable.ImageLintFailed("repo", "tag", "digest", "mediaType", "manifest", nil)
+		reloadable.ImageScanned("repo", "tag", "digest", "mediaType", events.ImageScanSummary{}, nil)
+		reloadable.ImageUpdated("repo", "tag", "digest", "mediaType", "manifest", nil)
+		reloadable.RepositoryCreated("repo", nil)
+
+		// each kind has to land on its own method
+		So(recorder.deleted.Load(), ShouldEqual, 1)
+		So(recorder.lintFailed.Load(), ShouldEqual, 1)
+		So(recorder.scanned.Load(), ShouldEqual, 1)
+		So(recorder.updated.Load(), ShouldEqual, 1)
+		So(recorder.created.Load(), ShouldEqual, 1)
+
+		So(reloadable.Swap(nil), ShouldEqual, recorder)
+
+		// the same calls with nothing installed must be no-ops
+		So(func() {
+			reloadable.ImageDeleted("repo", "tag", "digest", "mediaType", nil)
+			reloadable.ImageLintFailed("repo", "tag", "digest", "mediaType", "manifest", nil)
+			reloadable.ImageScanned("repo", "tag", "digest", "mediaType", events.ImageScanSummary{}, nil)
+			reloadable.ImageUpdated("repo", "tag", "digest", "mediaType", "manifest", nil)
+			reloadable.RepositoryCreated("repo", nil)
+		}, ShouldNotPanic)
+
+		So(recorder.deleted.Load(), ShouldEqual, 1)
+		So(recorder.lintFailed.Load(), ShouldEqual, 1)
+		So(recorder.scanned.Load(), ShouldEqual, 1)
+		So(recorder.updated.Load(), ShouldEqual, 1)
+		So(recorder.created.Load(), ShouldEqual, 1)
+	})
+
+	Convey("A nil wrapper is safe for every event kind", t, func() {
+		var reloadable *events.ReloadableRecorder
+
+		So(func() {
+			reloadable.ImageUpdated("repo", "tag", "digest", "mediaType", "manifest", nil)
+			reloadable.ImageDeleted("repo", "tag", "digest", "mediaType", nil)
+			reloadable.ImageLintFailed("repo", "tag", "digest", "mediaType", "manifest", nil)
+			reloadable.ImageScanned("repo", "tag", "digest", "mediaType", events.ImageScanSummary{}, nil)
+		}, ShouldNotPanic)
+	})
+
+	Convey("A zero value wrapper is usable before anything is installed", t, func() {
+		var reloadable events.ReloadableRecorder
+
+		So(func() { reloadable.RepositoryCreated("repo", nil) }, ShouldNotPanic)
+
+		recorder := &countingRecorder{}
+		So(reloadable.Swap(recorder), ShouldBeNil)
+
+		reloadable.RepositoryCreated("repo", nil)
+		So(recorder.created.Load(), ShouldEqual, 1)
+	})
+
+	Convey("Swap waits for a call already inside the delegate", t, func() {
+		entered, release := make(chan struct{}), make(chan struct{})
+		blocking := &blockingRecorder{entered: entered, release: release}
+		reloadable := events.NewReloadableRecorder(blocking)
+
+		go reloadable.RepositoryCreated("repo", nil)
+		<-entered
+
+		swapped := make(chan events.Recorder, 1)
+
+		go func() { swapped <- reloadable.Swap(&countingRecorder{}) }()
+
+		// it cannot be handed back while a call is still inside it
+		select {
+		case <-swapped:
+			t.Fatal("Swap returned while the delegate was still in use")
+		case <-time.After(200 * time.Millisecond):
+		}
+
+		close(release)
+
+		select {
+		case replaced := <-swapped:
+			So(replaced, ShouldEqual, blocking)
+		case <-time.After(5 * time.Second):
+			t.Fatal("Swap did not return after the call finished")
+		}
+	})
+}
+
+// blockingRecorder holds a forwarded call open.
+type blockingRecorder struct {
+	countingRecorder
+
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (r *blockingRecorder) RepositoryCreated(string, *events.EventContext) {
+	close(r.entered)
+	<-r.release
+}

--- a/pkg/extensions/extension_events.go
+++ b/pkg/extensions/extension_events.go
@@ -35,6 +35,8 @@ func NewEventRecorder(config *config.Config, log log.Logger) (events.Recorder, e
 		case eventsconfig.HTTP:
 			sink, err := events.NewHTTPSink(sinkConfig)
 			if err != nil {
+				closeSinks(sinks, log)
+
 				return nil, err
 			}
 
@@ -42,6 +44,8 @@ func NewEventRecorder(config *config.Config, log log.Logger) (events.Recorder, e
 		case eventsconfig.NATS:
 			sink, err := events.NewNATSSink(sinkConfig)
 			if err != nil {
+				closeSinks(sinks, log)
+
 				return nil, err
 			}
 
@@ -63,4 +67,13 @@ func NewEventRecorder(config *config.Config, log log.Logger) (events.Recorder, e
 	}
 
 	return events.NewRecorderWithIdentity(log, identity, sinks...)
+}
+
+// closeSinks releases sinks already built when a later one fails.
+func closeSinks(sinks []events.Sink, log log.Logger) {
+	for _, sink := range sinks {
+		if err := sink.Close(); err != nil {
+			log.Error().Err(err).Msg("failed to close event sink")
+		}
+	}
 }

--- a/pkg/extensions/extension_events_test.go
+++ b/pkg/extensions/extension_events_test.go
@@ -1,0 +1,118 @@
+//go:build events
+
+package extensions_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	. "github.com/smartystreets/goconvey/convey"
+
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/extensions"
+	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
+	eventsconf "zotregistry.dev/zot/v2/pkg/extensions/config/events"
+	"zotregistry.dev/zot/v2/pkg/log"
+)
+
+func TestNewEventRecorderSinkRollback(t *testing.T) {
+	Convey("A NATS sink connects while it is being built", t, func() {
+		natsServer := runTestNATSServer(t)
+
+		recorder, err := extensions.NewEventRecorder(
+			eventSinksConfig(natsSink(natsServer.ClientURL())), log.NewTestLogger())
+		So(err, ShouldBeNil)
+		So(recorder, ShouldNotBeNil)
+
+		So(awaitClients(natsServer, 1), ShouldEqual, 1)
+
+		recorder.Close()
+		So(awaitClients(natsServer, 0), ShouldEqual, 0)
+	})
+
+	Convey("A sink opened before a later one fails is closed again", t, func() {
+		natsServer := runTestNATSServer(t)
+
+		// the NATS sink connects before the HTTP sink fails
+		recorder, err := extensions.NewEventRecorder(
+			eventSinksConfig(natsSink(natsServer.ClientURL()), brokenHTTPSink()), log.NewTestLogger())
+		So(err, ShouldNotBeNil)
+		So(recorder, ShouldBeNil)
+
+		So(awaitClients(natsServer, 0), ShouldEqual, 0)
+	})
+}
+
+func natsSink(address string) eventsconf.SinkConfig {
+	return eventsconf.SinkConfig{
+		Type:    eventsconf.NATS,
+		Address: address,
+		Channel: "zot",
+		Timeout: 5 * time.Second,
+	}
+}
+
+func brokenHTTPSink() eventsconf.SinkConfig {
+	return eventsconf.SinkConfig{
+		Type:      eventsconf.HTTP,
+		Address:   "http://receiver",
+		Timeout:   5 * time.Second,
+		TLSConfig: &eventsconf.TLSConfig{CACertFile: "/nonexistent/ca.pem"},
+	}
+}
+
+func eventSinksConfig(sinks ...eventsconf.SinkConfig) *config.Config {
+	enabled := true
+	cfg := config.New()
+	cfg.Extensions = &extconf.ExtensionConfig{
+		Events: &eventsconf.Config{
+			Enable: &enabled,
+			Sinks:  sinks,
+		},
+	}
+
+	return cfg
+}
+
+// awaitClients waits for the server to settle on want connected clients.
+func awaitClients(natsServer *server.Server, want int) int {
+	clients := natsServer.NumClients()
+
+	for range 100 {
+		if clients == want {
+			break
+		}
+
+		time.Sleep(50 * time.Millisecond)
+
+		clients = natsServer.NumClients()
+	}
+
+	return clients
+}
+
+func runTestNATSServer(t *testing.T) *server.Server {
+	t.Helper()
+
+	natsServer, err := server.NewServer(&server.Options{
+		Host:           "127.0.0.1",
+		Port:           -1,
+		NoLog:          true,
+		NoSigs:         true,
+		MaxControlLine: 4096,
+	})
+	if err != nil {
+		t.Fatalf("failed to create NATS server: %v", err)
+	}
+
+	go natsServer.Start()
+
+	if !natsServer.ReadyForConnections(5 * time.Second) {
+		t.Fatal("NATS server failed to start")
+	}
+
+	t.Cleanup(natsServer.Shutdown)
+
+	return natsServer
+}


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:

No existing issue.

**What does this PR do / Why do we need it**:

The event recorder is built once in `Controller.InitEventRecorder` and handed to every image store and to the CVE scanner, so a config reload never reaches it. `LoadNewConfig` re-applies accessControl and htpasswd, and `Extensions.Events` is not part of the reloadable set, so changing a sink address, a token or the sinks list logs a successful reload while deliveries keep going to the old sink until the process restarts. accessControl and htpasswd already reload, which leaves the events extension as the odd one out.

This makes it reload the same way:

- The recorder sits behind a wrapper guarding it with a `sync.RWMutex`. Every consumer is handed the wrapper once, so replacing the delegate reaches all of them and no emit site changes. The read side is held across the whole forwarded call, so once `Swap` returns nothing can still be inside the delegate it handed back and the caller is free to close it. A nil delegate records nothing, which is how a build or a configuration without events already behaves, and it is what lets a reload enable events on a server that started without them. `Close` goes out through the same detach: it swaps the delegate out before closing it, so a call already inside has returned, and dispatched its publish, before the sinks it was publishing to are torn down.
- `LoadNewConfig` rebuilds and swaps when the events config changed, then closes the recorder it replaced. Sinks are live connections, so this rebuilds rather than re-reads, and only when the config actually moved: `Config.EventsFingerprint` answers that, next to the storage fingerprint that already serves the same purpose, so an unrelated edit does not tear down open connections. The fingerprint compared against is the one the installed recorder was built from, and it only advances after a successful swap, so a rebuild that failed on something temporary is retried when the same config comes back instead of looking like it had been applied.
- `UpdateReloadableConfig` carries `Extensions.Events` across a reload, in the same shape as the sync and scrub extensions beside it.

Replacing a recorder makes three existing rough edges reachable, so all three are fixed here:

- Publishing dispatches asynchronously, so closing a replaced recorder could tear a sink down while an event was still going out to it. The recorder tracks in-flight publishes and `Close` waits for them.
- Building a recorder returned on the first bad sink without closing the ones already opened, leaking a connection on every failed reload. The sinks built so far are now closed before returning.
- `HTTPSink.Close` was a no-op even though every sink clones its own transport, so a sink dropped by a reload kept its pooled connections, and their goroutines, for the life of the process. It now releases them.

Event sink credentials are already masked by `Config.Sanitize`, so the reload log does not expose them.

**How to verify it**

Unit tests cover the wrapper (every event kind, swap, enable, disable, close, a nil and a zero value wrapper, publishing concurrently with a swap, and that a swap and a close each wait for a call already inside the delegate), that `Close` waits for a publish still in flight and detaches what it closed, and that closing an HTTP sink drops the connection it pooled. Controller tests drive `LoadNewConfig` itself against live receivers and assert that deliveries move between them, that enabling by reload starts delivery and disabling stops it, that an unchanged config keeps the existing sinks, that an image store handed the recorder at startup follows the swap, and that a rebuild which fails leaves the previous recorder delivering. All of them fail without the reload wiring, and the suite is clean under `-race`.
