### PR TITLE
fix(api): don't 500 on GET manifest when download-stats update fails

### DIFF
--- a/pkg/api/routes.go
+++ b/pkg/api/routes.go
@@ -578,12 +578,13 @@ func (rh *RouteHandler) GetManifest(response http.ResponseWriter, request *http.
 	}
 
 	if rh.c.MetaDB != nil {
-		err := meta.OnGetManifest(name, reference, mediaType, content, rh.c.StoreController, rh.c.MetaDB, rh.c.Log)
-		if err != nil && !errors.Is(err, zerr.ErrImageMetaNotFound) && !errors.Is(err, zerr.ErrRepoMetaNotFound) {
-			response.WriteHeader(http.StatusInternalServerError)
-
-			return
-		}
+		// OnGetManifest only updates best-effort download bookkeeping (download count and
+		// last-pull timestamp). The manifest has already been retrieved and verified above, so a
+		// failure here must not fail the client's read. In particular, a burst of concurrent
+		// pulls of the same repo contends the per-repo metaDB lock and UpdateStatsOnDownload
+		// returns a lock error; turning that into a 500 discards a perfectly good manifest and
+		// causes spurious ImagePullBackOff. The hook owns logging; ignore the returned error.
+		_ = meta.OnGetManifest(name, reference, mediaType, content, rh.c.StoreController, rh.c.MetaDB, rh.c.Log)
 	}
 
 	response.Header().Set(constants.DistContentDigestKey, digest.String())

--- a/pkg/api/routes_manifest_test.go
+++ b/pkg/api/routes_manifest_test.go
@@ -3,7 +3,9 @@
 package api_test
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,8 +23,12 @@ import (
 	ext "zotregistry.dev/zot/v2/pkg/extensions"
 	extconf "zotregistry.dev/zot/v2/pkg/extensions/config"
 	syncconf "zotregistry.dev/zot/v2/pkg/extensions/config/sync"
+	"zotregistry.dev/zot/v2/pkg/log"
 	"zotregistry.dev/zot/v2/pkg/test/mocks"
 )
+
+// Stand-in for a contended redis/redsync lock error from UpdateStatsOnDownload.
+var errStatsLockContention = errors.New("failed to acquire redis lock")
 
 type mockSyncOnDemand struct {
 	syncImageFn                   func(ctx context.Context, repo, reference string) error
@@ -67,6 +73,82 @@ func newSyncTestRouteHandler(
 	ctlr.SyncOnDemand = syncOnDemand
 
 	return api.NewRouteHandler(ctlr)
+}
+
+func TestGetManifestServesDespiteStatsError(t *testing.T) {
+	Convey("GetManifest serves the manifest when download-stats update fails", t, func() {
+		const (
+			reference    = "v1.0"
+			statsFailMsg = "failed to update stats on download image"
+		)
+
+		manifest := []byte(`{"schemaVersion":2}`)
+		digest := godigest.FromBytes(manifest)
+
+		newHandler := func(statsErr error) (*api.RouteHandler, *bytes.Buffer) {
+			var logBuf bytes.Buffer
+
+			ctlr := api.NewController(config.New())
+			ctlr.Log = log.NewLoggerWithWriter("debug", &logBuf)
+			ctlr.Router = mux.NewRouter()
+			ctlr.StoreController.DefaultStore = mocks.MockedImageStore{
+				GetImageManifestFn: func(_ string, _ string) ([]byte, godigest.Digest, string, error) {
+					return manifest, digest, ispec.MediaTypeImageManifest, nil
+				},
+			}
+			ctlr.MetaDB = mocks.MetaDBMock{
+				UpdateStatsOnDownloadFn: func(_ string, _ string) error {
+					return statsErr
+				},
+			}
+
+			return api.NewRouteHandler(ctlr), &logBuf
+		}
+
+		newReq := func() *http.Request {
+			req := httptest.NewRequestWithContext(
+				context.Background(),
+				http.MethodGet,
+				"http://example.com/v2/test/manifests/"+reference,
+				http.NoBody,
+			)
+
+			return mux.SetURLVars(req, map[string]string{
+				"name":      "test",
+				"reference": reference,
+			})
+		}
+
+		assertServed := func(handler *api.RouteHandler) {
+			rec := httptest.NewRecorder()
+			handler.GetManifest(rec, newReq())
+
+			resp := rec.Result()
+			defer resp.Body.Close()
+
+			So(resp.StatusCode, ShouldEqual, http.StatusOK)
+			So(resp.Header.Get(constants.DistContentDigestKey), ShouldEqual, digest.String())
+			So(resp.Header.Get("Content-Type"), ShouldEqual, ispec.MediaTypeImageManifest)
+
+			body, readErr := io.ReadAll(resp.Body)
+			So(readErr, ShouldBeNil)
+			So(body, ShouldResemble, manifest)
+		}
+
+		Convey("when UpdateStatsOnDownload returns ErrRepoMetaNotFound", func() {
+			handler, logBuf := newHandler(zerr.ErrRepoMetaNotFound)
+			assertServed(handler)
+			So(logBuf.String(), ShouldNotContainSubstring, statsFailMsg)
+		})
+
+		Convey("when UpdateStatsOnDownload returns a lock-style error", func() {
+			handler, logBuf := newHandler(errStatsLockContention)
+			assertServed(handler)
+			So(logBuf.String(), ShouldContainSubstring, `"level":"warn"`)
+			So(logBuf.String(), ShouldContainSubstring, statsFailMsg)
+			So(logBuf.String(), ShouldNotContainSubstring, `"level":"error"`)
+		})
+	})
 }
 
 func TestGetManifestCheckInterval(t *testing.T) {

--- a/pkg/extensions/search/search_test.go
+++ b/pkg/extensions/search/search_test.go
@@ -6132,7 +6132,7 @@ func TestMetaDBWhenReadingImages(t *testing.T) {
 			So(repoResponseStruct.Repos[0].DownloadCount, ShouldEqual, 3)
 		})
 
-		Convey("Error when incrementing", func() {
+		Convey("Stats increment error does not fail manifest GET", func() {
 			ctlr.MetaDB = mocks.MetaDBMock{
 				UpdateStatsOnDownloadFn: func(repo string, tag string) error {
 					return ErrTestError
@@ -6141,7 +6141,7 @@ func TestMetaDBWhenReadingImages(t *testing.T) {
 
 			resp, err := resty.R().Get(baseURL + "/v2/" + "repo1" + "/manifests/" + "1.0.1")
 			So(err, ShouldBeNil)
-			So(resp.StatusCode(), ShouldEqual, http.StatusInternalServerError)
+			So(resp.StatusCode(), ShouldEqual, http.StatusOK)
 		})
 	})
 

--- a/pkg/meta/hooks.go
+++ b/pkg/meta/hooks.go
@@ -353,7 +353,14 @@ func OnGetManifest(name, reference, mediaType string, body []byte,
 
 	err = metaDB.UpdateStatsOnDownload(name, reference)
 	if err != nil {
-		log.Error().Err(err).Str("repository", name).Str("reference", reference).
+		// Expected when meta lags the image store; keep quiet (caller already served the manifest).
+		if errors.Is(err, zerr.ErrImageMetaNotFound) || errors.Is(err, zerr.ErrRepoMetaNotFound) {
+			return err
+		}
+
+		// Best-effort bookkeeping: the caller serves the manifest regardless of this error
+		// (e.g. a contended per-repo metaDB lock under a concurrent pull burst), so log at warn.
+		log.Warn().Err(err).Str("repository", name).Str("reference", reference).
 			Msg("failed to update stats on download image")
 
 		return err


### PR DESCRIPTION
OnGetManifest only updates best-effort download bookkeeping after the manifest is already retrieved. Treat hook failures as non-fatal so a contended metaDB lock under concurrent pulls cannot cause spurious ImagePullBackOff. Keep not-found quiet, log other stats failures at warn, and cover the path with a regression test.

Fixes #4390

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
