### PR TITLE
Lock repositories individually so a write or GC pass on one no longer stalls every other

### DIFF
--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -144,8 +144,11 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 		return zerr.ErrRepoNotFound
 	}
 
-	gc.imgStore.Lock(&lockLatency)
-	defer gc.imgStore.Unlock(&lockLatency)
+	// Scoped to this repository unless dedupe makes blobs cross-repository;
+	// see ImageStore.GCLock. Holding the store-wide write lock here meant a
+	// pass over any one repository blocked reads and writes of every other.
+	gc.imgStore.GCLock(repo, &lockLatency)
+	defer gc.imgStore.GCUnlock(repo, &lockLatency)
 
 	/* this index (which represents the index.json of this repo) is the root point from which we
 	search for dangling manifests/blobs

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -46,15 +46,20 @@ const (
 type ImageStore struct {
 	rootDir     string
 	storeDriver storageTypes.Driver
-	lock        *sync.RWMutex
-	log         zlog.Logger
-	metrics     monitoring.MetricServer
-	events      events.Recorder
-	cache       storageTypes.Cache
-	dedupe      bool
-	linter      common.Lint
-	commit      bool
-	compat      []compat.MediaCompatibility
+	// lock gates the store as a whole. Repository-scoped operations take it
+	// shared, plus that repository's own mutex from repoLocks, so unrelated
+	// repositories proceed concurrently. Cross-repository operations take it
+	// exclusively and keep excluding every repository-scoped operation.
+	lock      *sync.RWMutex
+	repoLocks sync.Map
+	log       zlog.Logger
+	metrics   monitoring.MetricServer
+	events    events.Recorder
+	cache     storageTypes.Cache
+	dedupe    bool
+	linter    common.Lint
+	commit    bool
+	compat    []compat.MediaCompatibility
 	// dedupeRebuildDone is set once RunDedupeBlobs has walked all blobs, i.e. the
 	// cache accounts for every pre-existing blob; see deleteBlob.
 	dedupeRebuildDone atomic.Bool
@@ -120,6 +125,104 @@ func (is *ImageStore) RUnlock(lockStart *time.Time) {
 	// includes time spent in acquiring and holding a lock
 	latency := lockEnd.Sub(*lockStart)
 	monitoring.ObserveStorageLockLatency(is.metrics, latency, is.RootDir(), storageConstants.RLOCK) // histogram
+}
+
+// repoMutex returns the lock guarding one repository, creating it on first use.
+func (is *ImageStore) repoMutex(repo string) *sync.RWMutex {
+	mu, _ := is.repoLocks.LoadOrStore(repo, &sync.RWMutex{})
+
+	rwmu, _ := mu.(*sync.RWMutex)
+
+	return rwmu
+}
+
+// RLockRepo read-locks a single repository. The store gate is taken shared, so
+// a read never waits on work in an unrelated repository, only on a
+// cross-repository operation holding the gate exclusively.
+func (is *ImageStore) RLockRepo(repo string, lockStart *time.Time) {
+	*lockStart = time.Now()
+
+	is.lock.RLock()
+	is.repoMutex(repo).RLock()
+}
+
+// RUnlockRepo releases RLockRepo, innermost lock first.
+func (is *ImageStore) RUnlockRepo(repo string, lockStart *time.Time) {
+	is.repoMutex(repo).RUnlock()
+	is.lock.RUnlock()
+
+	lockEnd := time.Now()
+	latency := lockEnd.Sub(*lockStart)
+	monitoring.ObserveStorageLockLatency(is.metrics, latency, is.RootDir(), storageConstants.RLOCK)
+}
+
+// LockRepo write-locks a single repository. Writers exclude each other and the
+// readers of that repository; a write no longer stalls reads of every other
+// repository in the store.
+func (is *ImageStore) LockRepo(repo string, lockStart *time.Time) {
+	*lockStart = time.Now()
+
+	is.lock.RLock()
+	is.repoMutex(repo).Lock()
+}
+
+// UnlockRepo releases LockRepo, innermost lock first.
+func (is *ImageStore) UnlockRepo(repo string, lockStart *time.Time) {
+	is.repoMutex(repo).Unlock()
+	is.lock.RUnlock()
+
+	lockEnd := time.Now()
+	latency := lockEnd.Sub(*lockStart)
+	monitoring.ObserveStorageLockLatency(is.metrics, latency, is.RootDir(), storageConstants.RWLOCK)
+}
+
+// dedupeActive reports whether blobs can be shared between repositories, which
+// is what lets work on one repository affect another. Gated on the dedupe flag
+// together with a cache, the same condition every dedupe path here uses; on
+// remote storage a cache exists even with dedupe off, so the cache alone is not
+// the signal.
+func (is *ImageStore) dedupeActive() bool {
+	return is.dedupe && fmt.Sprintf("%v", is.cache) != fmt.Sprintf("%v", nil)
+}
+
+// LockBlobWrite takes the lock a blob write or delete in one repository needs.
+// With dedupe active a blob is shared between repositories through the dedupe
+// cache: an upload in repository A links against B's copy and a delete in A can
+// strip B's, so those writes are cross-repository and hold the whole store.
+// With dedupe off a blob write touches nothing outside its own repository.
+// Manifest operations never touch shared state and stay repository-scoped
+// regardless of dedupe.
+func (is *ImageStore) LockBlobWrite(repo string, lockStart *time.Time) {
+	if is.dedupeActive() {
+		is.Lock(lockStart)
+
+		return
+	}
+
+	is.LockRepo(repo, lockStart)
+}
+
+// UnlockBlobWrite releases LockBlobWrite, mirroring its choice of lock.
+func (is *ImageStore) UnlockBlobWrite(repo string, lockStart *time.Time) {
+	if is.dedupeActive() {
+		is.Unlock(lockStart)
+
+		return
+	}
+
+	is.UnlockRepo(repo, lockStart)
+}
+
+// GCLock takes the lock a garbage-collection pass over one repository needs. A
+// pass deletes blobs, so it follows the blob-write rule: store-wide with dedupe
+// active, repository-scoped otherwise.
+func (is *ImageStore) GCLock(repo string, lockStart *time.Time) {
+	is.LockBlobWrite(repo, lockStart)
+}
+
+// GCUnlock releases GCLock.
+func (is *ImageStore) GCUnlock(repo string, lockStart *time.Time) {
+	is.UnlockBlobWrite(repo, lockStart)
 }
 
 // Lock write-lock.
@@ -227,8 +330,8 @@ func (is *ImageStore) initRepo(ctx context.Context, name string) error {
 func (is *ImageStore) InitRepo(ctx context.Context, name string) error {
 	var lockLatency time.Time
 
-	is.Lock(&lockLatency)
-	defer is.Unlock(&lockLatency)
+	is.LockRepo(name, &lockLatency)
+	defer is.UnlockRepo(name, &lockLatency)
 
 	return is.initRepo(ctx, name)
 }
@@ -504,8 +607,8 @@ func (is *ImageStore) GetImageTags(repo string) ([]string, error) {
 		return nil, zerr.ErrRepoNotFound
 	}
 
-	is.RLock(&lockLatency)
-	defer is.RUnlock(&lockLatency)
+	is.RLockRepo(repo, &lockLatency)
+	defer is.RUnlockRepo(repo, &lockLatency)
 
 	index, err := common.GetIndex(is, repo, is.log)
 	if err != nil {
@@ -526,9 +629,9 @@ func (is *ImageStore) GetImageManifest(repo, reference string) ([]byte, godigest
 
 	var err error
 
-	is.RLock(&lockLatency)
+	is.RLockRepo(repo, &lockLatency)
 	defer func() {
-		is.RUnlock(&lockLatency)
+		is.RUnlockRepo(repo, &lockLatency)
 
 		if err == nil {
 			monitoring.IncDownloadCounter(is.metrics, repo)
@@ -581,9 +684,9 @@ func (is *ImageStore) PutImageManifest(ctx context.Context, repo, reference, med
 
 	var err error
 
-	is.Lock(&lockLatency)
+	is.LockRepo(repo, &lockLatency)
 	defer func() {
-		is.Unlock(&lockLatency)
+		is.UnlockRepo(repo, &lockLatency)
 
 		if err == nil {
 			if is.storeDriver.Name() == storageConstants.LocalStorageDriverName {
@@ -821,8 +924,8 @@ func (is *ImageStore) DeleteImageManifest(ctx context.Context, repo, reference s
 
 	var lockLatency time.Time
 
-	is.Lock(&lockLatency)
-	defer is.Unlock(&lockLatency)
+	is.LockRepo(repo, &lockLatency)
+	defer is.UnlockRepo(repo, &lockLatency)
 
 	err := is.deleteImageManifest(ctx, repo, reference, detectCollisions)
 	if err != nil {
@@ -1168,8 +1271,8 @@ func (is *ImageStore) FinishBlobUpload(repo, uuid string, body io.Reader, dstDig
 
 	var lockLatency time.Time
 
-	is.Lock(&lockLatency)
-	defer is.Unlock(&lockLatency)
+	is.LockBlobWrite(repo, &lockLatency)
+	defer is.UnlockBlobWrite(repo, &lockLatency)
 
 	// Chunk PUT/PATCH no longer call InitRepo (that lock stalled unread bodies vs GC).
 	// Recreate the OCI layout here, while we already hold the store lock for the move,
@@ -1282,8 +1385,8 @@ func (is *ImageStore) FullBlobUpload(ctx context.Context, repo string, body io.R
 
 	var lockLatency time.Time
 
-	is.Lock(&lockLatency)
-	defer is.Unlock(&lockLatency)
+	is.LockBlobWrite(repo, &lockLatency)
+	defer is.UnlockBlobWrite(repo, &lockLatency)
 
 	if err := is.initRepo(ctx, repo); err != nil {
 		return "", -1, err
@@ -1505,11 +1608,11 @@ func (is *ImageStore) CheckBlob(ctx context.Context, repo string, digest godiges
 	blobPath := is.BlobPath(repo, digest)
 
 	if is.dedupe && fmt.Sprintf("%v", is.cache) != fmt.Sprintf("%v", nil) {
-		is.Lock(&lockLatency)
-		defer is.Unlock(&lockLatency)
+		is.LockBlobWrite(repo, &lockLatency)
+		defer is.UnlockBlobWrite(repo, &lockLatency)
 	} else {
-		is.RLock(&lockLatency)
-		defer is.RUnlock(&lockLatency)
+		is.RLockRepo(repo, &lockLatency)
+		defer is.RUnlockRepo(repo, &lockLatency)
 	}
 
 	binfo, err := is.storeDriver.Stat(blobPath)
@@ -1683,8 +1786,8 @@ func (is *ImageStore) GetBlobPartial(repo string, digest godigest.Digest, mediaT
 		return nil, -1, -1, err
 	}
 
-	is.RLock(&lockLatency)
-	defer is.RUnlock(&lockLatency)
+	is.RLockRepo(repo, &lockLatency)
+	defer is.RUnlockRepo(repo, &lockLatency)
 
 	binfo, err := is.originalBlobInfo(repo, digest)
 	if err != nil {
@@ -1776,8 +1879,8 @@ func (is *ImageStore) GetBlob(repo string, digest godigest.Digest, mediaType str
 		return nil, -1, err
 	}
 
-	is.RLock(&lockLatency)
-	defer is.RUnlock(&lockLatency)
+	is.RLockRepo(repo, &lockLatency)
+	defer is.RUnlockRepo(repo, &lockLatency)
 
 	binfo, err := is.originalBlobInfo(repo, digest)
 	if err != nil {
@@ -1807,8 +1910,8 @@ func (is *ImageStore) GetBlobRedirectURL(r *http.Request, repo string, digest go
 		return "", nil
 	}
 
-	is.RLock(&lockLatency)
-	defer is.RUnlock(&lockLatency)
+	is.RLockRepo(repo, &lockLatency)
+	defer is.RUnlockRepo(repo, &lockLatency)
 
 	binfo, err := is.originalBlobInfo(repo, digest)
 	if err != nil {
@@ -1876,8 +1979,8 @@ func (is *ImageStore) GetReferrers(repo string, gdigest godigest.Digest, artifac
 ) (ispec.Index, error) {
 	var lockLatency time.Time
 
-	is.RLock(&lockLatency)
-	defer is.RUnlock(&lockLatency)
+	is.RLockRepo(repo, &lockLatency)
+	defer is.RUnlockRepo(repo, &lockLatency)
 
 	return common.GetReferrers(is, repo, gdigest, artifactTypes, is.log)
 }
@@ -1973,8 +2076,8 @@ func (is *ImageStore) DeleteBlob(repo string, digest godigest.Digest) error {
 		return err
 	}
 
-	is.Lock(&lockLatency)
-	defer is.Unlock(&lockLatency)
+	is.LockBlobWrite(repo, &lockLatency)
+	defer is.UnlockBlobWrite(repo, &lockLatency)
 
 	return is.deleteBlob(repo, digest)
 }

--- a/pkg/storage/imagestore/repo_lock_test.go
+++ b/pkg/storage/imagestore/repo_lock_test.go
@@ -1,0 +1,274 @@
+package imagestore_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	godigest "github.com/opencontainers/go-digest"
+
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	zlog "zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/storage"
+	"zotregistry.dev/zot/v2/pkg/storage/cache"
+	"zotregistry.dev/zot/v2/pkg/storage/imagestore"
+	"zotregistry.dev/zot/v2/pkg/storage/local"
+	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
+	testImage "zotregistry.dev/zot/v2/pkg/test/image-utils"
+)
+
+// slowDriver is the local driver with writes to one repository stalled, standing
+// in for the round-trip latency a remote driver has on every call.
+type slowDriver struct {
+	storageTypes.Driver
+
+	slowRepo string
+	delay    time.Duration
+}
+
+func (d *slowDriver) WriteFile(filepath string, content []byte) (int, error) {
+	if strings.Contains(filepath, d.slowRepo) {
+		time.Sleep(d.delay)
+	}
+
+	return d.Driver.WriteFile(filepath, content)
+}
+
+// finishes reports whether fn returns before the deadline.
+func finishes(fn func()) bool {
+	done := make(chan struct{})
+
+	go func() {
+		fn()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		return true
+	case <-time.After(2 * time.Second):
+		return false
+	}
+}
+
+// A write to one repository must not stall reads of another. The store held a
+// single RWMutex: PutImageManifest took it exclusively across every storage
+// round-trip, so GetImageManifest on an unrelated repository queued behind it.
+func TestWriteToOneRepoDoesNotBlockReadsOfAnother(t *testing.T) {
+	const (
+		slowRepo = "slow-repo"
+		fastRepo = "fast-repo"
+		delay    = 2 * time.Second
+	)
+
+	log := zlog.NewTestLogger()
+	metrics := monitoring.NewNopMetricServer()
+	driver := &slowDriver{Driver: local.New(true), slowRepo: slowRepo, delay: delay}
+	store := imagestore.NewImageStore(t.TempDir(), "", false, false, log, metrics, nil,
+		driver, nil, nil, nil)
+	ctrl := storage.StoreController{DefaultStore: store}
+	ctx := context.Background()
+
+	if err := testImage.WriteImageToFileSystem(testImage.CreateDefaultImage(), fastRepo, "v1", ctrl); err != nil {
+		t.Fatalf("seeding %s: %v", fastRepo, err)
+	}
+
+	slowImage := testImage.CreateRandomImage()
+
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+
+	started := make(chan struct{})
+
+	go func() {
+		defer wg.Done()
+		close(started)
+		// Stalls inside the driver for `delay`; the result is irrelevant, the hold is not.
+		_, _, _ = store.PutImageManifest(ctx, slowRepo, "v1",
+			slowImage.Manifest.MediaType, slowImage.ManifestDescriptor.Data, nil)
+	}()
+
+	<-started
+	time.Sleep(300 * time.Millisecond)
+
+	start := time.Now()
+	body, _, _, err := store.GetImageManifest(fastRepo, "v1")
+	blocked := time.Since(start)
+
+	wg.Wait()
+
+	if err != nil || len(body) == 0 {
+		t.Fatalf("reading %s: %v", fastRepo, err)
+	}
+
+	if blocked > delay/4 {
+		t.Fatalf("read of %s blocked %v behind a write to %s", fastRepo, blocked, slowRepo)
+	}
+}
+
+// A GC pass over one repository must not stall the others when dedupe is off,
+// and must still protect the repository it is collecting.
+func TestGCLockIsRepoScopedWithoutDedupe(t *testing.T) {
+	log := zlog.NewTestLogger()
+	metrics := monitoring.NewNopMetricServer()
+	store := imagestore.NewImageStore(t.TempDir(), "", false, false, log, metrics, nil,
+		local.New(true), nil, nil, nil)
+
+	var gcLatency time.Time
+
+	store.GCLock("repo-a", &gcLatency)
+	defer store.GCUnlock("repo-a", &gcLatency)
+
+	if !finishes(func() {
+		var t2 time.Time
+
+		store.RLockRepo("repo-b", &t2)
+		store.RUnlockRepo("repo-b", &t2)
+	}) {
+		t.Fatal("read of repo-b blocked behind GC of repo-a")
+	}
+
+	if finishes(func() {
+		var t2 time.Time
+
+		store.LockRepo("repo-a", &t2)
+		store.UnlockRepo("repo-a", &t2)
+	}) {
+		t.Fatal("write to repo-a proceeded during its own GC pass")
+	}
+}
+
+// Remote storage creates a cache even with dedupe off; the cache alone must not
+// widen the GC lock back to the whole store.
+func TestGCLockIsRepoScopedWithCacheButDedupeOff(t *testing.T) {
+	rootDir := t.TempDir()
+	log := zlog.NewTestLogger()
+	metrics := monitoring.NewNopMetricServer()
+
+	boltCache, err := cache.NewBoltDBCache(cache.BoltDBDriverParameters{
+		RootDir: rootDir, Name: "cache", UseRelPaths: true,
+	}, log)
+	if err != nil || boltCache == nil {
+		t.Skipf("boltdb cache unavailable: %v", err)
+	}
+
+	var c storageTypes.Cache = boltCache
+
+	store := imagestore.NewImageStore(rootDir, "", false, false, log, metrics, nil,
+		local.New(true), c, nil, nil)
+
+	var gcLatency time.Time
+
+	store.GCLock("repo-a", &gcLatency)
+	defer store.GCUnlock("repo-a", &gcLatency)
+
+	if !finishes(func() {
+		var t2 time.Time
+
+		store.RLockRepo("repo-b", &t2)
+		store.RUnlockRepo("repo-b", &t2)
+	}) {
+		t.Fatal("repo-b blocked behind GC of repo-a with dedupe off")
+	}
+}
+
+// With dedupe on, blobs are shared across repositories and a GC pass must keep
+// holding the whole store.
+func TestGCLockStaysStoreWideWithDedupe(t *testing.T) {
+	rootDir := t.TempDir()
+	log := zlog.NewTestLogger()
+	metrics := monitoring.NewNopMetricServer()
+
+	boltCache, err := cache.NewBoltDBCache(cache.BoltDBDriverParameters{
+		RootDir: rootDir, Name: "cache", UseRelPaths: true,
+	}, log)
+	if err != nil || boltCache == nil {
+		t.Skipf("boltdb cache unavailable: %v", err)
+	}
+
+	var c storageTypes.Cache = boltCache
+
+	store := imagestore.NewImageStore(rootDir, "", true, false, log, metrics, nil,
+		local.New(true), c, nil, nil)
+
+	var gcLatency time.Time
+
+	store.GCLock("repo-a", &gcLatency)
+	defer store.GCUnlock("repo-a", &gcLatency)
+
+	if finishes(func() {
+		var t2 time.Time
+
+		store.RLockRepo("repo-b", &t2)
+		store.RUnlockRepo("repo-b", &t2)
+	}) {
+		t.Fatal("repo-b proceeded during a dedupe-enabled GC pass")
+	}
+}
+
+// With dedupe active, the same blob uploaded to many repositories at once
+// links every copy through the shared dedupe cache, so those writes are
+// cross-repository and must still serialise; each copy has to land.
+func TestDedupedConcurrentUploadsOfOneBlobAllLand(t *testing.T) {
+	const repos = 12
+
+	rootDir := t.TempDir()
+	log := zlog.NewTestLogger()
+	metrics := monitoring.NewNopMetricServer()
+
+	boltCache, err := cache.NewBoltDBCache(cache.BoltDBDriverParameters{
+		RootDir: rootDir, Name: "cache", UseRelPaths: true,
+	}, log)
+	if err != nil || boltCache == nil {
+		t.Skipf("boltdb cache unavailable: %v", err)
+	}
+
+	var c storageTypes.Cache = boltCache
+
+	store := imagestore.NewImageStore(rootDir, "", true, false, log, metrics, nil,
+		local.New(true), c, nil, nil)
+
+	content := []byte(strings.Repeat("shared-layer-", 4096))
+	digest := godigest.FromBytes(content)
+
+	var wg sync.WaitGroup
+
+	errs := make([]error, repos)
+
+	for i := range repos {
+		wg.Add(1)
+
+		go func(i int) {
+			defer wg.Done()
+
+			repo := fmt.Sprintf("repo-%d", i)
+			if err := store.InitRepo(context.Background(), repo); err != nil {
+				errs[i] = err
+
+				return
+			}
+
+			_, _, errs[i] = store.FullBlobUpload(context.Background(), repo, bytes.NewReader(content), digest)
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("upload to repo-%d failed: %v", i, err)
+		}
+	}
+
+	for i := range repos {
+		ok, _, err := store.CheckBlob(context.Background(), fmt.Sprintf("repo-%d", i), digest)
+		if err != nil || !ok {
+			t.Fatalf("blob missing from repo-%d after concurrent deduped uploads: ok=%v err=%v", i, ok, err)
+		}
+	}
+}

--- a/pkg/storage/types/types.go
+++ b/pkg/storage/types/types.go
@@ -26,6 +26,12 @@ type ImageStore interface { //nolint:interfacebloat
 	DirExists(d string) bool
 	RootDir() string
 	RLock(*time.Time)
+	RLockRepo(string, *time.Time)
+	RUnlockRepo(string, *time.Time)
+	LockRepo(string, *time.Time)
+	UnlockRepo(string, *time.Time)
+	GCLock(string, *time.Time)
+	GCUnlock(string, *time.Time)
 	RUnlock(*time.Time)
 	Lock(*time.Time)
 	Unlock(*time.Time)

--- a/pkg/test/mocks/image_store_mock.go
+++ b/pkg/test/mocks/image_store_mock.go
@@ -89,6 +89,24 @@ func (is MockedImageStore) RUnlock(t *time.Time) {
 func (is MockedImageStore) RLock(t *time.Time) {
 }
 
+func (is MockedImageStore) RLockRepo(repo string, t *time.Time) {
+}
+
+func (is MockedImageStore) RUnlockRepo(repo string, t *time.Time) {
+}
+
+func (is MockedImageStore) LockRepo(repo string, t *time.Time) {
+}
+
+func (is MockedImageStore) UnlockRepo(repo string, t *time.Time) {
+}
+
+func (is MockedImageStore) GCLock(repo string, t *time.Time) {
+}
+
+func (is MockedImageStore) GCUnlock(repo string, t *time.Time) {
+}
+
 func (is MockedImageStore) Name() string {
 	if is.NameFn != nil {
 		return is.NameFn()


### PR DESCRIPTION
ImageStore holds a single RWMutex, so a manifest write or garbage-collection pass on one repository blocks reads and writes of every other repository for as long as its storage round-trips take. Repository-scoped operations now take the store lock shared plus a per-repository mutex, while cross-repository operations and dedupe-enabled GC keep the exclusive store lock unchanged.