### PR TITLE
perf(storage): read each manifest once per repository walk and prefetch them concurrently

### DIFF
--- a/pkg/storage/common/common.go
+++ b/pkg/storage/common/common.go
@@ -427,6 +427,145 @@ func UpdateIndexWithPrunedImageManifests(imgStore storageTypes.ImageStore, index
 	return nil
 }
 
+// walkReadParallelism bounds concurrent blob reads when a repository-wide walk
+// warms its memo. Remote drivers are latency-bound, so a modest fan-out
+// collapses a long sequential walk without swamping the backend.
+const walkReadParallelism = 32
+
+// concurrentReader is implemented by stores whose reads are safe to issue from
+// many goroutines at once. Anything else, such as a test double, is read
+// sequentially with unchanged semantics.
+type concurrentReader interface {
+	ConcurrentReadSafe() bool
+}
+
+// WalkMemo holds the manifests and indexes one repository-wide walk has parsed,
+// so a digest referenced many times within that walk is read from storage once.
+// It lives for a single walk: a GC pass or one manifest update. Across walks,
+// storage stays authoritative, so a blob altered or removed between them is
+// seen. A nil *WalkMemo reads through without memoising.
+type WalkMemo struct {
+	mu        sync.Mutex
+	indexes   map[godigest.Digest]ispec.Index
+	manifests map[godigest.Digest]ispec.Manifest
+}
+
+// NewWalkMemo returns an empty memo for one walk.
+func NewWalkMemo() *WalkMemo {
+	return &WalkMemo{
+		indexes:   map[godigest.Digest]ispec.Index{},
+		manifests: map[godigest.Digest]ispec.Manifest{},
+	}
+}
+
+// Index is GetImageIndex through the memo.
+func (m *WalkMemo) Index(imgStore storageTypes.ImageStore, repo string, digest godigest.Digest, log zlog.Logger,
+) (ispec.Index, error) {
+	if m == nil {
+		return GetImageIndex(imgStore, repo, digest, log)
+	}
+
+	m.mu.Lock()
+	idx, ok := m.indexes[digest]
+	m.mu.Unlock()
+
+	if ok {
+		return idx, nil
+	}
+
+	idx, err := GetImageIndex(imgStore, repo, digest, log)
+	if err != nil {
+		return idx, err
+	}
+
+	m.mu.Lock()
+	m.indexes[digest] = idx
+	m.mu.Unlock()
+
+	return idx, nil
+}
+
+// Manifest is GetImageManifest through the memo.
+func (m *WalkMemo) Manifest(imgStore storageTypes.ImageStore, repo string, digest godigest.Digest, log zlog.Logger,
+) (ispec.Manifest, error) {
+	if m == nil {
+		return GetImageManifest(imgStore, repo, digest, log)
+	}
+
+	m.mu.Lock()
+	man, ok := m.manifests[digest]
+	m.mu.Unlock()
+
+	if ok {
+		return man, nil
+	}
+
+	man, err := GetImageManifest(imgStore, repo, digest, log)
+	if err != nil {
+		return man, err
+	}
+
+	m.mu.Lock()
+	m.manifests[digest] = man
+	m.mu.Unlock()
+
+	return man, nil
+}
+
+// Prefetch reads the given descriptors into the memo concurrently, so the
+// sequential, order-sensitive walk that follows runs from memory instead of
+// one storage round-trip per entry. Errors are not returned: the walk re-reads
+// and reports them in its own terms. Stores that do not declare their reads
+// concurrency-safe are left to the walk's own sequential reads.
+func (m *WalkMemo) Prefetch(imgStore storageTypes.ImageStore, repo string, descs []ispec.Descriptor, log zlog.Logger) {
+	if m == nil {
+		return
+	}
+
+	if reader, ok := imgStore.(concurrentReader); !ok || !reader.ConcurrentReadSafe() {
+		return
+	}
+
+	var wg sync.WaitGroup
+
+	sem := make(chan struct{}, walkReadParallelism)
+
+	for _, desc := range descs {
+		isIndex := compat.IsImageIndexMediaType(desc.MediaType)
+		isManifest := compat.IsImageManifestMediaType(desc.MediaType)
+
+		if !isIndex && !isManifest {
+			continue
+		}
+
+		m.mu.Lock()
+		_, haveIdx := m.indexes[desc.Digest]
+		_, haveMan := m.manifests[desc.Digest]
+		m.mu.Unlock()
+
+		if (isIndex && haveIdx) || (isManifest && haveMan) {
+			continue
+		}
+
+		wg.Add(1)
+
+		go func(dgst godigest.Digest, isIndex bool) {
+			defer wg.Done()
+
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			if isIndex {
+				_, _ = m.Index(imgStore, repo, dgst, log)
+			} else {
+				_, _ = m.Manifest(imgStore, repo, dgst, log)
+			}
+		}(desc.Digest, isIndex)
+	}
+
+	wg.Wait()
+}
+
 // PruneImageManifestsFromIndex is a helper routine that prunes image manifests from an index.
 // Before an image index manifest is pushed to a repo, its constituent manifests
 // are pushed first, so when updating/removing this image index manifest, we also
@@ -457,8 +596,14 @@ func PruneImageManifestsFromIndex(imgStore storageTypes.ImageStore, repo string,
 		inUse[manifest.Digest.Encoded()]++
 	}
 
+	// Every other image index in the repository is read to learn which of the
+	// old index's constituents it still references: one read per index, and on a
+	// repository that overwrites a multi-arch tag per build the count only grows.
+	memo := NewWalkMemo()
+	memo.Prefetch(imgStore, repo, otherImgIndexes, log)
+
 	for _, otherIndex := range otherImgIndexes {
-		oindex, err := GetImageIndex(imgStore, repo, otherIndex.Digest, log)
+		oindex, err := memo.Index(imgStore, repo, otherIndex.Digest, log)
 		if err != nil {
 			// Handle missing blobs gracefully - log warning and continue with other indexes
 			var pathNotFoundErr driver.PathNotFoundError
@@ -657,6 +802,14 @@ is returned to the caller.
 */
 func GetReferencedBlobs(imgStore storageTypes.ImageStore, repo string, log zlog.Logger,
 ) (map[godigest.Digest]struct{}, error) {
+	return GetReferencedBlobsWithMemo(nil, imgStore, repo, log)
+}
+
+// GetReferencedBlobsWithMemo is GetReferencedBlobs reading through memo, so a GC
+// pass that has already parsed the repository's manifests does not read them
+// again to compute the blob set.
+func GetReferencedBlobsWithMemo(memo *WalkMemo, imgStore storageTypes.ImageStore, repo string, log zlog.Logger,
+) (map[godigest.Digest]struct{}, error) {
 	dir := path.Join(imgStore.RootDir(), repo)
 	if !imgStore.DirExists(dir) {
 		return nil, zerr.ErrRepoNotFound
@@ -670,16 +823,18 @@ func GetReferencedBlobs(imgStore storageTypes.ImageStore, repo string, log zlog.
 	referenced := map[godigest.Digest]struct{}{}
 	seen := map[godigest.Digest]struct{}{}
 
-	if err := collectReferencedBlobs(imgStore, repo, index, referenced, seen, log); err != nil {
+	if err := collectReferencedBlobs(memo, imgStore, repo, index, referenced, seen, log); err != nil {
 		return nil, err
 	}
 
 	return referenced, nil
 }
 
-func collectReferencedBlobs(imgStore storageTypes.ImageStore, repo string,
+func collectReferencedBlobs(memo *WalkMemo, imgStore storageTypes.ImageStore, repo string,
 	index ispec.Index, referenced map[godigest.Digest]struct{}, seen map[godigest.Digest]struct{}, log zlog.Logger,
 ) error {
+	memo.Prefetch(imgStore, repo, index.Manifests, log)
+
 	for _, desc := range index.Manifests {
 		referenced[desc.Digest] = struct{}{}
 
@@ -691,7 +846,7 @@ func collectReferencedBlobs(imgStore storageTypes.ImageStore, repo string,
 
 		switch {
 		case compat.IsImageIndexMediaType(desc.MediaType):
-			indexImage, err := GetImageIndex(imgStore, repo, desc.Digest, log)
+			indexImage, err := memo.Index(imgStore, repo, desc.Digest, log)
 			if err != nil {
 				var pathNotFoundErr driver.PathNotFoundError
 				if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
@@ -707,11 +862,11 @@ func collectReferencedBlobs(imgStore storageTypes.ImageStore, repo string,
 				return err
 			}
 
-			if err := collectReferencedBlobs(imgStore, repo, indexImage, referenced, seen, log); err != nil {
+			if err := collectReferencedBlobs(memo, imgStore, repo, indexImage, referenced, seen, log); err != nil {
 				return err
 			}
 		case compat.IsImageManifestMediaType(desc.MediaType):
-			manifestContent, err := GetImageManifest(imgStore, repo, desc.Digest, log)
+			manifestContent, err := memo.Manifest(imgStore, repo, desc.Digest, log)
 			if err != nil {
 				var pathNotFoundErr driver.PathNotFoundError
 				if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {

--- a/pkg/storage/gc/gc.go
+++ b/pkg/storage/gc/gc.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/distribution/distribution/v3/registry/storage/driver"
@@ -64,12 +65,18 @@ type GarbageCollect struct {
 	auditLog  *zlog.Logger
 	log       zlog.Logger
 	metrics   monitoring.MetricServer
+	// memos holds one WalkMemo per repository for the duration of its pass, so
+	// every read of a manifest or index during that pass hits storage once.
+	// Passes over one repository never overlap (the repository is locked), and
+	// the map is shared by the value-receiver copies of this struct.
+	memos *sync.Map
 }
 
 func NewGarbageCollect(imgStore types.ImageStore, metaDB mTypes.MetaDB, opts Options,
 	auditLog *zlog.Logger, log zlog.Logger, metrics monitoring.MetricServer,
 ) GarbageCollect {
 	return GarbageCollect{
+		memos:     &sync.Map{},
 		imgStore:  imgStore,
 		metaDB:    metaDB,
 		opts:      opts,
@@ -136,6 +143,22 @@ func (gc GarbageCollect) CleanRepo(ctx context.Context, repo string) error {
 	return nil
 }
 
+// memo returns the WalkMemo for a repository's in-progress pass, or nil (read-
+// through) when called outside one.
+func (gc GarbageCollect) memo(repo string) *common.WalkMemo {
+	if gc.memos == nil {
+		return nil
+	}
+
+	if v, ok := gc.memos.Load(repo); ok {
+		if memo, ok := v.(*common.WalkMemo); ok {
+			return memo
+		}
+	}
+
+	return nil
+}
+
 func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 	var lockLatency time.Time
 
@@ -146,6 +169,15 @@ func (gc GarbageCollect) cleanRepo(ctx context.Context, repo string) error {
 
 	gc.imgStore.Lock(&lockLatency)
 	defer gc.imgStore.Unlock(&lockLatency)
+
+	// One memo for this pass: the referenced-set and orphan-blob walks each read
+	// every manifest and index in the repository, and did so from storage every
+	// time, one round-trip per entry. Storage is authoritative again once the
+	// pass ends.
+	if gc.memos != nil {
+		gc.memos.Store(repo, common.NewWalkMemo())
+		defer gc.memos.Delete(repo)
+	}
 
 	/* this index (which represents the index.json of this repo) is the root point from which we
 	search for dangling manifests/blobs
@@ -447,7 +479,7 @@ func (gc GarbageCollect) syncManifestRemoval(repo string, desc ispec.Descriptor,
 func (gc GarbageCollect) imageIndexHasStaleNestedManifests(repo string, desc ispec.Descriptor,
 	existingBlobs map[string]bool,
 ) (bool, error) {
-	indexImage, err := common.GetImageIndex(gc.imgStore, repo, desc.Digest, gc.log)
+	indexImage, err := gc.memo(repo).Index(gc.imgStore, repo, desc.Digest, gc.log)
 	if err != nil {
 		var pathNotFoundErr driver.PathNotFoundError
 		if errors.Is(err, zerr.ErrBlobNotFound) || errors.As(err, &pathNotFoundErr) {
@@ -585,7 +617,7 @@ func (gc GarbageCollect) removeReferrerByIndexDesc(repo string, rootIndex *ispec
 	if !cached {
 		var err error
 
-		indexImage, err = common.GetImageIndex(gc.imgStore, repo, desc.Digest, gc.log)
+		indexImage, err = gc.memo(repo).Index(gc.imgStore, repo, desc.Digest, gc.log)
 		if err != nil {
 			if isMissingBlobErr(err) {
 				missing[desc.Digest] = struct{}{}
@@ -624,7 +656,7 @@ func (gc GarbageCollect) removeReferrerByManifestDesc(repo string, rootIndex *is
 	if !cached {
 		var err error
 
-		image, err = common.GetImageManifest(gc.imgStore, repo, desc.Digest, gc.log)
+		image, err = gc.memo(repo).Manifest(gc.imgStore, repo, desc.Digest, gc.log)
 		if err != nil {
 			if isMissingBlobErr(err) {
 				missing[desc.Digest] = struct{}{}
@@ -940,6 +972,8 @@ func (gc GarbageCollect) removeUntaggedManifests(ctx context.Context, repo strin
 func (gc GarbageCollect) identifyManifestsReferencedInIndex(index ispec.Index, repo string,
 	referenced map[godigest.Digest]bool, seen map[godigest.Digest]struct{},
 ) error {
+	gc.memo(repo).Prefetch(gc.imgStore, repo, index.Manifests, gc.log)
+
 	for _, desc := range index.Manifests {
 		if _, ok := seen[desc.Digest]; ok {
 			continue
@@ -948,7 +982,7 @@ func (gc GarbageCollect) identifyManifestsReferencedInIndex(index ispec.Index, r
 		seen[desc.Digest] = struct{}{}
 
 		if compat.IsImageIndexMediaType(desc.MediaType) {
-			indexImage, err := common.GetImageIndex(gc.imgStore, repo, desc.Digest, gc.log)
+			indexImage, err := gc.memo(repo).Index(gc.imgStore, repo, desc.Digest, gc.log)
 			if err != nil {
 				if isMissingBlobErr(err) {
 					gc.log.Warn().Err(err).Str("module", "gc").Str("repository", repo).
@@ -977,7 +1011,7 @@ func (gc GarbageCollect) identifyManifestsReferencedInIndex(index ispec.Index, r
 				return err
 			}
 		} else if compat.IsImageManifestMediaType(desc.MediaType) {
-			image, err := common.GetImageManifest(gc.imgStore, repo, desc.Digest, gc.log)
+			image, err := gc.memo(repo).Manifest(gc.imgStore, repo, desc.Digest, gc.log)
 			if err != nil {
 				if isMissingBlobErr(err) {
 					gc.log.Warn().Err(err).Str("module", "gc").Str("repo", repo).
@@ -1060,7 +1094,7 @@ func (gc GarbageCollect) deleteUnreferencedBlobs(repo string, delay time.Duratio
 ) (int, error) {
 	gc.log.Debug().Str("module", "gc").Str("repository", repo).Msg("cleaning orphan blobs")
 
-	refBlobs, err := common.GetReferencedBlobs(gc.imgStore, repo, gc.log)
+	refBlobs, err := common.GetReferencedBlobsWithMemo(gc.memo(repo), gc.imgStore, repo, gc.log)
 	if err != nil {
 		log.Error().Err(err).Str("module", "gc").Str("repository", repo).Msg("failed to get referenced blobs in repo")
 

--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -105,6 +105,12 @@ func NewImageStore(rootDir string, cacheDir string, dedupe, commit bool, log zlo
 	return imgStore
 }
 
+// ConcurrentReadSafe reports that this store's reads may be issued from many
+// goroutines at once, which lets repository-wide walks prefetch in parallel.
+func (is *ImageStore) ConcurrentReadSafe() bool {
+	return true
+}
+
 // RLock read-lock.
 func (is *ImageStore) RLock(lockStart *time.Time) {
 	*lockStart = time.Now()

--- a/pkg/storage/imagestore/walk_memo_test.go
+++ b/pkg/storage/imagestore/walk_memo_test.go
@@ -1,0 +1,204 @@
+package imagestore_test
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"zotregistry.dev/zot/v2/pkg/api/config"
+	"zotregistry.dev/zot/v2/pkg/extensions/monitoring"
+	zlog "zotregistry.dev/zot/v2/pkg/log"
+	"zotregistry.dev/zot/v2/pkg/storage"
+	"zotregistry.dev/zot/v2/pkg/storage/gc"
+	"zotregistry.dev/zot/v2/pkg/storage/imagestore"
+	"zotregistry.dev/zot/v2/pkg/storage/local"
+	storageTypes "zotregistry.dev/zot/v2/pkg/storage/types"
+	testImage "zotregistry.dev/zot/v2/pkg/test/image-utils"
+	"zotregistry.dev/zot/v2/pkg/test/mocks"
+)
+
+const testRepo = "ci-repo"
+
+// countingDriver counts and optionally delays storage reads. On remote storage
+// every read is a network round-trip, so the count and the serialisation of
+// those reads, not local wall-clock, are what predict latency.
+type countingDriver struct {
+	storageTypes.Driver
+
+	reads     atomic.Int64
+	readDelay time.Duration
+}
+
+func (d *countingDriver) ReadFile(path string) ([]byte, error) {
+	d.reads.Add(1)
+
+	if d.readDelay > 0 {
+		time.Sleep(d.readDelay)
+	}
+
+	return d.Driver.ReadFile(path)
+}
+
+func newCountingStore(t *testing.T, readDelay time.Duration) (storageTypes.ImageStore, *countingDriver,
+	storage.StoreController,
+) {
+	t.Helper()
+
+	counter := &countingDriver{Driver: local.New(true), readDelay: readDelay}
+	store := imagestore.NewImageStore(t.TempDir(), "", false, false,
+		zlog.NewTestLogger(), monitoring.NewNopMetricServer(), nil, counter, nil, nil, nil)
+
+	return store, counter, storage.StoreController{DefaultStore: store}
+}
+
+func sortedTags(t *testing.T, store storageTypes.ImageStore) []string {
+	t.Helper()
+
+	tags, err := store.GetImageTags(testRepo)
+	if err != nil {
+		t.Fatalf("tags: %v", err)
+	}
+
+	sort.Strings(tags)
+
+	return tags
+}
+
+func sameTags(before, after []string) bool {
+	if len(before) != len(after) {
+		return false
+	}
+
+	for i := range before {
+		if before[i] != after[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// seedMultiarchBuilds writes count multi-arch builds and returns how many
+// distinct manifests and indexes that put in the repository.
+func seedMultiarchBuilds(t *testing.T, ctrl storage.StoreController, count int) int {
+	t.Helper()
+
+	distinct := 0
+
+	for i := range count {
+		mi := testImage.CreateRandomMultiarch()
+		if err := testImage.WriteMultiArchImageToFileSystem(mi, testRepo, fmt.Sprintf("build-%d", i), ctrl); err != nil {
+			t.Fatalf("seeding build %d: %v", i, err)
+		}
+
+		distinct += 1 + len(mi.Images)
+	}
+
+	return distinct
+}
+
+// Overwriting a multi-arch tag reads every other image index in the repository
+// to decide what the old index's constituents are still referenced by. Those
+// reads are independent, so they must not run one round-trip at a time: on a
+// repository with thousands of tagged builds a serial walk is minutes per push.
+func TestOverwritingMultiarchTagReadsOtherIndexesConcurrently(t *testing.T) {
+	const (
+		existingIndexes = 64
+		readDelay       = 20 * time.Millisecond
+	)
+
+	store, counter, ctrl := newCountingStore(t, 0)
+
+	_ = seedMultiarchBuilds(t, ctrl, existingIndexes)
+
+	latest := testImage.CreateRandomMultiarch()
+	if err := testImage.WriteMultiArchImageToFileSystem(latest, testRepo, "latest", ctrl); err != nil {
+		t.Fatalf("seeding latest: %v", err)
+	}
+
+	tagsBefore := sortedTags(t, store)
+
+	next := testImage.CreateRandomMultiarch()
+	for _, img := range next.Images {
+		if err := testImage.WriteImageToFileSystem(img, testRepo, img.DigestStr(), ctrl); err != nil {
+			t.Fatalf("writing constituent: %v", err)
+		}
+	}
+
+	// From here every read costs readDelay, as it would against remote storage.
+	counter.readDelay = readDelay
+	counter.reads.Store(0)
+
+	start := time.Now()
+
+	if _, _, err := store.PutImageManifest(context.Background(), testRepo, "latest",
+		next.IndexDescriptor.MediaType, next.IndexDescriptor.Data, nil); err != nil {
+		t.Fatalf("overwrite: %v", err)
+	}
+
+	elapsed := time.Since(start)
+	reads := counter.reads.Load()
+	serial := time.Duration(reads) * readDelay
+
+	t.Logf("indexes=%d reads=%d elapsed=%v (serial would be %v)", existingIndexes, reads, elapsed, serial)
+
+	if reads < existingIndexes {
+		t.Fatalf("expected at least one read per other index, got %d", reads)
+	}
+
+	if elapsed > serial/3 {
+		t.Fatalf("overwrite took %v for %d reads; they are still serialised (serial=%v)", elapsed, reads, serial)
+	}
+
+	if !sameTags(tagsBefore, sortedTags(t, store)) {
+		t.Fatal("tag set changed across an overwrite of an unrelated tag")
+	}
+}
+
+// A GC pass reads every manifest and index in the repository in more than one
+// place: to find what is referenced, to compute the live blob set, and per
+// retention checks. Within a pass each blob must be read once, not once per
+// walk, and the pass must still collect exactly what it did before.
+func TestGCPassReadsEachManifestOnce(t *testing.T) {
+	const builds = 40
+
+	store, counter, ctrl := newCountingStore(t, 0)
+	log := zlog.NewTestLogger()
+	metrics := monitoring.NewNopMetricServer()
+
+	distinct := int64(seedMultiarchBuilds(t, ctrl, builds)) + 1 // + the orphan
+
+	orphan := testImage.CreateRandomImage()
+	if err := testImage.WriteImageToFileSystem(orphan, testRepo, orphan.DigestStr(), ctrl); err != nil {
+		t.Fatalf("seeding orphan: %v", err)
+	}
+
+	collector := gc.NewGarbageCollect(store, mocks.MetaDBMock{}, gc.Options{
+		Delay:          0,
+		ImageRetention: config.ImageRetention{Delay: 0},
+	}, nil, log, metrics)
+
+	tagsBefore := sortedTags(t, store)
+
+	counter.reads.Store(0)
+
+	if err := collector.CleanRepo(context.Background(), testRepo); err != nil {
+		t.Fatalf("gc: %v", err)
+	}
+
+	reads := counter.reads.Load()
+
+	// Allow index.json and a small constant on top of one read per blob.
+	t.Logf("builds=%d distinct manifests+indexes=%d gc reads=%d", builds, distinct, reads)
+
+	if reads > distinct+8 {
+		t.Fatalf("gc read %d blobs for %d distinct manifests and indexes; the pass is re-reading", reads, distinct)
+	}
+
+	if !sameTags(tagsBefore, sortedTags(t, store)) {
+		t.Fatal("gc changed the tag set")
+	}
+}


### PR DESCRIPTION
Overwriting a multi-arch tag and every GC pass read each manifest and index in the repository from storage one round-trip at a time, and a GC pass re-read the same blobs in each of its walks, so on a repository with thousands of tagged builds a single push or collection took minutes. Each repository-wide walk now parses a blob once through a memo scoped to that walk and prefetches the walk's blobs concurrently, so storage stays authoritative between walks while the walk itself runs from memory.