### PR TITLE
Dump all goroutine stacks on SIGUSR1 without stopping the server

### DIFF
--- a/pkg/cli/server/config_reloader.go
+++ b/pkg/cli/server/config_reloader.go
@@ -2,10 +2,14 @@ package server
 
 import (
 	"errors"
+	"fmt"
+	"io"
 	"os"
 	"os/signal"
+	"runtime"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 
@@ -65,6 +69,28 @@ func initShutDownRoutine(ctlr *api.Controller, hr *HotReloader) {
 
 	// handle SIGINT and SIGHUP.
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT, syscall.SIGHUP)
+
+	// SIGUSR1 writes every goroutine's stack to stderr without stopping the
+	// server. signal.Ignore() above swallows SIGQUIT, so the runtime's own dump
+	// can never fire, and the pprof endpoint is behind authentication in most
+	// deployments; this keeps a stack trace of a live stall one signal away.
+	dumpCh := make(chan os.Signal, 1)
+	signal.Notify(dumpCh, syscall.SIGUSR1)
+
+	go dumpGoroutinesOnSignal(dumpCh, os.Stderr)
+}
+
+// dumpGoroutinesOnSignal writes all goroutine stacks to out each time a signal
+// arrives on ch. It never exits the process.
+func dumpGoroutinesOnSignal(ch <-chan os.Signal, out io.Writer) {
+	const bufSize = 64 << 20
+
+	for range ch {
+		buf := make([]byte, bufSize)
+		n := runtime.Stack(buf, true)
+		fmt.Fprintf(out, "=== goroutine dump (SIGUSR1) %s ===\n%s\n=== end goroutine dump ===\n",
+			time.Now().UTC().Format(time.RFC3339), buf[:n])
+	}
 }
 
 func (hr *HotReloader) Stop() {

--- a/pkg/cli/server/goroutine_dump_internal_test.go
+++ b/pkg/cli/server/goroutine_dump_internal_test.go
@@ -1,0 +1,80 @@
+package server
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestDumpGoroutinesOnSignalWritesStacksAndKeepsRunning(t *testing.T) {
+	sigCh := make(chan os.Signal, 1)
+
+	var (
+		mu  sync.Mutex
+		out bytes.Buffer
+	)
+
+	writer := lockedWriter{mu: &mu, w: &out}
+
+	done := make(chan struct{})
+
+	go func() {
+		dumpGoroutinesOnSignal(sigCh, writer)
+		close(done)
+	}()
+
+	for i := range 2 {
+		sigCh <- syscall.SIGUSR1
+
+		deadline := time.After(5 * time.Second)
+
+		for {
+			mu.Lock()
+			count := strings.Count(out.String(), "=== end goroutine dump ===")
+			mu.Unlock()
+
+			if count == i+1 {
+				break
+			}
+
+			select {
+			case <-deadline:
+				t.Fatalf("dump %d not written", i+1)
+			case <-time.After(10 * time.Millisecond):
+			}
+		}
+	}
+
+	mu.Lock()
+	text := out.String()
+	mu.Unlock()
+
+	if !strings.Contains(text, "goroutine ") || !strings.Contains(text, "TestDumpGoroutinesOnSignalWritesStacksAndKeepsRunning") {
+		t.Fatal("dump does not contain goroutine stacks")
+	}
+
+	select {
+	case <-done:
+		t.Fatal("handler exited; it must keep serving signals")
+	default:
+	}
+
+	close(sigCh)
+	<-done
+}
+
+type lockedWriter struct {
+	mu *sync.Mutex
+	w  *bytes.Buffer
+}
+
+func (l lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.w.Write(p)
+}


### PR DESCRIPTION
signal.Ignore() swallows SIGQUIT and the pprof endpoint sits behind authentication, so there is no way to get a stack trace from a live server that is stalling. SIGUSR1 now writes every goroutine's stack to stderr and the server keeps running.