### PR TITLE
fix: set Strict-Transport-Security header on TLS responses

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -200,8 +200,11 @@ func (c *Controller) Run() error {
 		return err
 	}
 	server := &http.Server{
-		Addr:              addr,
-		Handler:           c.Router,
+		Addr: addr,
+		// mux.Router only runs its Use() middlewares for matched routes, so
+		// unmatched requests (404/405) would otherwise skip HSTS. Wrap the
+		// whole router here so every response gets it.
+		Handler:           StrictTransportSecurityHandler()(c.Router),
 		ReadTimeout:       c.Config.GetHTTPReadTimeout(),
 		WriteTimeout:      c.Config.GetHTTPWriteTimeout(),
 		IdleTimeout:       idleTimeout,

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2155,6 +2155,42 @@ func TestTLSWithBasicAuth(t *testing.T) {
 	})
 }
 
+func TestStrictTransportSecurityOnUnmatchedRoute(t *testing.T) {
+	Convey("Make a new TLS controller", t, func() {
+		_, serverCertPath, serverKeyPath, _, _, caCertPEM := setupTestCerts(t)
+
+		caCertPool := x509.NewCertPool()
+		caCertPool.AppendCertsFromPEM(caCertPEM)
+
+		resty.SetTLSClientConfig(&tls.Config{RootCAs: caCertPool, MinVersion: tls.VersionTLS12})
+
+		defer func() { resty.SetTLSClientConfig(nil) }()
+
+		conf := config.New()
+		conf.HTTP.Port = "0"
+		conf.HTTP.TLS = &config.TLSConfig{
+			Cert: serverCertPath,
+			Key:  serverKeyPath,
+		}
+
+		ctlr := makeController(conf, t.TempDir())
+
+		cm := test.NewControllerManager(ctlr)
+		secureBaseURL := cm.StartAndWait()
+
+		defer cm.StopServer()
+
+		// this path doesn't match any registered route, so mux.Router falls back to
+		// its NotFoundHandler, which never runs router.Use() middlewares - HSTS must
+		// still be set because it's applied at the http.Server.Handler boundary.
+		resp, err := resty.R().Get(secureBaseURL + "/this-route-does-not-exist")
+		So(err, ShouldBeNil)
+		So(resp, ShouldNotBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusNotFound)
+		So(resp.Header().Get("Strict-Transport-Security"), ShouldEqual, "max-age=63072000; includeSubDomains")
+	})
+}
+
 func TestTLSWithBasicAuthAllowReadAccess(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		// Generate certificates dynamically for the test

--- a/pkg/api/security_headers.go
+++ b/pkg/api/security_headers.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gorilla/mux"
+)
+
+const hstsHeaderValue = "max-age=63072000; includeSubDomains"
+
+// StrictTransportSecurityHandler is a HTTP middleware that sets the
+// Strict-Transport-Security header on every response served over TLS,
+// instructing browsers to only ever reach this host over HTTPS.
+func StrictTransportSecurityHandler() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+			if request.TLS != nil {
+				response.Header().Set("Strict-Transport-Security", hstsHeaderValue)
+			}
+
+			next.ServeHTTP(response, request)
+		})
+	}
+}


### PR DESCRIPTION



**What type of PR is this?**

bug

**Which issue does this PR fix**:

Fix HSTS header for zot API and UI

**What does this PR do / Why do we need it**:

Zot never sent HSTS and has no config option for it, so browsers could be downgraded to plain HTTP on a MITM'd network path even though the server only listens on HTTPS. Add a middleware that sets Strict-Transport-Security (2yr max-age, includeSubDomains) whenever a request arrives over TLS, applied globally alongside the other top-level middleware in controller.go.

**If an issue # is not available please add repro steps and logs showing the issue**:

Just run zot and use curl -v to see the headers set.

**Testing done on this change**:

All unit tests passed.

**Automation added to e2e**:

Not required. There is an existing test that is currently logging a warning which will now pass.

**Will this break upgrades or downgrades?**

No. The PR does this ONLY for https.

**Does this PR introduce any user-facing change?**:

No.

```release-note
Fix HSTS header for zot API and UI
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
