### PR TITLE
fix(authn): avoid session CookieStore panic for anonymous UI clients

### DIFF
--- a/pkg/api/authn.go
+++ b/pkg/api/authn.go
@@ -468,8 +468,11 @@ func (amw *AuthnMiddleware) tryAuthnHandlers(ctlr *Controller) mux.MiddlewareFun
 			case !isAuthorizationHeaderEmpty(request) && authConfig.IsBasicAuthnEnabled():
 				authenticated, err = amw.basicAuthn(ctlr, userAc, response, request)
 
-			// The session header is an explicit attempt to use session authentication
-			case hasSessionHeader(request):
+			// The session header is an explicit attempt to use session authentication.
+			// CookieStore is only created when basic authn is enabled; without it, skip session
+			// handling so open/anonymous access still works for UI clients that send
+			// X-ZOT-API-CLIENT (see allowAnonymousAccess in mgmt → zot-ui).
+			case hasSessionHeader(request) && ctlr.CookieStore != nil:
 				authenticated, err = amw.sessionAuthn(ctlr, userAc, response, request)
 				if err != nil {
 					break

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -7357,6 +7357,84 @@ func TestAuthorizationWithOnlyAnonymousPolicy(t *testing.T) {
 	})
 }
 
+// anonymous-only (no CookieStore) + UI X-ZOT-API-CLIENT must not panic on search.
+func TestAnonymousOnlyWithUIClientHeader(t *testing.T) {
+	Convey("anonymous-only access with UI client header does not panic", t, func() {
+		const testRepo = "docker.com/library/nginx"
+
+		defaultVal := true
+		conf := config.New()
+		conf.Storage.GC = false
+		conf.HTTP.Port = "0"
+		conf.HTTP.Auth = &config.AuthConfig{}
+		conf.HTTP.AccessControl = &config.AccessControlConfig{
+			Repositories: config.Repositories{
+				"**": config.PolicyGroup{
+					AnonymousPolicy: []string{"read", "create", "update"},
+				},
+			},
+		}
+		conf.Extensions = &extconf.ExtensionConfig{
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
+			UI:     &extconf.UIConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
+		}
+
+		ctlr := makeController(conf, t.TempDir())
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+
+		defer cm.StopServer()
+
+		So(ctlr.CookieStore, ShouldBeNil)
+
+		err := UploadImage(CreateRandomImage(), baseURL, testRepo, "alpine")
+		So(err, ShouldBeNil)
+
+		uiClient := resty.R().
+			SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue)
+
+		resp, err := uiClient.Get(baseURL + "/v2/")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		resp, err = uiClient.Get(baseURL + "/v2/_catalog")
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+
+		query := `{RepoListWithNewestImage{Results{Name NewestImage{Tag}}}}`
+		resp, err = uiClient.Get(baseURL + constants.FullSearchPrefix + "?query=" + url.QueryEscape(query))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+		So(string(resp.Body()), ShouldContainSubstring, testRepo)
+	})
+
+	Convey("open registry (no accessControl) with UI client header does not panic", t, func() {
+		defaultVal := true
+		conf := config.New()
+		conf.Storage.GC = false
+		conf.HTTP.Port = "0"
+		conf.HTTP.Auth = &config.AuthConfig{}
+		conf.Extensions = &extconf.ExtensionConfig{
+			Search: &extconf.SearchConfig{BaseConfig: extconf.BaseConfig{Enable: &defaultVal}},
+		}
+
+		ctlr := makeController(conf, t.TempDir())
+		cm := test.NewControllerManager(ctlr)
+		baseURL := cm.StartAndWait()
+
+		defer cm.StopServer()
+
+		So(ctlr.CookieStore, ShouldBeNil)
+
+		resp, err := resty.R().
+			SetHeader(constants.SessionClientHeaderName, constants.SessionClientHeaderValue).
+			Get(baseURL + constants.FullSearchPrefix + "?query=" +
+				url.QueryEscape(`{RepoListWithNewestImage{Results{Name}}}`))
+		So(err, ShouldBeNil)
+		So(resp.StatusCode(), ShouldEqual, http.StatusOK)
+	})
+}
+
 func TestAuthorizationWithAnonymousPolicyBasicAuthAndSessionHeader(t *testing.T) {
 	Convey("Make a new controller", t, func() {
 		const TestRepo = "my-repos/repo"


### PR DESCRIPTION
UI search sent X-ZOT-API-CLIENT when mgmt reported allowAnonymousAccess, but CookieStore is only created with basic auth. Session auth then nil-deref'd and returned 500, so the UI stayed empty despite MetaDB having images (anonymous-only accessControl, no htpasswd/LDAP/OIDC).

Long-standing UI behavior: whenever localStorage.authConfig has any keys, axios adds X-ZOT-API-CLIENT: zot-ui. That dates back to the old auth flow.

What changed recently (~Aug 30–31):
- zot https://github.com/project-zot/zot/pull/4368 — mgmt puts allowAnonymousAccess: true on http.auth when any anonymousPolicy exists.
 - zui https://github.com/project-zot/zui/pull/559 — guest login uses that flag instead of probing GET /v2/ https://github.com/project-zot/zot/issues/4361.

Before that, anonymous-only often got empty auth: {} → UI stored "{}" → no header.
After that, mgmt returns {"allowAnonymousAccess": true} → non-empty → UI treats auth as “enabled” → sends the header.

Skip session handling when CookieStore is nil so requests fall through to anonymous/open auth. Fixes #4416.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
