### PR TITLE
fix: skip invalid repo dirs like lost+found during storage walks

### DIFF
--- a/pkg/storage/imagestore/imagestore.go
+++ b/pkg/storage/imagestore/imagestore.go
@@ -327,8 +327,17 @@ func (is *ImageStore) GetNextRepositories(lastRepo string, maxEntries int, filte
 
 		rel = filepath.ToSlash(rel)
 
-		if ok, err := is.ValidateRepo(rel); !ok || err != nil {
-			return nil //nolint:nilerr // ignore invalid repos
+		ok, err := is.ValidateRepo(rel)
+		if errors.Is(err, zerr.ErrInvalidRepositoryName) {
+			// Names that can never be repos (e.g. lost+found): do not descend —
+			// listing unreadable FS dirs would fail the whole walk.
+			return driver.ErrSkipDir
+		}
+
+		if !ok || err != nil {
+			// Not an OCI layout yet, but the name is valid — keep walking children
+			// so nested repos (path "org" → "org/team") are still discovered.
+			return nil //nolint:nilerr
 		}
 
 		if lastRepo == rel {
@@ -341,7 +350,7 @@ func (is *ImageStore) GetNextRepositories(lastRepo string, maxEntries int, filte
 			found = true
 		}
 
-		ok, err := filterFn(rel)
+		ok, err = filterFn(rel)
 		if err != nil {
 			return err
 		}
@@ -403,8 +412,17 @@ func (is *ImageStore) GetRepositories() ([]string, error) {
 
 		rel = filepath.ToSlash(rel)
 
-		if ok, err := is.ValidateRepo(rel); !ok || err != nil {
-			return nil //nolint:nilerr // ignore invalid repos
+		ok, err := is.ValidateRepo(rel)
+		if errors.Is(err, zerr.ErrInvalidRepositoryName) {
+			// Names that can never be repos (e.g. lost+found): do not descend —
+			// listing unreadable FS dirs would fail the whole walk.
+			return driver.ErrSkipDir
+		}
+
+		if !ok || err != nil {
+			// Not an OCI layout yet, but the name is valid — keep walking children
+			// so nested repos (path "org" → "org/team") are still discovered.
+			return nil //nolint:nilerr
 		}
 
 		stores = append(stores, rel)
@@ -468,8 +486,16 @@ func (is *ImageStore) GetNextRepository(processedRepos map[string]struct{}) (str
 		}
 
 		ok, err := is.ValidateRepo(rel)
+		if errors.Is(err, zerr.ErrInvalidRepositoryName) {
+			// Names that can never be repos (e.g. lost+found): do not descend —
+			// listing unreadable FS dirs would fail the whole walk.
+			return driver.ErrSkipDir
+		}
+
 		if !ok || err != nil {
-			return nil //nolint:nilerr // ignore invalid repos
+			// Not an OCI layout yet, but the name is valid — keep walking children
+			// so nested repos (path "org" → "org/team") are still discovered.
+			return nil //nolint:nilerr
 		}
 
 		store = rel

--- a/pkg/storage/local/local_test.go
+++ b/pkg/storage/local/local_test.go
@@ -3380,6 +3380,139 @@ func TestGetRepositories(t *testing.T) {
 		t.Logf("repos %v", repos)
 		So(len(repos), ShouldEqual, 0)
 	})
+
+	Convey("GetRepositories ignores unreadable lost+found", t, func() {
+		// Regression for https://github.com/project-zot/zot/issues/4413:
+		// ext4 mount roots often contain a root-owned lost+found. Walking into it
+		// used to fail GetRepositories with permission denied.
+		dir := t.TempDir()
+
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
+			RootDir:     dir,
+			Name:        "cache",
+			UseRelPaths: true,
+		}, log)
+
+		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
+
+		repoDir := path.Join(dir, "myrepo")
+		So(os.MkdirAll(path.Join(repoDir, ispec.ImageBlobsDir), 0o755), ShouldBeNil)
+
+		il := ispec.ImageLayout{Version: ispec.ImageLayoutVersion}
+		layoutFileContent, err := json.Marshal(il)
+		So(err, ShouldBeNil)
+
+		err = os.WriteFile(path.Join(repoDir, ispec.ImageIndexFile), []byte("{}"),
+			storageConstants.DefaultFilePerms)
+		So(err, ShouldBeNil)
+		err = os.WriteFile(path.Join(repoDir, ispec.ImageLayoutFile), layoutFileContent,
+			storageConstants.DefaultFilePerms)
+		So(err, ShouldBeNil)
+
+		lostFound := path.Join(dir, "lost+found")
+		So(os.MkdirAll(path.Join(lostFound, "orphan"), 0o755), ShouldBeNil)
+		So(os.Chmod(lostFound, 0o000), ShouldBeNil)
+
+		defer func() {
+			_ = os.Chmod(lostFound, 0o755)
+		}()
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldResemble, []string{"myrepo"})
+	})
+
+	Convey("Skip invalid repo names (lost+found) without failing; still find nested repos", t, func() {
+		dir := t.TempDir()
+
+		log := zlog.NewTestLogger()
+		metrics := monitoring.NewNopMetricServer()
+		cacheDriver, _ := storage.Create("boltdb", cache.BoltDBDriverParameters{
+			RootDir:     dir,
+			Name:        "cache",
+			UseRelPaths: true,
+		}, log)
+
+		imgStore := local.NewImageStore(dir, true, true, log, metrics, nil, cacheDriver, nil, nil)
+
+		writeMinimalOCILayout := func(repo string) {
+			repoDir := path.Join(dir, repo)
+			So(os.MkdirAll(path.Join(repoDir, ispec.ImageBlobsDir), 0o755), ShouldBeNil)
+
+			il := ispec.ImageLayout{Version: ispec.ImageLayoutVersion}
+			layoutFileContent, err := json.Marshal(il)
+			So(err, ShouldBeNil)
+
+			err = os.WriteFile(path.Join(repoDir, ispec.ImageIndexFile), []byte("{}"),
+				storageConstants.DefaultFilePerms)
+			So(err, ShouldBeNil)
+			err = os.WriteFile(path.Join(repoDir, ispec.ImageLayoutFile), layoutFileContent,
+				storageConstants.DefaultFilePerms)
+			So(err, ShouldBeNil)
+		}
+
+		// Nested valid repos under a namespace prefix that is not itself a layout.
+		writeMinimalOCILayout("org/team")
+		writeMinimalOCILayout("org/group/app")
+		writeMinimalOCILayout("toplevel")
+
+		// ext4-style junk: invalid distribution name with nested contents, unreadable
+		// like a root-owned lost+found. Without ErrSkipDir on invalid names, Walk
+		// would List this dir and fail the whole GetRepositories call.
+		lostFound := path.Join(dir, "lost+found")
+		So(os.MkdirAll(path.Join(lostFound, "orphan-inode"), 0o755), ShouldBeNil)
+		err := os.WriteFile(path.Join(lostFound, "orphan-inode", "data"), []byte("x"),
+			storageConstants.DefaultFilePerms)
+		So(err, ShouldBeNil)
+		So(os.Chmod(lostFound, 0o000), ShouldBeNil)
+
+		defer func() {
+			_ = os.Chmod(lostFound, 0o755)
+		}()
+
+		// Another invalid-name tree with nested folders (readable): must be skipped,
+		// not mistaken for repos and not break discovery of valid nested paths.
+		So(os.MkdirAll(path.Join(dir, "_invalid", "nested", "deep"), 0o755), ShouldBeNil)
+		err = os.WriteFile(path.Join(dir, "_invalid", "nested", "deep", "file"), []byte("x"),
+			storageConstants.DefaultFilePerms)
+		So(err, ShouldBeNil)
+
+		repos, err := imgStore.GetRepositories()
+		So(err, ShouldBeNil)
+		So(repos, ShouldContain, "org/team")
+		So(repos, ShouldContain, "org/group/app")
+		So(repos, ShouldContain, "toplevel")
+		So(len(repos), ShouldEqual, 3)
+		So(repos, ShouldNotContain, "lost+found")
+		So(repos, ShouldNotContain, "_invalid")
+		So(repos, ShouldNotContain, "org") // namespace prefix only, not a layout
+
+		nextRepos, more, err := imgStore.GetNextRepositories("", 10, func(repo string) (bool, error) {
+			return true, nil
+		})
+		So(err, ShouldBeNil)
+		So(more, ShouldBeFalse)
+		So(nextRepos, ShouldContain, "org/team")
+		So(nextRepos, ShouldContain, "org/group/app")
+		So(nextRepos, ShouldContain, "toplevel")
+		So(len(nextRepos), ShouldEqual, 3)
+
+		found := map[string]struct{}{}
+		for range 5 {
+			repo, err := imgStore.GetNextRepository(found)
+			So(err, ShouldBeNil)
+			if repo == "" {
+				break
+			}
+			found[repo] = struct{}{}
+		}
+		So(found, ShouldContainKey, "org/team")
+		So(found, ShouldContainKey, "org/group/app")
+		So(found, ShouldContainKey, "toplevel")
+		So(len(found), ShouldEqual, 3)
+	})
 }
 
 func TestGetNextRepository(t *testing.T) {


### PR DESCRIPTION
GetRepositories and related walks returned nil for invalid names, so the local driver still descended into unreadable lost+found and failed with permission denied (e.g. DedupeTaskGenerator). Return ErrSkipDir on ErrInvalidRepositoryName so nested repos under valid prefixes still work.

Fixes #4413

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
